### PR TITLE
Fix address wraparound problem in disas

### DIFF
--- a/z80sim/srcsim/simctl.c
+++ b/z80sim/srcsim/simctl.c
@@ -67,7 +67,7 @@
 #include "memory.h"
 
 extern void cpu_z80(void), cpu_8080(void);
-extern void disass(int, unsigned char **, int);
+extern void disass(int, unsigned char **, int, unsigned char *);
 extern int exatoi(char *);
 extern int getkey(void);
 extern void int_on(void), int_off(void);
@@ -210,7 +210,7 @@ static void do_step(void)
 	print_head();
 	print_reg();
 	p = mem_base() + PC;
-	disass(cpu, &p, PC);
+	disass(cpu, &p, PC, mem_base());
 }
 
 /*
@@ -373,9 +373,7 @@ static void do_list(char *s)
 		wrk_ram = mem_base() + exatoi(s);
 	for (i = 0; i <	10; i++) {
 		printf("%04x - ", (unsigned int)(wrk_ram - mem_base()));
-		disass(cpu, &wrk_ram, wrk_ram - mem_base());
-		if (wrk_ram > mem_base() + 65535)
-			wrk_ram = mem_base();
+		disass(cpu, &wrk_ram, wrk_ram - mem_base(), mem_base());
 	}
 }
 


### PR DESCRIPTION
The disassembler doesn't wraparound from high addresses to low addresses when a instruction is near the end of the memory. It picks garbage bytes just after the memory.

E.g. assemble LD HL,1234h from FFFF:
```
>>> m ffff
ffff = 65 : 21
0000 = cb : 34
0001 = fb : 12
0002 = 66 : q
```
 and disassemble it:
```
>>> lffff
ffff - LD	HL,00DF
...
```

I've fixed this problem by adding one more parameter to disass(), the memory base. When it is not null, base will be considered as the base of the simulated memory and wraparounds will be handled.
Of course, addresse wraparound is also handled when computing relative jumps addresses.
There are probably more elegant solution bu this one requires less changes.