### PR TITLE
fixed: mutex initialisation and redundant frontpanel updates

### DIFF
--- a/frontpanel/lp_main.cpp
+++ b/frontpanel/lp_main.cpp
@@ -116,6 +116,7 @@ int start_threads(void)
   int n;
 
   pthread_mutex_init(&data_lock,NULL);
+  pthread_mutex_init(&data_sample_lock,NULL);
   thread_info.run = 1;
   //n = pthread_create(&thread_info.thread_id, &attr, lp_mainloop_thread, &thread_info.thread_no);
   n = pthread_create(&thread_info.thread_id, NULL, lp_mainloop_thread, &thread_info.thread_no);

--- a/z80sim/srcsim/sim1.c
+++ b/z80sim/srcsim/sim1.c
@@ -553,14 +553,6 @@ leave:
 		cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
 #endif
 
-#ifdef FRONTPANEL
-		/* update frontpanel */
-		fp_clock++;
-		fp_led_address = PC;
-		fp_led_data = dma_read(PC);
-		fp_sampleData();
-#endif
-
 		int_protection = 0;
 		states = (*op_sim[memrdr(PC++)]) (); /* execute next opcode */
 		t += states;

--- a/z80sim/srcsim/sim1a.c
+++ b/z80sim/srcsim/sim1a.c
@@ -520,14 +520,6 @@ leave:
 		cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
 #endif
 
-#ifdef FRONTPANEL
-		/* update frontpanel */
-		fp_clock++;
-		fp_led_address = PC;
-		fp_led_data = dma_read(PC);
-		fp_sampleData();
-#endif
-
 		int_protection = 0;
 		states = (*op_sim[memrdr(PC++)]) (); /* execute next opcode */
 		t += states;


### PR DESCRIPTION
This Pull-Request contains proposed fixes for two issues:

- Redundant frontpanel updates being made in `sim1.c` and `sim1a.c` #8 

- No mutex initialisation for data_sample_lock in `lp_main.cpp` #7
