### PR TITLE
Refactor code out of simctl.c to improve separation of concerns for hardware IO simulation

### DIFF
--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -36,6 +36,7 @@
 #include "../../iodevices/cromemco-dazzler.h"
 #include "../../iodevices/imsai-vio.h"
 #include "../../frontpanel/frontpanel.h"
+#include "memory.h"
 
 /*
  *	Forward declarations for I/O functions
@@ -587,6 +588,10 @@ static void (*port_out[256]) (BYTE) = {
  */
 void init_io(void)
 {
+	/* initialise IMSAI VIO if firmware is loaded */
+	if (!strncmp((char *) mem_base() + 0xfffd, "VI0", 3))
+		imsai_vio_init();
+
 }
 
 /*
@@ -604,6 +609,17 @@ void exit_io(void)
 
 	/* shutdown VIO */
 	imsai_vio_off();
+}
+
+/*
+ *	This function is to reset the I/O devices. It is
+ *	called from the CPU simulation when an External Clear is performed.
+ */
+void reset_io(void)
+{
+	cromemco_dazzler_off();
+	imsai_fif_reset();
+	hwctl_lock = 0xff;
 }
 
 /*

--- a/z80sim/srcsim/sim0.c
+++ b/z80sim/srcsim/sim0.c
@@ -71,8 +71,9 @@
 #define BUFSIZE	256		/* buffer size for file I/O */
 
 static void init_cpu(void);
-int load_core(void);
 static void save_core(void);
+int load_core(void);
+int load_file(char *);
 static int load_mos(int, char *), load_hex(char *), checksum(char *);
 extern void int_on(void), int_off(void), mon(void);
 extern void init_io(void), exit_io(void);
@@ -317,9 +318,13 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 
 	init_rom();		/* initialise ROM's */
 
-	if (l_flag)		/* load core */
+	if (l_flag)	{			/* load core */
 		if (load_core())
 			return(1);
+	} else if (x_flag) { 	/* OR load memory from file */
+		if (load_file(xfn))
+			return(1);
+	}
 
 	int_on();		/* initialize UNIX interrupts */
 	init_io();		/* initialize I/O devices */


### PR DESCRIPTION
## Change : make External Clear (Reset down) toggle also trigger Reset (Reset Up) toggle
The IMSAI documentation states that the External Clear toggle is wired (via a diode) to the Reset toggle line so that a processor reset also occurs when when an External Clear is performed
## Added: `iosim->reset_io()` to reset h/w
Based on the previous change it looked logical to add a `reset_io()` function to the `iosim.c` module
## Change: separation of concerns - move h/w init to `iosim->init_io()`
A lot of simulated hardware initialisation is occurring in the `simctl.c` module `mon()` function, meanwhile the `iosim.c` module `init_io()` function has remained empty. It seems like a good separation-of-concerns to move this simulated hardware initialisation to `init_io()`
## Change: load core, bootrom or executable earlier in sim0->main()

1. there are duplicate calls to `load_core()`. One is made in the `sim0.c` module `main()` function, the second is made in the `simctl.c` module `load()` function.
2. With the above change to move simulated hardware initialisation to `init_io()` the current design calls the `sim0.c` module `load_file()` function from the `simctl.c` module `load()` function. This is too late, after the the call to `init_io()` in the `sim0.c` module. For example, this results in the VIO ROM being loaded after the attempt to initialise the VIO. 
It makes logical sense to have both `load_core()` and `load_file()` called earlier from the `main()` function in the `sim0.c` module . This is where they are defined, this is where other memory memory initialisation calls occur and any ROM images should be loaded before simulated hardware initialisation occurs in `init_io()`
