### PR TITLE
Put a few values into #defines in sim.h to help with platform portability and machine configuration

### DIFF
--- a/imsaisim/srcsim/config.c
+++ b/imsaisim/srcsim/config.c
@@ -150,9 +150,9 @@ void config(void)
 					slf = 2;
 			} else if (!strcmp(t1, "ram")) {
 				ram_size = atoi(t2);
-				if (ram_size > 54) {
-					printf("Maximal possible RAM size is 54KB\n");
-					ram_size = 54;
+				if (ram_size > MAX_RAM) {
+					printf("Maximal possible RAM size is %dKB\n", MAX_RAM);
+					ram_size = MAX_RAM;
 				}
 				printf("RAM size is %d KB\n", ram_size);
 			} else {

--- a/imsaisim/srcsim/config.c
+++ b/imsaisim/srcsim/config.c
@@ -54,7 +54,7 @@ void config(void)
 	FILE *fp;
 	char buf[BUFSIZE];
 	char *s, *t1, *t2;
-	char fn[4095];
+	char fn[MAX_LFN - 1];
 
 	strcpy(&fn[0], &confdir[0]);
 	strcat(&fn[0], "/system.conf");

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -37,6 +37,8 @@
 #define HAS_CONFIG	/* has configuration files somewhere */
 #define HAS_DAZZLER	/* has simulated I/O for Cromemeco Dazzler */
 
+#define MAX_RAM		54	/* Maximum RAM size */
+
 /*
  *	Default CPU
  */

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -54,6 +54,7 @@
 #define USR_REL	"1.18"
 #define USR_CPR	"Copyright (C) 2008-2018 by Udo Munk"
 
+#define MAX_LFN		4096	/* maximum long file name length */
 #define LENCMD		80		/* length of command buffers etc */
 
 #define S_FLAG		128		/* bit definitions of CPU flags */

--- a/iodevices/imsai-fif.c
+++ b/iodevices/imsai-fif.c
@@ -68,7 +68,7 @@ static char *disks[4] = {
 	"drived.dsk"
 };
 
-static char fn[4096];		/* path/filename for disk image */
+static char fn[MAX_LFN];		/* path/filename for disk image */
 static int fdstate = 0;		/* state of the fd */
 
 /*

--- a/z80sim/srcsim/sim0.c
+++ b/z80sim/srcsim/sim0.c
@@ -478,7 +478,7 @@ int load_core(void)
  */
 int load_file(char *s)
 {
-	char fn[LENCMD];
+	char fn[MAX_LFN];
 	BYTE fileb[5];
 	register char *pfn = fn;
 	int fd;

--- a/z80sim/srcsim/simglb.c
+++ b/z80sim/srcsim/simglb.c
@@ -145,10 +145,10 @@ int u_flag;			/* flag for -u option */
 /*
  *	Variables for configuration and disk images
  */
-char xfn[4096];			/* buffer for filename (option -x) */
+char xfn[MAX_LFN];			/* buffer for filename (option -x) */
 char *diskdir = NULL;		/* path for disk images (option -d) */
-char diskd[4096];		/* disk image directory in use */
-char confdir[4096];		/* path for configuration files */
+char diskd[MAX_LFN];		/* disk image directory in use */
+char confdir[MAX_LFN];		/* path for configuration files */
 
 /*
  *	Precompiled table to get parity as fast as possible


### PR DESCRIPTION
Note: The use of `MAX_LFN` in `sim0.c` and `simglb.c `will require this `#define` to be added to `sim.h` for all machines.