### PR TITLE
Simulated baudrate on serial I/O

### DIFF
--- a/imsaisim/conf_3d/system.conf
+++ b/imsaisim/conf_3d/system.conf
@@ -2,6 +2,8 @@
 sio1_upper_case		0
 sio1_strip_parity	1
 sio1_drop_nulls		1
+sio1_baud_rate      115200 
+# typical baud rate values are 110, 300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200
 
 # SIO 2, Ports 4/5, not connected and used for VIO keyboard
 sio2_upper_case		0

--- a/imsaisim/srcsim/config.c
+++ b/imsaisim/srcsim/config.c
@@ -39,6 +39,7 @@ extern int exatoi(char *);
 extern int sio1_upper_case;	/* SIO 1 translate input to upper case */
 extern int sio1_strip_parity;	/* SIO 1 strip parity from output */
 extern int sio1_drop_nulls;	/* SIO 1 drop nulls after CR/LF */
+extern int sio1_baud_rate;	/* SIO 1 simulated baud rate */
 
 extern int sio2_upper_case;	/* SIO 2 translate input to upper case */
 extern int sio2_strip_parity;	/* SIO 2 strip parity from output */
@@ -137,6 +138,8 @@ void config(void)
 					printf("system.conf: illegal value for %s: %s\n", t1, t2);
 					break;
 				}
+			} else if (!strcmp(t1, "sio1_baud_rate")) {
+				sio1_baud_rate = atoi(t2);
 			} else if (!strcmp(t1, "fp_fps")) {
 				fp_fps = (float) atoi(t2);
 			} else if (!strcmp(t1, "fp_size")) {


### PR DESCRIPTION
This addresses the issue identified with `poll()` #15 leading to high CPU utilisation.