### PR TITLE
Updates to behaviour of Data Bus LEDs to more closely simulate the IMSAI 8080 CP-A front panel

### DIFF
--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -677,7 +677,7 @@ void io_out(BYTE addrl, BYTE addrh, BYTE data)
 
 	fp_clock += 6;
 	fp_led_address = (addrh << 8) + addrl;
-	fp_led_data = 0xff;
+	fp_led_data = io_data; // Always show the OUT byte on the data LEDs
 	fp_sampleData();
 	wait_step();
 }

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -657,6 +657,9 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 	fp_sampleData();
 	wait_step();
 
+	/* when INP on port 0FFh - get last set value of Programmed Input toggles */
+	if(io_port == 0xFF) io_data = (*port_in[io_port]) ();
+
 	return(io_data);
 }
 

--- a/imsaisim/srcsim/memory.h
+++ b/imsaisim/srcsim/memory.h
@@ -31,7 +31,7 @@ static inline void memwrt(WORD addr, BYTE data)
 
 	fp_clock++;
 	fp_led_address = addr;
-	fp_led_data = 0xff;
+	fp_led_data = data; // Always show the data byte on the data LEDs
 	fp_sampleData();
 	wait_step();
 

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -332,6 +332,11 @@ void wait_step(void)
 	cpu_switch = 3;
 
 	while ((cpu_switch == 3) && !reset) {
+		/* when INP on port 0FFh - feed Programmed Input toggles to Data Bus LEDs */
+		if((cpu_bus == (CPU_WO | CPU_INP)) && (fp_led_address == 0xFFFF)) {
+			fp_led_data = address_switch >> 8;
+		}
+
 		fp_clock++;
 		fp_sampleData();
 


### PR DESCRIPTION
These updates are a result of reading the manual for the IMSAI 8080 CP-A front panel and looking at videos of a real IMSAI 8080 CP-A front panel in operation. How I wish I had a real machine to compare with.