### PR TITLE
Update: Issue #35 - let VIO handle mode in refresh loop not in memwrt()

### DIFF
--- a/imsaisim/srcsim/memory.h
+++ b/imsaisim/srcsim/memory.h
@@ -14,7 +14,6 @@
 
 extern void init_memory(void), reset_memory(void), init_rom(void);
 extern void wait_step(void), wait_int_step(void);
-extern void imsai_vio_ctrl(BYTE);
 extern BYTE memory[];
 extern int p_tab[];
 
@@ -62,9 +61,6 @@ static inline void memwrt(WORD addr, BYTE data)
 	fp_led_data = data;
 	fp_sampleData();
 	wait_step();
-
-	if (addr == 0xf7ff)
-		imsai_vio_ctrl(data);
 }
 
 static inline BYTE memrdr(WORD addr)


### PR DESCRIPTION
For performance reasons every memwrt() should **not** have to check for the VIO mode control byte.
It is enough for the VIO refresh() loop to do this each time, and using a double-buffer for the mode control byte pays back for cost of the dma_read(0xf7ff).