### PR TITLE
Bug fix in banked ROM, improve readability for memory events, enhance VIO release of memory

### DIFF
--- a/imsaisim/conf_2d/system.conf
+++ b/imsaisim/conf_2d/system.conf
@@ -29,5 +29,5 @@ vio_fg			FFFFFF
 # add scanlines to VIO monitor, 0 = no scanlines
 vio_scanlines		1
 
-# RAM size in 1 KB pages, max 54 pages possible
-ram			54
+# RAM size in 1 KB pages, max 64 pages possible
+ram			64

--- a/imsaisim/conf_3d/system.conf
+++ b/imsaisim/conf_3d/system.conf
@@ -29,5 +29,5 @@ vio_fg			FFFFFF
 # add scanlines to VIO monitor, 0 = no scanlines
 vio_scanlines		1
 
-# RAM size in 1 KB pages, max 54 pages possible
+# RAM size in 1 KB pages, max 64 pages possible
 ram			64

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -604,9 +604,11 @@ void init_io(void)
 	if (!strncmp((char *) mem_base() + 0xfffd, "VI0", 3)) {
 		imsai_vio_init();
 	} else {
-		/* if no VIO firmware loaded convert the ROM to RAM */
-		p_tab[62] = MEM_RW;
-		p_tab[63] = MEM_RW;
+		/* if no VIO firmware loaded release the ROM and RAM */
+		MEM_RELEASE(60);
+		MEM_RELEASE(61);
+		MEM_RELEASE(62);
+		MEM_RELEASE(63);
 	}
 }
 

--- a/imsaisim/srcsim/memory.c
+++ b/imsaisim/srcsim/memory.c
@@ -58,11 +58,10 @@ void groupswap() {
 		rdrvec[54] = &memory[54<<10];
 		rdrvec[55] = &memory[55<<10];
 
-		/* only RW if ram_size allows */
-		p_tab[52] = (ram_size > 52) ? MEM_RW : MEM_NONE;
-		// p_tab[53] = (ram_size > 53) ? MEM_RW : MEM_NONE;
-		p_tab[54] = (ram_size > 54) ? MEM_RW : MEM_NONE;
-		p_tab[55] = (ram_size > 55) ? MEM_RW : MEM_NONE;
+		MEM_RELEASE(52);
+		// MEM_RELEASE(53);
+		MEM_RELEASE(54);
+		MEM_RELEASE(55);
 	} else {
 		rdrvec[52] = &mpubram[0x0000];
 		// rdrvec[53] = &mpubram[0x0400];
@@ -72,12 +71,10 @@ void groupswap() {
 		rdrvec[54] = &mpubrom[0x0000];
 		rdrvec[55] = &mpubrom[0x0400];
 
-		/* must be RW while RAM is switched in */
-		p_tab[52] = MEM_RW;
-		// p_tab[53] = MEM_RW;
-		/* only RW if ram_size allows */
-		p_tab[54] = (ram_size > 54) ? MEM_RW : MEM_RO;
-		p_tab[55] = (ram_size > 55) ? MEM_RW : MEM_RO;
+		MEM_RESERVE_RAM(52);
+		// MEM_RESERVE_RAM(53);
+		MEM_ROM_BANK_ON(54);
+		MEM_ROM_BANK_ON(55);
 	}
 }
 
@@ -94,7 +91,7 @@ void init_memory(void)
 
 	/* then set the first ram_size pages to RAM */
 	for (i = 0; i < ram_size; i++)
-		p_tab[i] = MEM_RW;
+		MEM_RESERVE_RAM(i);
 
 #ifdef HAS_BANKED_ROM
 	if(r_flag) {
@@ -106,17 +103,17 @@ void init_memory(void)
 	groupswap();
 	cyclecount = 0;
 #else
-	p_tab[54] = MEM_RO; 
-	p_tab[55] = MEM_RO;
+	MEM_RESERVE_ROM(54);
+	MEM_RESERVE_ROM(55);
 #endif
 
 	/* set F000 - F800 to RAM, this is display memory for the VIO */
-	p_tab[60] = MEM_RW;
-	p_tab[61] = MEM_RW;
+	MEM_RESERVE_RAM(60);
+	MEM_RESERVE_RAM(61);
 
 	/* set F800 - FFFF to ROM, this is the VIO firmware ROM */
-	p_tab[62] = MEM_RO;
-	p_tab[63] = MEM_RO;
+	MEM_RESERVE_ROM(62);
+	MEM_RESERVE_ROM(63);
 }
 
 void reset_memory(void) {

--- a/imsaisim/srcsim/memory.h
+++ b/imsaisim/srcsim/memory.h
@@ -68,8 +68,6 @@ static inline void memwrt(WORD addr, BYTE data)
 static inline BYTE memrdr(WORD addr)
 {
 	register BYTE data = _MEMMAPPED(addr);
-	if(cyclecount && --cyclecount == 0) 
-		groupswap();
 
 	cpu_bus |= CPU_WO | CPU_MEMR;
 
@@ -81,6 +79,9 @@ static inline BYTE memrdr(WORD addr)
 		fp_led_data = 0xff;
 	fp_sampleData();
 	wait_step();
+
+	if(cyclecount && --cyclecount == 0) 
+		groupswap();
 
 	return(fp_led_data);
 }

--- a/imsaisim/srcsim/memory.h
+++ b/imsaisim/srcsim/memory.h
@@ -18,6 +18,7 @@ extern void init_memory(void), reset_memory(void), init_rom(void);
 extern void wait_step(void), wait_int_step(void);
 extern BYTE memory[];
 extern int p_tab[];
+extern int ram_size;
 
 #define MEM_RW		0	/* memory is readable and writeable */
 #define MEM_RO		1	/* memory is read-only */
@@ -47,6 +48,11 @@ extern void groupswap();
 #define _GROUPINIT	0x00	// Power-on default
 #define _GROUP0 	0x40	// 2K ROM @ 0000-07FF
 #define _GROUP1 	0x80	// 2K ROM @ D800-DFFF, 256 byte RAM @ DOOO-DOFF (actually 1K RAM @ DOOO-D3FF)
+
+#define MEM_RELEASE(page) 		p_tab[(page)] = (ram_size > (page))?MEM_RW:MEM_NONE	// return page to RAM pool
+#define MEM_ROM_BANK_ON(page)	p_tab[(page)] = (ram_size > (page))?MEM_RW:MEM_RO	// reserve page as banked ROM
+#define MEM_RESERVE_RAM(page)	p_tab[(page)] = MEM_RW								// reserve page as RAM
+#define MEM_RESERVE_ROM(page)	p_tab[(page)] = MEM_RO								// reserve page as ROM
 
 /*
  * memory access for the CPU cores


### PR DESCRIPTION
- Fixes a bug in the banked ROM code when `ram_size` < 56K
- Improves readability of memory events with the use of some macros
- Improves on solution for #36 by also releasing the RAM as well as the ROM (also cares about `ram_size`)
- Updates the `system.conf` files for the 64K maximum RAM size now supported