### PR TITLE
Updates to GNUmakefile for altairsim & imsaisim 

### DIFF
--- a/altairsim/srcsim/GNUmakefile
+++ b/altairsim/srcsim/GNUmakefile
@@ -90,9 +90,9 @@ ifneq ($(DEBUG),)
 CFLAGS = -O -g -c $(PLAT_CFLAGS) $(DEFS) $(INCL)
 endif
 
-LFLAGS = $(PLAT_LFLAGS) \
+LFLAGS = -L$(DIR_FP) $(SRC_LIBS) \
 	-ljpeg -lGL -lGLU -lX11 \
-	-L$(DIR_FP) $(SRC_LIBS)
+	$(PLAT_LFLAGS)
 
 # core system source files for the CPU simulation - only change if the core changes
 SRC_CORE = sim0.c sim1.c sim1a.c sim2.c sim3.c sim4.c sim5.c sim6.c sim7.c simfun.c simglb.c simint.c

--- a/imsaisim/srcsim/GNUmakefile
+++ b/imsaisim/srcsim/GNUmakefile
@@ -92,9 +92,9 @@ ifneq ($(DEBUG),)
 CFLAGS = -O -g -c $(PLAT_CFLAGS) $(DEFS) $(INCL)
 endif
 
-LFLAGS = $(PLAT_LFLAGS) \
-	-ljpeg -lGL -lGLU -lX11 \
-	-L$(DIR_FP) -L$(DIR_CIV) $(SRC_LIBS)
+LFLAGS = -L$(DIR_FP) -L$(DIR_CIV) $(SRC_LIBS) \
+        -ljpeg -lGL -lGLU -lX11 \
+        $(PLAT_LFLAGS)
 
 # core system source files for the CPU simulation - only change if the core changes
 SRC_CORE = sim0.c sim1.c sim1a.c sim2.c sim3.c sim4.c sim5.c sim6.c sim7.c simfun.c simglb.c simint.c


### PR DESCRIPTION
Fixes build issue on Linux (Ubuntu 16.04) for me. 
There are some conflict with the ordering of libraries for the linker.
What the `GNUmakefile` produces now it almost the same as the existing build system and works for me.