### PR TITLE
implement new memory config strategy using system.conf ram/rom/boot directives

### DIFF
--- a/imsaisim/boot
+++ b/imsaisim/boot
@@ -3,7 +3,7 @@
 BOOTENV=`sed '/^#/d;s/#.*$//;' conf/boot.conf | xargs`
 
 if [ -f disks/drivea.dsk ]; then
-	env $BOOTENV ./imsaisim -r -x mpu-a-rom.hex $*
+	env $BOOTENV ./imsaisim -R $*
 else
 	echo "no boot disk in drive a:"
 fi

--- a/imsaisim/bootvio
+++ b/imsaisim/bootvio
@@ -3,7 +3,7 @@
 BOOTENV=`sed '/^#/d;s/#.*$//;' conf/boot.conf | xargs`
 
 if [ -f disks/drivea.dsk ]; then
-	env $BOOTENV ./imsaisim -r -x mpu-a-vio-rom.hex $*
+	env $BOOTENV ./imsaisim -R -M2 $*
 else
 	echo "no boot disk in drive a:"
 fi

--- a/imsaisim/conf_2d/system.conf
+++ b/imsaisim/conf_2d/system.conf
@@ -48,5 +48,37 @@ vio_fg			FFFFFF
 # add scanlines to VIO monitor, 0 = no scanlines
 vio_scanlines		1
 
-# RAM size in 1 KB pages, max 64 pages possible
-ram			64
+[MEMORY 1]
+# Default memory configuration used in most situations with MPU-A ROM:
+# 256 pages RAM, 8 pages ROM (replaces or overlays RAM)
+ram         0,256
+rom         0xd8,8,mpu-a-rom.hex
+# Boot switch, start address of the boot ROM
+boot        0xd800
+
+[MEMORY 2]
+# Memory configuration for running MPU-A ROM and VIO ROM:
+# 240 pages RAM, 8 pages ROM (replaces or overlays RAM)
+# 8 pages of RAM and 8 pages of ROM for the VIO from 0xf000
+ram         0,0xf0
+rom         0xd8,8,mpu-a-rom.hex
+ram         0xf0,8
+rom         0xf8,8,viofm1.hex
+# Boot switch, start address of the boot ROM
+boot        0xd800
+
+[MEMORY 3]
+# Memory configuration for running with MEMON80 ROM:
+# 248 pages RAM, 8 pages ROM
+ram         0,0xf8
+rom         0xf8,8,memon80.hex
+# Boot switch, start address of the boot ROM
+boot        0xf800
+
+[MEMORY 4]
+# Memory configuration for running ROM based XYBASIC:
+# 16K ROM, 48K RAM
+rom         0,64,xybasic.hex
+ram         64,192
+# Boot switch, start address of the boot ROM
+boot        0x0000

--- a/imsaisim/conf_3d/system.conf
+++ b/imsaisim/conf_3d/system.conf
@@ -48,5 +48,37 @@ vio_fg			FFFFFF
 # add scanlines to VIO monitor, 0 = no scanlines
 vio_scanlines		1
 
-# RAM size in 1 KB pages, max 64 pages possible
-ram			64
+[MEMORY 1]
+# Default memory configuration used in most situations with MPU-A ROM:
+# 256 pages RAM, 8 pages ROM (replaces or overlays RAM)
+ram         0,256
+rom         0xd8,8,mpu-a-rom.hex
+# Boot switch, start address of the boot ROM
+boot        0xd800
+
+[MEMORY 2]
+# Memory configuration for running MPU-A ROM and VIO ROM:
+# 240 pages RAM, 8 pages ROM (replaces or overlays RAM)
+# 8 pages of RAM and 8 pages of ROM for the VIO from 0xf000
+ram         0,0xf0
+rom         0xd8,8,mpu-a-rom.hex
+ram         0xf0,8
+rom         0xf8,8,viofm1.hex
+# Boot switch, start address of the boot ROM
+boot        0xd800
+
+[MEMORY 3]
+# Memory configuration for running with MEMON80 ROM:
+# 248 pages RAM, 8 pages ROM
+ram         0,0xf8
+rom         0xf8,8,memon80.hex
+# Boot switch, start address of the boot ROM
+boot        0xf800
+
+[MEMORY 4]
+# Memory configuration for running ROM based XYBASIC:
+# 16K ROM, 48K RAM
+rom         0,64,xybasic.hex
+ram         64,192
+# Boot switch, start address of the boot ROM
+boot        0x0000

--- a/imsaisim/cpm22
+++ b/imsaisim/cpm22
@@ -5,4 +5,4 @@ ln disks/library/cpm22.dsk disks/drivea.dsk
 
 BOOTENV=`sed '/^#/d;s/#.*$//;' conf/boot.conf | xargs`
 
-env $BOOTENV ./imsaisim -r -x mpu-a-rom.hex $*
+env $BOOTENV ./imsaisim -R $*

--- a/imsaisim/cpm3
+++ b/imsaisim/cpm3
@@ -6,4 +6,4 @@ ln disks/library/cpm3-2.dsk disks/driveb.dsk
 
 BOOTENV=`sed '/^#/d;s/#.*$//;' conf/boot.conf | xargs`
 
-env $BOOTENV ./imsaisim -r -x mpu-a-rom.hex $*
+env $BOOTENV ./imsaisim -R $*

--- a/imsaisim/imdos202
+++ b/imsaisim/imdos202
@@ -5,4 +5,4 @@ ln disks/library/imdos202.dsk disks/drivea.dsk
 
 BOOTENV=`sed '/^#/d;s/#.*$//;' conf/boot.conf | xargs`
 
-env $BOOTENV ./imsaisim -r -x mpu-a-rom.hex $*
+env $BOOTENV ./imsaisim -R $*

--- a/imsaisim/imdos205r0
+++ b/imsaisim/imdos205r0
@@ -6,4 +6,4 @@ ln disks/library/imdos205r0-2.dsk disks/driveb.dsk
 
 BOOTENV=`sed '/^#/d;s/#.*$//;' conf/boot.conf | xargs`
 
-env $BOOTENV ./imsaisim -r -x mpu-a-rom.hex $*
+env $BOOTENV ./imsaisim -R $*

--- a/imsaisim/imsai-cpm13
+++ b/imsaisim/imsai-cpm13
@@ -5,4 +5,4 @@ ln disks/library/imsai-cpm13.dsk disks/drivea.dsk
 
 BOOTENV=`sed '/^#/d;s/#.*$//;' conf/boot.conf | xargs`
 
-env $BOOTENV ./imsaisim -r -x mpu-a-rom.hex $*
+env $BOOTENV ./imsaisim -R $*

--- a/imsaisim/srcsim/config.h
+++ b/imsaisim/srcsim/config.h
@@ -35,6 +35,5 @@
 
 extern void config(void);
 
-extern int  ram_size;
 extern int  fp_size;
 extern BYTE fp_port;

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -687,15 +687,6 @@ void init_io(void)
 	if ((getmem(0xfffd) == 'V') && (getmem(0xfffe) == 'I') &&
 	    (getmem(0xffff) == '0')) {
 		imsai_vio_init();
-	} else {
-		/* release the RAM */
-		MEM_RELEASE(60);
-		MEM_RELEASE(61);
-		/* if no firmware loaded release the ROM */
-		if (getmem(0xf800) == 0xff) {
-			MEM_RELEASE(62);
-			MEM_RELEASE(63);
-		}
 	}
 
 	imsai_fif_reset();

--- a/imsaisim/srcsim/memory.c
+++ b/imsaisim/srcsim/memory.c
@@ -18,15 +18,22 @@
  * 20-JUL-2021 log banked memory
  */
 
+#include <unistd.h>
+#include <stdlib.h>
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
-#include "../../frontpanel/frontpanel.h"
 #include "memory.h"
 /* #define LOG_LOCAL_LEVEL LOG_DEBUG */
 #include "log.h"
 
 static const char *TAG = "memory";
+
+extern int load_file(char *, BYTE, BYTE);
+
+struct memmap memconf[MAXMEMSECT][MAXMEMMAP] 	/* memory map */
+	= { { { MEM_RW, 0, 0x100, NULL } } };		/* default config to 64K RAM only */
+WORD boot_switch[MAXMEMSECT];					/* boot address for switch */
 
 /* 64KB memory system bank 0 */
 BYTE memory[64 << 10];
@@ -34,14 +41,16 @@ BYTE memory[64 << 10];
 BYTE mpubrom[2 << 10];
 BYTE mpubram[2 << 10];
 
+#define MAXPAGES 256
 /* Memory access read and write vector tables system bank 0 */
-BYTE *rdrvec[64];
-BYTE *wrtvec[64];
+BYTE *rdrvec[MAXPAGES];
+BYTE *wrtvec[MAXPAGES];
 int cyclecount;
 static BYTE groupsel;
 
 /* page table with memory configuration/state system bank 0 */
-int p_tab[64];		/* 64 pages a 1 KB */
+int p_tab[MAXPAGES];		/* 256 pages of 256 bytes */
+int _p_tab[MAXPAGES];		/* copy of p_tab[] for RAM only */
 
 /* additional memory banks */
 static BYTE bnk1[SEGSIZ];
@@ -72,38 +81,70 @@ void groupswap(void)
 
 	if (groupsel & _GROUP0) {
 		rdrvec[0] = &memory[0x0000];
-		rdrvec[1] = &memory[0x0400];
+		rdrvec[1] = &memory[0x0100];
+		rdrvec[2] = &memory[0x0200];
+		rdrvec[3] = &memory[0x0300];
+		rdrvec[4] = &memory[0x0400];
+		rdrvec[5] = &memory[0x0500];
+		rdrvec[6] = &memory[0x0600];
+		rdrvec[7] = &memory[0x0700];
 	} else {
 		rdrvec[0] = &mpubrom[0x0000];
-		rdrvec[1] = &mpubrom[0x0400];
+		rdrvec[1] = &mpubrom[0x0100];
+		rdrvec[2] = &mpubrom[0x0200];
+		rdrvec[3] = &mpubrom[0x0300];
+		rdrvec[4] = &mpubrom[0x0400];
+		rdrvec[5] = &mpubrom[0x0500];
+		rdrvec[6] = &mpubrom[0x0600];
+		rdrvec[7] = &mpubrom[0x0700];
 	}
 
 	if (groupsel & _GROUP1) {
-		rdrvec[52] = &memory[52 << 10];
-		/* rdrvec[53] = &memory[53 << 10]; */
-		wrtvec[52] = &memory[52 << 10];
-		/* wrtvec[53] = &memory[53 << 10]; */
+		rdrvec[0xD0] = &memory[0xD000];
+		wrtvec[0xD0] = &memory[0xD000];
 
-		rdrvec[54] = &memory[54 << 10];
-		rdrvec[55] = &memory[55 << 10];
+		rdrvec[0xD8] = &memory[0xD800];
+		rdrvec[0xD9] = &memory[0xD900];
+		rdrvec[0xDA] = &memory[0xDA00];
+		rdrvec[0xDB] = &memory[0xDB00];
+		rdrvec[0xDC] = &memory[0xDC00];
+		rdrvec[0xDD] = &memory[0xDD00];
+		rdrvec[0xDE] = &memory[0xDE00];
+		rdrvec[0xDF] = &memory[0xDF00];
 
-		MEM_RELEASE(52);
-		/* MEM_RELEASE(53); */
-		MEM_RELEASE(54);
-		MEM_RELEASE(55);
+		MEM_RELEASE(0xD0);
+
+		MEM_RELEASE(0xD8);
+		MEM_RELEASE(0xD9);
+		MEM_RELEASE(0xDA);
+		MEM_RELEASE(0xDB);
+		MEM_RELEASE(0xDC);
+		MEM_RELEASE(0xDD);
+		MEM_RELEASE(0xDE);
+		MEM_RELEASE(0xDF);
 	} else {
-		rdrvec[52] = &mpubram[0x0000];
-		/* rdrvec[53] = &mpubram[0x0400]; */
-		wrtvec[52] = &mpubram[0x0000];
-		/* wrtvec[53] = &mpubram[0x0400]; */
+		rdrvec[0xD0] = &mpubram[0x0000];
+		wrtvec[0xD0] = &mpubram[0x0000];
 
-		rdrvec[54] = &mpubrom[0x0000];
-		rdrvec[55] = &mpubrom[0x0400];
+		rdrvec[0xD8] = &mpubrom[0x0000];
+		rdrvec[0xD9] = &mpubrom[0x0100];
+		rdrvec[0xDA] = &mpubrom[0x0200];
+		rdrvec[0xDB] = &mpubrom[0x0300];
+		rdrvec[0xDC] = &mpubrom[0x0400];
+		rdrvec[0xDD] = &mpubrom[0x0500];
+		rdrvec[0xDE] = &mpubrom[0x0600];
+		rdrvec[0xDF] = &mpubrom[0x0700];
 
-		MEM_RESERVE_RAM(52);
-		/* MEM_RESERVE_RAM(53); */
-		MEM_ROM_BANK_ON(54);
-		MEM_ROM_BANK_ON(55);
+		MEM_RESERVE_RAM(0xD0);
+
+		MEM_ROM_BANK_ON(0xD8);
+		MEM_ROM_BANK_ON(0xD9);
+		MEM_ROM_BANK_ON(0xDA);
+		MEM_ROM_BANK_ON(0xDB);
+		MEM_ROM_BANK_ON(0xDC);
+		MEM_ROM_BANK_ON(0xDD);
+		MEM_ROM_BANK_ON(0xDE);
+		MEM_ROM_BANK_ON(0xDF);
 	}
 }
 
@@ -111,19 +152,61 @@ void init_memory(void)
 {
 	register int i;
 
+	LOG(TAG,"\r\n");
+
 	/* initialise memory page table, no memory available */
-	for (i = 0; i < 64; i++) {
+	for (i = 0; i < MAXPAGES; i++) {
 		p_tab[i] = MEM_NONE;
-		wrtvec[i] = &memory[i << 10];
-		rdrvec[i] = &memory[i << 10];		
+		wrtvec[i] = &memory[i << 8];
+		rdrvec[i] = &memory[i << 8];		
 	}
 
-	/* then set the first ram_size pages to RAM */
-	for (i = 0; i < ram_size; i++)
-		MEM_RESERVE_RAM(i);
+	for (i=0; i < MAXMEMMAP; i++) {
+		if (memconf[M_flag][i].size) {
+			switch (memconf[M_flag][i].type) {
+				case MEM_RW:
+					/* set the pages to RAM */
+					for (int j = 0; j < memconf[M_flag][i].size; j++)
+						MEM_RESERVE_RAM(memconf[M_flag][i].spage + j);
+
+					/* fill memory content of bank 0 with some initial value */
+					for (int j = memconf[M_flag][i].spage << 8; j < (memconf[M_flag][i].spage + memconf[M_flag][i].size) << 8; j++) {
+						if (m_flag >= 0) {
+							_MEMMAPPED(j) = m_flag;
+						} else {
+							_MEMMAPPED(j) = (BYTE) (rand() % 256);
+						}
+					}
+
+					LOG(TAG, "RAM %04XH - %04XH\r\n",
+				    memconf[M_flag][i].spage << 8, 
+					(memconf[M_flag][i].spage << 8) + (memconf[M_flag][i].size << 8) - 1);
+
+					break;
+				case MEM_RO:
+					/* set the pages to ROM */
+					LOG(TAG, "ROM %04XH - %04XH %s\r\n",
+				    memconf[M_flag][i].spage << 8, 
+					((memconf[M_flag][i].spage + memconf[M_flag][i].size) << 8) - 1,
+					memconf[M_flag][i].rom_file?memconf[M_flag][i].rom_file:"");
+					/* for the IMSAI, ROM must be initialised after MPU-B banked ROM is intialised */
+					/* see below */
+					break;
+			}
+		}
+	}
+
+	if (boot_switch[M_flag]) {
+		LOG(TAG, "Boot switch address at %04XH\r\n", boot_switch[M_flag]);
+	}
+
+	/* copy RAM page table for MPU-B banked ROM/RAM handling */
+	for (i = 0; i < MAXPAGES; i++) {
+		_p_tab[i] = p_tab[i];
+	}
 
 #ifdef HAS_BANKED_ROM
-	if (r_flag) {
+	if (R_flag) {
 		groupsel = _GROUPINIT;
 		LOG(TAG, "MPU-B Banked ROM/RAM enabled\r\n");
 	} else {
@@ -131,26 +214,49 @@ void init_memory(void)
 	}
 	groupswap();
 	cyclecount = 0;
-#else
-	MEM_RESERVE_ROM(54);
-	MEM_RESERVE_ROM(55);
 #endif
 
-	/* set F000 - F800 to RAM, this is display memory for the VIO */
-	MEM_RESERVE_RAM(60);
-	MEM_RESERVE_RAM(61);
-
-	/* set F800 - FFFF to ROM, this is the VIO firmware ROM */
-	MEM_RESERVE_ROM(62);
-	MEM_RESERVE_ROM(63);
-
+	LOG(TAG, "MMU has %d additional RAM banks of %d KB\r\n", num_banks, SEGSIZ >> 10);
 	LOG(TAG, "\r\n");
+
+	for (i=0; i < MAXMEMMAP; i++) {
+		if (memconf[M_flag][i].size) {
+			switch (memconf[M_flag][i].type) {
+				case MEM_RW:
+					/* set the pages to RAM */
+					/* for the IMSAI, RAM must be initialised before MPU-B banked ROM is intialised */
+					/* see above */
+					break;
+				case MEM_RO:
+					/* set the pages to ROM */
+					for (int j = 0; j < memconf[M_flag][i].size; j++)
+						MEM_RESERVE_ROM(memconf[M_flag][i].spage + j);
+
+					/* fill the ROM's with 0xff in case no firmware loaded */
+					for (int j = memconf[M_flag][i].spage << 8; j < (memconf[M_flag][i].spage + memconf[M_flag][i].size) << 8; j++) {
+						_MEMMAPPED(j) = 0xff;
+					}
+
+					/* load firmware into ROM if specified */
+					if (memconf[M_flag][i].rom_file) load_file(memconf[M_flag][i].rom_file, memconf[M_flag][i].spage, memconf[M_flag][i].size);
+
+					break;
+			}
+		}
+	}
+
+	/* set preferred start of boot ROM if specified */
+	if (boot_switch[M_flag]) {
+		PC = boot_switch[M_flag];
+	} else {
+		PC = 0x0000;
+	}
 }
 
 void reset_memory(void)
 {
 #ifdef HAS_BANKED_ROM
-	if (r_flag) {
+	if (R_flag) {
 		groupsel = _GROUPINIT;
 	} else {
 		groupsel = _GROUP0 | _GROUP1;
@@ -161,23 +267,10 @@ void reset_memory(void)
 	selbnk = 0;
 }
 
-/*
- * fill the ROM's with 0xff in case no firmware loaded
- */
-void init_rom(void)
-{
-	register unsigned int i;
-
-	for (i = 0xd800; i <= 0xdfff; i++)
-		_MEMMAPPED(i) = 0xff;
-	for (i = 0xf800; i <= 0xffff; i++)
-		_MEMMAPPED(i) = 0xff;
-}
-
 void ctrl_port_out(BYTE data)
 {
 #ifdef HAS_BANKED_ROM
-	if (r_flag) {
+	if (R_flag) {
 		groupsel = data;
 		cyclecount = 3;
 	}
@@ -189,7 +282,7 @@ void ctrl_port_out(BYTE data)
 BYTE ctrl_port_in(void)
 {
 #ifdef HAS_BANKED_ROM
-	if (r_flag) {
+	if (R_flag) {
 		groupsel = _GROUP0 | _GROUP1;
 		cyclecount = 3;
 	}

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -130,7 +130,7 @@ void mon(void)
 #endif
 
 #ifdef HAS_BANKED_ROM
-	if(r_flag)
+	if(R_flag)
 		PC = 0x0000;
 #endif
 

--- a/imsaisim/ucsd
+++ b/imsaisim/ucsd
@@ -7,4 +7,4 @@ ln disks/library/ucsd-iv-interp.dsk disks/drivec.dsk
 
 BOOTENV=`sed '/^#/d;s/#.*$//;' conf/boot.conf | xargs`
 
-env $BOOTENV ./imsaisim -r -x mpu-a-rom.hex $*
+env $BOOTENV ./imsaisim -R $*

--- a/imsaisim/um-cpm13
+++ b/imsaisim/um-cpm13
@@ -5,4 +5,4 @@ ln disks/library/um-cpm13.dsk disks/drivea.dsk
 
 BOOTENV=`sed '/^#/d;s/#.*$//;' conf/boot.conf | xargs`
 
-env $BOOTENV ./imsaisim -r -x mpu-a-rom.hex $*
+env $BOOTENV ./imsaisim -R $*

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -239,7 +239,7 @@ static int load_mos(char *fn, BYTE pstart, WORD psize)
 	for (i = laddr; i < 65536; i++) {
 		if (read(fd, fileb, 1) == 1) {
 			if (psize && i > ((pstart + psize) << 8)) {
-				LOGW(TAG, "tried to load mod file outside expected address range. Address: %04X", i);
+				LOGW(TAG, "tried to load mos file outside expected address range. Address: %04X", i);
 				return(1);
 			}
 			count++;

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -145,6 +145,8 @@ int f_flag;			/* flag for -f option */
 int u_flag;			/* flag for -u option */
 int r_flag;			/* flag for -r option */
 int c_flag;			/* flag for -c option */
+int M_flag = 0;		/* flag for -M option */
+int R_flag = 0;		/* flag for -R option */
 
 /*
  *	Variables for configuration and disk images

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -66,7 +66,7 @@ extern BYTE	cpu_state, bus_request;
 extern int	int_data;
 
 extern int	s_flag, l_flag, m_flag, x_flag, break_flag, i_flag, f_flag,
-		u_flag, r_flag, c_flag,
+		u_flag, r_flag, c_flag, M_flag, R_flag,
 		cpu_error, int_nmi, int_int, int_mode, parity[], sb_next,
 		int_protection;
 


### PR DESCRIPTION
NOTES:
- the **altiarsim** will be temporarily broken, because **sim0.c** no longer calls **init_rom()**
  - other machines wont notice because their **init_rom()** is empty
- the `-x filename` command still works, but does not tag the loaded memory space as ROM (it never has)
- `load_file()`, `load_mos()`, `load_hex()` and `checksum()` did move out of `sim0.c` and into `simfun.c`
  -  they did not look like they should belong in `sim0.c`