### PR TITLE
Register format

### DIFF
--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -419,7 +419,7 @@ void cpu_z80(void)
 		/* write history */
 		his[h_next].h_adr = PC;
 		his[h_next].h_af = (A << 8) + F;
-		his[h_next].h_bc = (B << 8) + C;
+		his[h_next].h_bc = BC;
 		his[h_next].h_de = (D << 8) + E;
 		his[h_next].h_hl = HL;
 		his[h_next].h_ix = IX;
@@ -857,7 +857,7 @@ static int op_ldln(void)		/* LD L,n */
 
 static int op_ldabc(void)		/* LD A,(BC) */
 {
-	A = memrdr((B << 8) + C);
+	A = memrdr(BC);
 	return(7);
 }
 
@@ -879,7 +879,7 @@ static int op_ldann(void)		/* LD A,(nn) */
 
 static int op_ldbca(void)		/* LD (BC),A */
 {
-	memwrt((B << 8) + C, A);
+	memwrt(BC, A);
 	return(7);
 }
 

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -420,7 +420,7 @@ void cpu_z80(void)
 		his[h_next].h_adr = PC;
 		his[h_next].h_af = (A << 8) + F;
 		his[h_next].h_bc = BC;
-		his[h_next].h_de = (D << 8) + E;
+		his[h_next].h_de = DE;
 		his[h_next].h_hl = HL;
 		his[h_next].h_ix = IX;
 		his[h_next].h_iy = IY;
@@ -863,7 +863,7 @@ static int op_ldabc(void)		/* LD A,(BC) */
 
 static int op_ldade(void)		/* LD A,(DE) */
 {
-	A = memrdr((D << 8) + E);
+	A = memrdr(DE);
 	return(7);
 }
 
@@ -885,7 +885,7 @@ static int op_ldbca(void)		/* LD (BC),A */
 
 static int op_lddea(void)		/* LD (DE),A */
 {
-	memwrt((D << 8) + E, A);
+	memwrt(DE, A);
 	return(7);
 }
 

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -443,7 +443,7 @@ void cpu_z80(void)
 		/* CPU interrupt handling */
 		if (int_nmi) {		/* non maskable interrupt */
 			IFF <<= 1 & 3;
-			memwrt(--SP, PC >> 8);
+			memwrt(--SP, PC_H);
 			memwrt(--SP, PC);
 			PC = 0x66;
 			int_nmi = 0;
@@ -478,7 +478,7 @@ void cpu_z80(void)
 
 			switch (int_mode) {
 			case 0:		/* IM 0 */
-				memwrt(--SP, PC >> 8);
+				memwrt(--SP, PC_H);
 				memwrt(--SP, PC);
 #ifdef FRONTPANEL
 				if (cpu_state & RESET)
@@ -520,7 +520,7 @@ void cpu_z80(void)
 				t += 13;
 				break;
 			case 1:		/* IM 1 */
-				memwrt(--SP, PC >> 8);
+				memwrt(--SP, PC_H);
 				memwrt(--SP, PC);
 #ifdef FRONTPANEL
 				if (cpu_state & RESET)
@@ -530,7 +530,7 @@ void cpu_z80(void)
 				t += 13;
 				break;
 			case 2:		/* IM 2 */
-				memwrt(--SP, PC >> 8);
+				memwrt(--SP, PC_H);
 				memwrt(--SP, PC);
 #ifdef FRONTPANEL
 				if (cpu_state & RESET)
@@ -2773,7 +2773,7 @@ static int op_call(void)		/* CALL */
 
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = i;
 	return(17);
@@ -2900,7 +2900,7 @@ static int op_calz(void)		/* CALL Z,nn */
 	if (F & Z_FLAG) {
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2917,7 +2917,7 @@ static int op_calnz(void)		/* CALL NZ,nn */
 	if (!(F & Z_FLAG)) {
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2937,7 +2937,7 @@ static int op_calc(void)		/* CALL C,nn */
 #ifdef BUS_8080
 		cpu_bus = CPU_WO | CPU_MEMR;
 #endif
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2954,7 +2954,7 @@ static int op_calnc(void)		/* CALL NC,nn */
 	if (!(F & C_FLAG)) {
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2971,7 +2971,7 @@ static int op_calpe(void)		/* CALL PE,nn */
 	if (F & P_FLAG) {
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2988,7 +2988,7 @@ static int op_calpo(void)		/* CALL PO,nn */
 	if (!(F & P_FLAG)) {
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -3005,7 +3005,7 @@ static int op_calm(void)		/* CALL M,nn */
 	if (F & S_FLAG) {
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -3022,7 +3022,7 @@ static int op_calp(void)		/* CALL P,nn */
 	if (!(F & S_FLAG)) {
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -3190,7 +3190,7 @@ static int op_jrnc(void)		/* JR NC,n */
 
 static int op_rst00(void)		/* RST 00 */
 {
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0;
 	return(11);
@@ -3198,7 +3198,7 @@ static int op_rst00(void)		/* RST 00 */
 
 static int op_rst08(void)		/* RST 08 */
 {
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x08;
 	return(11);
@@ -3206,7 +3206,7 @@ static int op_rst08(void)		/* RST 08 */
 
 static int op_rst10(void)		/* RST 10 */
 {
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x10;
 	return(11);
@@ -3214,7 +3214,7 @@ static int op_rst10(void)		/* RST 10 */
 
 static int op_rst18(void)		/* RST 18 */
 {
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x18;
 	return(11);
@@ -3222,7 +3222,7 @@ static int op_rst18(void)		/* RST 18 */
 
 static int op_rst20(void)		/* RST 20 */
 {
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x20;
 	return(11);
@@ -3230,7 +3230,7 @@ static int op_rst20(void)		/* RST 20 */
 
 static int op_rst28(void)		/* RST 28 */
 {
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x28;
 	return(11);
@@ -3238,7 +3238,7 @@ static int op_rst28(void)		/* RST 28 */
 
 static int op_rst30(void)		/* RST 30 */
 {
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x30;
 	return(11);
@@ -3246,7 +3246,7 @@ static int op_rst30(void)		/* RST 30 */
 
 static int op_rst38(void)		/* RST 38 */
 {
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x38;
 	return(11);

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -444,7 +444,7 @@ void cpu_z80(void)
 		if (int_nmi) {		/* non maskable interrupt */
 			IFF <<= 1 & 3;
 			memwrt(--SP, PC_H);
-			memwrt(--SP, PC);
+			memwrt(--SP, PC_L);
 			PC = 0x66;
 			int_nmi = 0;
 			t += 11;
@@ -479,7 +479,7 @@ void cpu_z80(void)
 			switch (int_mode) {
 			case 0:		/* IM 0 */
 				memwrt(--SP, PC_H);
-				memwrt(--SP, PC);
+				memwrt(--SP, PC_L);
 #ifdef FRONTPANEL
 				if (cpu_state & RESET)
 					goto leave;
@@ -521,7 +521,7 @@ void cpu_z80(void)
 				break;
 			case 1:		/* IM 1 */
 				memwrt(--SP, PC_H);
-				memwrt(--SP, PC);
+				memwrt(--SP, PC_L);
 #ifdef FRONTPANEL
 				if (cpu_state & RESET)
 					goto leave;
@@ -531,7 +531,7 @@ void cpu_z80(void)
 				break;
 			case 2:		/* IM 2 */
 				memwrt(--SP, PC_H);
-				memwrt(--SP, PC);
+				memwrt(--SP, PC_L);
 #ifdef FRONTPANEL
 				if (cpu_state & RESET)
 					goto leave;
@@ -2774,7 +2774,7 @@ static int op_call(void)		/* CALL */
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = i;
 	return(17);
 }
@@ -2901,7 +2901,7 @@ static int op_calz(void)		/* CALL Z,nn */
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2918,7 +2918,7 @@ static int op_calnz(void)		/* CALL NZ,nn */
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2938,7 +2938,7 @@ static int op_calc(void)		/* CALL C,nn */
 		cpu_bus = CPU_WO | CPU_MEMR;
 #endif
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2955,7 +2955,7 @@ static int op_calnc(void)		/* CALL NC,nn */
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2972,7 +2972,7 @@ static int op_calpe(void)		/* CALL PE,nn */
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2989,7 +2989,7 @@ static int op_calpo(void)		/* CALL PO,nn */
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -3006,7 +3006,7 @@ static int op_calm(void)		/* CALL M,nn */
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -3023,7 +3023,7 @@ static int op_calp(void)		/* CALL P,nn */
 		i = memrdr(PC++);
 		i += memrdr(PC++) << 8;
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -3191,7 +3191,7 @@ static int op_jrnc(void)		/* JR NC,n */
 static int op_rst00(void)		/* RST 00 */
 {
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0;
 	return(11);
 }
@@ -3199,7 +3199,7 @@ static int op_rst00(void)		/* RST 00 */
 static int op_rst08(void)		/* RST 08 */
 {
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x08;
 	return(11);
 }
@@ -3207,7 +3207,7 @@ static int op_rst08(void)		/* RST 08 */
 static int op_rst10(void)		/* RST 10 */
 {
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x10;
 	return(11);
 }
@@ -3215,7 +3215,7 @@ static int op_rst10(void)		/* RST 10 */
 static int op_rst18(void)		/* RST 18 */
 {
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x18;
 	return(11);
 }
@@ -3223,7 +3223,7 @@ static int op_rst18(void)		/* RST 18 */
 static int op_rst20(void)		/* RST 20 */
 {
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x20;
 	return(11);
 }
@@ -3231,7 +3231,7 @@ static int op_rst20(void)		/* RST 20 */
 static int op_rst28(void)		/* RST 28 */
 {
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x28;
 	return(11);
 }
@@ -3239,7 +3239,7 @@ static int op_rst28(void)		/* RST 28 */
 static int op_rst30(void)		/* RST 30 */
 {
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x30;
 	return(11);
 }
@@ -3247,7 +3247,7 @@ static int op_rst30(void)		/* RST 30 */
 static int op_rst38(void)		/* RST 38 */
 {
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x38;
 	return(11);
 }

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -1436,7 +1436,7 @@ static int op_adhlsp(void)		/* ADD HL,SP */
 	register int carry;
 
 	BYTE spl = SP & 0xff;
-	BYTE sph = SP >> 8;
+	BYTE sph = SP_H;
 	
 	carry = (L + spl > 255) ? 1 : 0;
 	L += spl;

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -1435,7 +1435,7 @@ static int op_adhlsp(void)		/* ADD HL,SP */
 {
 	register int carry;
 
-	BYTE spl = SP & 0xff;
+	BYTE spl = SP_L;
 	BYTE sph = SP_H;
 	
 	carry = (L + spl > 255) ? 1 : 0;

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -421,7 +421,7 @@ void cpu_z80(void)
 		his[h_next].h_af = (A << 8) + F;
 		his[h_next].h_bc = (B << 8) + C;
 		his[h_next].h_de = (D << 8) + E;
-		his[h_next].h_hl = (H << 8) + L;
+		his[h_next].h_hl = HL;
 		his[h_next].h_ix = IX;
 		his[h_next].h_iy = IY;
 		his[h_next].h_sp = SP;
@@ -901,49 +901,49 @@ static int op_ldnna(void)		/* LD (nn),A */
 
 static int op_ldhla(void)		/* LD (HL),A */
 {
-	memwrt((H << 8) + L, A);
+	memwrt(HL, A);
 	return(7);
 }
 
 static int op_ldhlb(void)		/* LD (HL),B */
 {
-	memwrt((H << 8) + L, B);
+	memwrt(HL, B);
 	return(7);
 }
 
 static int op_ldhlc(void)		/* LD (HL),C */
 {
-	memwrt((H << 8) + L, C);
+	memwrt(HL, C);
 	return(7);
 }
 
 static int op_ldhld(void)		/* LD (HL),D */
 {
-	memwrt((H << 8) + L, D);
+	memwrt(HL, D);
 	return(7);
 }
 
 static int op_ldhle(void)		/* LD (HL),E */
 {
-	memwrt((H << 8) + L, E);
+	memwrt(HL, E);
 	return(7);
 }
 
 static int op_ldhlh(void)		/* LD (HL),H */
 {
-	memwrt((H << 8) + L, H);
+	memwrt(HL, H);
 	return(7);
 }
 
 static int op_ldhll(void)		/* LD (HL),L */
 {
-	memwrt((H << 8) + L, L);
+	memwrt(HL, L);
 	return(7);
 }
 
 static int op_ldhl1(void)		/* LD (HL),n */
 {
-	memwrt((H << 8) + L, memrdr(PC++));
+	memwrt(HL, memrdr(PC++));
 	return(10);
 }
 
@@ -990,7 +990,7 @@ static int op_ldal(void)		/* LD A,L */
 
 static int op_ldahl(void)		/* LD A,(HL) */
 {
-	A = memrdr((H << 8) + L);
+	A = memrdr(HL);
 	return(7);
 }
 
@@ -1037,7 +1037,7 @@ static int op_ldbl(void)		/* LD B,L */
 
 static int op_ldbhl(void)		/* LD B,(HL) */
 {
-	B = memrdr((H << 8) + L);
+	B = memrdr(HL);
 	return(7);
 }
 
@@ -1084,7 +1084,7 @@ static int op_ldcl(void)		/* LD C,L */
 
 static int op_ldchl(void)		/* LD C,(HL) */
 {
-	C = memrdr((H << 8) + L);
+	C = memrdr(HL);
 	return(7);
 }
 
@@ -1131,7 +1131,7 @@ static int op_lddl(void)		/* LD D,L */
 
 static int op_lddhl(void)		/* LD D,(HL) */
 {
-	D = memrdr((H << 8) + L);
+	D = memrdr(HL);
 	return(7);
 }
 
@@ -1178,7 +1178,7 @@ static int op_ldel(void)		/* LD E,L */
 
 static int op_ldehl(void)		/* LD E,(HL) */
 {
-	E = memrdr((H << 8) + L);
+	E = memrdr(HL);
 	return(7);
 }
 
@@ -1225,7 +1225,7 @@ static int op_ldhl(void)		/* LD H,L */
 
 static int op_ldhhl(void)		/* LD H,(HL) */
 {
-	H = memrdr((H << 8) + L);
+	H = memrdr(HL);
 	return(7);
 }
 
@@ -1272,7 +1272,7 @@ static int op_ldll(void)		/* LD L,L */
 
 static int op_ldlhl(void)		/* LD L,(HL) */
 {
-	L = memrdr((H << 8) + L);
+	L = memrdr(HL);
 	return(7);
 }
 
@@ -1306,7 +1306,7 @@ static int op_ldspnn(void)		/* LD SP,nn */
 
 static int op_ldsphl(void)		/* LD SP,HL */
 {
-	SP = (H << 8) + L;
+	SP = HL;
 	return(6);
 }
 
@@ -1526,7 +1526,7 @@ static int op_andl(void)		/* AND L */
 
 static int op_andhl(void)		/* AND (HL) */
 {
-	A &= memrdr((H << 8) + L);
+	A &= memrdr(HL);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= H_FLAG;
@@ -1617,7 +1617,7 @@ static int op_orl(void)			/* OR L */
 
 static int op_orhl(void)		/* OR (HL) */
 {
-	A |= memrdr((H << 8) + L);
+	A |= memrdr(HL);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1705,7 +1705,7 @@ static int op_xorl(void)		/* XOR L */
 
 static int op_xorhl(void)		/* XOR (HL) */
 {
-	A ^= memrdr((H << 8) + L);
+	A ^= memrdr(HL);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1826,7 +1826,7 @@ static int op_addhl(void)		/* ADD A,(HL) */
 	register int i;
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	((A & 0xf) + (P & 0xf) > 0xf) ?	(F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ?	(F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
@@ -1963,7 +1963,7 @@ static int op_adchl(void)		/* ADC A,(HL) */
 	register int i, carry;
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ?	(F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ?	(F |= C_FLAG) : (F &= ~C_FLAG);
@@ -2089,7 +2089,7 @@ static int op_subhl(void)		/* SUB A,(HL) */
 	register int i;
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
@@ -2225,7 +2225,7 @@ static int op_sbchl(void)		/* SBC A,(HL) */
 	register int i, carry;
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	carry = (F & C_FLAG) ? 1 : 0;
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -2350,7 +2350,7 @@ static int op_cphl(void)		/* CP (HL) */
 	register int i;
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = (signed char) A - (signed char) P;
@@ -2459,7 +2459,7 @@ static int op_incihl(void)		/* INC (HL) */
 	register BYTE P;
 	WORD addr;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	P++;
 	memwrt(addr, P);
@@ -2553,7 +2553,7 @@ static int op_decihl(void)		/* DEC (HL) */
 	register BYTE P;
 	WORD addr;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	P--;
 	memwrt(addr, P);
@@ -2746,7 +2746,7 @@ static int op_jp(void)			/* JP */
 
 static int op_jphl(void)		/* JP (HL) */
 {
-	PC = (H << 8) + L;
+	PC = HL;
 	return(4);
 }
 

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -433,7 +433,7 @@ void cpu_8080(void)
 		his[h_next].h_af = (A << 8) + F;
 		his[h_next].h_bc = (B << 8) + C;
 		his[h_next].h_de = (D << 8) + E;
-		his[h_next].h_hl = (H << 8) + L;
+		his[h_next].h_hl = HL;
 		his[h_next].h_sp = SP;
 		h_next++;
 		if (h_next == HISIZE) {
@@ -826,49 +826,49 @@ static int op_stann(void)		/* STA nn */
 
 static int op_movma(void)		/* MOV M,A */
 {
-	memwrt((H << 8) + L, A);
+	memwrt(HL, A);
 	return(7);
 }
 
 static int op_movmb(void)		/* MOV M,B */
 {
-	memwrt((H << 8) + L, B);
+	memwrt(HL, B);
 	return(7);
 }
 
 static int op_movmc(void)		/* MOV M,C */
 {
-	memwrt((H << 8) + L, C);
+	memwrt(HL, C);
 	return(7);
 }
 
 static int op_movmd(void)		/* MOV M,D */
 {
-	memwrt((H << 8) + L, D);
+	memwrt(HL, D);
 	return(7);
 }
 
 static int op_movme(void)		/* MOV M,E */
 {
-	memwrt((H << 8) + L, E);
+	memwrt(HL, E);
 	return(7);
 }
 
 static int op_movmh(void)		/* MOV M,H */
 {
-	memwrt((H << 8) + L, H);
+	memwrt(HL, H);
 	return(7);
 }
 
 static int op_movml(void)		/* MOV M,L */
 {
-	memwrt((H << 8) + L, L);
+	memwrt(HL, L);
 	return(7);
 }
 
 static int op_mvimn(void)		/* MVI M,n */
 {
-	memwrt((H << 8) + L, memrdr(PC++));
+	memwrt(HL, memrdr(PC++));
 	return(10);
 }
 
@@ -915,7 +915,7 @@ static int op_moval(void)		/* MOV A,L */
 
 static int op_movam(void)		/* MOV A,M */
 {
-	A = memrdr((H << 8) + L);
+	A = memrdr(HL);
 	return(7);
 }
 
@@ -962,7 +962,7 @@ static int op_movbl(void)		/* MOV B,L */
 
 static int op_movbm(void)		/* MOV B,M */
 {
-	B = memrdr((H << 8) + L);
+	B = memrdr(HL);
 	return(7);
 }
 
@@ -1009,7 +1009,7 @@ static int op_movcl(void)		/* MOV C,L */
 
 static int op_movcm(void)		/* MOV C,M */
 {
-	C = memrdr((H << 8) + L);
+	C = memrdr(HL);
 	return(7);
 }
 
@@ -1056,7 +1056,7 @@ static int op_movdl(void)		/* MOV D,L */
 
 static int op_movdm(void)		/* MOV D,M */
 {
-	D = memrdr((H << 8) + L);
+	D = memrdr(HL);
 	return(7);
 }
 
@@ -1103,7 +1103,7 @@ static int op_movel(void)		/* MOV E,L */
 
 static int op_movem(void)		/* MOV E,M */
 {
-	E = memrdr((H << 8) + L);
+	E = memrdr(HL);
 	return(7);
 }
 
@@ -1150,7 +1150,7 @@ static int op_movhl(void)		/* MOV H,L */
 
 static int op_movhm(void)		/* MOV H,M */
 {
-	H = memrdr((H << 8) + L);
+	H = memrdr(HL);
 	return(7);
 }
 
@@ -1197,7 +1197,7 @@ static int op_movll(void)		/* MOV L,L */
 
 static int op_movlm(void)		/* MOV L,M */
 {
-	L = memrdr((H << 8) + L);
+	L = memrdr(HL);
 	return(7);
 }
 
@@ -1234,7 +1234,7 @@ static int op_sphl(void)		/* SPHL */
 #ifdef FRONTPANEL
 	adr_leds(H << 8 | L);
 #endif
-	SP = (H << 8) + L;
+	SP = HL;
 	return(5);
 }
 
@@ -1471,7 +1471,7 @@ static int op_anam(void)		/* ANA M */
 {
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	((A | P) & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	A &= P;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
@@ -1566,7 +1566,7 @@ static int op_oral(void)		/* ORA L */
 
 static int op_oram(void)		/* ORA M */
 {
-	A |= memrdr((H << 8) + L);
+	A |= memrdr(HL);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1654,7 +1654,7 @@ static int op_xral(void)		/* XRA L */
 
 static int op_xram(void)		/* XRA M */
 {
-	A ^= memrdr((H << 8) + L);
+	A ^= memrdr(HL);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1753,7 +1753,7 @@ static int op_addm(void)		/* ADD M */
 {
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	((A & 0xf) + (P & 0xf) > 0xf) ?	(F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ?	(F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + P;
@@ -1880,7 +1880,7 @@ static int op_adcm(void)		/* ADC M */
 	register int carry;
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ?	(F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ?	(F |= C_FLAG) : (F &= ~C_FLAG);
@@ -1985,7 +1985,7 @@ static int op_subm(void)		/* SUB M */
 {
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	((P & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - P;
@@ -2112,7 +2112,7 @@ static int op_sbbm(void)		/* SBB M */
 	register int carry;
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	carry = (F & C_FLAG) ? 1 : 0;
 	((P & 0xf) + carry > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -2229,7 +2229,7 @@ static int op_cmpm(void)		/* CMP M */
 	register BYTE i;
 	register BYTE P;
 
-	P = memrdr((H << 8) + L);
+	P = memrdr(HL);
 	((P & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = A - P;
@@ -2329,7 +2329,7 @@ static int op_inrm(void)		/* INR M */
 	register BYTE P;
 	WORD addr;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
         P++;
         memwrt(addr, P);
@@ -2415,7 +2415,7 @@ static int op_dcrm(void)		/* DCR M */
 	register BYTE P;
 	WORD addr;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	P--;
 	memwrt(addr, P);
@@ -2605,7 +2605,7 @@ static int op_undoc_jmp(void)		/* Undocumented JMP */
 
 static int op_pchl(void)		/* PCHL */
 {
-	PC = (H << 8) + L;
+	PC = HL;
 	return(5);
 }
 

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -1382,7 +1382,7 @@ static int op_dadsp(void)		/* DAD SP */
 	register int carry;
 
 	BYTE spl = SP & 0xff;
-	BYTE sph = SP >> 8;
+	BYTE sph = SP_H;
 	
 	carry = (L + spl > 255) ? 1 : 0;
 	L += spl;

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -432,7 +432,7 @@ void cpu_8080(void)
 		his[h_next].h_adr = PC;
 		his[h_next].h_af = (A << 8) + F;
 		his[h_next].h_bc = BC;
-		his[h_next].h_de = (D << 8) + E;
+		his[h_next].h_de = DE;
 		his[h_next].h_hl = HL;
 		his[h_next].h_sp = SP;
 		h_next++;
@@ -788,7 +788,7 @@ static int op_ldaxb(void)		/* LDAX B */
 
 static int op_ldaxd(void)		/* LDAX D */
 {
-	A = memrdr((D << 8) + E);
+	A = memrdr(DE);
 	return(7);
 }
 
@@ -810,7 +810,7 @@ static int op_staxb(void)		/* STAX B */
 
 static int op_staxd(void)		/* STAX D */
 {
-	memwrt((D << 8) + E, A);
+	memwrt(DE, A);
 	return(7);
 }
 

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -1381,7 +1381,7 @@ static int op_dadsp(void)		/* DAD SP */
 {
 	register int carry;
 
-	BYTE spl = SP & 0xff;
+	BYTE spl = SP_L;
 	BYTE sph = SP_H;
 	
 	carry = (L + spl > 255) ? 1 : 0;

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -482,7 +482,7 @@ void cpu_8080(void)
 #endif
 
 			memwrt(--SP, PC_H);
-			memwrt(--SP, PC);
+			memwrt(--SP, PC_L);
 
 #ifdef FRONTPANEL
 			if (cpu_state & RESET)
@@ -2619,7 +2619,7 @@ static int op_call(void)		/* CALL */
 	cpu_bus = CPU_STACK;
 #endif
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = i;
 	return(17);
 }
@@ -2774,7 +2774,7 @@ static int op_cz(void)			/* CZ nn */
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2794,7 +2794,7 @@ static int op_cnz(void)			/* CNZ nn */
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2814,7 +2814,7 @@ static int op_cc(void)			/* CC nn */
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2834,7 +2834,7 @@ static int op_cnc(void)			/* CNC nn */
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2854,7 +2854,7 @@ static int op_cpe(void)			/* CPE nn */
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2874,7 +2874,7 @@ static int op_cpo(void)			/* CPO nn */
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2894,7 +2894,7 @@ static int op_cm(void)			/* CM nn */
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -2914,7 +2914,7 @@ static int op_cp(void)			/* CP nn */
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC_H);
-		memwrt(--SP, PC);
+		memwrt(--SP, PC_L);
 		PC = i;
 		return(17);
 	} else {
@@ -3065,7 +3065,7 @@ static int op_rst0(void)		/* RST 0 */
 	cpu_bus = CPU_STACK;
 #endif
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0;
 	return(11);
 }
@@ -3076,7 +3076,7 @@ static int op_rst1(void)		/* RST 1 */
 	cpu_bus = CPU_STACK;
 #endif
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x08;
 	return(11);
 }
@@ -3087,7 +3087,7 @@ static int op_rst2(void)		/* RST 2 */
 	cpu_bus = CPU_STACK;
 #endif
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x10;
 	return(11);
 }
@@ -3098,7 +3098,7 @@ static int op_rst3(void)		/* RST 3 */
 	cpu_bus = CPU_STACK;
 #endif
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x18;
 	return(11);
 }
@@ -3109,7 +3109,7 @@ static int op_rst4(void)		/* RST 4 */
 	cpu_bus = CPU_STACK;
 #endif
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x20;
 	return(11);
 }
@@ -3120,7 +3120,7 @@ static int op_rst5(void)		/* RST 5 */
 	cpu_bus = CPU_STACK;
 #endif
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x28;
 	return(11);
 }
@@ -3131,7 +3131,7 @@ static int op_rst6(void)		/* RST 6 */
 	cpu_bus = CPU_STACK;
 #endif
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x30;
 	return(11);
 }
@@ -3142,7 +3142,7 @@ static int op_rst7(void)		/* RST 7 */
 	cpu_bus = CPU_STACK;
 #endif
 	memwrt(--SP, PC_H);
-	memwrt(--SP, PC);
+	memwrt(--SP, PC_L);
 	PC = 0x38;
 	return(11);
 }

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -481,7 +481,7 @@ void cpu_8080(void)
 			fp_sampleLightGroup(0, 0);
 #endif
 
-			memwrt(--SP, PC >> 8);
+			memwrt(--SP, PC_H);
 			memwrt(--SP, PC);
 
 #ifdef FRONTPANEL
@@ -2618,7 +2618,7 @@ static int op_call(void)		/* CALL */
 #ifdef BUS_8080
 	cpu_bus = CPU_STACK;
 #endif
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = i;
 	return(17);
@@ -2773,7 +2773,7 @@ static int op_cz(void)			/* CZ nn */
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2793,7 +2793,7 @@ static int op_cnz(void)			/* CNZ nn */
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2813,7 +2813,7 @@ static int op_cc(void)			/* CC nn */
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2833,7 +2833,7 @@ static int op_cnc(void)			/* CNC nn */
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2853,7 +2853,7 @@ static int op_cpe(void)			/* CPE nn */
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2873,7 +2873,7 @@ static int op_cpo(void)			/* CPO nn */
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2893,7 +2893,7 @@ static int op_cm(void)			/* CM nn */
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -2913,7 +2913,7 @@ static int op_cp(void)			/* CP nn */
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
-		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC_H);
 		memwrt(--SP, PC);
 		PC = i;
 		return(17);
@@ -3064,7 +3064,7 @@ static int op_rst0(void)		/* RST 0 */
 #ifdef BUS_8080
 	cpu_bus = CPU_STACK;
 #endif
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0;
 	return(11);
@@ -3075,7 +3075,7 @@ static int op_rst1(void)		/* RST 1 */
 #ifdef BUS_8080
 	cpu_bus = CPU_STACK;
 #endif
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x08;
 	return(11);
@@ -3086,7 +3086,7 @@ static int op_rst2(void)		/* RST 2 */
 #ifdef BUS_8080
 	cpu_bus = CPU_STACK;
 #endif
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x10;
 	return(11);
@@ -3097,7 +3097,7 @@ static int op_rst3(void)		/* RST 3 */
 #ifdef BUS_8080
 	cpu_bus = CPU_STACK;
 #endif
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x18;
 	return(11);
@@ -3108,7 +3108,7 @@ static int op_rst4(void)		/* RST 4 */
 #ifdef BUS_8080
 	cpu_bus = CPU_STACK;
 #endif
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x20;
 	return(11);
@@ -3119,7 +3119,7 @@ static int op_rst5(void)		/* RST 5 */
 #ifdef BUS_8080
 	cpu_bus = CPU_STACK;
 #endif
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x28;
 	return(11);
@@ -3130,7 +3130,7 @@ static int op_rst6(void)		/* RST 6 */
 #ifdef BUS_8080
 	cpu_bus = CPU_STACK;
 #endif
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x30;
 	return(11);
@@ -3141,7 +3141,7 @@ static int op_rst7(void)		/* RST 7 */
 #ifdef BUS_8080
 	cpu_bus = CPU_STACK;
 #endif
-	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC_H);
 	memwrt(--SP, PC);
 	PC = 0x38;
 	return(11);

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -431,7 +431,7 @@ void cpu_8080(void)
 		/* write history */
 		his[h_next].h_adr = PC;
 		his[h_next].h_af = (A << 8) + F;
-		his[h_next].h_bc = (B << 8) + C;
+		his[h_next].h_bc = BC;
 		his[h_next].h_de = (D << 8) + E;
 		his[h_next].h_hl = HL;
 		his[h_next].h_sp = SP;
@@ -782,7 +782,7 @@ static int op_mviln(void)		/* MVI L,n */
 
 static int op_ldaxb(void)		/* LDAX B */
 {
-	A = memrdr((B << 8) + C);
+	A = memrdr(BC);
 	return(7);
 }
 
@@ -804,7 +804,7 @@ static int op_ldann(void)		/* LDA nn */
 
 static int op_staxb(void)		/* STAX B */
 {
-	memwrt((B << 8) + C, A);
+	memwrt(BC, A);
 	return(7);
 }
 

--- a/z80core/sim2.c
+++ b/z80core/sim2.c
@@ -513,7 +513,7 @@ static int op_srlhl(void)		/* SRL (HL) */
 	register BYTE P;
 	WORD addr;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	(P & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	P >>= 1;
@@ -607,7 +607,7 @@ static int op_slahl(void)		/* SLA (HL) */
 	register BYTE P;
 	WORD addr;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	(P & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	P <<= 1;
@@ -730,7 +730,7 @@ static int op_rlhl(void)		/* RL (HL) */
 	WORD addr;
 	int old_c_flag;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	old_c_flag = F & C_FLAG;
 	(P & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -855,7 +855,7 @@ static int op_rrhl(void)		/* RR (HL) */
 	WORD addr;
 	int old_c_flag;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	old_c_flag = F & C_FLAG;
 	(P & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -980,7 +980,7 @@ static int op_rrchl(void)		/* RRC (HL) */
 	WORD addr;
 	int i;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	i = P & 1;
 	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -1105,7 +1105,7 @@ static int op_rlchl(void)		/* RLC (HL) */
 	WORD addr;
 	int i;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	i = P & 128;
 	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -1230,7 +1230,7 @@ static int op_srahl(void)		/* SRA (HL) */
 	WORD addr;
 	int i;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	i = P & 128;
 	(P & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -1581,49 +1581,49 @@ static int op_sb7l(void)		/* SET 7,L */
 
 static int op_sb0hl(void)		/* SET 0,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) | 1);
+	memwrt(HL, memrdr(HL) | 1);
 	return(15);
 }
 
 static int op_sb1hl(void)		/* SET 1,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) | 2);
+	memwrt(HL, memrdr(HL) | 2);
 	return(15);
 }
 
 static int op_sb2hl(void)		/* SET 2,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) | 4);
+	memwrt(HL, memrdr(HL) | 4);
 	return(15);
 }
 
 static int op_sb3hl(void)		/* SET 3,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) | 8);
+	memwrt(HL, memrdr(HL) | 8);
 	return(15);
 }
 
 static int op_sb4hl(void)		/* SET 4,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) | 16);
+	memwrt(HL, memrdr(HL) | 16);
 	return(15);
 }
 
 static int op_sb5hl(void)		/* SET 5,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) | 32);
+	memwrt(HL, memrdr(HL) | 32);
 	return(15);
 }
 
 static int op_sb6hl(void)		/* SET 6,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) | 64);
+	memwrt(HL, memrdr(HL) | 64);
 	return(15);
 }
 
 static int op_sb7hl(void)		/* SET 7,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) | 128);
+	memwrt(HL, memrdr(HL) | 128);
 	return(15);
 }
 
@@ -1965,49 +1965,49 @@ static int op_rb7l(void)		/* RES 7,L */
 
 static int op_rb0hl(void)		/* RES 0,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~1);
+	memwrt(HL, memrdr(HL) & ~1);
 	return(15);
 }
 
 static int op_rb1hl(void)		/* RES 1,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~2);
+	memwrt(HL, memrdr(HL) & ~2);
 	return(15);
 }
 
 static int op_rb2hl(void)		/* RES 2,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~4);
+	memwrt(HL, memrdr(HL) & ~4);
 	return(15);
 }
 
 static int op_rb3hl(void)		/* RES 3,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~8);
+	memwrt(HL, memrdr(HL) & ~8);
 	return(15);
 }
 
 static int op_rb4hl(void)		/* RES 4,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~16);
+	memwrt(HL, memrdr(HL) & ~16);
 	return(15);
 }
 
 static int op_rb5hl(void)		/* RES 5,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~32);
+	memwrt(HL, memrdr(HL) & ~32);
 	return(15);
 }
 
 static int op_rb6hl(void)		/* RES 6,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~64);
+	memwrt(HL, memrdr(HL) & ~64);
 	return(15);
 }
 
 static int op_rb7hl(void)		/* RES 7,(HL) */
 {
-	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~128);
+	memwrt(HL, memrdr(HL) & ~128);
 	return(15);
 }
 
@@ -2505,7 +2505,7 @@ static int op_tb0hl(void)		/* BIT 0,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr((H << 8) + L) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
+	(memrdr(HL) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
 	return(12);
 }
@@ -2514,7 +2514,7 @@ static int op_tb1hl(void)		/* BIT 1,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr((H << 8) + L) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
+	(memrdr(HL) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
 	return(12);
 }
@@ -2523,7 +2523,7 @@ static int op_tb2hl(void)		/* BIT 2,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr((H << 8) + L) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
+	(memrdr(HL) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
 	return(12);
 }
@@ -2532,7 +2532,7 @@ static int op_tb3hl(void)		/* BIT 3,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr((H << 8) + L) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
+	(memrdr(HL) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
 	return(12);
 }
@@ -2541,7 +2541,7 @@ static int op_tb4hl(void)		/* BIT 4,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr((H << 8) + L) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
+	(memrdr(HL) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
 	return(12);
 }
@@ -2550,7 +2550,7 @@ static int op_tb5hl(void)		/* BIT 5,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr((H << 8) + L) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
+	(memrdr(HL) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
 	return(12);
 }
@@ -2559,7 +2559,7 @@ static int op_tb6hl(void)		/* BIT 6,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr((H << 8) + L) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
+	(memrdr(HL) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
 	return(12);
 }
@@ -2568,7 +2568,7 @@ static int op_tb7hl(void)		/* BIT 7,(HL) */
 {
 	F &= ~N_FLAG;
 	F |= H_FLAG;
-	if (memrdr((H << 8) + L) & 128) {
+	if (memrdr(HL) & 128) {
 		F &= ~(Z_FLAG | P_FLAG);
 		F |= S_FLAG;
 	} else {
@@ -2708,7 +2708,7 @@ static int op_undoc_sllhl(void)		/* SLL (HL) */
 		return(0);
 	}
 
-	addr = (H << 8) + L;
+	addr = HL;
 	P = memrdr(addr);
 	(P & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	P = (P << 1) | 1;

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -649,7 +649,7 @@ static int op_addxs(void)		/* ADD IX,SP */
 	BYTE ixl = IX & 0xff;
 	BYTE ixh = IX >> 8;
 	BYTE spl = SP & 0xff;
-	BYTE sph = SP >> 8;
+	BYTE sph = SP_H;
 	
 	carry = (ixl + spl > 255) ? 1 : 0;
 	ixl += spl;

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -648,7 +648,7 @@ static int op_addxs(void)		/* ADD IX,SP */
 	register int carry;
 	BYTE ixl = IX & 0xff;
 	BYTE ixh = IX >> 8;
-	BYTE spl = SP & 0xff;
+	BYTE spl = SP_L;
 	BYTE sph = SP_H;
 	
 	carry = (ixl + spl > 255) ? 1 : 0;

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -405,7 +405,7 @@ static int op_popix(void)		/* POP IX */
 
 static int op_pusix(void)		/* PUSH IX */
 {
-	memwrt(--SP, IX >> 8);
+	memwrt(--SP, IX_H);
 	memwrt(--SP, IX);
 	return(15);
 }
@@ -422,7 +422,7 @@ static int op_exspx(void)		/* EX (SP),IX */
 
 	i = memrdr(SP) + (memrdr(SP + 1) << 8);
 	memwrt(SP, IX);
-	memwrt(SP + 1, IX >> 8);
+	memwrt(SP + 1, IX_H);
 	IX = i;
 	return(23);
 }
@@ -458,7 +458,7 @@ static int op_ldinx(void)		/* LD (nn),IX */
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
 	memwrt(i, IX);
-	memwrt(i + 1, IX >> 8);
+	memwrt(i + 1, IX_H);
 	return(20);
 }
 
@@ -613,7 +613,7 @@ static int op_addxb(void)		/* ADD IX,BC */
 {
 	register int carry;
 	BYTE ixl = IX & 0xff;
-	BYTE ixh = IX >> 8;
+	BYTE ixh = IX_H;
 	
 	carry = (ixl + C > 255) ? 1 : 0;
 	ixl += C;
@@ -630,7 +630,7 @@ static int op_addxd(void)		/* ADD IX,DE */
 {
 	register int carry;
 	BYTE ixl = IX & 0xff;
-	BYTE ixh = IX >> 8;
+	BYTE ixh = IX_H;
 	
 	carry = (ixl + E > 255) ? 1 : 0;
 	ixl += E;
@@ -647,7 +647,7 @@ static int op_addxs(void)		/* ADD IX,SP */
 {
 	register int carry;
 	BYTE ixl = IX & 0xff;
-	BYTE ixh = IX >> 8;
+	BYTE ixh = IX_H;
 	BYTE spl = SP_L;
 	BYTE sph = SP_H;
 	
@@ -666,7 +666,7 @@ static int op_addxx(void)		/* ADD IX,IX */
 {
 	register int carry;
 	BYTE ixl = IX & 0xff;
-	BYTE ixh = IX >> 8;
+	BYTE ixh = IX_H;
 	
 	carry = (ixl << 1 > 255) ? 1 : 0;
 	ixl <<= 1;
@@ -810,7 +810,7 @@ static int op_undoc_ldaixh(void)	/* LD A,IXH */
 		return(0);
 	}
 
-	A = IX >> 8;
+	A = IX_H;
 	return(8);
 }
 
@@ -832,7 +832,7 @@ static int op_undoc_ldbixh(void)	/* LD B,IXH */
 		return(0);
 	}
 
-	B = IX >> 8;
+	B = IX_H;
 	return(8);
 }
 
@@ -854,7 +854,7 @@ static int op_undoc_ldcixh(void)	/* LD C,IXH */
 		return(0);
 	}
 
-	C = IX >> 8;
+	C = IX_H;
 	return(8);
 }
 
@@ -876,7 +876,7 @@ static int op_undoc_lddixh(void)	/* LD D,IXH */
 		return(0);
 	}
 
-	D = IX >> 8;
+	D = IX_H;
 	return(8);
 }
 
@@ -898,7 +898,7 @@ static int op_undoc_ldeixh(void)	/* LD E,IXH */
 		return(0);
 	}
 
-	E = IX >> 8;
+	E = IX_H;
 	return(8);
 }
 
@@ -1019,7 +1019,7 @@ static int op_undoc_ldixlixh(void)	/* LD IXL,IXH */
 		return(0);
 	}
 
-	IX = (IX & 0xff00) | (IX >> 8);
+	IX = (IX & 0xff00) | (IX_H);
 	return(8);
 }
 
@@ -1130,7 +1130,7 @@ static int op_undoc_acaixh(void)	/* ADC A,IXH */
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = IX >> 8;
+	P = IX_H;
 	((A & 0xf) + (P	& 0xf) + carry > 0xf) ?	(F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ?	(F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
@@ -1174,7 +1174,7 @@ static int op_undoc_scaixh(void)	/* SBC A,IXH */
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = IX >> 8;
+	P = IX_H;
 	((P & 0xf) + carry > (A	& 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
@@ -1207,7 +1207,7 @@ static int op_undoc_oraixh(void)	/* OR IXH */
 		return(0);
 	}
 
-	A |= IX >> 8;
+	A |= IX_H;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1238,7 +1238,7 @@ static int op_undoc_andixh(void)	/* AND IXH */
 		return(0);
 	}
 
-	A &= IX >> 8;
+	A &= IX_H;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= H_FLAG;
@@ -1276,7 +1276,7 @@ static int op_undoc_incixh(void)	/* INC IXH */
 		return(0);
 	}
 
-	P = IX >> 8;
+	P = IX_H;
 	P++;
 	IX = (IX & 0x00ff) | (P << 8);
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1316,7 +1316,7 @@ static int op_undoc_decixh(void)	/* DEC IXH */
 		return(0);
 	}
 
-	P = IX >> 8;
+	P = IX_H;
 	P--;
 	IX = (IX & 0x00ff) | (P << 8);
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -612,7 +612,7 @@ static int op_decxd(void)		/* DEC (IX+d) */
 static int op_addxb(void)		/* ADD IX,BC */
 {
 	register int carry;
-	BYTE ixl = IX & 0xff;
+	BYTE ixl = IX_L;
 	BYTE ixh = IX_H;
 	
 	carry = (ixl + C > 255) ? 1 : 0;
@@ -629,7 +629,7 @@ static int op_addxb(void)		/* ADD IX,BC */
 static int op_addxd(void)		/* ADD IX,DE */
 {
 	register int carry;
-	BYTE ixl = IX & 0xff;
+	BYTE ixl = IX_L;
 	BYTE ixh = IX_H;
 	
 	carry = (ixl + E > 255) ? 1 : 0;
@@ -646,7 +646,7 @@ static int op_addxd(void)		/* ADD IX,DE */
 static int op_addxs(void)		/* ADD IX,SP */
 {
 	register int carry;
-	BYTE ixl = IX & 0xff;
+	BYTE ixl = IX_L;
 	BYTE ixh = IX_H;
 	BYTE spl = SP_L;
 	BYTE sph = SP_H;
@@ -665,7 +665,7 @@ static int op_addxs(void)		/* ADD IX,SP */
 static int op_addxx(void)		/* ADD IX,IX */
 {
 	register int carry;
-	BYTE ixl = IX & 0xff;
+	BYTE ixl = IX_L;
 	BYTE ixh = IX_H;
 	
 	carry = (ixl << 1 > 255) ? 1 : 0;
@@ -799,7 +799,7 @@ static int op_undoc_ldaixl(void)	/* LD A,IXL */
 		return(0);
 	}
 
-	A = IX & 0xff;
+	A = IX_L;
 	return(8);
 }
 
@@ -821,7 +821,7 @@ static int op_undoc_ldbixl(void)	/* LD B,IXL */
 		return(0);
 	}
 
-	B = IX & 0xff;
+	B = IX_L;
 	return(8);
 }
 
@@ -843,7 +843,7 @@ static int op_undoc_ldcixl(void)	/* LD C,IXL */
 		return(0);
 	}
 
-	C = IX & 0xff;
+	C = IX_L;
 	return(8);
 }
 
@@ -865,7 +865,7 @@ static int op_undoc_lddixl(void)	/* LD D,IXL */
 		return(0);
 	}
 
-	D = IX & 0xff;
+	D = IX_L;
 	return(8);
 }
 
@@ -887,7 +887,7 @@ static int op_undoc_ldeixl(void)	/* LD E,IXL */
 		return(0);
 	}
 
-	E = IX & 0xff;
+	E = IX_L;
 	return(8);
 }
 
@@ -1086,7 +1086,7 @@ static int op_undoc_cpixl(void)		/* CP IXL */
 		return(0);
 	}
 
-	P = IX & 0xff;
+	P = IX_L;
 	((P & 0xf) > (A	& 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = (signed char) A - (signed char) P;
@@ -1108,7 +1108,7 @@ static int op_undoc_acaixl(void)	/* ADC A,IXL */
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = IX & 0xff;
+	P = IX_L;
 	((A & 0xf) + (P	& 0xf) + carry > 0xf) ?	(F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ?	(F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
@@ -1152,7 +1152,7 @@ static int op_undoc_scaixl(void)	/* SBC A,IXL */
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = IX & 0xff;
+	P = IX_L;
 	((P & 0xf) + carry > (A	& 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
@@ -1192,7 +1192,7 @@ static int op_undoc_oraixl(void)	/* OR IXL */
 		return(0);
 	}
 
-	A |= IX & 0xff;
+	A |= IX_L;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1222,7 +1222,7 @@ static int op_undoc_andixl(void)	/* AND IXL */
 		return(0);
 	}
 
-	A &= IX & 0xff;
+	A &= IX_L;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= H_FLAG;
@@ -1256,7 +1256,7 @@ static int op_undoc_incixl(void)	/* INC IXL */
 		return(0);
 	}
 
-	P = IX & 0xff;
+	P = IX_L;
 	P++;
 	IX = (IX & 0xff00) | P;
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1296,7 +1296,7 @@ static int op_undoc_decixl(void)	/* DEC IXL */
 		return(0);
 	}
 
-	P = IX & 0xff;
+	P = IX_L;
 	P--;
 	IX = (IX & 0xff00) | P;
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);

--- a/z80core/sim4.c
+++ b/z80core/sim4.c
@@ -579,7 +579,7 @@ static int op_ini(void)			/* INI */
 	BYTE data;
 
 	data = io_in(C, B);
-	memwrt((H << 8) + L, data);
+	memwrt(HL, data);
 	L++;
 	if (!L)
 		H++;
@@ -596,7 +596,7 @@ static int op_inir(void)		/* INIR */
 	BYTE data;
 	register int t	= -21;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	do {
 		data = io_in(C, B);
 		memwrt(addr++, data);
@@ -615,7 +615,7 @@ static int op_ind(void)			/* IND */
 	BYTE data;
 
 	data = io_in(C, B);
-	memwrt((H << 8) + L, data);
+	memwrt(HL, data);
 	L--;
 	if (L == 0xff)
 		H--;
@@ -632,7 +632,7 @@ static int op_indr(void)		/* INDR */
 	BYTE data;
 	register int t	= -21;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	do {
 		data = io_in(C, B);
 		memwrt(addr--, data);
@@ -650,7 +650,7 @@ static int op_outi(void)		/* OUTI */
 	BYTE io_out(BYTE, BYTE, BYTE);
 	BYTE data;
 
-	data = memrdr((H << 8) + L);
+	data = memrdr(HL);
 	io_out(C, B, data);
 	L++;
 	if (!L)
@@ -668,7 +668,7 @@ static int op_otir(void)		/* OTIR */
 	BYTE data;
 	register int t	= -21;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	do {
 		data = memrdr(addr++);
 		io_out(C, B, data);
@@ -686,7 +686,7 @@ static int op_outd(void)		/* OUTD */
 	BYTE io_out(BYTE, BYTE, BYTE);
 	BYTE data;
 
-	data = memrdr((H << 8) + L);
+	data = memrdr(HL);
 	io_out(C, B, data);
 	L--;
 	if (L == 0xff)
@@ -704,7 +704,7 @@ static int op_otdr(void)		/* OTDR */
 	BYTE data;
 	register int t	= -21;
 
-	addr = (H << 8) + L;
+	addr = HL;
 	do {
 		data = memrdr(addr--);
 		io_out(C, B, data);
@@ -1037,7 +1037,7 @@ static int op_sbchs(void)		/* SBC HL,SP */
 
 static int op_ldi(void)			/* LDI */
 {
-	memwrt((D << 8) + E, memrdr((H << 8) + L));
+	memwrt((D << 8) + E, memrdr(HL));
 	E++;
 	if (!E)
 		D++;
@@ -1061,7 +1061,7 @@ static int op_ldir(void)		/* LDIR */
 
 	i = (B << 8) + C;
 	d = (D << 8) + E;
-	s = (H << 8) + L;
+	s = HL;
 	do {
 		memwrt(d++, memrdr(s++));
 		t += 21;
@@ -1091,7 +1091,7 @@ static int op_ldir(void)		/* LDIR */
 
 static int op_ldd(void)			/* LDD */
 {
-	memwrt((D << 8) + E, memrdr((H << 8) + L));
+	memwrt((D << 8) + E, memrdr(HL));
 	E--;
 	if (E == 0xff)
 		D--;
@@ -1115,7 +1115,7 @@ static int op_lddr(void)		/* LDDR */
 
 	i = (B << 8) + C;
 	d = (D << 8) + E;
-	s = (H << 8) + L;
+	s = HL;
 	do {
 		memwrt(d--, memrdr(s--));
 		t += 21;
@@ -1147,7 +1147,7 @@ static int op_cpi(void)		/* CPI */
 {
 	register BYTE i;
 
-	i = memrdr(((H << 8) + L));
+	i = memrdr((HL));
 	((i & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	i = A - i;
 	L++;
@@ -1172,7 +1172,7 @@ static int op_cpir(void)	/* CPIR */
 	register BYTE tmp;
 
 	i = (B << 8) + C;
-	s = (H << 8) + L;
+	s = HL;
 	do {
 		tmp = memrdr(s++);
 		((tmp & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1194,7 +1194,7 @@ static int op_cpdop(void)	/* CPD */
 {
 	register BYTE i;
 
-	i = memrdr(((H << 8) + L));
+	i = memrdr((HL));
 	((i & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	i = A - i;
 	L--;
@@ -1219,7 +1219,7 @@ static int op_cpdr(void)	/* CPDR */
 	register BYTE tmp;
 
 	i = (B << 8) + C;
-	s = (H << 8) + L;
+	s = HL;
 	do {
 		tmp = memrdr(s--);
 		((tmp & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1241,11 +1241,11 @@ static int op_oprld(void)	/* RLD (HL) */
 {
 	register BYTE i, j;
 
-	i = memrdr((H << 8) + L);
+	i = memrdr(HL);
 	j = A & 0x0f;
 	A = (A & 0xf0) | (i >> 4);
 	i = (i << 4) | j;
-	memwrt((H << 8) + L, i);
+	memwrt(HL, i);
 	F &= ~(H_FLAG | N_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
@@ -1257,11 +1257,11 @@ static int op_oprrd(void)	/* RRD (HL) */
 {
 	register BYTE i, j;
 
-	i = memrdr((H << 8) + L);
+	i = memrdr(HL);
 	j = A & 0x0f;
 	A = (A & 0xf0) | (i & 0x0f);
 	i = (i >> 4) | (j << 4);
-	memwrt((H << 8) + L, i);
+	memwrt(HL, i);
 	F &= ~(H_FLAG | N_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);

--- a/z80core/sim4.c
+++ b/z80core/sim4.c
@@ -1037,7 +1037,7 @@ static int op_sbchs(void)		/* SBC HL,SP */
 
 static int op_ldi(void)			/* LDI */
 {
-	memwrt((D << 8) + E, memrdr(HL));
+	memwrt(DE, memrdr(HL));
 	E++;
 	if (!E)
 		D++;
@@ -1060,7 +1060,7 @@ static int op_ldir(void)		/* LDIR */
 	register WORD s, d;
 
 	i = BC;
-	d = (D << 8) + E;
+	d = DE;
 	s = HL;
 	do {
 		memwrt(d++, memrdr(s++));
@@ -1091,7 +1091,7 @@ static int op_ldir(void)		/* LDIR */
 
 static int op_ldd(void)			/* LDD */
 {
-	memwrt((D << 8) + E, memrdr(HL));
+	memwrt(DE, memrdr(HL));
 	E--;
 	if (E == 0xff)
 		D--;
@@ -1114,7 +1114,7 @@ static int op_lddr(void)		/* LDDR */
 	register WORD s, d;
 
 	i = BC;
-	d = (D << 8) + E;
+	d = DE;
 	s = HL;
 	do {
 		memwrt(d--, memrdr(s--));

--- a/z80core/sim4.c
+++ b/z80core/sim4.c
@@ -1059,7 +1059,7 @@ static int op_ldir(void)		/* LDIR */
 	register WORD i;
 	register WORD s, d;
 
-	i = (B << 8) + C;
+	i = BC;
 	d = (D << 8) + E;
 	s = HL;
 	do {
@@ -1113,7 +1113,7 @@ static int op_lddr(void)		/* LDDR */
 	register WORD i;
 	register WORD s, d;
 
-	i = (B << 8) + C;
+	i = BC;
 	d = (D << 8) + E;
 	s = HL;
 	do {
@@ -1171,7 +1171,7 @@ static int op_cpir(void)	/* CPIR */
 	register WORD i;
 	register BYTE tmp;
 
-	i = (B << 8) + C;
+	i = BC;
 	s = HL;
 	do {
 		tmp = memrdr(s++);
@@ -1218,7 +1218,7 @@ static int op_cpdr(void)	/* CPDR */
 	register WORD i;
 	register BYTE tmp;
 
-	i = (B << 8) + C;
+	i = BC;
 	s = HL;
 	do {
 		tmp = memrdr(s--);

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -645,7 +645,7 @@ static int op_addys(void)		/* ADD IY,SP */
 	register int carry;
 	BYTE iyl = IY & 0xff;
 	BYTE iyh = IY >> 8;
-	BYTE spl = SP & 0xff;
+	BYTE spl = SP_L;
 	BYTE sph = SP_H;
 	
 	carry = (iyl + spl > 255) ? 1 : 0;

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -609,7 +609,7 @@ static int op_decyd(void)		/* DEC (IY+d) */
 static int op_addyb(void)		/* ADD IY,BC */
 {
 	register int carry;
-	BYTE iyl = IY & 0xff;
+	BYTE iyl = IY_L;
 	BYTE iyh = IY_H;
 	
 	carry = (iyl + C > 255) ? 1 : 0;
@@ -626,7 +626,7 @@ static int op_addyb(void)		/* ADD IY,BC */
 static int op_addyd(void)		/* ADD IY,DE */
 {
 	register int carry;
-	BYTE iyl = IY & 0xff;
+	BYTE iyl = IY_L;
 	BYTE iyh = IY_H;
 	
 	carry = (iyl + E > 255) ? 1 : 0;
@@ -643,7 +643,7 @@ static int op_addyd(void)		/* ADD IY,DE */
 static int op_addys(void)		/* ADD IY,SP */
 {
 	register int carry;
-	BYTE iyl = IY & 0xff;
+	BYTE iyl = IY_L;
 	BYTE iyh = IY_H;
 	BYTE spl = SP_L;
 	BYTE sph = SP_H;
@@ -662,7 +662,7 @@ static int op_addys(void)		/* ADD IY,SP */
 static int op_addyy(void)		/* ADD IY,IY */
 {
 	register int carry;
-	BYTE iyl = IY & 0xff;
+	BYTE iyl = IY_L;
 	BYTE iyh = IY_H;
 	
 	carry = (iyl << 1 > 255) ? 1 : 0;
@@ -796,7 +796,7 @@ static int op_undoc_ldaiyl(void)	/* LD A,IYL */
 		return(0);
 	}
 
-	A = IY & 0xff;
+	A = IY_L;
 	return(8);
 }
 
@@ -818,7 +818,7 @@ static int op_undoc_ldbiyl(void)	/* LD B,IYL */
 		return(0);
 	}
 
-	B = IY & 0xff;
+	B = IY_L;
 	return(8);
 }
 
@@ -840,7 +840,7 @@ static int op_undoc_ldciyl(void)	/* LD C,IYL */
 		return(0);
 	}
 
-	C = IY & 0xff;
+	C = IY_L;
 	return(8);
 }
 
@@ -862,7 +862,7 @@ static int op_undoc_lddiyl(void)	/* LD D,IYL */
 		return(0);
 	}
 
-	D = IY & 0xff;
+	D = IY_L;
 	return(8);
 }
 
@@ -884,7 +884,7 @@ static int op_undoc_ldeiyl(void)	/* LD E,IYL */
 		return(0);
 	}
 
-	E = IY & 0xff;
+	E = IY_L;
 	return(8);
 }
 
@@ -1082,7 +1082,7 @@ static int op_undoc_inciyl(void)	/* INC IYL */
 		return(0);
 	}
 
-	P = IY & 0xff;
+	P = IY_L;
 	P++;
 	IY = (IY & 0xff00) | P;
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1122,7 +1122,7 @@ static int op_undoc_deciyl(void)	/* DEC IYL */
 		return(0);
 	}
 
-	P = IY & 0xff;
+	P = IY_L;
 	P--;
 	IY = (IY & 0xff00) | P;
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -646,7 +646,7 @@ static int op_addys(void)		/* ADD IY,SP */
 	BYTE iyl = IY & 0xff;
 	BYTE iyh = IY >> 8;
 	BYTE spl = SP & 0xff;
-	BYTE sph = SP >> 8;
+	BYTE sph = SP_H;
 	
 	carry = (iyl + spl > 255) ? 1 : 0;
 	iyl += spl;

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -402,7 +402,7 @@ static int op_popiy(void)		/* POP IY */
 
 static int op_pusiy(void)		/* PUSH IY */
 {
-	memwrt(--SP, IY >> 8);
+	memwrt(--SP, IY_H);
 	memwrt(--SP, IY);
 	return(15);
 }
@@ -419,7 +419,7 @@ static int op_exspy(void)		/* EX (SP),IY */
 
 	i = memrdr(SP) + (memrdr(SP + 1) << 8);
 	memwrt(SP, IY);
-	memwrt(SP + 1, IY >> 8);
+	memwrt(SP + 1, IY_H);
 	IY = i;
 	return(23);
 }
@@ -455,7 +455,7 @@ static int op_ldiny(void)		/* LD (nn),IY */
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
 	memwrt(i, IY);
-	memwrt(i + 1, IY >> 8);
+	memwrt(i + 1, IY_H);
 	return(20);
 }
 
@@ -610,7 +610,7 @@ static int op_addyb(void)		/* ADD IY,BC */
 {
 	register int carry;
 	BYTE iyl = IY & 0xff;
-	BYTE iyh = IY >> 8;
+	BYTE iyh = IY_H;
 	
 	carry = (iyl + C > 255) ? 1 : 0;
 	iyl += C;
@@ -627,7 +627,7 @@ static int op_addyd(void)		/* ADD IY,DE */
 {
 	register int carry;
 	BYTE iyl = IY & 0xff;
-	BYTE iyh = IY >> 8;
+	BYTE iyh = IY_H;
 	
 	carry = (iyl + E > 255) ? 1 : 0;
 	iyl += E;
@@ -644,7 +644,7 @@ static int op_addys(void)		/* ADD IY,SP */
 {
 	register int carry;
 	BYTE iyl = IY & 0xff;
-	BYTE iyh = IY >> 8;
+	BYTE iyh = IY_H;
 	BYTE spl = SP_L;
 	BYTE sph = SP_H;
 	
@@ -663,7 +663,7 @@ static int op_addyy(void)		/* ADD IY,IY */
 {
 	register int carry;
 	BYTE iyl = IY & 0xff;
-	BYTE iyh = IY >> 8;
+	BYTE iyh = IY_H;
 	
 	carry = (iyl << 1 > 255) ? 1 : 0;
 	iyl <<= 1;
@@ -807,7 +807,7 @@ static int op_undoc_ldaiyh(void)	/* LD A,IYH */
 		return(0);
 	}
 
-	A = IY >> 8;
+	A = IY_H;
 	return(8);
 }
 
@@ -829,7 +829,7 @@ static int op_undoc_ldbiyh(void)	/* LD B,IYH */
 		return(0);
 	}
 
-	B = IY >> 8;
+	B = IY_H;
 	return(8);
 }
 
@@ -851,7 +851,7 @@ static int op_undoc_ldciyh(void)	/* LD C,IYH */
 		return(0);
 	}
 
-	C = IY >> 8;
+	C = IY_H;
 	return(8);
 }
 
@@ -873,7 +873,7 @@ static int op_undoc_lddiyh(void)	/* LD D,IYH */
 		return(0);
 	}
 
-	D = IY >> 8;
+	D = IY_H;
 	return(8);
 }
 
@@ -895,7 +895,7 @@ static int op_undoc_ldeiyh(void)	/* LD E,IYH */
 		return(0);
 	}
 
-	E = IY >> 8;
+	E = IY_H;
 	return(8);
 }
 
@@ -1016,7 +1016,7 @@ static int op_undoc_ldiyliyh(void)	/* LD IYL,IYH */
 		return(0);
 	}
 
-	IY = (IY & 0xff00) | (IY >> 8);
+	IY = (IY & 0xff00) | (IY_H);
 	return(8);
 }
 
@@ -1102,7 +1102,7 @@ static int op_undoc_inciyh(void)	/* INC IYH */
 		return(0);
 	}
 
-	P = IY >> 8;
+	P = IY_H;
 	P++;
 	IY = (IY & 0x00ff) | (P << 8);
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1142,7 +1142,7 @@ static int op_undoc_deciyh(void)	/* DEC IYH */
 		return(0);
 	}
 
-	P = IY >> 8;
+	P = IY_H;
 	P--;
 	IY = (IY & 0x00ff) | (P << 8);
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -55,6 +55,26 @@ extern BYTE	A, B, C, D, E, H, L, A_, B_, C_, D_, E_, H_, L_, I, IFF;
 extern WORD	PC, SP, IX, IY;
 extern int	F, F_;
 extern long	R;
+
+/* 
+ *  Macros for 16-bit psudeo registers BC, DE, HL 
+ *  and the H(igh) and L(ow) byte of true 16-bit registers PC, SP, IX, IY 
+ *  Note: these can only be used as right-hand operands in assignmets 
+ *        and wont' work as l-values in assignments 
+ */
+
+#define BC ((B << 8) + C)
+#define DE ((D << 8) + E)
+#define HL ((H << 8) + L)
+#define PC_H (PC >> 8)
+#define PC_L (PC)
+#define SP_H (SP >> 8)
+#define SP_L (SP & 0xff)
+#define IX_H (IX >> 8)
+#define IX_L (IX & 0xff)
+#define IY_H (IY >> 8)
+#define IY_L (IY & 0xff)
+
 extern BYTE	io_port, io_data;
 
 #ifdef BUS_8080


### PR DESCRIPTION
This makes no changes to the compiled code, and is at first only cosmetic.

But I will outline the purpose:
- makes the z80core code more "readable" 
  - by encapsulating the 8-bit <-> 16-bit "casting" for registers in a series of macros
- enables the 8080/Z80 register file to be simply implemented (using macros) as either 
  - global variables  - current implementation
  - a single global `struct` - an alternative implementation*
- will help me with the ESP32 port to avoid code divergence with the upstream Z80PACK

It is this second implementation (not included in this PR) that will help with the ESP32 port
- it makes the compiled z80core code more compact and faster
  - so less likely to move out of the ESP32 program cache
  - from my testing this makes the **imsaisim** up to 5% faster on the ESP32

If you are happy with this PR and accept it into the dev branch, I will then follow up with a second PR that lets you see and simply switch between the two (2) register file implementations with a simple `#define HAS_REG_STRUCT` statement in `sim.h`

There would be no obligation to accept the second PR into Z80PACK just because you have accepted this one. But you will at least see what I am doing in the ESP32 port.

*NOTE: there is a caveat with the `struct` based implementation
- it is dependent on knowing the "endianness" (big/little) of the target platform
- from my reading, you cannot determine this consistently across platforms and C compilers
- I know what it is for the ESP32 
- and a simple `#define LITTLE_ENADIAN` can be used to switch between the two (2) implementations
- but it is a complication you may prefer to avoid in Z80PACK
