### PR TITLE
update altairsim to new ram/rom config strategy

### DIFF
--- a/altairsim/boot
+++ b/altairsim/boot
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -f disks/drivea.dsk ]; then
-	./altairsim -x bootromt.hex $*
+	./altairsim -R $*
 else
 	echo "no boot disk in drive a:"
 fi

--- a/altairsim/conf/system.conf
+++ b/altairsim/conf/system.conf
@@ -52,58 +52,63 @@ vdm_scanlines		1
 # up to 6 ram/rom statements allowed
 # <><><><><><><><><><><><><><><><><><><><><><>
 
+[MEMORY 1]
 # Memory configuration for running CP/M:
 # 252 pages RAM, 4 pages ROM
 ram			0,252
-rom			252,4
+rom			252,4,bootromt.hex
 # Boot switch, start address of the boot ROM
 # If Tarbell boot ROM active don't use, flip CLR to cold start
 # If using MITS 88-DCDD with DBL set to ff00
-boot			fe00
+boot		0xfe00
 
+[MEMORY 2]
 # Minimal memory configuration for 4K BASIC:
 # 16 pages RAM, no ROM
-#ram			0,16
+ram			0,16
 # Boot switch at BASIC warm start
-#boot			0
+boot		0
 
+[MEMORY 3]
 # Home computer with 48KB RAM and 16KB BASIC ROM:
-#ram			0,192
-#rom			192,64
+ram			0,192
+rom			192,64,basicex41-rom.hex
 # Boot switch at BASIC ROM cold start
-#boot			c000
+boot		0xc000
 
+[MEMORY 4]
 # Configuration for Apple, 2K ROM followed by RAM:
-#ram			0,240
-#rom			240,8
-#ram			248,8
+ram			0,240
+rom			240,8,apple.hex
+ram			248,8
 # Boot switch, start address of Apple ROM
-#boot			f000
+boot		0xf000
 
+[MEMORY 5]
 # Configuration for Zapple, 4K ROM:
-#ram			0,240
-#rom			240,16
+ram			0,240
+rom			240,16,zapple.hex
 # Boot switch, start address of Zapple ROM
-#boot			f000
+boot		0xf000
 
+[MEMORY 6]
 # Configuration for memon/80, 2K ROM:
-#ram			0,248
-#rom			248,8
+ram			0,248
+rom			248,8,memon80.hex
 # Boot switch, start address of the memon/80 ROM
-#boot			f800
+boot		0xf800
 
+[MEMORY 7]
 # Configuration for CUTER, 2K ROM followed by RAM for ALS-8 etc.:
-#ram			0,192
-#rom			192,8
-#ram			200,56
+ram			0,192
+rom			192,8,cuter-mits.hex
+ram			200,56
 # Boot switch, start of CUTER ROM
-#boot			c000
+boot		0xc000
 
+[MEMORY 8]
 # Configuration for ALS-8 ROM
-#ram			0,224
-#rom			224,32
+ram			0,224
+rom			224,32,als8-rom.hex
 # Boot switch, warm start of ALS-8 ROM
-#boot			e060
-
-# enable/disable Tarbell bootstrap ROM
-tarbell_rom_enabled	1
+boot		0xe060

--- a/altairsim/cpm22
+++ b/altairsim/cpm22
@@ -3,4 +3,4 @@
 rm -f disks/drivea.dsk
 ln disks/library/cpm22.dsk disks/drivea.dsk
 
-./altairsim -x bootromt.hex $*
+./altairsim -R $*

--- a/altairsim/srcsim/config.h
+++ b/altairsim/srcsim/config.h
@@ -33,6 +33,5 @@
 
 extern void config(void);
 
-extern int  boot_switch;
 extern int  fp_size;
 extern BYTE fp_port;

--- a/altairsim/srcsim/memory.c
+++ b/altairsim/srcsim/memory.c
@@ -15,18 +15,33 @@
  * 21-AUG-2018 improved memory configuration
  */
 
+#include <unistd.h>
+#include <stdlib.h>
 #include <string.h>
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
 #include "../../frontpanel/frontpanel.h"
 #include "memory.h"
+/* #define LOG_LOCAL_LEVEL LOG_DEBUG */
+#include "log.h"
+
+static const char *TAG = "memory";
+
+extern int load_file(char *, BYTE, BYTE);
+
+struct memmap memconf[MAXMEMSECT][MAXMEMMAP] 	/* memory map */
+	= { { { MEM_RW, 0, 0x100, NULL } } };		/* default config to 64K RAM only */
+WORD _boot_switch[MAXMEMSECT];					/* boot address for switch */
+
+extern int  boot_switch;		/* boot address for switch */
 
 /* 64KB non banked memory */
 BYTE memory[65536];
 
+#define MAXPAGES 256
 /* page table with memory configuration/state */
-int p_tab[256];		/* 256 pages a 256 bytes */
+int p_tab[MAXPAGES];		/* 256 pages a 256 bytes */
 
 /* memory write protected flag */
 BYTE mem_wp;
@@ -35,30 +50,67 @@ void init_memory(void)
 {
 	register int i, j;
 
+	if (!memconf[M_flag][0].size) {
+		LOGW(TAG, "The [MEMORY %d] section appears missing or empty, setting memory map to default", M_flag + 1);
+		M_flag = 0;
+	}
+
 	/* initialise memory page table, no memory available */
-	for (i = 0; i < 256; i++)
+	for (i = 0; i < MAXPAGES; i++)
 		p_tab[i] = MEM_NONE;
 
 	/* set memory configuration from system.conf */
-	for (i = 0; i < MAXSEG; i++) {
-		if (memconf[i].type != -1) {
-			for (j = memconf[i].spage;
-			     j < memconf[i].spage + memconf[i].size; j++)
-				p_tab[j] = memconf[i].type;
+	for (i = 0; i < MAXMEMMAP; i++) {
+		if (memconf[M_flag][i].size) {
+
+			for (j = 0; j < memconf[M_flag][i].size; j++)
+				p_tab[memconf[M_flag][i].spage + j] = memconf[M_flag][i].type;
+
+			switch (memconf[M_flag][i].type) {
+				case MEM_RW:
+					/* fill memory content with some initial value */
+					for (int j = memconf[M_flag][i].spage << 8; j < (memconf[M_flag][i].spage + memconf[M_flag][i].size) << 8; j++) {
+						if (m_flag >= 0) {
+							memory[j] = m_flag;
+						} else {
+							memory[j] = (BYTE) (rand() % 256);
+						}
+					}
+
+					LOG(TAG, "RAM %04XH - %04XH\r\n",
+				    memconf[M_flag][i].spage << 8, 
+					(memconf[M_flag][i].spage << 8) + (memconf[M_flag][i].size << 8) - 1);
+
+					break;
+				case MEM_RO:
+
+					/* fill the ROM's with 0xff in case no firmware loaded */
+					for (int j = memconf[M_flag][i].spage; j < (memconf[M_flag][i].spage + memconf[M_flag][i].size); j++) {
+						memset(&memory[j << 8], 0xff, 256);
+					}
+
+					LOG(TAG, "ROM %04XH - %04XH %s\r\n\r\n",
+				    memconf[M_flag][i].spage << 8, 
+					((memconf[M_flag][i].spage + memconf[M_flag][i].size) << 8) - 1,
+					memconf[M_flag][i].rom_file?memconf[M_flag][i].rom_file:"");
+
+					/* load firmware into ROM if specified */
+					if (memconf[M_flag][i].rom_file) load_file(memconf[M_flag][i].rom_file, memconf[M_flag][i].spage, memconf[M_flag][i].size);
+
+					break;
+			}
 		}
 	}
-}
 
-/*
- * fill the ROM's with 0xff in case no firmware loaded
- */
-void init_rom(void)
-{
-	register int i;
-
-	for (i = 0; i < 256; i++) {
-		if (p_tab[i] == MEM_RO) {
-			memset(&memory[i << 8], 0xff, 256);
-		}
+	if (_boot_switch[M_flag]) {
+		LOG(TAG, "Boot switch address at %04XH\r\n", _boot_switch[M_flag]);
+		boot_switch = _boot_switch[M_flag];
 	}
+
+	tarbell_rom_enabled = R_flag;
+	LOG(TAG, "Tarbell bootstrap ROM %s\r\n",
+		(tarbell_rom_enabled) ?
+		"enabled" : "disabled");
+
+	LOG(TAG, "\r\n");
 }

--- a/altairsim/srcsim/memory.h
+++ b/altairsim/srcsim/memory.h
@@ -17,7 +17,11 @@
  * 31-JUL-2021 allow building machine without frontpanel
  */
 
-extern void init_memory(void), init_rom(void);
+#ifdef FRONTPANEL
+#include "../../frontpanel/frontpanel.h"
+#endif
+
+extern void init_memory(void);
 extern int wait_step(void);
 extern void wait_int_step(void);
 extern BYTE memory[], mem_wp;
@@ -31,17 +35,20 @@ extern int tarbell_rom_enabled, tarbell_rom_active;
 #define MEM_NONE	3	/* no memory available */
 
 /*
- * configuration for MAXSEG memory segments
+ * configuration for memory map(s)
  */
-#define MAXSEG	6
+#define MAXMEMMAP	6
+#define MAXMEMSECT	15
 
 struct memmap {
 	int type;	/* type of memory pages */
 	BYTE spage;	/* start page of segment */
-	BYTE size;	/* size of segment in pages */
+	WORD size;	/* size of segment in pages */
+	char *rom_file;
 };
 
-extern struct memmap memconf[MAXSEG];
+extern struct memmap memconf[MAXMEMSECT][MAXMEMMAP];
+extern WORD _boot_switch[MAXMEMSECT];					/* boot address for switch */
 
 /*
  * memory access for the CPU cores

--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -40,6 +40,7 @@
 #define HAS_DAZZLER	/* has simulated I/O for Cromemco Dazzler */
 #define HAS_DISKS	/* uses disk images */
 #define HAS_CONFIG	/* has configuration files somewhere */
+#define HAS_BANKED_ROM	/* emulates tarbell banked bootstrap ROM */
 
 #define NUMNSOC 0	/* number of TCP/IP sockets for SIO connections */
 #define NUMUSOC 2	/* number of UNIX sockets for SIO connections */

--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -53,6 +53,7 @@ extern void reset_cpu(void), reset_io(void);
 static const char *TAG = "system";
 
 #ifdef FRONTPANEL
+int  boot_switch;		/* boot address for switch */
 static BYTE fp_led_wait;
 static int cpu_switch;
 static int reset;


### PR DESCRIPTION
I have updated the **altiarsim** to use the same changes to the  `system.conf` ram/rom configuration strategy.

Note:
- the `tarbell_rom_enabled` directive has been removed from `system.conf` and replaced with the `-R` command line flag
- I used educated guesses for the correct ROM files (*.hex) for each `[MEMORY n]` section in `system.conf`
- this is not tested very much as I am unfamiliar with the **altairsim** and don't know what to expect
- only the start scripts `boot` and `cpm22` have been updated so far, the remainder need to be updated


