### PR TITLE
Dev

### DIFF
--- a/altairsim/srcsim/memory.h
+++ b/altairsim/srcsim/memory.h
@@ -173,11 +173,3 @@ static inline BYTE fp_read(WORD addr)
 	else
 		return(0xff);
 }
-
-/*
- * return memory base pointer for the simulation frame
- */
-static inline BYTE *mem_base(void)
-{
-	return(&memory[0]);
-}

--- a/cpmsim/srcsim/memory.c
+++ b/cpmsim/srcsim/memory.c
@@ -45,6 +45,8 @@ int wp_common;			/* write protect/unprotect common segment */
 
 void init_memory(void)
 {
+	register int i;
+
 	/* allocate the first 64KB bank, so that we have some memory */
 	if ((memory[0] = malloc(65536)) == NULL) {
 		LOGE(TAG, "can't allocate memory for bank 0");
@@ -53,8 +55,14 @@ void init_memory(void)
 		return;
 	}
 	maxbnk = 1;
-}
+	selbnk = 0;
 
-void init_rom(void)
-{
+	/* fill memory content of bank 0 with some initial value */
+	if (m_flag >= 0) {
+		for (i = 0; i < 65536; i++)
+			putmem(i, m_flag);
+	} else {
+		for (i = 0; i < 65536; i++)
+			putmem(i, (BYTE) (rand() % 256));
+	}
 }

--- a/cpmsim/srcsim/memory.h
+++ b/cpmsim/srcsim/memory.h
@@ -129,6 +129,9 @@ static inline BYTE getmem(WORD addr)
 
 /*
  * return memory base pointer for the simulation frame
+ *
+ * iosim.c still has a dependency on this
+ * 
  */
 static inline BYTE *mem_base(void)
 {

--- a/cpmsim/srcsim/memory.h
+++ b/cpmsim/srcsim/memory.h
@@ -32,7 +32,7 @@
 #define MAXSEG 16		/* max. number of memory banks */
 #define SEGSIZ 49152		/* default size of one bank = 48 KBytes */
 
-extern void init_memory(void), init_rom(void);
+extern void init_memory(void);
 
 extern BYTE *memory[];
 extern int selbnk, maxbnk, segsize, wp_common;

--- a/cromemcosim/srcsim/memory.h
+++ b/cromemcosim/srcsim/memory.h
@@ -45,7 +45,7 @@ struct memmap {
 extern struct memmap memconf[MAXMEMSECT][MAXMEMMAP];
 extern WORD _boot_switch[MAXMEMSECT];	/* boot address */
 
-extern void init_memory(void), init_rom(void);
+extern void init_memory(void);
 extern int wait_step(void);
 extern void wait_int_step(void);
 

--- a/imsaisim/srcsim/memory.h
+++ b/imsaisim/srcsim/memory.h
@@ -26,7 +26,7 @@
 #include "../../frontpanel/frontpanel.h"
 #endif
 
-extern void init_memory(void), reset_memory(void), init_rom(void);
+extern void init_memory(void), reset_memory(void);
 extern void groupswap(void);
 extern int wait_step(void);
 extern void wait_int_step(void);

--- a/imsaisim/srcsim/memory.h
+++ b/imsaisim/srcsim/memory.h
@@ -235,11 +235,3 @@ static inline void fp_write(WORD addr, BYTE data)
 		 *(banks[selbnk] + addr) = data;
 	}
 }
-
-/*
- * return memory base pointer for the simulation frame
- */
-static inline BYTE *mem_base(void)
-{
-	return(&memory[0]);
-}

--- a/mosteksim/srcsim/memory.c
+++ b/mosteksim/srcsim/memory.c
@@ -11,15 +11,24 @@
  *		computers by treating 0xe000-0xefff as ROM.
  */
 
+#include <stdlib.h>
 #include "sim.h"
+#include "simglb.h"
+#include "memory.h"
 
 /* 64KB non banked memory */
 BYTE memory[65536];		/* 64KB RAM */
 
 void init_memory(void)
 {
-}
+    register int i;
 
-void init_rom(void)
-{
+    /* fill memory content with some initial value */
+	if (m_flag >= 0) {
+		for (i = 0; i < 65536; i++)
+			putmem(i, m_flag);
+	} else {
+		for (i = 0; i < 65536; i++)
+			putmem(i, (BYTE) (rand() % 256));
+	}
 }

--- a/mosteksim/srcsim/memory.h
+++ b/mosteksim/srcsim/memory.h
@@ -12,7 +12,7 @@
  * 04-NOV-19 (Udo Munk) add functions for direct memory access
  */
 
-extern void init_memory(void), init_rom(void);
+extern void init_memory(void);
 extern BYTE memory[];
 
 /*

--- a/mosteksim/srcsim/memory.h
+++ b/mosteksim/srcsim/memory.h
@@ -58,5 +58,8 @@ static inline BYTE getmem(WORD addr)
 
 /*
  * return memory base pointer for the simulation frame
+ *
+ * simctl.c still has a dependency on this
+ * 
  */
 #define mem_base() (&memory[0])

--- a/z80sim/srcsim/memory.c
+++ b/z80sim/srcsim/memory.c
@@ -11,15 +11,24 @@
  * 15-AUG-17 don't use macros, use inline functions that coerce appropriate
  */
 
+#include <stdlib.h>
 #include "sim.h"
+#include "simglb.h"
+#include "memory.h"
 
 /* 64KB non banked memory */
 BYTE memory[65536];		/* 64KB RAM */
 
 void init_memory(void)
 {
-}
-
-void init_rom(void)
-{
+    register int i;
+    
+    /* fill memory content with some initial value */
+	if (m_flag >= 0) {
+		for (i = 0; i < 65536; i++)
+			putmem(i, m_flag);
+	} else {
+		for (i = 0; i < 65536; i++)
+			putmem(i, (BYTE) (rand() % 256));
+	}
 }

--- a/z80sim/srcsim/memory.h
+++ b/z80sim/srcsim/memory.h
@@ -12,7 +12,7 @@
  * 04-NOV-19 add functions for direct memory access
  */
 
-extern void init_memory(void), init_rom(void);
+extern void init_memory(void);
 extern BYTE memory[];
 
 /*

--- a/z80sim/srcsim/memory.h
+++ b/z80sim/srcsim/memory.h
@@ -56,5 +56,8 @@ static inline BYTE getmem(WORD addr)
 
 /*
  * return memory base pointer for the simulation frame
+ *
+ * simctl.c still has a dependency on this
+ * 
  */
 #define mem_base() (&memory[0])


### PR DESCRIPTION
Cleanup to complete memory changes:
- remove `mem_base()` where possible, comment if not yet possible
- remove `init_rom()`
- make sure `init_memory()` fills memory (or at least Bank 0) with values according to `-m` flag
  - this was removed from `sim0.c` early in this round of changes and needed to be reintroduced into `memory.c` for
    - cpmsim
    - mosteksim
    - z80sim