### PR TITLE
fix - use EQUates for OUT instructions

### DIFF
--- a/cromemcosim/dzmation.asm
+++ b/cromemcosim/dzmation.asm
@@ -748,7 +748,7 @@ CHAROUT:
         ANI     STATTXOK        ; READY BIT
         JZ      CHAROUT         ; LOOP UNTIL PORT IS READY
         MOV     A,M             ; GET THE CHARACTER
-        OUT     01H
+        OUT     DATAPORT
         RET
 
 ; <AT SIGN> (OR <SHIFT-P> ON A TELETYPE) FUNCTION ENTRY POINT (PUNCH ANIMATION)
@@ -800,7 +800,7 @@ CPWAIT:
         ANI     STATTXOK        ; READY BIT
         JZ      CPWAIT
         MOV     A,M
-        OUT     01H
+        OUT     DATAPORT
         INX     H
         JMP     CPWAIT
 


### PR DESCRIPTION
I was getting frustrated that I could not punch a tape from dazzlemation even after setting the EQUates for DATAPORT and STATPORT for the IMSAI SIO

It took me a long time to realise that the OUT instructions still had port 01H hardcoded and were not using the EQUates