### PR TITLE
fix error causing load hex file error

### DIFF
--- a/z80sim/srcsim/simctl.c
+++ b/z80sim/srcsim/simctl.c
@@ -72,7 +72,7 @@ extern void disass(int, unsigned char **, int, unsigned char *);
 extern int exatoi(char *);
 extern int getkey(void);
 extern void int_on(void), int_off(void);
-extern int load_file(char *);
+extern int load_file(char *, BYTE pstart, WORD psize);
 
 static void do_step(void);
 static void do_trace(char *);
@@ -172,7 +172,7 @@ void mon(void)
 			do_help();
 			break;
 		case 'r':
-			load_file(cmd + 1);
+			load_file(cmd + 1, 0, 0);
 			break;
 		case '!':
 			do_unix(cmd + 1);


### PR DESCRIPTION
this should fix an error i encountered in z80sim which causes problems when loading hex files

```
Release 1.38-dev, Copyright (C) 1987-2021 by Udo Munk

CPU speed is unlimited, CPU executes undocumented instructions
>>> r float.hex
W (0) func: tried to load hex record outside expected address range. Address: 0000-0020
>>>

```

commit 93c56c1a8e82baceea041ac416b4165f138c49c1 changed the function prototype for `load_file()` but the externs in z80sim never got modified.