### PR TITLE
Bus req

### DIFF
--- a/iodevices/cromemco-wdi.c
+++ b/iodevices/cromemco-wdi.c
@@ -160,9 +160,9 @@ static struct {
         BYTE state0;
         BYTE state1;
         BYTE state2;
-        unsigned long long T0;
-        unsigned long long T1;
-        unsigned long long T2;
+        Tstates_t T0;
+        Tstates_t T1;
+        Tstates_t T2;
     } ctc;
     struct {
         BYTE sector;
@@ -534,7 +534,7 @@ BYTE cromemco_wdi_ctc0_in(void)
 }
 BYTE cromemco_wdi_ctc1_in(void)
 {
-    unsigned long long Tdiff = T - wdi.ctc.T1;
+    Tstates_t Tdiff = T - wdi.ctc.T1;
     unsigned int sectors = (Tdiff * WMI_SECTORS + INDEX_INT / 10) / INDEX_INT; /* -10% on sector time */
 
 	LOGD(TAG, "IN: CTC #1 = %02x - Tdiff=%lld = %d sectors", wdi.ctc.now1, T - wdi.ctc.T1, sectors);

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -440,6 +440,34 @@ void cpu_z80(void)
 		}
 #endif
 
+		/* CPU DMA bus request handling */
+		if (bus_mode) {
+
+			if (!bus_request && (bus_mode != BUS_DMA_CONTINUOUS)) {
+				if (dma_bus_master) {
+					T += (*dma_bus_master)(0); /* hand control to the DMA bus master without BUS_ACK */
+				}
+			}
+
+			if (bus_request) {		/* dma bus request */
+	#ifdef FRONTPANEL
+				fp_clock += 1000;
+				fp_sampleData();
+	#endif
+				if (dma_bus_master) {
+					T += (*dma_bus_master)(1); /* hand control to the DMA bus master with BUS_ACK */
+				}
+				bus_request = 0; // FOR NOW - MAY BE NEED A PRIORITY SYSTEM LATER
+				if (bus_mode == BUS_DMA_CONTINUOUS)	{
+					end_bus_request();
+				}
+	#ifdef FRONTPANEL
+				fp_clock += 1000;
+				fp_sampleData();
+	#endif
+			}
+		}
+
 		/* CPU interrupt handling */
 		if (int_nmi) {		/* non maskable interrupt */
 			IFF <<= 1 & 3;

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -450,6 +450,34 @@ void cpu_8080(void)
 		}
 #endif
 
+		/* CPU DMA bus request handling */
+		if (bus_mode) {
+
+			if (!bus_request && (bus_mode != BUS_DMA_CONTINUOUS)) {
+				if (dma_bus_master) {
+					T += (*dma_bus_master)(0); /* hand control to the DMA bus master without BUS_ACK */
+				}
+			}
+
+			if (bus_request) {		/* dma bus request */
+	#ifdef FRONTPANEL
+				fp_clock += 1000;
+				fp_sampleData();
+	#endif
+				if (dma_bus_master) {
+					T += (*dma_bus_master)(1); /* hand control to the DMA bus master with BUS_ACK */
+				}
+				bus_request = 0; // FOR NOW - MAY BE NEED A PRIORITY SYSTEM LATER
+				if (bus_mode == BUS_DMA_CONTINUOUS)	{
+					end_bus_request();
+				}
+	#ifdef FRONTPANEL
+				fp_clock += 1000;
+				fp_sampleData();
+	#endif
+			}
+		}
+
 		/* CPU interrupt handling */
 		if (int_int) {
 			if (IFF != 3)

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -379,3 +379,23 @@ static int checksum(char *s)
 	else
 		return(1);
 }
+
+/*
+ *	Start a bus request cycle
+ */
+void start_bus_request(BusDMA_t mode, Tstates_t (*bus_master)(BYTE bus_ack)) {
+
+	bus_mode = mode;
+	dma_bus_master = bus_master;
+	bus_request = 1;
+} 
+
+/*
+ *	End a bus request cycle
+ */
+void end_bus_request(void) {
+
+	bus_mode = BUS_DMA_NONE;
+	dma_bus_master = NULL;
+	bus_request = 0;
+} 

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -52,6 +52,7 @@
 
 #include <stddef.h>
 #include "sim.h"
+#include "simglb.h"
 
 #define MAXCHAN 5	/* max number of channels for I/O busy detect */
 
@@ -76,7 +77,7 @@ long R;				/* Z80 refresh register */
 				/* is normally a 8 bit register */
 				/* the larger bits are used to measure the */
 				/* clock frequency */
-unsigned long long T;		/* CPU clock */
+Tstates_t T;			/* CPU clock */
 
 #ifdef BUS_8080
 BYTE cpu_bus;			/* CPU bus status, for frontpanels */

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -96,6 +96,8 @@ int int_int;			/* interrupt request */
 int int_data = -1;		/* data from interrupting device on data bus */
 int int_protection;		/* to delay interrupts after EI */
 BYTE bus_request;		/* request address/data bus from CPU */
+BusDMA_t bus_mode;		/* current bus mode dor dma */
+Tstates_t (*dma_bus_master)(BYTE bus_ack); /* call back function for DMA bus master */
 int tmax;			/* max t-states to execute in 10ms */
 int cpu_needed;			/* don't adjust CPU freq if needed */
 

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -51,6 +51,10 @@
  */
 
 typedef unsigned long long Tstates_t;	/* 64 bit unsigned for counting T-states */
+typedef enum { BUS_DMA_NONE, BUS_DMA_BYTE, BUS_DMA_BURST, BUS_DMA_CONTINUOUS } BusDMA_t;
+
+void start_bus_request(BusDMA_t mode, Tstates_t (*bus_master)(BYTE bus_ack));
+void end_bus_request(void);
 
 extern int	cpu;
 
@@ -58,7 +62,7 @@ extern BYTE	A, B, C, D, E, H, L, A_, B_, C_, D_, E_, H_, L_, I, IFF;
 extern WORD	PC, SP, IX, IY;
 extern int	F, F_;
 extern long	R;
-extern Tstates_t  T;
+extern Tstates_t T;
 extern BYTE	io_port, io_data;
 
 #ifdef BUS_8080
@@ -67,6 +71,8 @@ extern int	m1_step;
 #endif
 
 extern BYTE	cpu_state, bus_request;
+extern BusDMA_t bus_mode;
+extern Tstates_t (*dma_bus_master)(BYTE bus_ack);
 extern int	int_data;
 
 extern int	s_flag, l_flag, m_flag, x_flag, break_flag, i_flag, f_flag,

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -50,13 +50,15 @@
  *	Declaration of variables in simglb.c
  */
 
+typedef unsigned long long Tstates_t;	/* 64 bit unsigned for counting T-states */
+
 extern int	cpu;
 
 extern BYTE	A, B, C, D, E, H, L, A_, B_, C_, D_, E_, H_, L_, I, IFF;
 extern WORD	PC, SP, IX, IY;
 extern int	F, F_;
 extern long	R;
-extern unsigned long long  T;
+extern Tstates_t  T;
 extern BYTE	io_port, io_data;
 
 #ifdef BUS_8080


### PR DESCRIPTION
As per issue #123 

Also note:
- The WDI-II controller only uses CONTINUOUS mode DMA `BUS_DMA_CONTINUOUS`
- So I have not yet tested the operation of `BUS_DMA_BYTE` and `BUS_DMA_BURST` modes
- These are included for completeness, but they could be removed with a resulting simplification to the code

On a PC operating system (macOS, etc...) it is probably easier to see the HOLD light by running the simulation at a slower speed eg. `-f4`