### PR TITLE
z80core: more correct handling of refresh register

### DIFF
--- a/z80core/sim0.c
+++ b/z80core/sim0.c
@@ -473,7 +473,7 @@ void reset_cpu(void)
 
 	if (cpu == Z80) {
 		I = 0;
-		R = 0L;
+		R_ = R = 0L;
 	}
 }
 
@@ -510,6 +510,7 @@ static void save_core(void)
 	write(fd, (char *) &I, sizeof(I));
 	write(fd, (char *) &IFF, sizeof(IFF));
 	write(fd, (char *) &R, sizeof(R));
+	write(fd, (char *) &R_, sizeof(R_));
 	write(fd, (char *) &PC, sizeof(PC));
 	write(fd, (char *) &SP, sizeof(SP));
 	write(fd, (char *) &IX, sizeof(IX));
@@ -556,6 +557,7 @@ int load_core(void)
 	read(fd, (char *) &I, sizeof(I));
 	read(fd, (char *) &IFF, sizeof(IFF));
 	read(fd, (char *) &R, sizeof(R));
+	read(fd, (char *) &R_, sizeof(R_));
 	read(fd, (char *) &PC, sizeof(PC));
 	read(fd, (char *) &SP, sizeof(SP));
 	read(fd, (char *) &IX, sizeof(IX));

--- a/z80core/sim2.c
+++ b/z80core/sim2.c
@@ -415,7 +415,9 @@ int op_cb_handel(void)
 	fp_sampleLightGroup(0, 0);
 #endif
 
-	t = (*op_cb[memrdr(PC++)]) ();		/* execute next opcode */
+	t = (*op_cb[memrdr(PC++)]) ();	/* execute next opcode */
+
+	R++;				/* increment refresh register */
 
 	return(t);
 }

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -385,6 +385,8 @@ int op_dd_handel(void)
 
 	t = (*op_dd[memrdr(PC++)]) ();	/* execute next opcode */
 
+	R++;				/* increment refresh register */
+
 	return(t);
 }
 
@@ -398,6 +400,7 @@ static int trap_dd(void)
 	if (!u_flag) {
 		/* Treat 0xdd prefix as NOP on non IX-instructions */
 		PC--;
+		R--;
 		return(4);
 	}
 #endif

--- a/z80core/sim4.c
+++ b/z80core/sim4.c
@@ -367,6 +367,8 @@ int op_ed_handel(void)
 
 	t = (*op_ed[memrdr(PC++)]) ();	/* execute next opcode */
 
+	R++;				/* increment refresh register */
+
 	return(t);
 }
 
@@ -597,11 +599,13 @@ static int op_inir(void)		/* INIR */
 	register int t = -21;
 
 	addr = (H << 8) + L;
+	R -= 2;
 	do {
 		data = io_in(C, B);
 		memwrt(addr++, data);
 		B--;
 		t += 21;
+		R += 2;
 	} while (B);
 	H = addr >> 8;
 	L = addr;
@@ -633,11 +637,13 @@ static int op_indr(void)		/* INDR */
 	register int t = -21;
 
 	addr = (H << 8) + L;
+	R -= 2;
 	do {
 		data = io_in(C, B);
 		memwrt(addr--, data);
 		B--;
 		t += 21;
+		R += 2;
 	} while (B);
 	H = addr >> 8;
 	L = addr;
@@ -669,11 +675,13 @@ static int op_otir(void)		/* OTIR */
 	register int t = -21;
 
 	addr = (H << 8) + L;
+	R -= 2;
 	do {
 		data = memrdr(addr++);
 		io_out(C, B, data);
 		B--;
 		t += 21;
+		R += 2;
 	} while (B);
 	H = addr >> 8;
 	L = addr;
@@ -705,11 +713,13 @@ static int op_otdr(void)		/* OTDR */
 	register int t = -21;
 
 	addr = (H << 8) + L;
+	R -= 2;
 	do {
 		data = memrdr(addr--);
 		io_out(C, B, data);
 		B--;
 		t += 21;
+		R += 2;
 	} while (B);
 	H = addr >> 8;
 	L = addr;
@@ -729,7 +739,7 @@ static int op_ldai(void)		/* LD A,I */
 
 static int op_ldar(void)		/* LD A,R */
 {
-	A = (BYTE) R;
+	A = ((BYTE) R & 0x7f) | (R_ & 0x80);
 	F &= ~(N_FLAG | H_FLAG);
 	(IFF & 2) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -745,7 +755,7 @@ static int op_ldia(void)		/* LD I,A */
 
 static int op_ldra(void)		/* LD R,A */
 {
-	R = A;
+	R_ = R = A;
 	return(9);
 }
 
@@ -1062,9 +1072,11 @@ static int op_ldir(void)		/* LDIR */
 	i = (B << 8) + C;
 	d = (D << 8) + E;
 	s = (H << 8) + L;
+	R -= 2;
 	do {
 		memwrt(d++, memrdr(s++));
 		t += 21;
+		R += 2;
 	} while (--i);
 	B = C = 0;
 	D = d >> 8;
@@ -1116,9 +1128,11 @@ static int op_lddr(void)		/* LDDR */
 	i = (B << 8) + C;
 	d = (D << 8) + E;
 	s = (H << 8) + L;
+	R -= 2;
 	do {
 		memwrt(d--, memrdr(s--));
 		t += 21;
+		R += 2;
 	} while (--i);
 	B = C = 0;
 	D = d >> 8;
@@ -1173,11 +1187,13 @@ static int op_cpir(void)		/* CPIR */
 
 	i = (B << 8) + C;
 	s = (H << 8) + L;
+	R -= 2;
 	do {
 		tmp = memrdr(s++);
 		((tmp & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 		d = A - tmp;
 		t += 21;
+		R += 2;
 	} while (--i && d);
 	F |= N_FLAG;
 	B = i >> 8;
@@ -1220,11 +1236,13 @@ static int op_cpdr(void)		/* CPDR */
 
 	i = (B << 8) + C;
 	s = (H << 8) + L;
+	R -= 2;
 	do {
 		tmp = memrdr(s--);
 		((tmp & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 		d = A - tmp;
 		t += 21;
+		R += 2;
 	} while (--i && d);
 	F |= N_FLAG;
 	B = i >> 8;

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -385,6 +385,8 @@ int op_fd_handel(void)
 
 	t = (*op_fd[memrdr(PC++)]) ();	/* execute next opcode */
 
+	R++;				/* increment refresh register */
+
 	return(t);
 }
 
@@ -398,6 +400,7 @@ static int trap_fd(void)
 	if (!u_flag) {
 		/* Treat 0xfd prefix as NOP on non IY-instructions */
 		PC--;
+		R--;
 		return(4);
 	}
 #endif

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -77,6 +77,7 @@ long R;				/* Z80 refresh register */
 				/* is normally a 8 bit register */
 				/* the larger bits are used to measure the */
 				/* clock frequency */
+BYTE R_;			/* copy of low byte of R for keeping the 7th bit */
 Tstates_t T;			/* CPU clock */
 
 #ifdef BUS_8080

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -58,7 +58,7 @@ void end_bus_request(void);
 
 extern int	cpu;
 
-extern BYTE	A, B, C, D, E, H, L, A_, B_, C_, D_, E_, H_, L_, I, IFF;
+extern BYTE	A, B, C, D, E, H, L, A_, B_, C_, D_, E_, H_, L_, I, IFF, R_;
 extern WORD	PC, SP, IX, IY;
 extern int	F, F_;
 extern long	R;


### PR DESCRIPTION
The 7th bit of R must not be modified between LD R,A and LD A,R, so keep a copy of it in new R_ CPU state variable.

Save/load R_ with with save_core()/load_core().
Old core.z80 files are incompatible.
These functions should probably be moved to memory.c and reimplemented to make them work with banked memory.

Increment R for each opcode fetch.
Not sure of what happens with 0x[df]d 0xcb. MAME and the FUSE emulator also doesn't increment R there.

Unrolled block instructions need to increment R by 2 in each loop.