### PR TITLE
z80core: add single step version for all block instructions, flags for i/o

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -31,7 +31,7 @@
  */
 #define CPU_SPEED 2	/* default CPU speed */
 #define Z80_UNDOC	/* compile undocumented Z80 instructions */
-/*#define WANT_FASTM*/	/* much faster but not accurate Z80 block moves */
+/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 /*#define WANT_TIM*/	/* don't count t-states */
 /*#define HISIZE  1000*//* no history */
 /*#define SBSIZE  10*/	/* no breakpoints */

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -51,7 +51,7 @@
  */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define Z80_UNDOC	/* compile undocumented Z80 instructions */
-#define WANT_FASTM	/* much faster but not accurate Z80 block moves */
+#define WANT_FASTB	/* much faster but not accurate Z80 block instr. */
 /*#define WANT_TIM*/	/* don't count t-states */
 /*#define HISIZE  1000*//* no history */
 /*#define SBSIZE  10*/	/* no breakpoints */

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -32,7 +32,7 @@
  */
 #define CPU_SPEED 4	/* default CPU speed */
 #define Z80_UNDOC	/* compile undocumented Z80 instructions */
-/*#define WANT_FASTM*/	/* much faster but not accurate Z80 block moves */
+/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 /*#define WANT_TIM*/	/* don't count t-states */
 /*#define HISIZE  1000*//* no history */
 /*#define SBSIZE  10*/	/* no breakpoints */

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -31,7 +31,7 @@
  */
 #define CPU_SPEED 2	/* default CPU speed */
 #define Z80_UNDOC	/* compile undocumented Z80 instructions */
-/*#define WANT_FASTM*/	/* much faster but not accurate Z80 block moves */
+/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 /*#define WANT_TIM*/	/* don't count t-states */
 /*#define HISIZE  1000*//* no history */
 /*#define SBSIZE  10*/	/* no breakpoints */

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -18,7 +18,7 @@
  */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define Z80_UNDOC	/* compile undocumented Z80 instructions */
-/*#define WANT_FASTM*/	/* much faster but not accurate Z80 block moves */
+/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define WANT_TIM	/* count t-states */
 #define HISIZE	100	/* number of entries in history */
 #define SBSIZE	4	/* number of software breakpoints */

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -834,7 +834,7 @@ static int op_in(void)			/* IN A,(n) */
 
 static int op_out(void)			/* OUT (n),A */
 {
-	BYTE io_out(BYTE, BYTE, BYTE);
+	void io_out(BYTE, BYTE, BYTE);
 	BYTE addr;
 
 	addr = memrdr(PC++);

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -759,7 +759,7 @@ static int op_in(void)			/* IN n */
 
 static int op_out(void)			/* OUT n */
 {
-	BYTE io_out(BYTE, BYTE, BYTE);
+	void io_out(BYTE, BYTE, BYTE);
 	BYTE addr;
 
 	addr = memrdr(PC++);

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -53,7 +53,7 @@
  */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define Z80_UNDOC	/* compile undocumented Z80 instructions */
-/*#define WANT_FASTM*/	/* much faster but not accurate Z80 block moves */
+/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define WANT_TIM	/* count t-states */
 #define HISIZE	100	/* number of entries in history */
 #define SBSIZE	4	/* number of software breakpoints */

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -54,7 +54,7 @@
  */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define Z80_UNDOC	/* compile undocumented Z80 instructions */
-#define WANT_FASTM	/* much faster but not accurate Z80 block moves */
+#define WANT_FASTB	/* much faster but not accurate Z80 block instr. */
 /*#define WANT_TIM*/	/* count t-states */
 /*#define HISIZE 100*/	/* number of entries in history */
 /*#define SBSIZE 4*/	/* number of software breakpoints */
@@ -86,7 +86,7 @@
  *	The following lines of this file should not be modified by user
  */
 #define COPYR	"Copyright (C) 1987-2021 by Udo Munk"
-#define RELEASE	"1.37"
+#define RELEASE	"1.38-dev"
 
 #define MAX_LFN		4096		/* maximum long file name length */
 #define LENCMD		80		/* length of command buffers etc */


### PR DESCRIPTION
1. Generalized looping support for all block instructions by changing WANT_FASTM to WANT_FASTB and adding missing single step versions. This is, for example, needed for the CPU test program from github.com/raxoft/z80test, which has a self-modifying LDIR/LDDR test (just realized that already hat single step versions...).
2. Changed io_out declarations from "BYTE" to "void", which it really is.
3. Changed standard flags settings for the I/O block instructions according to "The Undocumented Z80 Documented".
4. B is decremented before port output in OUT block instructions according to the Aug 2016 edition of the "Z80 CPU User Manual".
5. Overstepped my authority ;-) and changed VERSION in sim.h.fast, which was forgotten by the project creator.