### PR TITLE
z80asm/z80sim: added remaining undoc'd instructions to dis-/assembler & 8080 asm

### DIFF
--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -1,6 +1,6 @@
 Usage:
 
-z80asm -ofile -f[b|m|h] -l[file] -s[n|a] -e<num> -x -u -v -dsymbol ... file ...
+z80asm -ofile -f[b|m|h] -l[file] -s[n|a] -e<num> {-x} {-8} {-u} -v -dsymbol ... file ...
 
 A maximum of 512 source files is allowed. If the filename of a source
 doesn't have an extension the default extension ".asm" will be
@@ -46,8 +46,11 @@ Useful for CP/M BIOS's, where unallocated data doesn't need to be
 part of the system image, if the complete image won't fit on the system
 tracks.
 
+Option 8:
+Change default personality to 8080.
+
 Option u:
-Accept undocumented instructions.
+Accept undocumented Z80 instructions.
 
 Option v:
 Verbose operation of the assembler.

--- a/mosteksim/srcsim/simctl.c
+++ b/mosteksim/srcsim/simctl.c
@@ -108,7 +108,7 @@ void mon(void)
 			do_list(cmd + 1);
 			break;
 		case 'm':
-			do_modify(cmd +	1);
+			do_modify(cmd + 1);
 			break;
 		case 'f':
 			do_fill(cmd + 1);
@@ -199,7 +199,7 @@ static void do_trace(char *s)
 	cpu_error = NONE;
 	print_head();
 	print_reg();
-	for (i = 0; i <	count; i++) {
+	for (i = 0; i < count; i++) {
 		switch(cpu) {
 		case Z80:
 			cpu_z80();
@@ -269,7 +269,7 @@ static int handel_break(void)
 	register int i;
 	int break_address;
 
-	for (i = 0; i <	SBSIZE;	i++)	/* search for breakpoint */
+	for (i = 0; i < SBSIZE; i++)	/* search for breakpoint */
 		if (soft[i].sb_adr == PC - 1)
 			goto was_softbreak;
 	return(0);
@@ -317,12 +317,12 @@ static void do_dump(char *s)
 	if (isxdigit((int)*s))
 		wrk_ram = mem_base() + exatoi(s) - exatoi(s) % 16;
 	printf("Adr    ");
-	for (i = 0; i <	16; i++)
+	for (i = 0; i < 16; i++)
 		printf("%02x ", i);
 	puts(" ASCII");
-	for (i = 0; i <	16; i++) {
+	for (i = 0; i < 16; i++) {
 		printf("%04x - ", (unsigned int)(wrk_ram - mem_base()));
-		for (j = 0; j <	16; j++) {
+		for (j = 0; j < 16; j++) {
 			printf("%02x ", *wrk_ram);
 			wrk_ram++;
 			if (wrk_ram > mem_base() + 65535)
@@ -330,8 +330,8 @@ static void do_dump(char *s)
 		}
 		putchar('\t');
 		for (j = -16; j < 0; j++)
-			printf("%c", ((c = *(wrk_ram  + j)) >= ' ' && c <= 0x7f)
-			       ?  c : '.');
+			printf("%c", ((c = *(wrk_ram + j)) >= ' ' && c <= 0x7f)
+			       ? c : '.');
 		putchar('\n');
 	}
 }
@@ -347,7 +347,7 @@ static void do_list(char *s)
 		s++;
 	if (isxdigit((int)*s))
 		wrk_ram = mem_base() + exatoi(s);
-	for (i = 0; i <	10; i++) {
+	for (i = 0; i < 10; i++) {
 		printf("%04x - ", (unsigned int)(wrk_ram - mem_base()));
 		disass(&wrk_ram, wrk_ram - mem_base());
 		if (wrk_ram > mem_base() + 65535)
@@ -414,7 +414,7 @@ static void do_fill(char *s)
 	}
 	while (i--) {
 		*p++ = val;
-		if (p >	mem_base() + 65535)
+		if (p > mem_base() + 65535)
 			p = mem_base();
 	}
 }
@@ -447,7 +447,7 @@ static void do_move(char *s)
 		puts("count missing");
 		return;
 	}
-	while (count--)	{
+	while (count--) {
 		*p2++ = *p1++;
 		if (p1 > mem_base() + 65535)
 			p1 = mem_base();
@@ -483,7 +483,7 @@ static void do_reg(char *s)
 
 	while (isspace((int)*s))
 		s++;
-	if (*s == '\0')	{
+	if (*s == '\0') {
 		print_head();
 		print_reg();
 	} else {
@@ -509,86 +509,86 @@ static void do_reg(char *s)
 		} else if (strncmp(s, "bc", 2) == 0) {
 			printf("BC = %04x : ", B * 256 + C);
 			fgets(nv, sizeof(nv), stdin);
-			B = (exatoi(nv)	& 0xffff) / 256;
-			C = (exatoi(nv)	& 0xffff) % 256;
+			B = (exatoi(nv) & 0xffff) / 256;
+			C = (exatoi(nv) & 0xffff) % 256;
 		} else if (strncmp(s, "de", 2) == 0) {
 			printf("DE = %04x : ", D * 256 + E);
 			fgets(nv, sizeof(nv), stdin);
-			D = (exatoi(nv)	& 0xffff) / 256;
-			E = (exatoi(nv)	& 0xffff) % 256;
+			D = (exatoi(nv) & 0xffff) / 256;
+			E = (exatoi(nv) & 0xffff) % 256;
 		} else if (strncmp(s, "hl", 2) == 0) {
 			printf("HL = %04x : ", H * 256 + L);
 			fgets(nv, sizeof(nv), stdin);
-			H = (exatoi(nv)	& 0xffff) / 256;
-			L = (exatoi(nv)	& 0xffff) % 256;
+			H = (exatoi(nv) & 0xffff) / 256;
+			L = (exatoi(nv) & 0xffff) % 256;
 		} else if ((strncmp(s, "ix", 2) == 0) && (cpu == Z80)) {
 			printf("IX = %04x : ", IX);
 			fgets(nv, sizeof(nv), stdin);
-			IX = exatoi(nv)	& 0xffff;
+			IX = exatoi(nv) & 0xffff;
 		} else if ((strncmp(s, "iy", 2) == 0) && (cpu == Z80)) {
 			printf("IY = %04x : ", IY);
 			fgets(nv, sizeof(nv), stdin);
-			IY = exatoi(nv)	& 0xffff;
+			IY = exatoi(nv) & 0xffff;
 		} else if (strncmp(s, "sp", 2) == 0) {
 			printf("SP = %04x : ", SP);
 			fgets(nv, sizeof(nv), stdin);
 			SP = (exatoi(nv) & 0xffff);
 		} else if (strncmp(s, "fs", 2) == 0) {
-			printf("S-FLAG = %c : ", (F & S_FLAG) ?	'1' : '0');
+			printf("S-FLAG = %c : ", (F & S_FLAG) ? '1' : '0');
 			fgets(nv, sizeof(nv), stdin);
-			F = (exatoi(nv)) ? (F |	S_FLAG)	: (F & ~S_FLAG);
+			F = (exatoi(nv)) ? (F | S_FLAG) : (F & ~S_FLAG);
 		} else if (strncmp(s, "fz", 2) == 0) {
-			printf("Z-FLAG = %c : ", (F & Z_FLAG) ?	'1' : '0');
+			printf("Z-FLAG = %c : ", (F & Z_FLAG) ? '1' : '0');
 			fgets(nv, sizeof(nv), stdin);
-			F = (exatoi(nv)) ? (F |	Z_FLAG)	: (F & ~Z_FLAG);
+			F = (exatoi(nv)) ? (F | Z_FLAG) : (F & ~Z_FLAG);
 		} else if (strncmp(s, "fh", 2) == 0) {
-			printf("H-FLAG = %c : ", (F & H_FLAG) ?	'1' : '0');
+			printf("H-FLAG = %c : ", (F & H_FLAG) ? '1' : '0');
 			fgets(nv, sizeof(nv), stdin);
-			F = (exatoi(nv)) ? (F |	H_FLAG)	: (F & ~H_FLAG);
+			F = (exatoi(nv)) ? (F | H_FLAG) : (F & ~H_FLAG);
 		} else if (strncmp(s, "fp", 2) == 0) {
-			printf("P-FLAG = %c : ", (F & P_FLAG) ?	'1' : '0');
+			printf("P-FLAG = %c : ", (F & P_FLAG) ? '1' : '0');
 			fgets(nv, sizeof(nv), stdin);
-			F = (exatoi(nv)) ? (F |	P_FLAG)	: (F & ~P_FLAG);
+			F = (exatoi(nv)) ? (F | P_FLAG) : (F & ~P_FLAG);
 		} else if ((strncmp(s, "fn", 2) == 0) && (cpu == Z80)) {
-			printf("N-FLAG = %c : ", (F & N_FLAG) ?	'1' : '0');
+			printf("N-FLAG = %c : ", (F & N_FLAG) ? '1' : '0');
 			fgets(nv, sizeof(nv), stdin);
-			F = (exatoi(nv)) ? (F |	N_FLAG)	: (F & ~N_FLAG);
+			F = (exatoi(nv)) ? (F | N_FLAG) : (F & ~N_FLAG);
 		} else if (strncmp(s, "fc", 2) == 0) {
-			printf("C-FLAG = %c : ", (F & C_FLAG) ?	'1' : '0');
+			printf("C-FLAG = %c : ", (F & C_FLAG) ? '1' : '0');
 			fgets(nv, sizeof(nv), stdin);
-			F = (exatoi(nv)) ? (F |	C_FLAG)	: (F & ~C_FLAG);
+			F = (exatoi(nv)) ? (F | C_FLAG) : (F & ~C_FLAG);
 		} else if (strncmp(s, "a'", 2) == 0) {
 			printf("A' = %02x : ", A_);
 			fgets(nv, sizeof(nv), stdin);
-			A_ = exatoi(nv)	& 0xff;
+			A_ = exatoi(nv) & 0xff;
 		} else if (strncmp(s, "f'", 2) == 0) {
 			printf("F' = %02x : ", F_);
 			fgets(nv, sizeof(nv), stdin);
-			F_ = exatoi(nv)	& 0xff;
+			F_ = exatoi(nv) & 0xff;
 		} else if ((strncmp(s, "b'", 2) == 0) && (cpu == Z80)) {
 			printf("B' = %02x : ", B_);
 			fgets(nv, sizeof(nv), stdin);
-			B_ = exatoi(nv)	& 0xff;
+			B_ = exatoi(nv) & 0xff;
 		} else if ((strncmp(s, "c'", 2) == 0) && (cpu == Z80)) {
 			printf("C' = %02x : ", C_);
 			fgets(nv, sizeof(nv), stdin);
-			C_ = exatoi(nv)	& 0xff;
+			C_ = exatoi(nv) & 0xff;
 		} else if ((strncmp(s, "d'", 2) == 0) && (cpu == Z80)) {
 			printf("D' = %02x : ", D_);
 			fgets(nv, sizeof(nv), stdin);
-			D_ = exatoi(nv)	& 0xff;
+			D_ = exatoi(nv) & 0xff;
 		} else if ((strncmp(s, "e'", 2) == 0) && (cpu == Z80)) {
 			printf("E' = %02x : ", E_);
 			fgets(nv, sizeof(nv), stdin);
-			E_ = exatoi(nv)	& 0xff;
+			E_ = exatoi(nv) & 0xff;
 		} else if ((strncmp(s, "h'", 2) == 0) && (cpu == Z80)) {
 			printf("H' = %02x : ", H_);
 			fgets(nv, sizeof(nv), stdin);
-			H_ = exatoi(nv)	& 0xff;
+			H_ = exatoi(nv) & 0xff;
 		} else if ((strncmp(s, "l'", 2) == 0) && (cpu == Z80)) {
 			printf("L' = %02x : ", L_);
 			fgets(nv, sizeof(nv), stdin);
-			L_ = exatoi(nv)	& 0xff;
+			L_ = exatoi(nv) & 0xff;
 		} else if ((strncmp(s, "i", 1) == 0) && (cpu == Z80)) {
 			printf("I = %02x : ", I);
 			fgets(nv, sizeof(nv), stdin);
@@ -652,13 +652,13 @@ static void print_head(void)
 static void print_reg(void)
 {
 	printf("%04x %02x ", PC, A);
-	printf("%c", F & S_FLAG ? '1' :	'0');
-	printf("%c", F & Z_FLAG ? '1' :	'0');
-	printf("%c", F & H_FLAG ? '1' :	'0');
-	printf("%c", F & P_FLAG ? '1' :	'0');
+	printf("%c", F & S_FLAG ? '1' : '0');
+	printf("%c", F & Z_FLAG ? '1' : '0');
+	printf("%c", F & H_FLAG ? '1' : '0');
+	printf("%c", F & P_FLAG ? '1' : '0');
 	if (cpu == Z80)
-		printf("%c", F & N_FLAG ? '1' :	'0');
-	printf("%c", F & C_FLAG ? '1' :	'0');
+		printf("%c", F & N_FLAG ? '1' : '0');
+	printf("%c", F & C_FLAG ? '1' : '0');
 	if (cpu == Z80) {
 		printf(" %02x ", I);
 		printf("%c", IFF & 1 ? '1' : '0');
@@ -685,9 +685,9 @@ static void do_break(char *s)
 #else
 	register int i;
 
-	if (*s == '\n')	{
+	if (*s == '\n') {
 		puts("No Addr Pass  Counter");
-		for (i = 0; i <	SBSIZE;	i++)
+		for (i = 0; i < SBSIZE; i++)
 			if (soft[i].sb_pass)
 				printf("%02d %04x %05d %05d\n", i,
 				       soft[i].sb_adr,soft[i].sb_pass,
@@ -708,15 +708,15 @@ static void do_break(char *s)
 	while (isspace((int)*s))
 		s++;
 	if (*s == 'c') {
-		*(mem_base() +	soft[i].sb_adr)	= soft[i].sb_oldopc;
-		memset((char *)	&soft[i], 0, sizeof(struct softbreak));
+		*(mem_base() + soft[i].sb_adr) = soft[i].sb_oldopc;
+		memset((char *) &soft[i], 0, sizeof(struct softbreak));
 		return;
 	}
 	if (soft[i].sb_pass)
 		*(mem_base() + soft[i].sb_adr) = soft[i].sb_oldopc;
 	soft[i].sb_adr = exatoi(s);
 	soft[i].sb_oldopc = *(mem_base() + soft[i].sb_adr);
-	*(mem_base() +	soft[i].sb_adr)	= 0x76;
+	*(mem_base() + soft[i].sb_adr) = 0x76;
 	while (!iscntrl((int)*s) && !ispunct((int)*s))
 		s++;
 	if (*s != ',')
@@ -743,7 +743,7 @@ static void do_hist(char *s)
 		s++;
 	switch (*s) {
 	case 'c':
-		memset((char *)	his, 0, sizeof(struct history) * HISIZE);
+		memset((char *) his, 0, sizeof(struct history) * HISIZE);
 		h_next = 0;
 		h_flag = 0;
 		break;
@@ -753,7 +753,7 @@ static void do_hist(char *s)
 			break;
 		}
 		e = h_next;
-		b = (h_flag) ? h_next +	1 : 0;
+		b = (h_flag) ? h_next + 1 : 0;
 		l = 0;
 		while (isspace((int)*s))
 			s++;
@@ -807,7 +807,7 @@ static void do_count(char *s)
 #else
 	while (isspace((int)*s))
 		s++;
-	if (*s == '\0')	{
+	if (*s == '\0') {
 		puts("start  stop  status  T-states");
 		printf("%04x   %04x    %s   %lu\n",
 		       t_start, t_end,
@@ -834,7 +834,7 @@ static void do_count(char *s)
  *	fetch the R register is incremented by one and after
  *	the timer is down and stops the emulation, the clock
  *	speed of the CPU is calculated with:
- *		f = R /	300000
+ *		f = R / 300000
  */
 static void do_clock(void)
 {
@@ -842,9 +842,9 @@ static void do_clock(void)
 	static struct sigaction newact;
 	static struct itimerval tim;
 
-	save[0]	= *(mem_base() + 0x0000); /* save memory locations */
-	save[1]	= *(mem_base() + 0x0001); /* 0000H - 0002H */
-	save[2]	= *(mem_base() + 0x0002);
+	save[0] = *(mem_base() + 0x0000); /* save memory locations */
+	save[1] = *(mem_base() + 0x0001); /* 0000H - 0002H */
+	save[2] = *(mem_base() + 0x0002);
 	*(mem_base() + 0x0000) = 0xc3;	/* store opcode JP 0000H at address */
 	*(mem_base() + 0x0001) = 0x00;	/* 0000H */
 	*(mem_base() + 0x0002) = 0x00;

--- a/z80asm/COPYING
+++ b/z80asm/COPYING
@@ -1,5 +1,6 @@
 Copyright (c) 1987-2022 Udo Munk
 Copyright (c) 2016-2017 Didier Derny
+Copyright (c) 2022 Thomas Eberhardt
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -1,7 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (c) 2022 Thomas Eberhardt
+ *	Copyright (C) 2022 by Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -1,6 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (c) 2022 Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2
@@ -16,6 +17,7 @@
  *	15-MAY-2018 mark unreferenced symbols in listing
  *	30-JUL-2021 fix verbose option
  *	28-JAN-2022 added syntax check for OUT (n),A
+ *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  */
 
 /*
@@ -29,7 +31,7 @@
 /*
  *	various constants
  */
-#define REL		"1.10"
+#define REL		"1.11-dev"
 #define COPYR		"Copyright (C) 1987-2022 by Udo Munk"
 #define SRCEXT		".asm"	/* filename extension source */
 #define OBJEXTBIN	".bin"	/* filename extension object */
@@ -59,7 +61,7 @@
  */
 struct opc {
 	char *op_name;		/* opcode name */
-	int (*op_fun) ();	/* function pointer code generation */
+	int (*op_fun) (int, int); /* function pointer code generation */
 	int  op_c1;		/* first base opcode */
 	int  op_c2;		/* second base opcode */
 };
@@ -70,6 +72,16 @@ struct opc {
 struct ope {
 	char *ope_name;		/* operand name */
 	int ope_sym;		/* symbol value operand */
+};
+
+/*
+ *	structure personality
+ */
+struct pers {
+	int no_opcodes;		/* number of opcode entries */
+	struct opc *opctab;	/* opcode table */
+	int no_operands;	/* number of operand entries */
+	struct ope *opetab;	/* operand table */
 };
 
 /*
@@ -104,10 +116,12 @@ struct inc {
 #define REGH		4	/* register H */
 #define REGL		5	/* register L */
 #define REGIHL		6	/* register indirect HL */
+#define REGM		6	/* register indirect HL (8080) */
 #define REGA		7	/* register A */
 #define REGI		8	/* register I */
 #define REGR		9	/* register R */
 #define REGAF		10	/* register pair AF */
+#define REGPSW		10	/* register pair AF (8080) */
 #define REGBC		11	/* register pair BC */
 #define REGDE		12	/* register pair DE */
 #define REGHL		13	/* register pair HL */
@@ -132,6 +146,13 @@ struct inc {
 #define FLGPO		36	/* flag parity odd */
 #define NOOPERA		98	/* no operand */
 #define NOREG		99	/* operand isn't register */
+
+/*
+ *	definitions of personalities
+ */
+#define	NUMPERS		2	/* number of personalities */
+#define PERSZ80		0	/* Z80 personality */
+#define PERS8080	1	/* 8080 personality */
 
 /*
  *	definitions of error numbers for error messages in listfile

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -1,7 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (c) 2022 Thomas Eberhardt
+ *	Copyright (C) 2022 by Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -1,6 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (c) 2022 Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2
@@ -16,6 +17,7 @@
  *	15-MAY-2018 mark unreferenced symbols in listing
  *	30-JUL-2021 fix verbose option
  *	28-JAN-2022 added syntax check for OUT (n),A
+ *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  */
 
 /*
@@ -77,3 +79,6 @@ unsigned
 struct sym
      *symtab[HASHSIZE],		/* symbol table */
      **symarray;		/* sorted symbol table */
+
+struct pers
+     *pers;			/* current personality */

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -1,7 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (c) 2022 Thomas Eberhardt
+ *	Copyright (C) 2022 by Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -1,6 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (c) 2022 Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2
@@ -16,6 +17,7 @@
  *	15-MAY-2018 mark unreferenced symbols in listing
  *	30-JUL-2021 fix verbose option
  *	28-JAN-2022 added syntax check for OUT (n),A
+ *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  */
 
 /*
@@ -51,9 +53,7 @@ extern int	list_flag,
 		prg_flag,
 		out_form,
 		symlen,
-		symsize,
-		no_opcodes,
-		no_operands;
+		symsize;
 
 extern FILE	*srcfp,
 		*objfp,
@@ -69,6 +69,5 @@ extern unsigned	c_line,
 extern struct sym *symtab[],
 		  **symarray;
 
-extern struct opc opctab[];
-
-extern struct ope opetab[];
+extern struct pers perstab[],
+		   *pers;

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -1,6 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (c) 2022 Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2
@@ -16,6 +17,7 @@
  *	15-MAY-2018 mark unreferenced symbols in listing
  *	30-JUL-2021 fix verbose option
  *	28-JAN-2022 added syntax check for OUT (n),A
+ *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  */
 
 /*
@@ -58,7 +60,7 @@ extern void a_sort_sym(int);
 
 static char *errmsg[] = {		/* error messages for fatal() */
 	"out of memory: %s",		/* 0 */
-	"usage: z80asm -f[b|m|h] -s[n|a] -e<num> {-x} {-u} -v -ofile -l[file] -dsymbol ... file ...",
+	"usage: z80asm -f[b|m|h] -s[n|a] -e<num> {-x} {-8} {-u} -v -ofile -l[file] -dsymbol ... file ...",
 	"Assembly halted",		/* 2 */
 	"can't open file %s",		/* 3 */
 	"internal error: %s"		/* 4 */
@@ -103,6 +105,7 @@ int main(int argc, char *argv[])
  */
 void init(void)
 {
+	pers = &perstab[PERSZ80];
 	errfp = stdout;
 }
 
@@ -177,6 +180,9 @@ void options(int argc, char *argv[])
 				*t = '\0';
 				if (put_sym(tmp, 0))
 					fatal(F_OUTMEM, "symbols");
+				break;
+			case '8':
+				pers = &perstab[PERS8080];
 				break;
 			case 'u':
 				undoc_flag = 1;

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -1,7 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (c) 2022 Thomas Eberhardt
+ *	Copyright (C) 2022 by Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2

--- a/z80asm/z80anum-orig.c
+++ b/z80asm/z80anum-orig.c
@@ -293,12 +293,12 @@ int strval(char *str)
 }
 
 /*
- *	check value for range -256 < value < 256
+ *	check value for range -129 < value < 256
  *	Output: value if in range, otherwise 0 and error message
  */
-int chk_v1(int i)
+int chk_byte(int i)
 {
-	if (i >= -255 && i <= 255)
+	if (i >= -128 && i <= 255)
 		return(i);
 	else {
 		asmerr(E_VALOUT);
@@ -307,12 +307,12 @@ int chk_v1(int i)
 }
 
 /*
- *	check value for range -128 < value < 128
+ *	check value for range -129 < value < 128
  *	Output: value if in range, otherwise 0 and error message
  */
-int chk_v2(int i)
+int chk_sbyte(int i)
 {
-	if (i >= -127 && i <= 127)
+	if (i >= -128 && i <= 127)
 		return(i);
 	else {
 		asmerr(E_VALOUT);

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -721,12 +721,12 @@ int eval(char *str) {
 /* from z80anum-orig.c */
 
 /*
- *	check value for range -256 < value < 256
+ *	check value for range -129 < value < 256
  *	Output: value if in range, otherwise 0 and error message
  */
-int chk_v1(int i)
+int chk_byte(int i)
 {
-  if (i >= -255 && i <= 255)
+  if (i >= -128 && i <= 255)
     return(i);
   else {
     asmerr(E_VALOUT);
@@ -735,12 +735,12 @@ int chk_v1(int i)
 }
 
 /*
- *	check value for range -128 < value < 128
+ *	check value for range -129 < value < 128
  *	Output: value if in range, otherwise 0 and error message
  */
-int chk_v2(int i)
+int chk_sbyte(int i)
 {
-  if (i >= -127 && i <= 127)
+  if (i >= -128 && i <= 127)
     return(i);
   else {
     asmerr(E_VALOUT);

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -1,6 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (c) 2022 Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2
@@ -16,6 +17,7 @@
  *	15-MAY-2018 mark unreferenced symbols in listing
  *	30-JUL-2021 fix verbose option
  *	28-JAN-2022 added syntax check for OUT (n),A
+ *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  */
 
 /*
@@ -25,29 +27,39 @@
 #include <stdio.h>
 #include "z80a.h"
 
-extern int op_1b(), op_2b(), op_pupo(), op_ex(), op_ld();
-extern int op_call(), op_ret(), op_jp(), op_jr(), op_djnz(), op_rst();
-extern int op_add(), op_adc(), op_sub(), op_sbc(), op_cp();
-extern int op_inc(), op_dec(), op_or(), op_xor(), op_and();
-extern int op_rl(), op_rr(), op_sla(), op_sra(), op_sll(), op_srl(), op_rlc(), op_rrc();
-extern int op_out(), op_in(), op_im();
-extern int op_set(), op_res(), op_bit();
-extern int op_org(), op_dl(), op_equ();
-extern int op_ds(), op_db(), op_dw(), op_dm();
-extern int op_misc();
-extern int op_cond();
-extern int op_glob();
+extern int op_1b(int, int), op_2b(int, int), op_pupo(int, int);
+extern int op_ex(int, int), op_ld(int, int);
+extern int op_call(int, int), op_ret(int, int), op_jp(int, int);
+extern int op_jr(int, int), op_djnz(int, int), op_rst(int, int);
+extern int op_add(int, int), op_adc(int, int), op_sub(int, int);
+extern int op_sbc(int, int), op_cp(int, int), op_decinc(int, int);
+extern int op_or(int, int), op_xor(int, int), op_and(int, int);
+extern int op_rotshf(int, int);
+extern int op_out(int, int), op_in(int, int), op_im(int, int);
+extern int op_trsbit(int, int);
+extern int op_pers(int, int), op_org(int, int), op_dl(int, int);
+extern int op_equ(int, int);
+extern int op_ds(int, int), op_db(int, int), op_dw(int, int), op_dm(int, int);
+extern int op_misc(int, int);
+extern int op_cond(int, int);
+extern int op_glob(int, int);
+extern int op8080_mov(int, int), op8080_alu(int, int), op8080_decinc(int, int);
+extern int op8080_reg16(int, int), op8080_regbd(int, int);
+extern int op8080_imm(int, int), op8080_rst(int, int), op8080_pupo(int, int);
+extern int op8080_addr(int, int), op8080_mvi(int, int), op8080_lxi(int, int);
 
 /*
- *	opcode table:
+ *	Z80 opcode table:
  *	includes entries for all opcodes and pseudo ops other than END
  *	must be sorted in ascending order!
  */
-struct opc opctab[] = {
+struct opc opctab_z80[] = {
+	{ ".8080",	op_pers,	PERS8080, 0	},
+	{ ".Z80",	op_pers,	PERSZ80, 0	},
 	{ "ADC",	op_adc,		0,	0	},
 	{ "ADD",	op_add,		0,	0	},
 	{ "AND",	op_and,		0,	0	},
-	{ "BIT",	op_bit,		0,	0	},
+	{ "BIT",	op_trsbit,	0x40,	0	},
 	{ "CALL",	op_call,	0,	0	},
 	{ "CCF",	op_1b,		0x3f,	0	},
 	{ "CP",		op_cp,		0,	0	},
@@ -57,7 +69,7 @@ struct opc opctab[] = {
 	{ "CPIR",	op_2b,		0xed,	0xb1	},
 	{ "CPL",	op_1b,		0x2f,	0	},
 	{ "DAA",	op_1b,		0x27,	0	},
-	{ "DEC",	op_dec,		0,	0	},
+	{ "DEC",	op_decinc,	0x05,	0x0b	},
 	{ "DEFB",	op_db,		0,	0	},
 	{ "DEFL",	op_dl,		0,	0	},
 	{ "DEFM",	op_dm,		0,	0	},
@@ -80,7 +92,7 @@ struct opc opctab[] = {
 	{ "IFNEQ",	op_cond,	4,	0	},
 	{ "IM",		op_im,		0,	0	},
 	{ "IN",		op_in,		0,	0	},
-	{ "INC",	op_inc,		0,	0	},
+	{ "INC",	op_decinc,	0x04,	0x03	},
 	{ "INCLUDE",	op_misc,	6,	0	},
 	{ "IND",	op_2b,		0xed,	0xaa	},
 	{ "INDR",	op_2b,		0xed,	0xba	},
@@ -105,47 +117,42 @@ struct opc opctab[] = {
 	{ "OUTD",	op_2b,		0xed,	0xab	},
 	{ "OUTI",	op_2b,		0xed,	0xa3	},
 	{ "PAGE",	op_misc,	4,	0	},
-	{ "POP",	op_pupo,	1,	0	},
+	{ "POP",	op_pupo,	0xc1,	0	},
 	{ "PRINT",	op_misc,	5,	0	},
 	{ "PUBLIC",	op_glob,	2,	0	},
-	{ "PUSH",	op_pupo,	2,	0	},
-	{ "RES",	op_res,		0,	0	},
+	{ "PUSH",	op_pupo,	0xc5,	0	},
+	{ "RES",	op_trsbit,	0x80,	0	},
 	{ "RET",	op_ret,		0,	0	},
 	{ "RETI",	op_2b,		0xed,	0x4d	},
 	{ "RETN",	op_2b,		0xed,	0x45	},
-	{ "RL",		op_rl,		0,	0	},
+	{ "RL",		op_rotshf,	0x10,	0	},
 	{ "RLA",	op_1b,		0x17,	0	},
-	{ "RLC",	op_rlc,		0,	0	},
+	{ "RLC",	op_rotshf,	0x00,	0	},
 	{ "RLCA",	op_1b,		0x07,	0	},
 	{ "RLD",	op_2b,		0xed,	0x6f	},
-	{ "RR",		op_rr,		0,	0	},
+	{ "RR",		op_rotshf,	0x18,	0	},
 	{ "RRA",	op_1b,		0x1f,	0	},
-	{ "RRC",	op_rrc,		0,	0	},
+	{ "RRC",	op_rotshf,	0x08,	0	},
 	{ "RRCA",	op_1b,		0x0f,	0	},
 	{ "RRD",	op_2b,		0xed,	0x67	},
 	{ "RST",	op_rst,		0,	0	},
 	{ "SBC",	op_sbc,		0,	0	},
 	{ "SCF",	op_1b,		0x37,	0	},
-	{ "SET",	op_set,		0,	0	},
-	{ "SLA",	op_sla,		0,	0	},
-	{ "SLL",	op_sll,		0,	0	},
-	{ "SRA",	op_sra,		0,	0	},
-	{ "SRL",	op_srl,		0,	0	},
+	{ "SET",	op_trsbit,	0xc0,	0	},
+	{ "SLA",	op_rotshf,	0x20,	0	},
+	{ "SLL",	op_rotshf,	0x30,	0	},
+	{ "SRA",	op_rotshf,	0x28,	0	},
+	{ "SRL",	op_rotshf,	0x38,	0	},
 	{ "SUB",	op_sub,		0,	0	},
 	{ "TITLE",	op_misc,	7,	0	},
 	{ "XOR",	op_xor,		0,	0	}
 };
 
 /*
- *	compute no. of table entries for search_op()
- */
-int no_opcodes = sizeof(opctab) / sizeof(struct opc);
-
-/*
- *	table with reserved operand words: registers and flags
+ *	table with reserved Z80 operand words: registers and flags
  *	must be sorted in ascending order!
  */
-struct ope opetab[] = {
+struct ope opetab_z80[] = {
 	{ "(BC)",	REGIBC },
 	{ "(DE)",	REGIDE },
 	{ "(HL)",	REGIHL },
@@ -182,6 +189,148 @@ struct ope opetab[] = {
 };
 
 /*
- *	compute no. of table entries
+ *	8080 opcode table:
+ *	includes entries for all opcodes and pseudo ops other than END
+ *	must be sorted in ascending order!
  */
-int no_operands = sizeof(opetab) / sizeof(struct ope);
+struct opc opctab_8080[] = {
+	{ ".8080",	op_pers,	PERS8080, 0	},
+	{ ".Z80",	op_pers,	PERSZ80, 0	},
+	{ "ACI",	op8080_imm,	0xce,	0	},
+	{ "ADC",	op8080_alu,	0x88,	0	},
+	{ "ADD",	op8080_alu,	0x80,	0	},
+	{ "ADI",	op8080_imm,	0xc6,	0	},
+	{ "ANA",	op8080_alu,	0xa0,	0	},
+	{ "ANI",	op8080_imm,	0xe6,	0	},
+	{ "CALL",	op8080_addr,	0xcd,	0	},
+	{ "CC",		op8080_addr,	0xdc,	0	},
+	{ "CM",		op8080_addr,	0xfc,	0	},
+	{ "CMA",	op_1b,		0x2f,	0	},
+	{ "CMC",	op_1b,		0x3f,	0	},
+	{ "CMP",	op8080_alu,	0xb8,	0	},
+	{ "CNC",	op8080_addr,	0xd4,	0	},
+	{ "CNZ",	op8080_addr,	0xc4,	0	},
+	{ "CP",		op8080_addr,	0xf4,	0	},
+	{ "CPE",	op8080_addr,	0xec,	0	},
+	{ "CPI",	op8080_imm,	0xfe,	0	},
+	{ "CPO",	op8080_addr,	0xe4,	0	},
+	{ "CZ",		op8080_addr,	0xcc,	0	},
+	{ "DAA",	op_1b,		0x27,	0	},
+	{ "DAD",	op8080_reg16,	0x09,	0	},
+	{ "DCR",	op8080_decinc,	0x05,	0	},
+	{ "DCX",	op8080_reg16,	0x0b,	0	},
+	{ "DEFB",	op_db,		0,	0	},
+	{ "DEFL",	op_dl,		0,	0	},
+	{ "DEFM",	op_dm,		0,	0	},
+	{ "DEFS",	op_ds,		0,	0	},
+	{ "DEFW",	op_dw,		0,	0	},
+	{ "DI",		op_1b,		0xf3,	0	},
+	{ "EI",		op_1b,		0xfb,	0	},
+	{ "EJECT",	op_misc,	1,	0	},
+	{ "ELSE",	op_cond,	98,	0	},
+	{ "ENDIF",	op_cond,	99,	0	},
+	{ "EQU",	op_equ,		0,	0	},
+	{ "EXTRN",	op_glob,	1,	0	},
+	{ "HLT",	op_1b,		0x76,	0	},
+	{ "IFDEF",	op_cond,	1,	0	},
+	{ "IFEQ",	op_cond,	3,	0	},
+	{ "IFNDEF",	op_cond,	2,	0	},
+	{ "IFNEQ",	op_cond,	4,	0	},
+	{ "IN",		op8080_imm,	0xdb,	0	},
+	{ "INCLUDE",	op_misc,	6,	0	},
+	{ "INR",	op8080_decinc,	0x04,	0	},
+	{ "INX",	op8080_reg16,	0x03,	0	},
+	{ "JC",		op8080_addr,	0xda,	0	},
+	{ "JM",		op8080_addr,	0xfa,	0	},
+	{ "JMP",	op8080_addr,	0xc3,	0	},
+	{ "JNC",	op8080_addr,	0xd2,	0	},
+	{ "JNZ",	op8080_addr,	0xc2,	0	},
+	{ "JP",		op8080_addr,	0xf2,	0	},
+	{ "JPE",	op8080_addr,	0xea,	0	},
+	{ "JPO",	op8080_addr,	0xe2,	0	},
+	{ "JZ",		op8080_addr,	0xca,	0	},
+	{ "LDA",	op8080_addr,	0x3a,	0	},
+	{ "LDAX",	op8080_regbd,	0x0a,	0	},
+	{ "LHLD",	op8080_addr,	0x2a,	0	},
+	{ "LIST",	op_misc,	2,	0	},
+	{ "LXI",	op8080_lxi,	0,	0	},
+	{ "MOV",	op8080_mov,	0,	0	},
+	{ "MVI",	op8080_mvi,	0,	0	},
+	{ "NOLIST",	op_misc,	3,	0	},
+	{ "NOP",	op_1b,		0,	0	},
+	{ "ORA",	op8080_alu,	0xb0,	0	},
+	{ "ORG",	op_org,		0,	0	},
+	{ "ORI",	op8080_imm,	0xf6,	0	},
+	{ "OUT",	op8080_imm,	0xd3,	0	},
+	{ "PAGE",	op_misc,	4,	0	},
+	{ "PCHL",	op_1b,		0xe9,	0	},
+	{ "POP",	op8080_pupo,	0xc1,	0	},
+	{ "PRINT",	op_misc,	5,	0	},
+	{ "PUBLIC",	op_glob,	2,	0	},
+	{ "PUSH",	op8080_pupo,	0xc5,	0	},
+	{ "RAL",	op_1b,		0x17,	0	},
+	{ "RAR",	op_1b,		0x1f,	0	},
+	{ "RC",		op_1b,		0xd8,	0	},
+	{ "RET",	op_1b,		0xc9,	0	},
+	{ "RLC",	op_1b,		0x07,	0	},
+	{ "RM",		op_1b,		0xf8,	0	},
+	{ "RNC",	op_1b,		0xd0,	0	},
+	{ "RNZ",	op_1b,		0xc0,	0	},
+	{ "RP",		op_1b,		0xf0,	0	},
+	{ "RPE",	op_1b,		0xe8,	0	},
+	{ "RPO",	op_1b,		0xe0,	0	},
+	{ "RRC",	op_1b,		0x0f,	0	},
+	{ "RST",	op8080_rst,	0,	0	},
+	{ "RZ",		op_1b,		0xc8,	0	},
+	{ "SBB",	op8080_alu,	0x98,	0	},
+	{ "SBI",	op8080_imm,	0xde,	0	},
+	{ "SHLD",	op8080_addr,	0x22,	0	},
+	{ "SPHL",	op_1b,		0xf9,	0	},
+	{ "STA",	op8080_addr,	0x32,	0	},
+	{ "STAX",	op8080_regbd,	0x02,	0	},
+	{ "STC",	op_1b,		0x37,	0	},
+	{ "SUB",	op8080_alu,	0x90,	0	},
+	{ "SUI",	op8080_imm,	0xd6,	0	},
+	{ "TITLE",	op_misc,	7,	0	},
+	{ "XCHG",	op_1b,		0xeb,	0	},
+	{ "XRA",	op8080_alu,	0xa8,	0	},
+	{ "XRI",	op8080_imm,	0xee,	0	},
+	{ "XTHL",	op_1b,		0xe3,	0	},
+};
+
+/*
+ *	table with reserved 8080 operand words: registers and flags
+ *	must be sorted in ascending order!
+ */
+struct ope opetab_8080[] = {
+	{ "A",		REGA   },
+	{ "B",		REGB   },
+	{ "C",		REGC   },
+	{ "D",		REGD   },
+	{ "E",		REGE   },
+	{ "H",		REGH   },
+	{ "L",		REGL   },
+	{ "M",		REGM   },
+	{ "PSW",	REGPSW },
+	{ "SP",		REGSP  }
+};
+
+/*
+ *	table of personalities
+ */
+struct pers perstab[NUMPERS] = {
+	/* PERSZ80 */
+	{
+		sizeof(opctab_z80) / sizeof(struct opc),
+		opctab_z80,
+		sizeof(opetab_z80) / sizeof(struct ope),
+		opetab_z80
+	},
+	/* PERS8080 */
+	{
+		sizeof(opctab_8080) / sizeof(struct opc),
+		opctab_8080,
+		sizeof(opetab_8080) / sizeof(struct ope),
+		opetab_8080
+	}
+};

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -1,7 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (c) 2022 Thomas Eberhardt
+ *	Copyright (C) 2022 by Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -16,6 +16,7 @@
  *	15-MAY-2018 mark unreferenced symbols in listing
  *	30-JUL-2021 fix verbose option
  *	28-JAN-2022 added syntax check for OUT (n),A
+ *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  */
 
 /*

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -1,7 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (c) 2022 Thomas Eberhardt
+ *	Copyright (C) 2022 by Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -1,6 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (c) 2022 Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2
@@ -16,6 +17,7 @@
  *	15-MAY-2018 mark unreferenced symbols in listing
  *	30-JUL-2021 fix verbose option
  *	28-JAN-2022 added syntax check for OUT (n),A
+ *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  */
 
 /*
@@ -42,9 +44,18 @@ extern int put_sym(char *, int);
 extern void put_label(void);
 
 /*
+ *	.8080 and .Z80
+ */
+int op_pers(int new_pers, int dummy)
+{
+	pers = &perstab[new_pers];
+	return(0);
+}
+
+/*
  *	ORG
  */
-int op_org(void)
+int op_org(int dummy1, int dummy2)
 {
 	register int i;
 
@@ -72,7 +83,7 @@ int op_org(void)
 /*
  *	EQU
  */
-int op_equ(void)
+int op_equ(int dummy1, int dummy2)
 {
 	if (!gencode)
 		return(0);
@@ -93,7 +104,7 @@ int op_equ(void)
 /*
  *	DEFL
  */
-int op_dl(void)
+int op_dl(int dummy1, int dummy2)
 {
 	if (!gencode)
 		return(0);
@@ -107,7 +118,7 @@ int op_dl(void)
 /*
  *	DEFS
  */
-int op_ds(void)
+int op_ds(int dummy1, int dummy2)
 {
 	register int val;
 
@@ -128,7 +139,7 @@ int op_ds(void)
 /*
  *	DEFB
  */
-int op_db(void)
+int op_db(int dummy1, int dummy2)
 {
 	register int i;
 	register char *p;
@@ -173,7 +184,7 @@ hyp_error:
 /*
  *	DEFM
  */
-int op_dm(void)
+int op_dm(int dummy1, int dummy2)
 {
 	register int i;
 	register char *p;
@@ -205,7 +216,7 @@ int op_dm(void)
 /*
  *	DEFW
  */
-int op_dw(void)
+int op_dw(int dummy1, int dummy2)
 {
 	register int i, len, temp;
 	register char *p;

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -653,7 +653,7 @@ int op_ld(int dummy1, int dummy2)
 /*
  *	LD [A,B,C,D,E,H,L],?
  */
-int ldreg(int base_op, int base_op2)
+int ldreg(int base_op, int base_opn)
 {
 	register int op;
 	register int i, len;
@@ -661,21 +661,21 @@ int ldreg(int base_op, int base_op2)
 
 	p = get_second(operand);
 	switch (op = get_reg(p)) {
-	case REGA:			/* LD REG,A */
-	case REGB:			/* LD REG,B */
-	case REGC:			/* LD REG,C */
-	case REGD:			/* LD REG,D */
-	case REGE:			/* LD REG,E */
-	case REGH:			/* LD REG,H */
-	case REGL:			/* LD REG,L */
-	case REGIHL:			/* LD REG,(HL) */
+	case REGA:			/* LD reg,A */
+	case REGB:			/* LD reg,B */
+	case REGC:			/* LD reg,C */
+	case REGD:			/* LD reg,D */
+	case REGE:			/* LD reg,E */
+	case REGH:			/* LD reg,H */
+	case REGL:			/* LD reg,L */
+	case REGIHL:			/* LD reg,(HL) */
 		len = 1;
 		ops[0] = base_op + op;
 		break;
-	case REGIXH:			/* LD REG,IXH (undocumented) */
-	case REGIXL:			/* LD REG,IXL (undocumented) */
-	case REGIYH:			/* LD REG,IYH (undocumented) */
-	case REGIYL:			/* LD REG,IYL (undocumented) */
+	case REGIXH:			/* LD reg,IXH (undocumented) */
+	case REGIXL:			/* LD reg,IXL (undocumented) */
+	case REGIYH:			/* LD reg,IYH (undocumented) */
+	case REGIYL:			/* LD reg,IYL (undocumented) */
 		if ((base_op & 0xf0) != 0x60) {
 			/* only for A,B,C,D,E */
 			switch (op) {
@@ -708,10 +708,10 @@ int ldreg(int base_op, int base_op2)
 			asmerr(E_ILLOPE);
 		}
 		break;
-	case REGI:			/* LD REG,I */
-	case REGR:			/* LD REG,R */
-	case REGIBC:			/* LD REG,(BC) */
-	case REGIDE:			/* LD REG,(DE) */
+	case REGI:			/* LD reg,I */
+	case REGR:			/* LD reg,R */
+	case REGIBC:			/* LD reg,(BC) */
+	case REGIDE:			/* LD reg,(DE) */
 		if (base_op == 0x78) {
 			/* only for A */
 			switch (op) {
@@ -744,14 +744,14 @@ int ldreg(int base_op, int base_op2)
 		break;
 	case NOREG:			/* operand isn't register */
 		if (strncmp(p, "(IX+", 4) == 0) {
-			len = 3;	/* LD REG,(IX+d) */
+			len = 3;	/* LD reg,(IX+d) */
 			if (pass == 2) {
 				ops[0] = 0xdd;
 				ops[1] = base_op + 0x06;
 				ops[2] = chk_sbyte(calc_val(strchr(p, '+') + 1));
 			}
 		} else if (strncmp(p, "(IY+", 4) == 0) {
-			len = 3;	/* LD REG,(IY+d) */
+			len = 3;	/* LD reg,(IY+d) */
 			if (pass == 2) {
 				ops[0] = 0xfd;
 				ops[1] = base_op + 0x06;
@@ -766,10 +766,10 @@ int ldreg(int base_op, int base_op2)
 				ops[1] = i & 255;
 				ops[2] = i >> 8;
 			}
-		} else {		/* LD REG,n */
+		} else {		/* LD reg,n */
 			len = 2;
 			if (pass == 2) {
-				ops[0] = base_op2;
+				ops[0] = base_opn;
 				ops[1] = chk_byte(eval(p));
 			}
 		}
@@ -1710,7 +1710,7 @@ int aluop(int base_op, char *p)
 			len = 3;	/* ALUOP {A,}(IY+d) */
 			if (pass == 2) {
 				ops[0] = 0xfd;
-				ops[1] = base_op + 006;
+				ops[1] = base_op + 0x06;
 				ops[2] = chk_sbyte(calc_val(strchr(p, '+') + 1));
 			}
 		} else {
@@ -2087,24 +2087,24 @@ int op8080_mov(int dummy1, int dummy2)
 		*p2++ = *p1++;
 	*p2 = '\0';
 	switch (op1 = get_reg(tmp)) {
-	case REGA:			/* MOV A,R */
-	case REGB:			/* MOV B,R */
-	case REGC:			/* MOV C,R */
-	case REGD:			/* MOV D,R */
-	case REGE:			/* MOV E,R */
-	case REGH:			/* MOV H,R */
-	case REGL:			/* MOV L,R */
-	case REGM:			/* MOV M,R */
+	case REGA:			/* MOV A,reg */
+	case REGB:			/* MOV B,reg */
+	case REGC:			/* MOV C,reg */
+	case REGD:			/* MOV D,reg */
+	case REGE:			/* MOV E,reg */
+	case REGH:			/* MOV H,reg */
+	case REGL:			/* MOV L,reg */
+	case REGM:			/* MOV M,reg */
 		p1 = get_second(operand);
 		switch (op2 = get_reg(p1)) {
-		case REGA:		/* MOV R,A */
-		case REGB:		/* MOV R,B */
-		case REGC:		/* MOV R,C */
-		case REGD:		/* MOV R,D */
-		case REGE:		/* MOV R,E */
-		case REGH:		/* MOV R,H */
-		case REGL:		/* MOV R,L */
-		case REGM:		/* MOV R,M */
+		case REGA:		/* MOV reg,A */
+		case REGB:		/* MOV reg,B */
+		case REGC:		/* MOV reg,C */
+		case REGD:		/* MOV reg,D */
+		case REGE:		/* MOV reg,E */
+		case REGH:		/* MOV reg,H */
+		case REGL:		/* MOV reg,L */
+		case REGM:		/* MOV reg,M */
 			if (op1 == REGM && op2 == REGM) {
 				ops[0] = 0;
 				asmerr(E_ILLOPE);
@@ -2396,7 +2396,7 @@ int op8080_mvi(int dummy1, int dummy2)
 	case REGM:			/* MVI M,n */
 		p1 = get_second(operand);
 		switch (get_reg(p1)) {
-		case NOREG:		/* MVI R,n */
+		case NOREG:		/* MVI reg,n */
 			len = 2;
 			if (pass == 2) {
 				ops[0] = 0x06 + (op << 3);
@@ -2451,7 +2451,7 @@ int op8080_lxi(int dummy1, int dummy2)
 	case REGSP:			/* LXI SP,nn */
 		p1 = get_second(operand);
 		switch (get_reg(p1)) {
-		case NOREG:		/* LXI R,nn */
+		case NOREG:		/* LXI reg,nn */
 			len = 3;
 			if (pass == 2) {
 				i = eval(p1);

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -1,7 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (c) 2022 Thomas Eberhardt
+ *	Copyright (C) 2022 by Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2
@@ -1479,7 +1479,7 @@ int op_sbc(int dummy1, int dummy2)
 }
 
 /*
- *	SBC AND ADC HL,?
+ *	SBC HL,? and ADC HL,?
  */
 int sbadchl(int base_op)
 {

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -1,6 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (c) 2022 Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2
@@ -16,10 +17,11 @@
  *	15-MAY-2018 mark unreferenced symbols in listing
  *	30-JUL-2021 fix verbose option
  *	28-JAN-2022 added syntax check for OUT (n),A
+ *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  */
 
 /*
- *	processing of all real Z80 opcodes
+ *	processing of all real Z80/8080 opcodes
  */
 
 #include <stdio.h>
@@ -28,18 +30,16 @@
 #include "z80aglb.h"
 
 char *get_second(char *);
-int lda(void), ldb(void), ldc(void), ldd(void), lde(void);
-int ldh(void), ldl(void);
-int ldixh(void), ldixl(void), ldiyh(void), ldiyl(void);
-int ldbc(void), ldde(void), ldhl(void), ldix(void), ldiy(void);
-int ldsp(void), ldihl(void), ldiix(void), ldiiy(void), ldinn(void);
-int adda(void), addhl(void), addix(void), addiy(void);
-int adca(void), adchl(void), sbca(void), sbchl(void);
+int ldreg(int, int), ldixhl(int, int), ldiyhl(int, int);
+int ldbcde(int), ldhl(void), ldixy(int);
+int ldsp(void), ldihl(void), ldiixy(int), ldinn(void);
+int addhl(void), addix(void), addiy(void), sbadchl(int);
+int aluop(int, char *);
 
 extern int eval(char *);
 extern int calc_val(char *);
-extern int chk_v1(int);
-extern int chk_v2(int);
+extern int chk_byte(int);
+extern int chk_sbyte(int);
 extern void asmerr(int);
 extern int get_reg(char *);
 extern void put_label(void);
@@ -49,11 +49,10 @@ extern void put_label(void);
  */
 int op_1b(int b1, int dummy)
 {
-	if (pass == 1) {		/* Pass 1 */
+	if (pass == 1)
 		if (*label)
 			put_label();
-	} else				/* Pass 2 */
-		ops[0] = b1;
+	ops[0] = b1;
 	return(1);
 }
 
@@ -62,34 +61,32 @@ int op_1b(int b1, int dummy)
  */
 int op_2b(int b1, int b2)
 {
-	if (pass == 1) {		/* Pass 1 */
+	if (pass == 1)
 		if (*label)
 			put_label();
-	} else {			/* Pass 2 */
-		ops[0] = b1;
-		ops[1] = b2;
-	}
+	ops[0] = b1;
+	ops[1] = b2;
 	return(2);
 }
 
 /*
  *	IM
  */
-int op_im(void)
+int op_im(int dummy1, int dummy2)
 {
-	if (pass == 1)
+	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
-	if (pass == 2) {
+	} else {			/* PASS 2 */
 		ops[0] = 0xed;
 		switch(eval(operand)) {
-		case 0:
+		case 0:			/* IM 0 */
 			ops[1] = 0x46;
 			break;
-		case 1:
+		case 1:			/* IM 1 */
 			ops[1] = 0x56;
 			break;
-		case 2:
+		case 2:			/* IM 2 */
 			ops[1] = 0x5e;
 			break;
 		default:
@@ -104,7 +101,7 @@ int op_im(void)
 /*
  *	PUSH and POP
  */
-int op_pupo(int op_code, int dummy)
+int op_pupo(int base_op, int dummy)
 {
 	register int len;
 
@@ -112,72 +109,38 @@ int op_pupo(int op_code, int dummy)
 		if (*label)
 			put_label();
 	switch (get_reg(operand)) {
-	case REGAF:
-		if (pass == 2) {
-			if (op_code == 1)
-				ops[0] = 0xf1;		/* POP AF */
-			else
-				ops[0] = 0xf5;		/* PUSH AF */
-		}
+	case REGAF:			/* PUSH/POP AF */
 		len = 1;
+		ops[0] = base_op + 0x30;
 		break;
-	case REGBC:
-		if (pass == 2) {
-			if (op_code == 1)
-				ops[0] = 0xc1;		/* POP BC */
-			else
-				ops[0] = 0xc5;		/* PUSH BC */
-		}
+	case REGBC:			/* PUSH/POP BC */
 		len = 1;
+		ops[0] = base_op;
 		break;
-	case REGDE:
-		if (pass == 2) {
-			if (op_code == 1)
-				ops[0] = 0xd1;		/* POP DE */
-			else
-				ops[0] = 0xd5;		/* PUSH DE */
-		}
+	case REGDE:			/* PUSH/POP DE */
 		len = 1;
+		ops[0] = base_op + 0x10;
 		break;
-	case REGHL:
-		if (pass == 2) {
-			if (op_code == 1)
-				ops[0] = 0xe1;		/* POP HL */
-			else
-				ops[0] = 0xe5;		/* PUSH HL */
-		}
+	case REGHL:			/* PUSH/POP HL */
 		len = 1;
+		ops[0] = base_op + 0x20;
 		break;
-	case REGIX:
-		if (pass == 2) {
-			if (op_code == 1) {
-				ops[0] = 0xdd;		/* POP IX */
-				ops[1] = 0xe1;
-			} else {
-				ops[0] = 0xdd;		/* PUSH IX */
-				ops[1] = 0xe5;
-			}
-		}
+	case REGIX:			/* PUSH/POP IX */
 		len = 2;
+		ops[0] = 0xdd;
+		ops[1] = base_op + 0x20;
 		break;
-	case REGIY:
-		if (pass == 2) {
-			if (op_code == 1) {
-				ops[0] = 0xfd;		/* POP IY */
-				ops[1] = 0xe1;
-			} else {
-				ops[0] = 0xfd;		/* PUSH IY */
-				ops[1] = 0xe5;
-			}
-		}
+	case REGIY:			/* PUSH/POP IY */
 		len = 2;
+		ops[0] = 0xfd;
+		ops[1] = base_op + 0x20;
 		break;
-	case NOOPERA:					/* missing operand */
+	case NOOPERA:			/* missing operand */
 		len = 1;
 		ops[0] = 0;
 		asmerr(E_MISOPE);
 		break;
-	default:					/* invalid operand */
+	default:			/* invalid operand */
 		len = 1;
 		ops[0] = 0;
 		asmerr(E_ILLOPE);
@@ -188,7 +151,7 @@ int op_pupo(int op_code, int dummy)
 /*
  *	EX
  */
-int op_ex(void)
+int op_ex(int dummy1, int dummy2)
 {
 	register int len;
 
@@ -196,25 +159,25 @@ int op_ex(void)
 		if (*label)
 			put_label();
 	if (strncmp(operand, "DE,HL", 5) == 0) {
+		len = 1;
 		ops[0] = 0xeb;
-		len = 1;
 	} else if (strncmp(operand, "AF,AF'", 7) == 0) {
+		len = 1;
 		ops[0] = 0x08;
-		len = 1;
 	} else if (strncmp(operand, "(SP),HL", 7) == 0) {
-		ops[0] = 0xe3;
 		len = 1;
+		ops[0] = 0xe3;
 	} else if (strncmp(operand, "(SP),IX", 7) == 0) {
+		len = 2;
 		ops[0] = 0xdd;
 		ops[1] = 0xe3;
-		len = 2;
 	} else if (strncmp(operand, "(SP),IY", 7) == 0) {
+		len = 2;
 		ops[0] = 0xfd;
 		ops[1] = 0xe3;
-		len = 2;
 	} else {
-		ops[0] = 0;
 		len = 1;
+		ops[0] = 0;
 		asmerr(E_ILLOPE);
 	}
 	return(len);
@@ -223,15 +186,15 @@ int op_ex(void)
 /*
  *	CALL
  */
-int op_call(void)
+int op_call(int dummy1, int dummy2)
 {
 	register char *p1, *p2;
 	register int i;
 
-	if (pass == 1) {	/* PASS 1 */
+	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
-	} else {		/* PASS 2 */
+	} else {			/* PASS 2 */
 		p1 = operand;
 		p2 = tmp;
 		while (*p1 != ',' && *p1 != '\0')
@@ -311,16 +274,16 @@ int op_call(void)
 /*
  *	RST
  */
-int op_rst(void)
+int op_rst(int dummy1, int dummy2)
 {
 	register int op;
 
-	if (pass == 1) {	/* PASS 1 */
+	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
-	} else {		/* PASS 2 */
+	} else {			/* PASS 2 */
 		op = eval(operand);
-		if ((op / 8 > 7) || (op % 8 != 0)) {
+		if (op < 0 || (op / 8 > 7) || (op % 8 != 0)) {
 			ops[0] = 0;
 			asmerr(E_VALOUT);
 		} else
@@ -332,41 +295,41 @@ int op_rst(void)
 /*
  *	RET
  */
-int op_ret(void)
+int op_ret(int dummy1, int dummy2)
 {
-	if (pass == 1) {	/* PASS 1 */
+	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
-	} else {		/* PASS 2 */
+	} else {			/* PASS 2 */
 		switch (get_reg(operand)) {
-		case NOOPERA:			/* RET */
+		case NOOPERA:		/* RET */
 			ops[0] = 0xc9;
 			break;
-		case REGC:			/* RET C */
+		case REGC:		/* RET C */
 			ops[0] = 0xd8;
 			break;
-		case FLGNC:			/* RET NC */
+		case FLGNC:		/* RET NC */
 			ops[0] = 0xd0;
 			break;
-		case FLGZ:			/* RET Z */
+		case FLGZ:		/* RET Z */
 			ops[0] = 0xc8;
 			break;
-		case FLGNZ:			/* RET NZ */
+		case FLGNZ:		/* RET NZ */
 			ops[0] = 0xc0;
 			break;
-		case FLGPE:			/* RET PE */
+		case FLGPE:		/* RET PE */
 			ops[0] = 0xe8;
 			break;
-		case FLGPO:			/* RET PO */
+		case FLGPO:		/* RET PO */
 			ops[0] = 0xe0;
 			break;
-		case FLGM:			/* RET M */
+		case FLGM:		/* RET M */
 			ops[0] = 0xf8;
 			break;
-		case FLGP:			/* RET P */
+		case FLGP:		/* RET P */
 			ops[0] = 0xf0;
 			break;
-		default:			/* invalid operand */
+		default:		/* invalid operand */
 			ops[0] = 0;
 			asmerr(E_ILLOPE);
 		}
@@ -377,7 +340,7 @@ int op_ret(void)
 /*
  *	JP
  */
-int op_jp(void)
+int op_jp(int dummy1, int dummy2)
 {
 	register char *p1, *p2;
 	register int i, len;
@@ -464,18 +427,18 @@ int op_jp(void)
 		}
 		break;
 	case REGIHL:			/* JP (HL) */
-		ops[0] = 0xe9;
 		len = 1;
+		ops[0] = 0xe9;
 		break;
 	case REGIIX:			/* JP (IX) */
+		len = 2;
 		ops[0] = 0xdd;
 		ops[1] = 0xe9;
-		len = 2;
 		break;
 	case REGIIY:			/* JP (IY) */
+		len = 2;
 		ops[0] = 0xfd;
 		ops[1] = 0xe9;
-		len = 2;
 		break;
 	case NOREG:			/* JP nn */
 		len = 3;
@@ -487,13 +450,13 @@ int op_jp(void)
 		}
 		break;
 	case NOOPERA:			/* missing operand */
-		ops[0] = 0;
 		len = 1;
+		ops[0] = 0;
 		asmerr(E_MISOPE);
 		break;
 	default:			/* invalid operand */
-		ops[0] = 0;
 		len = 1;
+		ops[0] = 0;
 		asmerr(E_ILLOPE);
 	}
 	return(len);
@@ -502,46 +465,46 @@ int op_jp(void)
 /*
  *	JR
  */
-int op_jr(void)
+int op_jr(int dummy1, int dummy2)
 {
 	register char *p1, *p2;
 
-	if (pass == 1) {	/* PASS 1 */
+	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
-	} else {		/* PASS 2 */
+	} else {			/* PASS 2 */
 		p1 = operand;
 		p2 = tmp;
 		while (*p1 != ',' && *p1 != '\0')
 			*p2++ = *p1++;
 		*p2 = '\0';
 		switch (get_reg(tmp)) {
-		case REGC:			/* JR C,n */
+		case REGC:		/* JR C,n */
 			ops[0] = 0x38;
-			ops[1] = chk_v2(eval(strchr(operand, ',') + 1) - pc - 2);
+			ops[1] = chk_sbyte(eval(strchr(operand, ',') + 1) - pc - 2);
 			break;
-		case FLGNC:			/* JR NC,n */
+		case FLGNC:		/* JR NC,n */
 			ops[0] = 0x30;
-			ops[1] = chk_v2(eval(strchr(operand, ',') + 1) - pc - 2);
+			ops[1] = chk_sbyte(eval(strchr(operand, ',') + 1) - pc - 2);
 			break;
-		case FLGZ:			/* JR Z,n */
+		case FLGZ:		/* JR Z,n */
 			ops[0] = 0x28;
-			ops[1] = chk_v2(eval(strchr(operand, ',') + 1) - pc - 2);
+			ops[1] = chk_sbyte(eval(strchr(operand, ',') + 1) - pc - 2);
 			break;
-		case FLGNZ:			/* JR NZ,n */
+		case FLGNZ:		/* JR NZ,n */
 			ops[0] = 0x20;
-			ops[1] = chk_v2(eval(strchr(operand, ',') + 1) - pc - 2);
+			ops[1] = chk_sbyte(eval(strchr(operand, ',') + 1) - pc - 2);
 			break;
-		case NOREG:			/* JR n */
+		case NOREG:		/* JR n */
 			ops[0] = 0x18;
-			ops[1] = chk_v2(eval(operand) - pc - 2);
+			ops[1] = chk_sbyte(eval(operand) - pc - 2);
 			break;
-		case NOOPERA:			/* missing operand */
+		case NOOPERA:		/* missing operand */
 			ops[0] = 0;
 			ops[1] = 0;
 			asmerr(E_MISOPE);
 			break;
-		default:			/* invalid operand */
+		default:		/* invalid operand */
 			ops[0] = 0;
 			ops[1] = 0;
 			asmerr(E_ILLOPE);
@@ -553,14 +516,14 @@ int op_jr(void)
 /*
  *	DJNZ
  */
-int op_djnz(void)
+int op_djnz(int dummy1, int dummy2)
 {
-	if (pass == 1) {	/* PASS 1 */
+	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
-	} else {		/* PASS 2 */
+	} else {			/* PASS 2 */
 		ops[0] = 0x10;
-		ops[1] = chk_v2(eval(operand) - pc - 2);
+		ops[1] = chk_sbyte(eval(operand) - pc - 2);
 	}
 	return(2);
 }
@@ -568,9 +531,9 @@ int op_djnz(void)
 /*
  *	LD
  */
-int op_ld(void)
+int op_ld(int dummy1, int dummy2)
 {
-	register int len;
+	register int len, op;
 	register char *p1, *p2;
 
 	if (pass == 1)
@@ -581,39 +544,27 @@ int op_ld(void)
 	while (*p1 != ',' && *p1 != '\0')
 		*p2++ = *p1++;
 	*p2 = '\0';
-	switch (get_reg(tmp)) {
+	switch (op = get_reg(tmp)) {
 	case REGA:			/* LD A,? */
-		len = lda();
-		break;
 	case REGB:			/* LD B,? */
-		len = ldb();
-		break;
 	case REGC:			/* LD C,? */
-		len = ldc();
-		break;
 	case REGD:			/* LD D,? */
-		len = ldd();
-		break;
 	case REGE:			/* LD E,? */
-		len = lde();
-		break;
 	case REGH:			/* LD H,? */
-		len = ldh();
-		break;
 	case REGL:			/* LD L,? */
-		len = ldl();
+		len = ldreg(0x40 + (op << 3), 0x06 + (op << 3));
 		break;
 	case REGIXH:			/* LD IXH,? (undocumented) */
-		len = ldixh();
+		len = ldixhl(0x60, 0x26);
 		break;
 	case REGIXL:			/* LD IXL,? (undocumented) */
-		len = ldixl();
+		len = ldixhl(0x68, 0x2e);
 		break;
 	case REGIYH:			/* LD IYH,? (undocumented) */
-		len = ldiyh();
+		len = ldiyhl(0x60, 0x26);
 		break;
 	case REGIYL:			/* LD IYL,? (undocumented) */
-		len = ldiyl();
+		len = ldiyhl(0x68, 0x2e);
 		break;
 	case REGI:			/* LD I,A */
 		if (get_reg(get_second(operand)) == REGA) {
@@ -638,19 +589,19 @@ int op_ld(void)
 		asmerr(E_ILLOPE);
 		break;
 	case REGBC:			/* LD BC,? */
-		len = ldbc();
+		len = ldbcde(0x01);
 		break;
 	case REGDE:			/* LD DE,? */
-		len = ldde();
+		len = ldbcde(0x11);
 		break;
 	case REGHL:			/* LD HL,? */
 		len = ldhl();
 		break;
 	case REGIX:			/* LD IX,? */
-		len = ldix();
+		len = ldixy(0xdd);
 		break;
 	case REGIY:			/* LD IY,? */
-		len = ldiy();
+		len = ldixy(0xfd);
 		break;
 	case REGSP:			/* LD SP,? */
 		len = ldsp();
@@ -685,11 +636,11 @@ int op_ld(void)
 		break;
 	default:
 		if (strncmp(operand, "(IX+", 4) == 0)
-			len = ldiix();	/* LD (IX+d),? */
+			len = ldiixy(0xdd);	/* LD (IX+d),? */
 		else if (strncmp(operand, "(IY+", 4) == 0)
-			len = ldiiy();	/* LD (IY+d),? */
+			len = ldiixy(0xfd);	/* LD (IY+d),? */
 		else if (*operand == '(')
-			len = ldinn();	/* LD (nn),? */
+			len = ldinn();		/* LD (nn),? */
 		else {			/* invalid operand */
 			len = 1;
 			ops[0] = 0;
@@ -700,9 +651,9 @@ int op_ld(void)
 }
 
 /*
- *	LD A,?
+ *	LD [A,B,C,D,E,H,L],?
  */
-int lda(void)
+int ldreg(int base_op, int base_op2)
 {
 	register int op;
 	register int i, len;
@@ -710,107 +661,136 @@ int lda(void)
 
 	p = get_second(operand);
 	switch (op = get_reg(p)) {
-	case REGA:			/* LD A,A */
-	case REGB:			/* LD A,B */
-	case REGC:			/* LD A,C */
-	case REGD:			/* LD A,D */
-	case REGE:			/* LD A,E */
-	case REGH:			/* LD A,H */
-	case REGL:			/* LD A,L */
-	case REGIHL:			/* LD A,(HL) */
+	case REGA:			/* LD REG,A */
+	case REGB:			/* LD REG,B */
+	case REGC:			/* LD REG,C */
+	case REGD:			/* LD REG,D */
+	case REGE:			/* LD REG,E */
+	case REGH:			/* LD REG,H */
+	case REGL:			/* LD REG,L */
+	case REGIHL:			/* LD REG,(HL) */
 		len = 1;
-		ops[0] = 0x78 + op;
+		ops[0] = base_op + op;
 		break;
-	case REGIXH:			/* LD A,IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x7c;
+	case REGIXH:			/* LD REG,IXH (undocumented) */
+	case REGIXL:			/* LD REG,IXL (undocumented) */
+	case REGIYH:			/* LD REG,IYH (undocumented) */
+	case REGIYL:			/* LD REG,IYL (undocumented) */
+		if ((base_op & 0xf0) != 0x60) {
+			/* only for A,B,C,D,E */
+			switch (op) {
+			case REGIXH:	/* LD [ABCDE],IXH (undocumented) */
+				len = 2;
+				ops[0] = 0xdd;
+				ops[1] = base_op + 0x04;
+				break;
+			case REGIXL:	/* LD [ABCDE],IXL (undocumented) */
+				len = 2;
+				ops[0] = 0xdd;
+				ops[1] = base_op + 0x05;
+				break;
+			case REGIYH:	/* LD [ABCDE],IYH (undocumented) */
+				len = 2;
+				ops[0] = 0xfd;
+				ops[1] = base_op + 0x04;
+				break;
+			case REGIYL:	/* LD [ABCDE],IYL (undocumented) */
+				len = 2;
+				ops[0] = 0xfd;
+				ops[1] = base_op + 0x05;
+				break;
+			}
+		}
+		else {
+			/* not for H, L */
+			len = 1;
+			ops[0] = 0;
+			asmerr(E_ILLOPE);
+		}
 		break;
-	case REGIXL:			/* LD A,IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x7d;
-		break;
-	case REGIYH:			/* LD A,IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x7c;
-		break;
-	case REGIYL:			/* LD A,IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x7d;
-		break;
-	case REGI:			/* LD A,I */
-		len = 2;
-		ops[0] = 0xed;
-		ops[1] = 0x57;
-		break;
-	case REGR:			/* LD A,R */
-		len = 2;
-		ops[0] = 0xed;
-		ops[1] = 0x5f;
-		break;
-	case REGIBC:			/* LD A,(BC) */
-		len = 1;
-		ops[0] = 0x0a;
-		break;
-	case REGIDE:			/* LD A,(DE) */
-		len = 1;
-		ops[0] = 0x1a;
+	case REGI:			/* LD REG,I */
+	case REGR:			/* LD REG,R */
+	case REGIBC:			/* LD REG,(BC) */
+	case REGIDE:			/* LD REG,(DE) */
+		if (base_op == 0x78) {
+			/* only for A */
+			switch (op) {
+			case REGI:	/* LD A,I */
+				len = 2;
+				ops[0] = 0xed;
+				ops[1] = 0x57;
+				break;
+			case REGR:	/* LD A,R */
+				len = 2;
+				ops[0] = 0xed;
+				ops[1] = 0x5f;
+				break;
+			case REGIBC:	/* LD A,(BC) */
+				len = 1;
+				ops[0] = 0x0a;
+				break;
+			case REGIDE:	/* LD A,(DE) */
+				len = 1;
+				ops[0] = 0x1a;
+				break;
+			}
+		}
+		else {
+			/* not A */
+			len = 1;
+			ops[0] = 0;
+			asmerr(E_ILLOPE);
+		}
 		break;
 	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) { /* LD A,(IX+d) */
-			len = 3;
+		if (strncmp(p, "(IX+", 4) == 0) {
+			len = 3;	/* LD REG,(IX+d) */
 			if (pass == 2) {
 				ops[0] = 0xdd;
-				ops[1] = 0x7e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
+				ops[1] = base_op + 0x06;
+				ops[2] = chk_sbyte(calc_val(strchr(p, '+') + 1));
 			}
-			break;
-		}
-		if (strncmp(p, "(IY+", 4) == 0) { /* LD A,(IY+d) */
-			len = 3;
+		} else if (strncmp(p, "(IY+", 4) == 0) {
+			len = 3;	/* LD REG,(IY+d) */
 			if (pass == 2) {
 				ops[0] = 0xfd;
-				ops[1] = 0x7e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
+				ops[1] = base_op + 0x06;
+				ops[2] = chk_sbyte(calc_val(strchr(p, '+') + 1));
 			}
-			break;
-		}
-		if (*p == '(' && *(p + strlen(p) - 1) == ')') {
-			len = 3;		/* LD A,(nn) */
+		} else if (base_op == 0x78 && *p == '(' && *(p + strlen(p) - 1) == ')') {
+			/* only for A */
+			len = 3;	/* LD A,(nn) */
 			if (pass == 2) {
 				i = calc_val(p + 1);
 				ops[0] = 0x3a;
 				ops[1] = i & 255;
 				ops[2] = i >> 8;
 			}
-			break;
-		}
-		len = 2;			/* LD A,n */
-		if (pass == 2) {
-			ops[0] = 0x3e;
-			ops[1] = chk_v1(eval(p));
+		} else {		/* LD REG,n */
+			len = 2;
+			if (pass == 2) {
+				ops[0] = base_op2;
+				ops[1] = chk_byte(eval(p));
+			}
 		}
 		break;
-	case NOOPERA:				/* missing operand */
-		len = 1;
+	case NOOPERA:			/* missing operand */
 		ops[0] = 0;
+		len = 1;
 		asmerr(E_MISOPE);
 		break;
-	default:				/* invalid operand */
-		len = 1;
+	default:			/* invalid operand */
 		ops[0] = 0;
+		len = 1;
 		asmerr(E_ILLOPE);
 	}
 	return(len);
 }
 
 /*
- *	LD B,?
+ *	LD IX[HL],? (undocumented)
  */
-int ldb(void)
+int ldixhl(int base_op, int base_opn)
 {
 	register int op;
 	register int len;
@@ -818,471 +798,31 @@ int ldb(void)
 
 	p = get_second(operand);
 	switch (op = get_reg(p)) {
-	case REGA:			/* LD B,A */
-	case REGB:			/* LD B,B */
-	case REGC:			/* LD B,C */
-	case REGD:			/* LD B,D */
-	case REGE:			/* LD B,E */
-	case REGH:			/* LD B,H */
-	case REGL:			/* LD B,L */
-	case REGIHL:			/* LD B,(HL) */
-		len = 1;
-		ops[0] = 0x40 + op;
-		break;
-	case REGIXH:			/* LD B,IXH (undocumented) */
+	case REGA:			/* LD IX[HL],A (undocumented) */
+	case REGB:			/* LD IX[HL],B (undocumented) */
+	case REGC:			/* LD IX[HL],C (undocumented) */
+	case REGD:			/* LD IX[HL],D (undocumented) */
+	case REGE:			/* LD IX[HL],E (undocumented) */
 		len = 2;
 		ops[0] = 0xdd;
-		ops[1] = 0x44;
+		ops[1] = base_op + op;
 		break;
-	case REGIXL:			/* LD B,IXL (undocumented) */
+	case REGIXH:			/* LD IX[HL],IXH (undocumented) */
 		len = 2;
 		ops[0] = 0xdd;
-		ops[1] = 0x45;
+		ops[1] = base_op + 0x04;
 		break;
-	case REGIYH:			/* LD B,IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x44;
-		break;
-	case REGIYL:			/* LD B,IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x45;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) { /* LD B,(IX+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x46;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		if (strncmp(p, "(IY+", 4) == 0) { /* LD B,(IY+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x46;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		len = 2;			/* LD B,n */
-		if (pass == 2) {
-			ops[0] = 0x06;
-			ops[1] = chk_v1(eval(p));
-		}
-		break;
-	case NOOPERA:				/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:				/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD C,?
- */
-int ldc(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* LD C,A */
-	case REGB:			/* LD C,B */
-	case REGC:			/* LD C,C */
-	case REGD:			/* LD C,D */
-	case REGE:			/* LD C,E */
-	case REGH:			/* LD C,H */
-	case REGL:			/* LD C,L */
-	case REGIHL:			/* LD C,(HL) */
-		len = 1;
-		ops[0] = 0x48 + op;
-		break;
-	case REGIXH:			/* LD C,IXH (undocumented) */
+	case REGIXL:			/* LD IX[HL],IXL (undocumented) */
 		len = 2;
 		ops[0] = 0xdd;
-		ops[1] = 0x4c;
+		ops[1] = base_op + 0x05;
 		break;
-	case REGIXL:			/* LD C,IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x4d;
-		break;
-	case REGIYH:			/* LD C,IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x4c;
-		break;
-	case REGIYL:			/* LD C,IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x4d;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) { /* LD C,(IX+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x4e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		if (strncmp(p, "(IY+", 4) == 0) { /* LD C,(IY+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x4e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		len = 2;			/* LD C,n */
-		if (pass == 2) {
-			ops[0] = 0x0e;
-			ops[1] = chk_v1(eval(p));
-		}
-		break;
-	case NOOPERA:				/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:				/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD D,?
- */
-int ldd(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* LD D,A */
-	case REGB:			/* LD D,B */
-	case REGC:			/* LD D,C */
-	case REGD:			/* LD D,D */
-	case REGE:			/* LD D,E */
-	case REGH:			/* LD D,H */
-	case REGL:			/* LD D,L */
-	case REGIHL:			/* LD D,(HL) */
-		len = 1;
-		ops[0] = 0x50 + op;
-		break;
-	case REGIXH:			/* LD D,IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x54;
-		break;
-	case REGIXL:			/* LD D,IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x55;
-		break;
-	case REGIYH:			/* LD D,IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x54;
-		break;
-	case REGIYL:			/* LD D,IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x55;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) { /* LD D,(IX+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x56;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		if (strncmp(p, "(IY+", 4) == 0) { /* LD D,(IY+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x56;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		len = 2;			/* LD D,n */
-		if (pass == 2) {
-			ops[0] = 0x16;
-			ops[1] = chk_v1(eval(p));
-		}
-		break;
-	case NOOPERA:				/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:				/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD E,?
- */
-int lde(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* LD E,A */
-	case REGB:			/* LD E,B */
-	case REGC:			/* LD E,C */
-	case REGD:			/* LD E,D */
-	case REGE:			/* LD E,E */
-	case REGH:			/* LD E,H */
-	case REGL:			/* LD E,L */
-	case REGIHL:			/* LD E,(HL) */
-		len = 1;
-		ops[0] = 0x58 + op;
-		break;
-	case REGIXH:			/* LD E,IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x5c;
-		break;
-	case REGIXL:			/* LD E,IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x5d;
-		break;
-	case REGIYH:			/* LD E,IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x5c;
-		break;
-	case REGIYL:			/* LD E,IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x5d;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) { /* LD E,(IX+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x5e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		if (strncmp(p, "(IY+", 4) == 0) { /* LD E,(IY+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x5e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		len = 2;			/* LD E,n */
-		if (pass == 2) {
-			ops[0] = 0x1e;
-			ops[1] = chk_v1(eval(p));
-		}
-		break;
-	case NOOPERA:				/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:				/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD H,?
- */
-int ldh(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* LD H,A */
-	case REGB:			/* LD H,B */
-	case REGC:			/* LD H,C */
-	case REGD:			/* LD H,D */
-	case REGE:			/* LD H,E */
-	case REGH:			/* LD H,H */
-	case REGL:			/* LD H,L */
-	case REGIHL:			/* LD H,(HL) */
-		len = 1;
-		ops[0] = 0x60 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) { /* LD H,(IX+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x66;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		if (strncmp(p, "(IY+", 4) == 0) { /* LD H,(IY+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x66;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		len = 2;			/* LD H,n */
-		if (pass == 2) {
-			ops[0] = 0x26;
-			ops[1] = chk_v1(eval(p));
-		}
-		break;
-	case NOOPERA:				/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:				/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD L,?
- */
-int ldl(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* LD L,A */
-	case REGB:			/* LD L,B */
-	case REGC:			/* LD L,C */
-	case REGD:			/* LD L,D */
-	case REGE:			/* LD L,E */
-	case REGH:			/* LD L,H */
-	case REGL:			/* LD L,L */
-	case REGIHL:			/* LD L,(HL) */
-		len = 1;
-		ops[0] = 0x68 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) { /* LD L,(IX+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x6e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		if (strncmp(p, "(IY+", 4) == 0) { /* LD L,(IY+d) */
-			len = 3;
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x6e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-			break;
-		}
-		len = 2;			/* LD L,n */
-		if (pass == 2) {
-			ops[0] = 0x2e;
-			ops[1] = chk_v1(eval(p));
-		}
-		break;
-	case NOOPERA:				/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:				/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD IXH,? (undocumented)
- */
-int ldixh(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* LD IXH,A (undocumented) */
-	case REGB:			/* LD IXH,B (undocumented) */
-	case REGC:			/* LD IXH,C (undocumented) */
-	case REGD:			/* LD IXH,D (undocumented) */
-	case REGE:			/* LD IXH,E (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x60 + op;
-		break;
-	case REGIXH:			/* LD IXH,IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x64;
-		break;
-	case REGIXL:			/* LD IXH,IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x65;
-		break;
-	case NOREG:			/* operand isn't register */
-		len = 3;		/* LD IXH,n (undocumented) */
+	case NOREG:			/* LD IX[HL],n (undocumented) */
+		len = 3;
 		if (pass == 2) {
 			ops[0] = 0xdd;
-			ops[1] = 0x26;
-			ops[2] = chk_v1(eval(p));
+			ops[1] = base_opn;
+			ops[2] = chk_byte(eval(p));
 		}
 		break;
 	case NOOPERA:			/* missing operand */
@@ -1299,9 +839,9 @@ int ldixh(void)
 }
 
 /*
- *	LD IXL,? (undocumented)
+ *	LD IY[HL],? (undocumented)
  */
-int ldixl(void)
+int ldiyhl(int base_op, int base_opn)
 {
 	register int op;
 	register int len;
@@ -1309,82 +849,31 @@ int ldixl(void)
 
 	p = get_second(operand);
 	switch (op = get_reg(p)) {
-	case REGA:			/* LD IXL,A (undocumented) */
-	case REGB:			/* LD IXL,B (undocumented) */
-	case REGC:			/* LD IXL,C (undocumented) */
-	case REGD:			/* LD IXL,D (undocumented) */
-	case REGE:			/* LD IXL,E (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x68 + op;
-		break;
-	case REGIXH:			/* LD IXL,IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x6c;
-		break;
-	case REGIXL:			/* LD IXL,IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x6d;
-		break;
-	case NOREG:			/* operand isn't register */
-		len = 3;		/* LD IXL,n (undocumented) */
-		if (pass == 2) {
-			ops[0] = 0xdd;
-			ops[1] = 0x2e;
-			ops[2] = chk_v1(eval(p));
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD IYH,? (undocumented)
- */
-int ldiyh(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* LD IYH,A (undocumented) */
-	case REGB:			/* LD IYH,B (undocumented) */
-	case REGC:			/* LD IYH,C (undocumented) */
-	case REGD:			/* LD IYH,D (undocumented) */
-	case REGE:			/* LD IYH,E (undocumented) */
+	case REGA:			/* LD IY[HL],A (undocumented) */
+	case REGB:			/* LD IY[HL],B (undocumented) */
+	case REGC:			/* LD IY[HL],C (undocumented) */
+	case REGD:			/* LD IY[HL],D (undocumented) */
+	case REGE:			/* LD IY[HL],E (undocumented) */
 		len = 2;
 		ops[0] = 0xfd;
-		ops[1] = 0x60 + op;
+		ops[1] = base_op + op;
 		break;
-	case REGIYH:			/* LD IYH,IYH (undocumented) */
+	case REGIYH:			/* LD IY[HL],IYH (undocumented) */
 		len = 2;
 		ops[0] = 0xfd;
-		ops[1] = 0x64;
+		ops[1] = base_op + 0x04;
 		break;
-	case REGIYL:			/* LD IYH,IYL (undocumented) */
+	case REGIYL:			/* LD IY[HL],IYL (undocumented) */
 		len = 2;
 		ops[0] = 0xfd;
-		ops[1] = 0x65;
+		ops[1] = base_op + 0x05;
 		break;
-	case NOREG:			/* operand isn't register */
-		len = 3;		/* LD IYH,n (undocumented) */
+	case NOREG:			/* LD IY[HL],n (undocumented) */
+		len = 3;
 		if (pass == 2) {
 			ops[0] = 0xfd;
-			ops[1] = 0x26;
-			ops[2] = chk_v1(eval(p));
+			ops[1] = base_opn;
+			ops[2] = chk_byte(eval(p));
 		}
 		break;
 	case NOOPERA:			/* missing operand */
@@ -1401,135 +890,41 @@ int ldiyh(void)
 }
 
 /*
- *	LD IYL,? (undocumented)
+ *	LD {BC,DE},?
  */
-int ldiyl(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* LD IYL,A (undocumented) */
-	case REGB:			/* LD IYL,B (undocumented) */
-	case REGC:			/* LD IYL,C (undocumented) */
-	case REGD:			/* LD IYL,D (undocumented) */
-	case REGE:			/* LD IYL,E (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x68 + op;
-		break;
-	case REGIYH:			/* LD IYL,IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x6c;
-		break;
-	case REGIYL:			/* LD IYL,IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x6d;
-		break;
-	case NOREG:			/* operand isn't register */
-		len = 3;		/* LD IYL,n (undocumented) */
-		if (pass == 2) {
-			ops[0] = 0xfd;
-			ops[1] = 0x2e;
-			ops[2] = chk_v1(eval(p));
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD BC,?
- */
-int ldbc(void)
+int ldbcde(int base_op)
 {
 	register int i, len;
 	register char *p;
 
 	p = get_second(operand);
 	switch (get_reg(p)) {
-	case NOREG:				/* operand isn't register */
+	case NOREG:			/* operand isn't register */
 		if (*p == '(' && *(p + strlen(p) - 1) == ')') {
-			len = 4;		/* LD BC,(nn) */
+			len = 4;	/* LD {BC,DE},(nn) */
 			if (pass == 2) {
 				i = calc_val(p + 1);
 				ops[0] = 0xed;
-				ops[1] = 0x4b;
+				ops[1] = base_op + 0x4a;
 				ops[2] = i & 0xff;
 				ops[3] = i >> 8;
 			}
-			break;
-		}
-		len = 3;			/* LD BC,nn */
-		if (pass == 2) {
-			i = eval(p);
-			ops[0] = 0x01;
-			ops[1] = i & 0xff;
-			ops[2] = i >> 8;
+		} else {
+			len = 3;	/* LD {BC,DE},nn */
+			if (pass == 2) {
+				i = eval(p);
+				ops[0] = base_op;
+				ops[1] = i & 0xff;
+				ops[2] = i >> 8;
+			}
 		}
 		break;
-	case NOOPERA:				/* missing operand */
+	case NOOPERA:			/* missing operand */
 		len = 1;
 		ops[0] = 0;
 		asmerr(E_MISOPE);
 		break;
-	default:				/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD DE,?
- */
-int ldde(void)
-{
-	register int i, len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (get_reg(p)) {
-	case NOREG:				/* operand isn't register */
-		if (*p == '(' && *(p + strlen(p) - 1) == ')') {
-			len = 4;		/* LD DE,(nn) */
-			if (pass == 2) {
-				i = calc_val(p + 1);
-				ops[0] = 0xed;
-				ops[1] = 0x5b;
-				ops[2] = i & 0xff;
-				ops[3] = i >> 8;
-			}
-			break;
-		}
-		len = 3;			/* LD DE,nn */
-		if (pass == 2) {
-			i = eval(p);
-			ops[0] = 0x11;
-			ops[1] = i & 0xff;
-			ops[2] = i >> 8;
-		}
-		break;
-	case NOOPERA:				/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:				/* invalid operand */
+	default:			/* invalid operand */
 		len = 1;
 		ops[0] = 0;
 		asmerr(E_ILLOPE);
@@ -1547,31 +942,31 @@ int ldhl(void)
 
 	p = get_second(operand);
 	switch (get_reg(p)) {
-	case NOREG:				/* operand isn't register */
+	case NOREG:			/* operand isn't register */
 		if (*p == '(' && *(p + strlen(p) - 1) == ')') {
-			len = 3;		/* LD HL,(nn) */
+			len = 3;	/* LD HL,(nn) */
 			if (pass == 2) {
 				i = calc_val(p + 1);
 				ops[0] = 0x2a;
 				ops[1] = i & 0xff;
 				ops[2] = i >> 8;
 			}
-			break;
-		}
-		len = 3;			/* LD HL,nn */
-		if (pass == 2) {
-			i = eval(p);
-			ops[0] = 0x21;
-			ops[1] = i & 0xff;
-			ops[2] = i >> 8;
+		} else {
+			len = 3;	/* LD HL,nn */
+			if (pass == 2) {
+				i = eval(p);
+				ops[0] = 0x21;
+				ops[1] = i & 0xff;
+				ops[2] = i >> 8;
+			}
 		}
 		break;
-	case NOOPERA:				/* missing operand */
+	case NOOPERA:			/* missing operand */
 		len = 1;
 		ops[0] = 0;
 		asmerr(E_MISOPE);
 		break;
-	default:				/* invalid operand */
+	default:			/* invalid operand */
 		len = 1;
 		ops[0] = 0;
 		asmerr(E_ILLOPE);
@@ -1580,86 +975,42 @@ int ldhl(void)
 }
 
 /*
- *	LD IX,?
+ *	LD I[XY],?
  */
-int ldix(void)
+int ldixy(int prefix)
 {
 	register int i, len;
 	register char *p;
 
 	p = get_second(operand);
 	switch (get_reg(p)) {
-	case NOREG:				/* operand isn't register */
+	case NOREG:			/* operand isn't register */
 		if (*p == '(' && *(p + strlen(p) - 1) == ')') {
-			len = 4;		/* LD IX,(nn) */
+			len = 4;	/* LD I[XY],(nn) */
 			if (pass == 2) {
 				i = calc_val(p + 1);
-				ops[0] = 0xdd;
+				ops[0] = prefix;
 				ops[1] = 0x2a;
 				ops[2] = i & 0xff;
 				ops[3] = i >> 8;
 			}
-			break;
-		}
-		len = 4;			/* LD IX,nn */
-		if (pass == 2) {
-			i = eval(p);
-			ops[0] = 0xdd;
-			ops[1] = 0x21;
-			ops[2] = i & 0xff;
-			ops[3] = i >> 8;
-		}
-		break;
-	case NOOPERA:				/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:				/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD IY,?
- */
-int ldiy(void)
-{
-	register int i, len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (get_reg(p)) {
-	case NOREG:				/* operand isn't register */
-		if (*p == '(' && *(p + strlen(p) - 1) == ')') {
-			len = 4;		/* LD IY,(nn) */
+		} else {
+			len = 4;	/* LD I[XY],nn */
 			if (pass == 2) {
-				i = calc_val(p + 1);
-				ops[0] = 0xfd;
-				ops[1] = 0x2a;
+				i = eval(p);
+				ops[0] = prefix;
+				ops[1] = 0x21;
 				ops[2] = i & 0xff;
 				ops[3] = i >> 8;
 			}
-			break;
-		}
-		len = 4;			/* LD IY,nn */
-		if (pass == 2) {
-			i = eval(p);
-			ops[0] = 0xfd;
-			ops[1] = 0x21;
-			ops[2] = i & 0xff;
-			ops[3] = i >> 8;
 		}
 		break;
-	case NOOPERA:				/* missing operand */
+	case NOOPERA:			/* missing operand */
 		len = 1;
 		ops[0] = 0;
 		asmerr(E_MISOPE);
 		break;
-	default:				/* invalid operand */
+	default:			/* invalid operand */
 		len = 1;
 		ops[0] = 0;
 		asmerr(E_ILLOPE);
@@ -1701,14 +1052,14 @@ int ldsp(void)
 				ops[2] = i & 0xff;
 				ops[3] = i >> 8;
 			}
-			break;
-		}
-		len = 3;		/* LD SP,nn */
-		if (pass == 2) {
-			i = eval(p);
-			ops[0] = 0x31;
-			ops[1] = i & 0xff;
-			ops[2] = i >> 8;
+		} else {
+			len = 3;	/* LD SP,nn */
+			if (pass == 2) {
+				i = eval(p);
+				ops[0] = 0x31;
+				ops[1] = i & 0xff;
+				ops[2] = i >> 8;
+			}
 		}
 		break;
 	case NOOPERA:			/* missing operand */
@@ -1745,11 +1096,11 @@ int ldihl(void)
 		len = 1;
 		ops[0] = 0x70 + op;
 		break;
-	case NOREG:			/* operand isn't register */
-		len = 2;		/* LD (HL),n */
+	case NOREG:			/* LD (HL),n */
+		len = 2;
 		if (pass == 2) {
 			ops[0] = 0x36;
-			ops[1] = chk_v1(eval(p));
+			ops[1] = chk_byte(eval(p));
 		}
 		break;
 	case NOOPERA:			/* missing operand */
@@ -1766,9 +1117,9 @@ int ldihl(void)
 }
 
 /*
- *	LD (IX+d),?
+ *	LD (I[XY]+d),?
  */
-int ldiix(void)
+int ldiixy(int prefix)
 {
 	register int op;
 	register int len;
@@ -1776,74 +1127,27 @@ int ldiix(void)
 
 	p = get_second(operand);
 	switch (op = get_reg(p)) {
-	case REGA:			/* LD (IX+d),A */
-	case REGB:			/* LD (IX+d),B */
-	case REGC:			/* LD (IX+d),C */
-	case REGD:			/* LD (IX+d),D */
-	case REGE:			/* LD (IX+d),E */
-	case REGH:			/* LD (IX+d),H */
-	case REGL:			/* LD (IX+d),L */
+	case REGA:			/* LD (I[XY]+d),A */
+	case REGB:			/* LD (I[XY]+d),B */
+	case REGC:			/* LD (I[XY]+d),C */
+	case REGD:			/* LD (I[XY]+d),D */
+	case REGE:			/* LD (I[XY]+d),E */
+	case REGH:			/* LD (I[XY]+d),H */
+	case REGL:			/* LD (I[XY]+d),L */
 		len = 3;
 		if (pass == 2) {
-			ops[0] = 0xdd;
+			ops[0] = prefix;
 			ops[1] = 0x70 + op;
-			ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
+			ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
 		}
 		break;
-	case NOREG:			/* LD (IX+d),n */
+	case NOREG:			/* LD (I[XY]+d),n */
 		len = 4;
 		if (pass == 2) {
-			ops[0] = 0xdd;
+			ops[0] = prefix;
 			ops[1] = 0x36;
-			ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			ops[3] = chk_v1(eval(p));
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	LD (IY+d),?
- */
-int ldiiy(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* LD (IY+d),A */
-	case REGB:			/* LD (IY+d),B */
-	case REGC:			/* LD (IY+d),C */
-	case REGD:			/* LD (IY+d),D */
-	case REGE:			/* LD (IY+d),E */
-	case REGH:			/* LD (IY+d),H */
-	case REGL:			/* LD (IY+d),L */
-		len = 3;
-		if (pass == 2) {
-			ops[0] = 0xfd;
-			ops[1] = 0x70 + op;
-			ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-		}
-		break;
-	case NOREG:			/* LD (IY+d),n */
-		len = 4;
-		if (pass == 2) {
-			ops[0] = 0xfd;
-			ops[1] = 0x36;
-			ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			ops[3] = chk_v1(eval(p));
+			ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
+			ops[3] = chk_byte(eval(p));
 		}
 		break;
 	case NOOPERA:			/* missing operand */
@@ -1953,7 +1257,7 @@ int ldinn(void)
 /*
  *	ADD ?,?
  */
-int op_add(void)
+int op_add(int dummy1, int dummy2)
 {
 	register int len;
 	register char *p1, *p2;
@@ -1968,7 +1272,7 @@ int op_add(void)
 	*p2 = '\0';
 	switch (get_reg(tmp)) {
 	case REGA:			/* ADD A,? */
-		len = adda();
+		len = aluop(0x80, get_second(operand));
 		break;
 	case REGHL:			/* ADD HL,? */
 		len = addhl();
@@ -1978,84 +1282,6 @@ int op_add(void)
 		break;
 	case REGIY:			/* ADD IY,? */
 		len = addiy();
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	ADD A,?
- */
-int adda(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* ADD A,A */
-	case REGB:			/* ADD A,B */
-	case REGC:			/* ADD A,C */
-	case REGD:			/* ADD A,D */
-	case REGE:			/* ADD A,E */
-	case REGH:			/* ADD A,H */
-	case REGL:			/* ADD A,L */
-	case REGIHL:			/* ADD A,(HL) */
-		len = 1;
-		ops[0] = 0x80 + op;
-		break;
-	case REGIXH:			/* ADD A,IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x84;
-		break;
-	case REGIXL:			/* ADD A,IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x85;
-		break;
-	case REGIYH:			/* ADD A,IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x84;
-		break;
-	case REGIYL:			/* ADD A,IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x85;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) {
-			len = 3;	/* ADD A,(IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x86;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-		} else if (strncmp(p, "(IY+", 4) == 0) {
-			len = 3;	/* ADD A,(IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x86;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-		} else {
-			len = 2;	/* ADD A,n */
-			if (pass == 2) {
-				ops[0] = 0xc6;
-				ops[1] = chk_v1(eval(p));
-			}
-		}
 		break;
 	case NOOPERA:			/* missing operand */
 		len = 1;
@@ -2090,12 +1316,10 @@ int addhl(void)
 		break;
 	case NOOPERA:			/* missing operand */
 		ops[0] = 0;
-		ops[1] = 0;
 		asmerr(E_MISOPE);
 		break;
 	default:			/* invalid operand */
 		ops[0] = 0;
-		ops[1] = 0;
 		asmerr(E_ILLOPE);
 	}
 	return(1);
@@ -2174,7 +1398,7 @@ int addiy(void)
 /*
  *	ADC ?,?
  */
-int op_adc(void)
+int op_adc(int dummy1, int dummy2)
 {
 	register int len;
 	register char *p1, *p2;
@@ -2189,10 +1413,10 @@ int op_adc(void)
 	*p2 = '\0';
 	switch (get_reg(tmp)) {
 	case REGA:			/* ADC A,? */
-		len = adca();
+		len = aluop(0x88, get_second(operand));
 		break;
 	case REGHL:			/* ADC HL,? */
-		len = adchl();
+		len = sbadchl(0x4a);
 		break;
 	case NOOPERA:			/* missing operand */
 		len = 1;
@@ -2205,203 +1429,23 @@ int op_adc(void)
 		asmerr(E_ILLOPE);
 	}
 	return(len);
-}
-
-/*
- *	ADC A,?
- */
-int adca(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* ADC A,A */
-	case REGB:			/* ADC A,B */
-	case REGC:			/* ADC A,C */
-	case REGD:			/* ADC A,D */
-	case REGE:			/* ADC A,E */
-	case REGH:			/* ADC A,H */
-	case REGL:			/* ADC A,L */
-	case REGIHL:			/* ADC A,(HL) */
-		len = 1;
-		ops[0] = 0x88 + op;
-		break;
-	case REGIXH:			/* ADC A,IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x8c;
-		break;
-	case REGIXL:			/* ADC A,IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x8d;
-		break;
-	case REGIYH:			/* ADC A,IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x8c;
-		break;
-	case REGIYL:			/* ADC A,IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x8d;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) {
-			len = 3;	/* ADC A,(IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x8e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-		} else if (strncmp(p, "(IY+", 4) == 0) {
-			len = 3;	/* ADC A,(IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x8e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-		} else {
-			len = 2;	/* ADD A,n */
-			if (pass == 2) {
-				ops[0] = 0xce;
-				ops[1] = chk_v1(eval(p));
-			}
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	ADC HL,?
- */
-int adchl(void)
-{
-	switch (get_reg(get_second(operand))) {
-	case REGBC:			/* ADC HL,BC */
-		ops[0] = 0xed;
-		ops[1] = 0x4a;
-		break;
-	case REGDE:			/* ADC HL,DE */
-		ops[0] = 0xed;
-		ops[1] = 0x5a;
-		break;
-	case REGHL:			/* ADC HL,HL */
-		ops[0] = 0xed;
-		ops[1] = 0x6a;
-		break;
-	case REGSP:			/* ADC HL,SP */
-		ops[0] = 0xed;
-		ops[1] = 0x7a;
-		break;
-	case NOOPERA:			/* missing operand */
-		ops[0] = 0;
-		ops[1] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		ops[0] = 0;
-		ops[1] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(2);
 }
 
 /*
  *	SUB
  */
-int op_sub(void)
+int op_sub(int dummy1, int dummy2)
 {
-	register int len, op;
-
 	if (pass == 1)
 		if (*label)
 			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* SUB A */
-	case REGB:			/* SUB B */
-	case REGC:			/* SUB C */
-	case REGD:			/* SUB D */
-	case REGE:			/* SUB E */
-	case REGH:			/* SUB H */
-	case REGL:			/* SUB L */
-	case REGIHL:			/* SUB (HL) */
-		len = 1;
-		ops[0] = 0x90 + op;
-		break;
-	case REGIXH:			/* SUB IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x94;
-		break;
-	case REGIXL:			/* SUB IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x95;
-		break;
-	case REGIYH:			/* SUB IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x94;
-		break;
-	case REGIYL:			/* SUB IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x95;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 3;	/* SUB (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x96;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 3;	/* SUB (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x96;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else {
-			len = 2;	/* SUB n */
-			if (pass == 2) {
-				ops[0] = 0xd6;
-				ops[1] = chk_v1(eval(operand));
-			}
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
+	return(aluop(0x90, operand));
 }
 
 /*
  *	SBC ?,?
  */
-int op_sbc(void)
+int op_sbc(int dummy1, int dummy2)
 {
 	register int len;
 	register char *p1, *p2;
@@ -2416,10 +1460,10 @@ int op_sbc(void)
 	*p2 = '\0';
 	switch (get_reg(tmp)) {
 	case REGA:			/* SBC A,? */
-		len = sbca();
+		len = aluop(0x98, get_second(operand));
 		break;
 	case REGHL:			/* SBC HL,? */
-		len = sbchl();
+		len = sbadchl(0x42);
 		break;
 	case NOOPERA:			/* missing operand */
 		len = 1;
@@ -2435,104 +1479,26 @@ int op_sbc(void)
 }
 
 /*
- *	SBC A,?
+ *	SBC AND ADC HL,?
  */
-int sbca(void)
-{
-	register int op;
-	register int len;
-	register char *p;
-
-	p = get_second(operand);
-	switch (op = get_reg(p)) {
-	case REGA:			/* SBC A,A */
-	case REGB:			/* SBC A,B */
-	case REGC:			/* SBC A,C */
-	case REGD:			/* SBC A,D */
-	case REGE:			/* SBC A,E */
-	case REGH:			/* SBC A,H */
-	case REGL:			/* SBC A,L */
-	case REGIHL:			/* SBC A,(HL) */
-		len = 1;
-		ops[0] = 0x98 + op;
-		break;
-	case REGIXH:			/* SBC A,IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x9c;
-		break;
-	case REGIXL:			/* SBC A,IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x9d;
-		break;
-	case REGIYH:			/* SBC A,IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x9c;
-		break;
-	case REGIYL:			/* SBC A,IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x9d;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p, "(IX+", 4) == 0) {
-			len = 3;	/* SBC A,(IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x9e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-		} else if (strncmp(p, "(IY+", 4) == 0) {
-			len = 3;	/* SBC A,(IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x9e;
-				ops[2] = chk_v2(calc_val(strchr(p, '+') + 1));
-			}
-		} else {
-			len = 2;	/* SBC A,n */
-			if (pass == 2) {
-				ops[0] = 0xde;
-				ops[1] = chk_v1(eval(p));
-			}
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	SBC HL,?
- */
-int sbchl(void)
+int sbadchl(int base_op)
 {
 	switch (get_reg(get_second(operand))) {
-	case REGBC:			/* SBC HL,BC */
+	case REGBC:			/* SBC/ADC HL,BC */
 		ops[0] = 0xed;
-		ops[1] = 0x42;
+		ops[1] = base_op;
 		break;
-	case REGDE:			/* SBC HL,DE */
+	case REGDE:			/* SBC/ADC HL,DE */
 		ops[0] = 0xed;
-		ops[1] = 0x52;
+		ops[1] = base_op + 0x10;
 		break;
-	case REGHL:			/* SBC HL,HL */
+	case REGHL:			/* SBC/ADC HL,HL */
 		ops[0] = 0xed;
-		ops[1] = 0x62;
+		ops[1] = base_op + 0x20;
 		break;
-	case REGSP:			/* SBC HL,SP */
+	case REGSP:			/* SBC/ADC HL,SP */
 		ops[0] = 0xed;
-		ops[1] = 0x72;
+		ops[1] = base_op + 0x30;
 		break;
 	case NOOPERA:			/* missing operand */
 		ops[0] = 0;
@@ -2548,9 +1514,9 @@ int sbchl(void)
 }
 
 /*
- *	INC
+ *	DEC and INC
  */
-int op_inc(void)
+int op_decinc(int base_op, int base_op16)
 {
 	register int len, op;
 
@@ -2558,179 +1524,77 @@ int op_inc(void)
 		if (*label)
 			put_label();
 	switch (op = get_reg(operand)) {
-	case REGA:			/* INC A */
-	case REGB:			/* INC B */
-	case REGC:			/* INC C */
-	case REGD:			/* INC D */
-	case REGE:			/* INC E */
-	case REGH:			/* INC H */
-	case REGL:			/* INC L */
-	case REGIHL:			/* INC (HL) */
+	case REGA:			/* INC/DEC A */
+	case REGB:			/* INC/DEC B */
+	case REGC:			/* INC/DEC C */
+	case REGD:			/* INC/DEC D */
+	case REGE:			/* INC/DEC E */
+	case REGH:			/* INC/DEC H */
+	case REGL:			/* INC/DEC L */
+	case REGIHL:			/* INC/DEC (HL) */
 		len = 1;
-		ops[0] = 0x04 + (op << 3);
+		ops[0] = base_op + (op << 3);
 		break;
-	case REGBC:			/* INC BC */
+	case REGBC:			/* INC/DEC BC */
 		len = 1;
-		ops[0] = 0x03;
+		ops[0] = base_op16;
 		break;
-	case REGDE:			/* INC DE */
+	case REGDE:			/* INC/DEC DE */
 		len = 1;
-		ops[0] = 0x13;
+		ops[0] = base_op16 + 0x10;
 		break;
-	case REGHL:			/* INC HL */
+	case REGHL:			/* INC/DEC HL */
 		len = 1;
-		ops[0] = 0x23;
+		ops[0] = base_op16 + 0x20;
 		break;
-	case REGSP:			/* INC SP */
+	case REGSP:			/* INC/DEC SP */
 		len = 1;
-		ops[0] = 0x33;
+		ops[0] = base_op16 + 0x30;
 		break;
-	case REGIX:			/* INC IX */
+	case REGIX:			/* INC/DEC IX */
 		len = 2;
 		ops[0] = 0xdd;
-		ops[1] = 0x23;
+		ops[1] = base_op16 + 0x20;
 		break;
-	case REGIY:			/* INC IY */
+	case REGIY:			/* INC/DEC IY */
 		len = 2;
 		ops[0] = 0xfd;
-		ops[1] = 0x23;
+		ops[1] = base_op16 + 0x20;
 		break;
-	case REGIXH:			/* INC IXH (undocumented) */
+	case REGIXH:			/* INC/DEC IXH (undocumented) */
 		len = 2;
 		ops[0] = 0xdd;
-		ops[1] = 0x24;
+		ops[1] = base_op + 0x20;
 		break;
-	case REGIXL:			/* INC IXL (undocumented) */
+	case REGIXL:			/* INC/DEC IXL (undocumented) */
 		len = 2;
 		ops[0] = 0xdd;
-		ops[1] = 0x2c;
+		ops[1] = base_op + 0x28;
 		break;
-	case REGIYH:			/* INC IYH (undocumented) */
+	case REGIYH:			/* INC/DEC IYH (undocumented) */
 		len = 2;
 		ops[0] = 0xfd;
-		ops[1] = 0x24;
+		ops[1] = base_op + 0x20;
 		break;
-	case REGIYL:			/* INC IYL (undocumented) */
+	case REGIYL:			/* INC/DEC IYL (undocumented) */
 		len = 2;
 		ops[0] = 0xfd;
-		ops[1] = 0x2c;
+		ops[1] = base_op + 0x28;
 		break;
 	case NOREG:			/* operand isn't register */
 		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 3;	/* INC (IX+d) */
+			len = 3;	/* INC/DEC (IX+d) */
 			if (pass == 2) {
 				ops[0] = 0xdd;
-				ops[1] = 0x34;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
+				ops[1] = base_op + 0x30;
+				ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
 			}
 		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 3;	/* INC (IY+d) */
+			len = 3;	/* INC/DEC (IY+d) */
 			if (pass == 2) {
 				ops[0] = 0xfd;
-				ops[1] = 0x34;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else {
-			len = 1;
-			ops[0] = 0;
-			asmerr(E_ILLOPE);
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	DEC
- */
-int op_dec(void)
-{
-	register int len, op;
-
-	if (pass == 1)
-		if (*label)
-			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* DEC A */
-	case REGB:			/* DEC B */
-	case REGC:			/* DEC C */
-	case REGD:			/* DEC D */
-	case REGE:			/* DEC E */
-	case REGH:			/* DEC H */
-	case REGL:			/* DEC L */
-	case REGIHL:			/* DEC (HL) */
-		len = 1;
-		ops[0] = 0x05 + (op << 3);
-		break;
-	case REGBC:			/* DEC BC */
-		len = 1;
-		ops[0] = 0x0b;
-		break;
-	case REGDE:			/* DEC DE */
-		len = 1;
-		ops[0] = 0x1b;
-		break;
-	case REGHL:			/* DEC HL */
-		len = 1;
-		ops[0] = 0x2b;
-		break;
-	case REGSP:			/* DEC SP */
-		len = 1;
-		ops[0] = 0x3b;
-		break;
-	case REGIX:			/* DEC IX */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x2b;
-		break;
-	case REGIY:			/* DEC IY */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x2b;
-		break;
-	case REGIXH:			/* DEC IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x25;
-		break;
-	case REGIXL:			/* DEC IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0x2d;
-		break;
-	case REGIYH:			/* DEC IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x25;
-		break;
-	case REGIYL:			/* DEC IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0x2d;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 3;	/* DEC (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0x35;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 3;	/* DEC (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0x35;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
+				ops[1] = base_op + 0x30;
+				ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
 			}
 		} else {
 			len = 1;
@@ -2754,299 +1618,106 @@ int op_dec(void)
 /*
  *	OR
  */
-int op_or(void)
+int op_or(int dummy1, int dummy2)
 {
-	register int len, op;
-
 	if (pass == 1)
 		if (*label)
 			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* OR A */
-	case REGB:			/* OR B */
-	case REGC:			/* OR C */
-	case REGD:			/* OR D */
-	case REGE:			/* OR E */
-	case REGH:			/* OR H */
-	case REGL:			/* OR L */
-	case REGIHL:			/* OR (HL) */
-		len = 1;
-		ops[0] = 0xb0 + op;
-		break;
-	case REGIXH:			/* OR IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0xb4;
-		break;
-	case REGIXL:			/* OR IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0xb5;
-		break;
-	case REGIYH:			/* OR IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0xb4;
-		break;
-	case REGIYL:			/* OR IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0xb5;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 3;	/* OR (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xb6;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 3;	/* OR (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xb6;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else {
-			len = 2;	/* OR n */
-			if (pass == 2) {
-				ops[0] = 0xf6;
-				ops[1] = chk_v1(eval(operand));
-			}
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
+	return(aluop(0xb0, operand));
 }
 
 /*
  *	XOR
  */
-int op_xor(void)
+int op_xor(int dummy1, int dummy2)
 {
-	register int len, op;
-
 	if (pass == 1)
 		if (*label)
 			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* XOR A */
-	case REGB:			/* XOR B */
-	case REGC:			/* XOR C */
-	case REGD:			/* XOR D */
-	case REGE:			/* XOR E */
-	case REGH:			/* XOR H */
-	case REGL:			/* XOR L */
-	case REGIHL:			/* XOR (HL) */
-		len = 1;
-		ops[0] = 0xa8 + op;
-		break;
-	case REGIXH:			/* XOR IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0xac;
-		break;
-	case REGIXL:			/* XOR IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0xad;
-		break;
-	case REGIYH:			/* XOR IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0xac;
-		break;
-	case REGIYL:			/* XOR IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0xad;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 3;	/* XOR (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xae;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 3;	/* XOR (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xae;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else {
-			len = 2;	/* XOR n */
-			if (pass == 2) {
-				ops[0] = 0xee;
-				ops[1] = chk_v1(eval(operand));
-			}
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
+	return(aluop(0xa8, operand));
 }
 
 /*
  *	AND
  */
-int op_and(void)
+int op_and(int dummy1, int dummy2)
 {
-	register int len, op;
-
 	if (pass == 1)
 		if (*label)
 			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* AND A */
-	case REGB:			/* AND B */
-	case REGC:			/* AND C */
-	case REGD:			/* AND D */
-	case REGE:			/* AND E */
-	case REGH:			/* AND H */
-	case REGL:			/* AND L */
-	case REGIHL:			/* AND (HL) */
-		len = 1;
-		ops[0] = 0xa0 + op;
-		break;
-	case REGIXH:			/* AND IXH (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0xa4;
-		break;
-	case REGIXL:			/* AND IXL (undocumented) */
-		len = 2;
-		ops[0] = 0xdd;
-		ops[1] = 0xa5;
-		break;
-	case REGIYH:			/* AND IYH (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0xa4;
-		break;
-	case REGIYL:			/* AND IYL (undocumented) */
-		len = 2;
-		ops[0] = 0xfd;
-		ops[1] = 0xa5;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 3;	/* AND (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xa6;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 3;	/* AND (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xa6;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-			}
-		} else {
-			len = 2;	/* AND n */
-			if (pass == 2) {
-				ops[0] = 0xe6;
-				ops[1] = chk_v1(eval(operand));
-			}
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
+	return(aluop(0xa0, operand));
 }
 
 /*
  *	CP
  */
-int op_cp(void)
+int op_cp(int dummy1, int dummy2)
 {
-	register int len, op;
-
 	if (pass == 1)
 		if (*label)
 			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* CP A */
-	case REGB:			/* CP B */
-	case REGC:			/* CP C */
-	case REGD:			/* CP D */
-	case REGE:			/* CP E */
-	case REGH:			/* CP H */
-	case REGL:			/* CP L */
-	case REGIHL:			/* CP (HL) */
+	return(aluop(0xb8, operand));
+}
+
+/*
+ *	ADD A, ADC A, SUB, SBC A, AND, XOR, OR, CP
+ */
+int aluop(int base_op, char *p)
+{
+	register int len, op;
+
+	switch (op = get_reg(p)) {
+	case REGA:			/* ALUOP {A,}A */
+	case REGB:			/* ALUOP {A,}B */
+	case REGC:			/* ALUOP {A,}C */
+	case REGD:			/* ALUOP {A,}D */
+	case REGE:			/* ALUOP {A,}E */
+	case REGH:			/* ALUOP {A,}H */
+	case REGL:			/* ALUOP {A,}L */
+	case REGIHL:			/* ALUOP {A,}(HL) */
 		len = 1;
-		ops[0] = 0xb8 + op;
+		ops[0] = base_op + op;
 		break;
-	case REGIXH:			/* CP IXH (undocumented) */
+	case REGIXH:			/* ALUOP {A,}IXH (undocumented) */
 		len = 2;
 		ops[0] = 0xdd;
-		ops[1] = 0xbc;
+		ops[1] = base_op + 0x04;
 		break;
-	case REGIXL:			/* CP IXL (undocumented) */
+	case REGIXL:			/* ALUOP {A,}IXL (undocumented) */
 		len = 2;
 		ops[0] = 0xdd;
-		ops[1] = 0xbd;
+		ops[1] = base_op + 0x05;
 		break;
-	case REGIYH:			/* CP IYH (undocumented) */
+	case REGIYH:			/* ALUOP {A,}IYH (undocumented) */
 		len = 2;
 		ops[0] = 0xfd;
-		ops[1] = 0xbc;
+		ops[1] = base_op + 0x04;
 		break;
-	case REGIYL:			/* CP IYL (undocumented) */
+	case REGIYL:			/* ALUOP {A,}IYL (undocumented) */
 		len = 2;
 		ops[0] = 0xfd;
-		ops[1] = 0xbd;
+		ops[1] = base_op + 0x05;
 		break;
 	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 3;	/* CP (IX+d) */
+		if (strncmp(p, "(IX+", 4) == 0) {
+			len = 3;	/* ALUOP {A,}(IX+d) */
 			if (pass == 2) {
 				ops[0] = 0xdd;
-				ops[1] = 0xbe;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
+				ops[1] = base_op + 0x06;
+				ops[2] = chk_sbyte(calc_val(strchr(p, '+') + 1));
 			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 3;	/* CP (IY+d) */
+		} else if (strncmp(p, "(IY+", 4) == 0) {
+			len = 3;	/* ALUOP {A,}(IY+d) */
 			if (pass == 2) {
 				ops[0] = 0xfd;
-				ops[1] = 0xbe;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
+				ops[1] = base_op + 006;
+				ops[2] = chk_sbyte(calc_val(strchr(p, '+') + 1));
 			}
 		} else {
-			len = 2;	/* OR n */
+			len = 2;	/* ALUOP {A,}n */
 			if (pass == 2) {
-				ops[0] = 0xfe;
-				ops[1] = chk_v1(eval(operand));
+				ops[0] = base_op + 0x46;
+				ops[1] = chk_byte(eval(p));
 			}
 		}
 		break;
@@ -3064,457 +1735,93 @@ int op_cp(void)
 }
 
 /*
- *	RL
+ *	RLC, RRC, RL, RR, SLA, SRA, SLL, SRL
  */
-int op_rl(void)
+int op_rotshf(int base_op, int dummy)
 {
+	register char *p;
 	register int len, op;
 
 	if (pass == 1)
 		if (*label)
 			put_label();
 	switch (op = get_reg(operand)) {
-	case REGA:			/* RL A */
-	case REGB:			/* RL B */
-	case REGC:			/* RL C */
-	case REGD:			/* RL D */
-	case REGE:			/* RL E */
-	case REGH:			/* RL H */
-	case REGL:			/* RL L */
-	case REGIHL:			/* RL (HL) */
+	case REGA:			/* ROTSHF A */
+	case REGB:			/* ROTSHF B */
+	case REGC:			/* ROTSHF C */
+	case REGD:			/* ROTSHF D */
+	case REGE:			/* ROTSHF E */
+	case REGH:			/* ROTSHF H */
+	case REGL:			/* ROTSHF L */
+	case REGIHL:			/* ROTSHF (HL) */
 		len = 2;
 		ops[0] = 0xcb;
-		ops[1] = 0x10 + op;
+		ops[1] = base_op + op;
 		break;
 	case NOREG:			/* operand isn't register */
 		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 4;	/* RL (IX+d) */
-			if (pass == 2) {
+			len = 4;
+			if (pass == 1)
+				break;
+			if (undoc_flag && (p = strrchr(operand, ')'))
+				       && *(p + 1) == ',') {
+				switch (op = get_reg(p + 2)) {
+				case REGA:	/* ROTSHF (IX+d),A (undocumented) */
+				case REGB:	/* ROTSHF (IX+d),B (undocumented) */
+				case REGC:	/* ROTSHF (IX+d),C (undocumented) */
+				case REGD:	/* ROTSHF (IX+d),D (undocumented) */
+				case REGE:	/* ROTSHF (IX+d),E (undocumented) */
+				case REGH:	/* ROTSHF (IX+d),H (undocumented) */
+				case REGL:	/* ROTSHF (IX+d),L (undocumented) */
+					ops[0] = 0xdd;
+					ops[1] = 0xcb;
+					ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
+					ops[3] = base_op + op;
+					break;
+				default:	/* invalid operand */
+					ops[0] = 0;
+					ops[1] = 0;
+					ops[2] = 0;
+					ops[3] = 0;
+					asmerr(E_ILLOPE);
+				}
+			} else {		/* ROTSHF (IX+d) */
 				ops[0] = 0xdd;
 				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x16;
+				ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
+				ops[3] = base_op + 0x06;
 			}
 		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 4;	/* RL (IY+d) */
-			if (pass == 2) {
+			len = 4;
+			if (pass == 1)
+				break;
+			if (undoc_flag && (p = strrchr(operand, ')'))
+				       && *(p + 1) == ',') {
+				switch (op = get_reg(p + 2)) {
+				case REGA:	/* ROTSHF (IY+d),A (undocumented) */
+				case REGB:	/* ROTSHF (IY+d),B (undocumented) */
+				case REGC:	/* ROTSHF (IY+d),C (undocumented) */
+				case REGD:	/* ROTSHF (IY+d),D (undocumented) */
+				case REGE:	/* ROTSHF (IY+d),E (undocumented) */
+				case REGH:	/* ROTSHF (IY+d),H (undocumented) */
+				case REGL:	/* ROTSHF (IY+d),L (undocumented) */
+					ops[0] = 0xfd;
+					ops[1] = 0xcb;
+					ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
+					ops[3] = base_op + op;
+					break;
+				default:	/* invalid operand */
+					ops[0] = 0;
+					ops[1] = 0;
+					ops[2] = 0;
+					ops[3] = 0;
+					asmerr(E_ILLOPE);
+				}
+			} else {		/* ROTSHF (IY+d) */
 				ops[0] = 0xfd;
 				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x16;
-			}
-		} else {
-			len = 1;
-			ops[0] = 0;
-			asmerr(E_ILLOPE);
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	RR
- */
-int op_rr(void)
-{
-	register int len, op;
-
-	if (pass == 1)
-		if (*label)
-			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* RR A */
-	case REGB:			/* RR B */
-	case REGC:			/* RR C */
-	case REGD:			/* RR D */
-	case REGE:			/* RR E */
-	case REGH:			/* RR H */
-	case REGL:			/* RR L */
-	case REGIHL:			/* RR (HL) */
-		len = 2;
-		ops[0] = 0xcb;
-		ops[1] = 0x18 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 4;	/* RR (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x1e;
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 4;	/* RR (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x1e;
-			}
-		} else {
-			len = 1;
-			ops[0] = 0;
-			asmerr(E_ILLOPE);
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	SLA
- */
-int op_sla(void)
-{
-	register int len, op;
-
-	if (pass == 1)
-		if (*label)
-			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* SLA A */
-	case REGB:			/* SLA B */
-	case REGC:			/* SLA C */
-	case REGD:			/* SLA D */
-	case REGE:			/* SLA E */
-	case REGH:			/* SLA H */
-	case REGL:			/* SLA L */
-	case REGIHL:			/* SLA (HL) */
-		len = 2;
-		ops[0] = 0xcb;
-		ops[1] = 0x20 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 4;	/* SLA (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x26;
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 4;	/* SLA (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x26;
-			}
-		} else {
-			len = 1;
-			ops[0] = 0;
-			asmerr(E_ILLOPE);
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	SRA
- */
-int op_sra(void)
-{
-	register int len, op;
-
-	if (pass == 1)
-		if (*label)
-			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* SRA A */
-	case REGB:			/* SRA B */
-	case REGC:			/* SRA C */
-	case REGD:			/* SRA D */
-	case REGE:			/* SRA E */
-	case REGH:			/* SRA H */
-	case REGL:			/* SRA L */
-	case REGIHL:			/* SRA (HL) */
-		len = 2;
-		ops[0] = 0xcb;
-		ops[1] = 0x28 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 4;	/* SRA (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x2e;
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 4;	/* SRA (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x2e;
-			}
-		} else {
-			len = 1;
-			ops[0] = 0;
-			asmerr(E_ILLOPE);
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	SLL (undocumented)
- */
-int op_sll(void)
-{
-	register int len, op;
-
-	if (pass == 1)
-		if (*label)
-			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* SLL A (undocumented) */
-	case REGB:			/* SLL B (undocumented) */
-	case REGC:			/* SLL C (undocumented) */
-	case REGD:			/* SLL D (undocumented) */
-	case REGE:			/* SLL E (undocumented) */
-	case REGH:			/* SLL H (undocumented) */
-	case REGL:			/* SLL L (undocumented) */
-	case REGIHL:			/* SLL (HL) (undocumented) */
-		len = 2;
-		ops[0] = 0xcb;
-		ops[1] = 0x30 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 4;	/* SLL (IX+d) (undocumented) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x36;
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 4;	/* SLL (IY+d) (undocumented) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x36;
-			}
-		} else {
-			len = 1;
-			ops[0] = 0;
-			asmerr(E_ILLOPE);
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	SRL
- */
-int op_srl(void)
-{
-	register int len, op;
-
-	if (pass == 1)
-		if (*label)
-			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* SRL A */
-	case REGB:			/* SRL B */
-	case REGC:			/* SRL C */
-	case REGD:			/* SRL D */
-	case REGE:			/* SRL E */
-	case REGH:			/* SRL H */
-	case REGL:			/* SRL L */
-	case REGIHL:			/* SRL (HL) */
-		len = 2;
-		ops[0] = 0xcb;
-		ops[1] = 0x38 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 4;	/* SRL (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x3e;
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 4;	/* SRL (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x3e;
-			}
-		} else {
-			len = 1;
-			ops[0] = 0;
-			asmerr(E_ILLOPE);
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	RLC
- */
-int op_rlc(void)
-{
-	register int len, op;
-
-	if (pass == 1)
-		if (*label)
-			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* RLC A */
-	case REGB:			/* RLC B */
-	case REGC:			/* RLC C */
-	case REGD:			/* RLC D */
-	case REGE:			/* RLC E */
-	case REGH:			/* RLC H */
-	case REGL:			/* RLC L */
-	case REGIHL:			/* RLC (HL) */
-		len = 2;
-		ops[0] = 0xcb;
-		ops[1] = 0x00 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 4;	/* RLC (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x06;
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 4;	/* RLC (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x06;
-			}
-		} else {
-			len = 1;
-			ops[0] = 0;
-			asmerr(E_ILLOPE);
-		}
-		break;
-	case NOOPERA:			/* missing operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_MISOPE);
-		break;
-	default:			/* invalid operand */
-		len = 1;
-		ops[0] = 0;
-		asmerr(E_ILLOPE);
-	}
-	return(len);
-}
-
-/*
- *	RRC
- */
-int op_rrc(void)
-{
-	register int len, op;
-
-	if (pass == 1)
-		if (*label)
-			put_label();
-	switch (op = get_reg(operand)) {
-	case REGA:			/* RRC A */
-	case REGB:			/* RRC B */
-	case REGC:			/* RRC C */
-	case REGD:			/* RRC D */
-	case REGE:			/* RRC E */
-	case REGH:			/* RRC H */
-	case REGL:			/* RRC L */
-	case REGIHL:			/* RRC (HL) */
-		len = 2;
-		ops[0] = 0xcb;
-		ops[1] = 0x08 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(operand, "(IX+", 4) == 0) {
-			len = 4;	/* RRC (IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x0e;
-			}
-		} else if (strncmp(operand, "(IY+", 4) == 0) {
-			len = 4;	/* RRC (IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x0e;
+				ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
+				ops[3] = base_op + 0x06;
 			}
 		} else {
 			len = 1;
@@ -3538,7 +1845,7 @@ int op_rrc(void)
 /*
  *	OUT
  */
-int op_out(void)
+int op_out(int dummy1, int dummy2)
 {
 	register int op;
 	register char *p;
@@ -3547,13 +1854,9 @@ int op_out(void)
 		if (*label)
 			put_label();
 	} else {			/* PASS 2 */
-		if (undoc_flag && strncmp(operand, "(C),0", 5) == 0) {
-			ops[0] = 0xed;	/* OUT (C),0 (undocumented) */
-			ops[1] = 0x71;
-			return(2);
-		}
 		if (strncmp(operand, "(C),", 4) == 0) {
-			switch(op = get_reg(get_second(operand))) {
+			p = get_second(operand);
+			switch(op = get_reg(p)) {
 			case REGA:	/* OUT (C),A */
 			case REGB:	/* OUT (C),B */
 			case REGC:	/* OUT (C),C */
@@ -3569,18 +1872,26 @@ int op_out(void)
 				ops[1] = 0;
 				asmerr(E_MISOPE);
 				break;
-			default:	/* invalid operand */
-				ops[0] = 0;
-				ops[1] = 0;
-				asmerr(E_ILLOPE);
+			default:
+				if (undoc_flag && *p == '0') {
+					ops[0] = 0xed;	/* OUT (C),0 (undocumented) */
+					ops[1] = 0x71;
+				} else {	/* invalid operand */
+					ops[0] = 0;
+					ops[1] = 0;
+					asmerr(E_ILLOPE);
+				}
 			}
 		} else {
 			/* check syntax for OUT (n),A */
 			p = strchr(operand, ')');
-			if (strncmp(p, "),A", 3))
+			if (strncmp(p, "),A", 3)) {
+				ops[0] = 0;
+				ops[1] = 0;
 				asmerr(E_ILLOPE);
+			}
 			ops[0] = 0xd3;	/* OUT (n),A */
-			ops[1] = chk_v1(calc_val(operand + 1));
+			ops[1] = chk_byte(calc_val(operand + 1));
 		}
 	}
 	return(2);
@@ -3589,7 +1900,7 @@ int op_out(void)
 /*
  *	IN
  */
-int op_in(void)
+int op_in(int dummy1, int dummy2)
 {
 	register char *p1, *p2;
 	register int op;
@@ -3598,11 +1909,6 @@ int op_in(void)
 		if (*label)
 			put_label();
 	} else {			/* PASS 2 */
-		if (undoc_flag && strncmp(operand, "F,(C)", 5) == 0) {
-			ops[0] = 0xed;	/* IN F,(C) (undocumented) */
-			ops[1] = 0x70;
-			return(2);
-		}
 		p1 = operand;
 		p2 = tmp;
 		while (*p1 != ',' && *p1 != '\0')
@@ -3615,7 +1921,7 @@ int op_in(void)
 				ops[1] = 0x78;
 			} else {
 				ops[0] = 0xdb;	/* IN A,(n) */
-				ops[1] = chk_v1(calc_val(get_second(operand) + 1));
+				ops[1] = chk_byte(calc_val(get_second(operand) + 1));
 			}
 			break;
 		case REGB:			/* IN B,(C) */
@@ -3627,19 +1933,24 @@ int op_in(void)
 			ops[0] = 0xed;
 			ops[1] = 0x40 + (op << 3);
 			break;
-		default:			/* invalid operand */
-			ops[0] = 0;
-			ops[1] = 0;
-			asmerr(E_ILLOPE);
+		default:
+			if (undoc_flag && strncmp(operand, "F,(C)", 5) == 0) {
+				ops[0] = 0xed;	/* IN F,(C) (undocumented) */
+				ops[1] = 0x70;
+			} else {		/* invalid operand */
+				ops[0] = 0;
+				ops[1] = 0;
+				asmerr(E_ILLOPE);
+			}
 		}
 	}
 	return(2);
 }
 
 /*
- *	SET
+ *	BIT, RES, SET
  */
-int op_set(void)
+int op_trsbit(int base_op, int dummy)
 {
 	register char *p1, *p2;
 	register int len;
@@ -3663,43 +1974,96 @@ int op_set(void)
 			asmerr(E_VALOUT);
 	}
 	switch (op = get_reg(++p1)) {
-	case REGA:			/* SET n,A */
-	case REGB:			/* SET n,B */
-	case REGC:			/* SET n,C */
-	case REGD:			/* SET n,D */
-	case REGE:			/* SET n,E */
-	case REGH:			/* SET n,H */
-	case REGL:			/* SET n,L */
-	case REGIHL:			/* SET n,(HL) */
-		ops[1] = 0xc0 + i * 8 + op;
+	case REGA:			/* TRSBIT n,A */
+	case REGB:			/* TRSBIT n,B */
+	case REGC:			/* TRSBIT n,C */
+	case REGD:			/* TRSBIT n,D */
+	case REGE:			/* TRSBIT n,E */
+	case REGH:			/* TRSBIT n,H */
+	case REGL:			/* TRSBIT n,L */
+	case REGIHL:			/* TRSBIT n,(HL) */
+		ops[1] = base_op + i * 8 + op;
 		break;
 	case NOREG:			/* operand isn't register */
 		if (strncmp(p1, "(IX+", 4) == 0) {
-			len = 4;	/* SET n,(IX+d) */
-			if (pass == 2) {
+			len = 4;
+			if (pass == 1)
+				break;
+			if (undoc_flag && base_op != 0x40 && (p2 = strrchr(p1, ')'))
+							  && *(p2 + 1) == ',') {
+				/* only for SET/RES */
+				switch (op = get_reg(p2 + 2)) {
+				case REGA:	/* SETRES n,(IX+d),A (undocumented) */
+				case REGB:	/* SETRES n,(IX+d),B (undocumented) */
+				case REGC:	/* SETRES n,(IX+d),C (undocumented) */
+				case REGD:	/* SETRES n,(IX+d),D (undocumented) */
+				case REGE:	/* SETRES n,(IX+d),E (undocumented) */
+				case REGH:	/* SETRES n,(IX+d),H (undocumented) */
+				case REGL:	/* SETRES n,(IX+d),L (undocumented) */
+					ops[0] = 0xdd;
+					ops[1] = 0xcb;
+					ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
+					ops[3] = base_op + i * 8 + op;
+					break;
+				default:	/* invalid operand */
+					ops[0] = 0;
+					ops[1] = 0;
+					ops[2] = 0;
+					ops[3] = 0;
+					asmerr(E_ILLOPE);
+				}
+			} else {		/* TRSBIT n,(IX+d) */
 				ops[0] = 0xdd;
 				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0xc6 + i * 8;
+				ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
+				ops[3] = base_op + 0x06 + i * 8;
 			}
 		} else if (strncmp(p1, "(IY+", 4) == 0) {
-			len = 4;	/* SET n,(IY+d) */
-			if (pass == 2) {
+			len = 4;
+			if (pass == 1)
+				break;
+			if (undoc_flag && base_op != 0x40 && (p2 = strrchr(p1, ')'))
+							  && *(p2 + 1) == ',') {
+				/* only for SET/RES */
+				switch (op = get_reg(p2 + 2)) {
+				case REGA:	/* SETRES n,(IY+d),A (undocumented) */
+				case REGB:	/* SETRES n,(IY+d),B (undocumented) */
+				case REGC:	/* SETRES n,(IY+d),C (undocumented) */
+				case REGD:	/* SETRES n,(IY+d),D (undocumented) */
+				case REGE:	/* SETRES n,(IY+d),E (undocumented) */
+				case REGH:	/* SETRES n,(IY+d),H (undocumented) */
+				case REGL:	/* SETRES n,(IY+d),L (undocumented) */
+					ops[0] = 0xfd;
+					ops[1] = 0xcb;
+					ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
+					ops[3] = base_op + i * 8 + op;
+					break;
+				default:	/* invalid operand */
+					ops[0] = 0;
+					ops[1] = 0;
+					ops[2] = 0;
+					ops[3] = 0;
+					asmerr(E_ILLOPE);
+				}
+			} else {		/* TRSBIT n,(IY+d) */
 				ops[0] = 0xfd;
 				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0xc6 + i * 8;
+				ops[2] = chk_sbyte(calc_val(strchr(operand, '+') + 1));
+				ops[3] = base_op + 0x06 + i * 8;
 			}
 		} else {
+			ops[0] = 0;
 			ops[1] = 0;
 			asmerr(E_ILLOPE);
 		}
 		break;
 	case NOOPERA:			/* missing operand */
+		ops[0] = 0;
 		ops[1] = 0;
 		asmerr(E_MISOPE);
 		break;
 	default:			/* invalid operand */
+		ops[0] = 0;
 		ops[1] = 0;
 		asmerr(E_ILLOPE);
 	}
@@ -3707,140 +2071,417 @@ int op_set(void)
 }
 
 /*
- *	RES
+ *	8080 MOV
  */
-int op_res(void)
+int op8080_mov(int dummy1, int dummy2)
 {
 	register char *p1, *p2;
-	register int len;
-	register int i;
-	register int op;
+	register int op1, op2;
 
-	len = 2;
-	i = 0;
 	if (pass == 1)
 		if (*label)
 			put_label();
-	ops[0] = 0xcb;
 	p1 = operand;
 	p2 = tmp;
 	while (*p1 != ',' && *p1 != '\0')
 		*p2++ = *p1++;
 	*p2 = '\0';
-	if (pass == 2) {
-		i = eval(tmp);
-		if (i < 0 || i > 7)
-			asmerr(E_VALOUT);
-	}
-	switch (op = get_reg(++p1)) {
-	case REGA:			/* RES n,A */
-	case REGB:			/* RES n,B */
-	case REGC:			/* RES n,C */
-	case REGD:			/* RES n,D */
-	case REGE:			/* RES n,E */
-	case REGH:			/* RES n,H */
-	case REGL:			/* RES n,L */
-	case REGIHL:			/* RES n,(HL) */
-		ops[1] = 0x80 + i * 8 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p1, "(IX+", 4) == 0) {
-			len = 4;	/* RES n,(IX+d) */
-			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x86 + i * 8;
+	switch (op1 = get_reg(tmp)) {
+	case REGA:			/* MOV A,R */
+	case REGB:			/* MOV B,R */
+	case REGC:			/* MOV C,R */
+	case REGD:			/* MOV D,R */
+	case REGE:			/* MOV E,R */
+	case REGH:			/* MOV H,R */
+	case REGL:			/* MOV L,R */
+	case REGM:			/* MOV M,R */
+		p1 = get_second(operand);
+		switch (op2 = get_reg(p1)) {
+		case REGA:		/* MOV R,A */
+		case REGB:		/* MOV R,B */
+		case REGC:		/* MOV R,C */
+		case REGD:		/* MOV R,D */
+		case REGE:		/* MOV R,E */
+		case REGH:		/* MOV R,H */
+		case REGL:		/* MOV R,L */
+		case REGM:		/* MOV R,M */
+			if (op1 == REGM && op2 == REGM) {
+				ops[0] = 0;
+				asmerr(E_ILLOPE);
 			}
-		} else if (strncmp(p1, "(IY+", 4) == 0) {
-			len = 4;	/* RES n,(IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x86 + i * 8;
-			}
-		} else {
-			ops[1] = 0;
+			else
+				ops[0] = 0x40 + (op1 << 3) + op2;
+			break;
+		case NOOPERA:		/* missing operand */
+			ops[0] = 0;
+			asmerr(E_MISOPE);
+			break;
+		default:		/* invalid operand */
+			ops[0] = 0;
 			asmerr(E_ILLOPE);
 		}
 		break;
 	case NOOPERA:			/* missing operand */
-		ops[1] = 0;
+		ops[0] = 0;
 		asmerr(E_MISOPE);
 		break;
 	default:			/* invalid operand */
-		ops[1] = 0;
+		ops[0] = 0;
+		asmerr(E_ILLOPE);
+	}
+	return(1);
+}
+
+/*
+ *	8080 ADC, ADD, ANA, CMP, ORA, SBB, SUB, XRA
+ */
+int op8080_alu(int base_op, int dummy)
+{
+	register int op;
+
+	if (pass == 1)
+		if (*label)
+			put_label();
+	switch (op = get_reg(operand)) {
+	case REGA:			/* ALUOP A */
+	case REGB:			/* ALUOP B */
+	case REGC:			/* ALUOP C */
+	case REGD:			/* ALUOP D */
+	case REGE:			/* ALUOP E */
+	case REGH:			/* ALUOP H */
+	case REGL:			/* ALUOP L */
+	case REGM:			/* ALUOP M */
+		ops[0] = base_op + op;
+		break;
+	case NOOPERA:			/* missing operand */
+		ops[0] = 0;
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		ops[0] = 0;
+		asmerr(E_ILLOPE);
+	}
+	return(1);
+}
+
+/*
+ *	8080 DCR and INR
+ */
+int op8080_decinc(int base_op, int dummy)
+{
+	register int op;
+
+	if (pass == 1)
+		if (*label)
+			put_label();
+	switch (op = get_reg(operand)) {
+	case REGA:			/* DEC/INC A */
+	case REGB:			/* DEC/INC B */
+	case REGC:			/* DEC/INC C */
+	case REGD:			/* DEC/INC D */
+	case REGE:			/* DEC/INC E */
+	case REGH:			/* DEC/INC H */
+	case REGL:			/* DEC/INC L */
+	case REGM:			/* DEC/INC M */
+		ops[0] = base_op + (op << 3);
+		break;
+	case NOOPERA:			/* missing operand */
+		ops[0] = 0;
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		ops[0] = 0;
+		asmerr(E_ILLOPE);
+	}
+	return(1);
+}
+
+/*
+ *	8080 INX, DAD, DCX
+ */
+int op8080_reg16(int base_op, int dummy)
+{
+	register int op;
+
+	if (pass == 1)
+		if (*label)
+			put_label();
+	switch (op = get_reg(operand)) {
+	case REGB:			/* INX/DAD/DCX B */
+	case REGD:			/* INX/DAD/DCX D */
+	case REGH:			/* INX/DAD/DCX H */
+		ops[0] = base_op + (op << 3);
+		break;
+	case REGSP:			/* INX/DAD/DCX SP */
+		ops[0] = base_op + 0x30;
+		break;
+	case NOOPERA:			/* missing operand */
+		ops[0] = 0;
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		ops[0] = 0;
+		asmerr(E_ILLOPE);
+	}
+	return(1);
+}
+
+/*
+ *	8080 STAX and LDAX
+ */
+int op8080_regbd(int base_op, int dummy)
+{
+	register int op;
+
+	if (pass == 1)
+		if (*label)
+			put_label();
+	switch (op = get_reg(operand)) {
+	case REGB:			/* STAX/LDAX B */
+	case REGD:			/* STAX/LDAX D */
+		ops[0] = base_op + (op << 3);
+		break;
+	case NOOPERA:			/* missing operand */
+		ops[0] = 0;
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		ops[0] = 0;
+		asmerr(E_ILLOPE);
+	}
+	return(1);
+}
+
+/*
+ *	8080 ACI, ADI, ANI, CPI, ORI, SBI, SUI, XRI, OUT, IN
+ */
+int op8080_imm(int base_op, int dummy)
+{
+	register int len;
+
+	if (pass == 1)
+		if (*label)
+			put_label();
+	switch (get_reg(operand)) {
+	case NOREG:			/* IMMOP n */
+		len = 2;
+		if (pass == 2) {
+			ops[0] = base_op;
+			ops[1] = chk_byte(eval(operand));
+		}
+		break;
+	case NOOPERA:			/* missing operand */
+		len = 1;
+		ops[0] = 0;
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		len = 1;
+		ops[0] = 0;
 		asmerr(E_ILLOPE);
 	}
 	return(len);
 }
 
 /*
- *	BIT
+ *	8080 RST
  */
-int op_bit(void)
+int op8080_rst(int dummy1, int dummy2)
 {
-	register char *p1, *p2;
-	register int len;
-	register int i;
 	register int op;
 
-	len = 2;
-	i = 0;
+	if (pass == 1) {		/* PASS 1 */
+		if (*label)
+			put_label();
+	} else {			/* PASS 2 */
+		op = eval(operand);
+		if (op < 0 || op > 7) {
+			ops[0] = 0;
+			asmerr(E_VALOUT);
+		} else
+			ops[0] = 0xc7 + (op << 3);
+	}
+	return(1);
+}
+/*
+ *	8080 PUSH and POP
+ */
+int op8080_pupo(int base_op, int dummy)
+{
+	register int op;
+
 	if (pass == 1)
 		if (*label)
 			put_label();
-	ops[0] = 0xcb;
+	switch (op = get_reg(operand)) {
+	case REGB:			/* PUSH/POP B */
+	case REGD:			/* PUSH/POP D */
+	case REGH:			/* PUSH/POP H */
+		ops[0] = base_op + (op << 3);
+		break;
+	case REGPSW:			/* PUSH/POP PSW */
+		ops[0] = base_op + 0x30;
+		break;
+	case NOOPERA:			/* missing operand */
+		ops[0] = 0;
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		ops[0] = 0;
+		asmerr(E_ILLOPE);
+	}
+	return(1);
+}
+
+/*
+ *	8080 SHLD, LHLD, STA, LDA
+ *	     JMP, JNZ, JZ, JNC, JC, JPO, JPE, JP, JM
+ *	     CALL, CNZ, CZ, CNC, CC, CPO, CPE, CP, CM
+ */
+int op8080_addr(int base_op, int dummy)
+{
+	register int i, len;
+
+	if (pass == 1)
+		if (*label)
+			put_label();
+	switch (get_reg(operand)) {
+	case NOREG:			/* OP nn */
+		len = 3;
+		if (pass == 2) {
+			i = eval(operand);
+			ops[0] = base_op;
+			ops[1] = i & 0xff;
+			ops[2] = i >> 8;
+		}
+		break;
+	case NOOPERA:			/* missing operand */
+		len = 1;
+		ops[0] = 0;
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		len = 1;
+		ops[0] = 0;
+		asmerr(E_ILLOPE);
+	}
+	return(len);
+}
+
+/*
+ *	8080 MVI
+ */
+int op8080_mvi(int dummy1, int dummy2)
+{
+	register int len;
+	register char *p1, *p2;
+	register int op;
+
+	if (pass == 1)
+		if (*label)
+			put_label();
 	p1 = operand;
 	p2 = tmp;
 	while (*p1 != ',' && *p1 != '\0')
 		*p2++ = *p1++;
 	*p2 = '\0';
-	if (pass == 2) {
-		i = eval(tmp);
-		if (i < 0 || i > 7)
-			asmerr(E_VALOUT);
-	}
-	switch (op = get_reg(++p1)) {
-	case REGA:			/* BIT n,A */
-	case REGB:			/* BIT n,B */
-	case REGC:			/* BIT n,C */
-	case REGD:			/* BIT n,D */
-	case REGE:			/* BIT n,E */
-	case REGH:			/* BIT n,H */
-	case REGL:			/* BIT n,L */
-	case REGIHL:			/* BIT n,(HL) */
-		ops[1] = 0x40 + i * 8 + op;
-		break;
-	case NOREG:			/* operand isn't register */
-		if (strncmp(p1, "(IX+", 4) == 0) {
-			len = 4;	/* BIT n,(IX+d) */
+	switch (op = get_reg(tmp)) {
+	case REGA:			/* MVI A,n */
+	case REGB:			/* MVI B,n */
+	case REGC:			/* MVI C,n */
+	case REGD:			/* MVI D,n */
+	case REGE:			/* MVI E,n */
+	case REGH:			/* MVI H,n */
+	case REGL:			/* MVI L,n */
+	case REGM:			/* MVI M,n */
+		p1 = get_second(operand);
+		switch (get_reg(p1)) {
+		case NOREG:		/* MVI R,n */
+			len = 2;
 			if (pass == 2) {
-				ops[0] = 0xdd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x46 + i * 8;
+				ops[0] = 0x06 + (op << 3);
+				ops[1] = chk_byte(eval(p1));
 			}
-		} else if (strncmp(p1, "(IY+", 4) == 0) {
-			len = 4;	/* BIT n,(IY+d) */
-			if (pass == 2) {
-				ops[0] = 0xfd;
-				ops[1] = 0xcb;
-				ops[2] = chk_v2(calc_val(strchr(operand, '+') + 1));
-				ops[3] = 0x46 + i * 8;
-			}
-		} else {
-			ops[1] = 0;
+			break;
+		case NOOPERA:		/* missing operand */
+			len = 1;
+			ops[0] = 0;
+			asmerr(E_MISOPE);
+			break;
+		default:		/* invalid operand */
+			len = 1;
+			ops[0] = 0;
 			asmerr(E_ILLOPE);
 		}
 		break;
 	case NOOPERA:			/* missing operand */
-		ops[1] = 0;
+		len = 1;
+		ops[0] = 0;
 		asmerr(E_MISOPE);
 		break;
 	default:			/* invalid operand */
-		ops[1] = 0;
+		len = 1;
+		ops[0] = 0;
+		asmerr(E_ILLOPE);
+	}
+	return(len);
+}
+
+/*
+ *	8080 LXI
+ */
+int op8080_lxi(int dummy1, int dummy2)
+{
+	register int i, len;
+	register char *p1, *p2;
+	register int op;
+
+	if (pass == 1)
+		if (*label)
+			put_label();
+	p1 = operand;
+	p2 = tmp;
+	while (*p1 != ',' && *p1 != '\0')
+		*p2++ = *p1++;
+	*p2 = '\0';
+	switch (op = get_reg(tmp)) {
+	case REGB:			/* LXI B,nn */
+	case REGD:			/* LXI D,nn */
+	case REGH:			/* LXI H,nn */
+	case REGSP:			/* LXI SP,nn */
+		p1 = get_second(operand);
+		switch (get_reg(p1)) {
+		case NOREG:		/* LXI R,nn */
+			len = 3;
+			if (pass == 2) {
+				i = eval(p1);
+				if (op == REGSP)
+					ops[0] = 0x31;
+				else
+					ops[0] = 0x01 + (op << 3);
+				ops[1] = i & 0xff;
+				ops[2] = i >> 8;
+			}
+			break;
+		case NOOPERA:		/* missing operand */
+			len = 1;
+			ops[0] = 0;
+			asmerr(E_MISOPE);
+			break;
+		default:		/* invalid operand */
+			len = 1;
+			ops[0] = 0;
+			asmerr(E_ILLOPE);
+		}
+		break;
+	case NOOPERA:			/* missing operand */
+		len = 1;
+		ops[0] = 0;
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		len = 1;
+		ops[0] = 0;
 		asmerr(E_ILLOPE);
 	}
 	return(len);
@@ -3862,9 +2503,9 @@ char *get_second(char *s)
 }
 
 /*
- *	computes value of expressions in offsets:
- *	LD A,(IX+7)
- *		 --
+ *	computes value of the following expressions:
+ *	LD A,(IX+7)   LD A,(1234)
+ *		 --         -----
  */
 int calc_val(char *s)
 {

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -1,7 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (c) 2022 Thomas Eberhardt
+ *	Copyright (C) 2022 by Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -1,6 +1,7 @@
 /*
  *	Z80 - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (c) 2022 Thomas Eberhardt
  *
  *	History:
  *	17-SEP-1987 Development under Digital Research CP/M 2.2
@@ -16,6 +17,7 @@
  *	15-MAY-2018 mark unreferenced symbols in listing
  *	30-JUL-2021 fix verbose option
  *	28-JAN-2022 added syntax check for OUT (n),A
+ *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  */
 
 /*
@@ -45,10 +47,10 @@ struct opc *search_op(char *op_name)
 {
 	register int cond;
 	register struct opc *low, *high, *mid;
-	extern int op_sll();
+	extern int op_rotshf(int, int);
 
-	low = &opctab[0];
-	high = &opctab[no_opcodes - 1];
+	low = &pers->opctab[0];
+	high = &pers->opctab[pers->no_opcodes - 1];
 	while (low <= high) {
 		mid = low + (high - low) / 2;
 		if ((cond = strcmp(op_name, mid->op_name)) < 0)
@@ -56,7 +58,7 @@ struct opc *search_op(char *op_name)
 		else if (cond > 0)
 			low = mid + 1;
 		else if (!undoc_flag) {
-			if (mid->op_fun == op_sll)
+			if (mid->op_fun == op_rotshf && mid->op_c1 == 0x30) /* SLL */
 				return(NULL);
 			else
 				return(mid);
@@ -82,8 +84,8 @@ int get_reg(char *s)
 
 	if (s == NULL || *s == '\0')
 		return(NOOPERA);
-	low = &opetab[0];
-	high = &opetab[no_operands - 1];
+	low = &pers->opetab[0];
+	high = &pers->opetab[pers->no_operands - 1];
 	while (low <= high) {
 		mid = low + (high - low) / 2;
 		if ((cond = strcmp(s, mid->ope_name)) < 0)

--- a/z80sim/8080opsall.asm
+++ b/z80sim/8080opsall.asm
@@ -1,0 +1,272 @@
+	.8080
+	TITLE	'8080 Instruction Set in alphabetical order (incl. undocumented)'
+
+IND	EQU	5
+M	EQU	10H
+N	EQU	20H
+DIS	EQU	30H
+
+	ACI	N
+	ADC	A
+	ADC	B
+	ADC	C
+	ADC	D
+	ADC	E
+	ADC	H
+	ADC	L
+	ADC	M
+	ADD	A
+	ADD	B
+	ADD	C
+	ADD	D
+	ADD	E
+	ADD	H
+	ADD	L
+	ADD	M
+	ADI	N
+	ANA	A
+	ANA	B
+	ANA	C
+	ANA	D
+	ANA	E
+	ANA	H
+	ANA	L
+	ANA	M
+	ANI	N
+	CALL	NN
+	CC	NN
+	CM	NN
+	CMA
+	CMC
+	CMP	A
+	CMP	B
+	CMP	C
+	CMP	D
+	CMP	E
+	CMP	H
+	CMP	L
+	CMP	M
+	CNC	NN
+	CNZ	NN
+	CP	NN
+	CPE	NN
+	CPI	N
+	CPO	NN
+	CZ	NN
+	DAA
+	DAD	B
+	DAD	D
+	DAD	H
+	DAD	SP
+	DCR	A
+	DCR	B
+	DCR	C
+	DCR	D
+	DCR	E
+	DCR	H
+	DCR	L
+	DCR	M
+	DCX	B
+	DCX	D
+	DCX	H
+	DCX	SP
+	DI
+	EI
+	HLT
+	IN	N
+	INR	A
+	INR	B
+	INR	C
+	INR	D
+	INR	E
+	INR	H
+	INR	L
+	INR	M
+	INX	B
+	INX	D
+	INX	H
+	INX	SP
+	JC	NN
+	JM	NN
+	JMP	NN
+	JNC	NN
+	JNZ	NN
+	JP	NN
+	JPE	NN
+	JPO	NN
+	JZ	NN
+	LDA	NN
+	LDAX	B
+	LDAX	D
+	LHLD	NN
+	LXI	B,NN
+	LXI	D,NN
+	LXI	H,NN
+	LXI	SP,NN
+	MOV	A,A
+	MOV	A,B
+	MOV	A,C
+	MOV	A,D
+	MOV	A,E
+	MOV	A,H
+	MOV	A,L
+	MOV	A,M
+	MOV	B,A
+	MOV	B,B
+	MOV	B,C
+	MOV	B,D
+	MOV	B,E
+	MOV	B,H
+	MOV	B,L
+	MOV	B,M
+	MOV	C,A
+	MOV	C,B
+	MOV	C,C
+	MOV	C,D
+	MOV	C,E
+	MOV	C,H
+	MOV	C,L
+	MOV	C,M
+	MOV	D,A
+	MOV	D,B
+	MOV	D,C
+	MOV	D,D
+	MOV	D,E
+	MOV	D,H
+	MOV	D,L
+	MOV	D,M
+	MOV	E,A
+	MOV	E,B
+	MOV	E,C
+	MOV	E,D
+	MOV	E,E
+	MOV	E,H
+	MOV	E,L
+	MOV	E,M
+	MOV	H,A
+	MOV	H,B
+	MOV	H,C
+	MOV	H,D
+	MOV	H,E
+	MOV	H,H
+	MOV	H,L
+	MOV	H,M
+	MOV	L,A
+	MOV	L,B
+	MOV	L,C
+	MOV	L,D
+	MOV	L,E
+	MOV	L,H
+	MOV	L,L
+	MOV	L,M
+	MOV	M,A
+	MOV	M,B
+	MOV	M,C
+	MOV	M,D
+	MOV	M,E
+	MOV	M,H
+	MOV	M,L
+	MVI	A,N
+	MVI	B,N
+	MVI	C,N
+	MVI	D,N
+	MVI	E,N
+	MVI	H,N
+	MVI	L,N
+	MVI	M,N
+	NOP
+	ORA	A
+	ORA	B
+	ORA	C
+	ORA	D
+	ORA	E
+	ORA	H
+	ORA	L
+	ORA	M
+	ORI	N
+	OUT	N
+	PCHL
+	POP	B
+	POP	D
+	POP	H
+	POP	PSW
+	PUSH	B
+	PUSH	D
+	PUSH	H
+	PUSH	PSW
+	RAL
+	RAR
+	RC
+	RET
+	RLC
+	RM
+	RNC
+	RNZ
+	RP
+	RPE
+	RPO
+	RRC
+	RST	0
+	RST	1
+	RST	2
+	RST	3
+	RST	4
+	RST	5
+	RST	6
+	RST	7
+	RZ
+	SBB	A
+	SBB	B
+	SBB	C
+	SBB	D
+	SBB	E
+	SBB	H
+	SBB	L
+	SBB	M
+	SBI	N
+	SHLD	NN
+	SPHL
+	STA	NN
+	STAX	B
+	STAX	D
+	STC
+	SUB	A
+	SUB	B
+	SUB	C
+	SUB	D
+	SUB	E
+	SUB	H
+	SUB	L
+	SUB	M
+	SUI	N
+	XCHG
+	XRA	A
+	XRA	B
+	XRA	C
+	XRA	D
+	XRA	E
+	XRA	H
+	XRA	L
+	XRA	M
+	XRI	N
+	XTHL
+
+; Undocumented op-codes
+	DEFB	008H			; NOP
+	DEFB	010H			; NOP
+	DEFB	018H			; NOP
+	DEFB	020H			; NOP
+	DEFB	028H			; NOP
+	DEFB	030H			; NOP
+	DEFB	038H			; NOP
+	DEFB	0CBH			; JMP NN
+	DEFW	NN
+	DEFB	0D9H			; RET
+	DEFB	0DDH			; CALL NN
+	DEFW	NN
+	DEFB	0EDH			; CALL NN
+	DEFW	NN
+	DEFB	0FDH			; CALL NN
+	DEFW	NN
+
+NN:	DEFS	2

--- a/z80sim/Makefile
+++ b/z80sim/Makefile
@@ -1,4 +1,4 @@
-all: float.hex z80main.hex z80opsall.hex
+all: float.hex z80main.hex z80opsall.hex 8080opsall.hex
 
 float.hex: float.asm
 	z80asm -v -l -sn float.asm
@@ -8,6 +8,9 @@ z80main.hex: z80main.asm z80dis.asm z80ops.asm
 
 z80opsall.hex: z80opsall.asm
 	z80asm -v -l -sn -u z80opsall.asm
+
+8080opsall.hex: 8080opsall.asm
+	z80asm -v -l -sn 8080opsall.asm
 
 clean:
 	rm -f *.hex *.lis

--- a/z80sim/srcsim/iosim.c
+++ b/z80sim/srcsim/iosim.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 1987-2021 by Udo Munk
  *
- * This modul of the simulator contains a simple terminal I/O
+ * This module of the simulator contains a simple terminal I/O
  * simulation as an example.
  *
  * History:

--- a/z80sim/srcsim/simctl.c
+++ b/z80sim/srcsim/simctl.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 1987-2022 by Udo Munk
  *
- * This modul contains the user interface, a full qualified ICE,
+ * This module contains the user interface, a full qualified ICE,
  * for the Z80-CPU simulation.
  *
  * History:

--- a/z80sim/z80opsall.asm
+++ b/z80sim/z80opsall.asm
@@ -15,10 +15,10 @@ Z80OPS:
 	ADC	A,D
 	ADC	A,E
 	ADC	A,H
-	ADC	A,IXH
-	ADC	A,IXL
-	ADC	A,IYH
-	ADC	A,IYL
+	ADC	A,IXH			; Undocumented
+	ADC	A,IXL			; Undocumented
+	ADC	A,IYH			; Undocumented
+	ADC	A,IYL			; Undocumented
 	ADC	A,L
 	ADC	A,N
 	ADC	HL,BC
@@ -34,10 +34,10 @@ Z80OPS:
 	ADD	A,D
 	ADD	A,E
 	ADD	A,H
-	ADD	A,IXH
-	ADD	A,IXL
-	ADD	A,IYH
-	ADD	A,IYL
+	ADD	A,IXH			; Undocumented
+	ADD	A,IXL			; Undocumented
+	ADD	A,IYH			; Undocumented
+	ADD	A,IYL			; Undocumented
 	ADD	A,L
 	ADD	A,N
 	ADD	HL,BC
@@ -61,10 +61,10 @@ Z80OPS:
 	AND	D
 	AND	E
 	AND	H
-	AND	IXH
-	AND	IXL
-	AND	IYH
-	AND	IYL
+	AND	IXH			; Undocumented
+	AND	IXL			; Undocumented
+	AND	IYH			; Undocumented
+	AND	IYL			; Undocumented
 	AND	L
 	AND	N
 	BIT	0,(HL)
@@ -166,10 +166,10 @@ Z80OPS:
 	CP	D
 	CP	E
 	CP	H
-	CP	IXH
-	CP	IXL
-	CP	IYH
-	CP	IYL
+	CP	IXH			; Undocumented
+	CP	IXL			; Undocumented
+	CP	IYH			; Undocumented
+	CP	IYL			; Undocumented
 	CP	L
 	CP	N
 	CPD
@@ -191,11 +191,11 @@ Z80OPS:
 	DEC	H
 	DEC	HL
 	DEC	IX
-	DEC	IXH
-	DEC	IXL
+	DEC	IXH			; Undocumented
+	DEC	IXL			; Undocumented
 	DEC	IY
-	DEC	IYH
-	DEC	IYL
+	DEC	IYH			; Undocumented
+	DEC	IYL			; Undocumented
 	DEC	L
 	DEC	SP
 	DI
@@ -217,7 +217,7 @@ Z80OPS:
 	IN	C,(C)
 	IN	D,(C)
 	IN	E,(C)
-	IN	F,(C)
+	IN	F,(C)			; Undocumented
 	IN	H,(C)
 	IN	L,(C)
 	INC	(HL)
@@ -233,11 +233,11 @@ Z80OPS:
 	INC	H
 	INC	HL
 	INC	IX
-	INC	IXH
-	INC	IXL
+	INC	IXH			; Undocumented
+	INC	IXL			; Undocumented
 	INC	IY
-	INC	IYH
-	INC	IYL
+	INC	IYH			; Undocumented
+	INC	IYL			; Undocumented
 	INC	L
 	INC	SP
 	IND
@@ -307,10 +307,10 @@ Z80OPS:
 	LD	A,E
 	LD	A,H
 	LD	A,I
-	LD	A,IXH
-	LD	A,IXL
-	LD	A,IYH
-	LD	A,IYL
+	LD	A,IXH			; Undocumented
+	LD	A,IXL			; Undocumented
+	LD	A,IYH			; Undocumented
+	LD	A,IYL			; Undocumented
 	LD	A,L
 	LD	A,N
 	LD	B,(HL)
@@ -322,10 +322,10 @@ Z80OPS:
 	LD	B,D
 	LD	B,E
 	LD	B,H
-	LD	B,IXH
-	LD	B,IXL
-	LD	B,IYH
-	LD	B,IYL
+	LD	B,IXH			; Undocumented
+	LD	B,IXL			; Undocumented
+	LD	B,IYH			; Undocumented
+	LD	B,IYL			; Undocumented
 	LD	B,L
 	LD	B,N
 	LD	BC,(NN)
@@ -339,10 +339,10 @@ Z80OPS:
 	LD	C,D
 	LD	C,E
 	LD	C,H
-	LD	C,IXH
-	LD	C,IXL
-	LD	C,IYH
-	LD	C,IYL
+	LD	C,IXH			; Undocumented
+	LD	C,IXL			; Undocumented
+	LD	C,IYH			; Undocumented
+	LD	C,IYL			; Undocumented
 	LD	C,L
 	LD	C,N
 	LD	D,(HL)
@@ -354,10 +354,10 @@ Z80OPS:
 	LD	D,D
 	LD	D,E
 	LD	D,H
-	LD	D,IXH
-	LD	D,IXL
-	LD	D,IYH
-	LD	D,IYL
+	LD	D,IXH			; Undocumented
+	LD	D,IXL			; Undocumented
+	LD	D,IYH			; Undocumented
+	LD	D,IYL			; Undocumented
 	LD	D,L
 	LD	D,N
 	LD	DE,(NN)
@@ -371,10 +371,10 @@ Z80OPS:
 	LD	E,D
 	LD	E,E
 	LD	E,H
-	LD	E,IXH
-	LD	E,IXL
-	LD	E,IYH
-	LD	E,IYL
+	LD	E,IXH			; Undocumented
+	LD	E,IXL			; Undocumented
+	LD	E,IYH			; Undocumented
+	LD	E,IYL			; Undocumented
 	LD	E,L
 	LD	E,N
 	LD	H,(HL)
@@ -393,40 +393,40 @@ Z80OPS:
 	LD	I,A
 	LD	IX,(NN)
 	LD	IX,NN
-	LD	IXH,A
-	LD	IXH,B
-	LD	IXH,C
-	LD	IXH,D
-	LD	IXH,E
-	LD	IXH,IXH
-	LD	IXH,IXL
-	LD	IXH,N
-	LD	IXL,A
-	LD	IXL,B
-	LD	IXL,C
-	LD	IXL,D
-	LD	IXL,E
-	LD	IXL,IXH
-	LD	IXL,IXL
-	LD	IXL,N
+	LD	IXH,A			; Undocumented
+	LD	IXH,B			; Undocumented
+	LD	IXH,C			; Undocumented
+	LD	IXH,D			; Undocumented
+	LD	IXH,E			; Undocumented
+	LD	IXH,IXH			; Undocumented
+	LD	IXH,IXL			; Undocumented
+	LD	IXH,N			; Undocumented
+	LD	IXL,A			; Undocumented
+	LD	IXL,B			; Undocumented
+	LD	IXL,C			; Undocumented
+	LD	IXL,D			; Undocumented
+	LD	IXL,E			; Undocumented
+	LD	IXL,IXH			; Undocumented
+	LD	IXL,IXL			; Undocumented
+	LD	IXL,N			; Undocumented
 	LD	IY,(NN)
 	LD	IY,NN
-	LD	IYH,A
-	LD	IYH,B
-	LD	IYH,C
-	LD	IYH,D
-	LD	IYH,E
-	LD	IYH,IYH
-	LD	IYH,IYL
-	LD	IYH,N
-	LD	IYL,A
-	LD	IYL,B
-	LD	IYL,C
-	LD	IYL,D
-	LD	IYL,E
-	LD	IYL,IYH
-	LD	IYL,IYL
-	LD	IYL,N
+	LD	IYH,A			; Undocumented
+	LD	IYH,B			; Undocumented
+	LD	IYH,C			; Undocumented
+	LD	IYH,D			; Undocumented
+	LD	IYH,E			; Undocumented
+	LD	IYH,IYH			; Undocumented
+	LD	IYH,IYL			; Undocumented
+	LD	IYH,N			; Undocumented
+	LD	IYL,A			; Undocumented
+	LD	IYL,B			; Undocumented
+	LD	IYL,C			; Undocumented
+	LD	IYL,D			; Undocumented
+	LD	IYL,E			; Undocumented
+	LD	IYL,IYH			; Undocumented
+	LD	IYL,IYL			; Undocumented
+	LD	IYL,N			; Undocumented
 	LD	L,(HL)
 	LD	L,(IX+IND)
 	LD	L,(IY+IND)
@@ -458,15 +458,15 @@ Z80OPS:
 	OR	D
 	OR	E
 	OR	H
-	OR	IXH
-	OR	IXL
-	OR	IYH
-	OR	IYL
+	OR	IXH			; Undocumented
+	OR	IXL			; Undocumented
+	OR	IYH			; Undocumented
+	OR	IYL			; Undocumented
 	OR	L
 	OR	N
 	OTDR
 	OTIR
-	OUT	(C),0
+	OUT	(C),0			; Undocumented
 	OUT	(C),A
 	OUT	(C),B
 	OUT	(C),C
@@ -491,7 +491,21 @@ Z80OPS:
 	PUSH	IY
 	RES	0,(HL)
 	RES	0,(IX+IND)
+	RES	0,(IX+IND),A		; Undocumented
+	RES	0,(IX+IND),B		; Undocumented
+	RES	0,(IX+IND),C		; Undocumented
+	RES	0,(IX+IND),D		; Undocumented
+	RES	0,(IX+IND),E		; Undocumented
+	RES	0,(IX+IND),H		; Undocumented
+	RES	0,(IX+IND),L		; Undocumented
 	RES	0,(IY+IND)
+	RES	0,(IY+IND),A		; Undocumented
+	RES	0,(IY+IND),B		; Undocumented
+	RES	0,(IY+IND),C		; Undocumented
+	RES	0,(IY+IND),D		; Undocumented
+	RES	0,(IY+IND),E		; Undocumented
+	RES	0,(IY+IND),H		; Undocumented
+	RES	0,(IY+IND),L		; Undocumented
 	RES	0,A
 	RES	0,B
 	RES	0,C
@@ -501,7 +515,21 @@ Z80OPS:
 	RES	0,L
 	RES	1,(HL)
 	RES	1,(IX+IND)
+	RES	1,(IX+IND),A		; Undocumented
+	RES	1,(IX+IND),B		; Undocumented
+	RES	1,(IX+IND),C		; Undocumented
+	RES	1,(IX+IND),D		; Undocumented
+	RES	1,(IX+IND),E		; Undocumented
+	RES	1,(IX+IND),H		; Undocumented
+	RES	1,(IX+IND),L		; Undocumented
 	RES	1,(IY+IND)
+	RES	1,(IY+IND),A		; Undocumented
+	RES	1,(IY+IND),B		; Undocumented
+	RES	1,(IY+IND),C		; Undocumented
+	RES	1,(IY+IND),D		; Undocumented
+	RES	1,(IY+IND),E		; Undocumented
+	RES	1,(IY+IND),H		; Undocumented
+	RES	1,(IY+IND),L		; Undocumented
 	RES	1,A
 	RES	1,B
 	RES	1,C
@@ -511,7 +539,21 @@ Z80OPS:
 	RES	1,L
 	RES	2,(HL)
 	RES	2,(IX+IND)
+	RES	2,(IX+IND),A		; Undocumented
+	RES	2,(IX+IND),B		; Undocumented
+	RES	2,(IX+IND),C		; Undocumented
+	RES	2,(IX+IND),D		; Undocumented
+	RES	2,(IX+IND),E		; Undocumented
+	RES	2,(IX+IND),H		; Undocumented
+	RES	2,(IX+IND),L		; Undocumented
 	RES	2,(IY+IND)
+	RES	2,(IY+IND),A		; Undocumented
+	RES	2,(IY+IND),B		; Undocumented
+	RES	2,(IY+IND),C		; Undocumented
+	RES	2,(IY+IND),D		; Undocumented
+	RES	2,(IY+IND),E		; Undocumented
+	RES	2,(IY+IND),H		; Undocumented
+	RES	2,(IY+IND),L		; Undocumented
 	RES	2,A
 	RES	2,B
 	RES	2,C
@@ -521,7 +563,21 @@ Z80OPS:
 	RES	2,L
 	RES	3,(HL)
 	RES	3,(IX+IND)
+	RES	3,(IX+IND),A		; Undocumented
+	RES	3,(IX+IND),B		; Undocumented
+	RES	3,(IX+IND),C		; Undocumented
+	RES	3,(IX+IND),D		; Undocumented
+	RES	3,(IX+IND),E		; Undocumented
+	RES	3,(IX+IND),H		; Undocumented
+	RES	3,(IX+IND),L		; Undocumented
 	RES	3,(IY+IND)
+	RES	3,(IY+IND),A		; Undocumented
+	RES	3,(IY+IND),B		; Undocumented
+	RES	3,(IY+IND),C		; Undocumented
+	RES	3,(IY+IND),D		; Undocumented
+	RES	3,(IY+IND),E		; Undocumented
+	RES	3,(IY+IND),H		; Undocumented
+	RES	3,(IY+IND),L		; Undocumented
 	RES	3,A
 	RES	3,B
 	RES	3,C
@@ -531,7 +587,21 @@ Z80OPS:
 	RES	3,L
 	RES	4,(HL)
 	RES	4,(IX+IND)
+	RES	4,(IX+IND),A		; Undocumented
+	RES	4,(IX+IND),B		; Undocumented
+	RES	4,(IX+IND),C		; Undocumented
+	RES	4,(IX+IND),D		; Undocumented
+	RES	4,(IX+IND),E		; Undocumented
+	RES	4,(IX+IND),H		; Undocumented
+	RES	4,(IX+IND),L		; Undocumented
 	RES	4,(IY+IND)
+	RES	4,(IY+IND),A		; Undocumented
+	RES	4,(IY+IND),B		; Undocumented
+	RES	4,(IY+IND),C		; Undocumented
+	RES	4,(IY+IND),D		; Undocumented
+	RES	4,(IY+IND),E		; Undocumented
+	RES	4,(IY+IND),H		; Undocumented
+	RES	4,(IY+IND),L		; Undocumented
 	RES	4,A
 	RES	4,B
 	RES	4,C
@@ -541,7 +611,21 @@ Z80OPS:
 	RES	4,L
 	RES	5,(HL)
 	RES	5,(IX+IND)
+	RES	5,(IX+IND),A		; Undocumented
+	RES	5,(IX+IND),B		; Undocumented
+	RES	5,(IX+IND),C		; Undocumented
+	RES	5,(IX+IND),D		; Undocumented
+	RES	5,(IX+IND),E		; Undocumented
+	RES	5,(IX+IND),H		; Undocumented
+	RES	5,(IX+IND),L		; Undocumented
 	RES	5,(IY+IND)
+	RES	5,(IY+IND),A		; Undocumented
+	RES	5,(IY+IND),B		; Undocumented
+	RES	5,(IY+IND),C		; Undocumented
+	RES	5,(IY+IND),D		; Undocumented
+	RES	5,(IY+IND),E		; Undocumented
+	RES	5,(IY+IND),H		; Undocumented
+	RES	5,(IY+IND),L		; Undocumented
 	RES	5,A
 	RES	5,B
 	RES	5,C
@@ -551,7 +635,21 @@ Z80OPS:
 	RES	5,L
 	RES	6,(HL)
 	RES	6,(IX+IND)
+	RES	6,(IX+IND),A		; Undocumented
+	RES	6,(IX+IND),B		; Undocumented
+	RES	6,(IX+IND),C		; Undocumented
+	RES	6,(IX+IND),D		; Undocumented
+	RES	6,(IX+IND),E		; Undocumented
+	RES	6,(IX+IND),H		; Undocumented
+	RES	6,(IX+IND),L		; Undocumented
 	RES	6,(IY+IND)
+	RES	6,(IY+IND),A		; Undocumented
+	RES	6,(IY+IND),B		; Undocumented
+	RES	6,(IY+IND),C		; Undocumented
+	RES	6,(IY+IND),D		; Undocumented
+	RES	6,(IY+IND),E		; Undocumented
+	RES	6,(IY+IND),H		; Undocumented
+	RES	6,(IY+IND),L		; Undocumented
 	RES	6,A
 	RES	6,B
 	RES	6,C
@@ -561,7 +659,21 @@ Z80OPS:
 	RES	6,L
 	RES	7,(HL)
 	RES	7,(IX+IND)
+	RES	7,(IX+IND),A		; Undocumented
+	RES	7,(IX+IND),B		; Undocumented
+	RES	7,(IX+IND),C		; Undocumented
+	RES	7,(IX+IND),D		; Undocumented
+	RES	7,(IX+IND),E		; Undocumented
+	RES	7,(IX+IND),H		; Undocumented
+	RES	7,(IX+IND),L		; Undocumented
 	RES	7,(IY+IND)
+	RES	7,(IY+IND),A		; Undocumented
+	RES	7,(IY+IND),B		; Undocumented
+	RES	7,(IY+IND),C		; Undocumented
+	RES	7,(IY+IND),D		; Undocumented
+	RES	7,(IY+IND),E		; Undocumented
+	RES	7,(IY+IND),H		; Undocumented
+	RES	7,(IY+IND),L		; Undocumented
 	RES	7,A
 	RES	7,B
 	RES	7,C
@@ -582,7 +694,21 @@ Z80OPS:
 	RETN
 	RL	(HL)
 	RL	(IX+IND)
+	RL	(IX+IND),A		; Undocumented
+	RL	(IX+IND),B		; Undocumented
+	RL	(IX+IND),C		; Undocumented
+	RL	(IX+IND),D		; Undocumented
+	RL	(IX+IND),E		; Undocumented
+	RL	(IX+IND),H		; Undocumented
+	RL	(IX+IND),L		; Undocumented
 	RL	(IY+IND)
+	RL	(IY+IND),A		; Undocumented
+	RL	(IY+IND),B		; Undocumented
+	RL	(IY+IND),C		; Undocumented
+	RL	(IY+IND),D		; Undocumented
+	RL	(IY+IND),E		; Undocumented
+	RL	(IY+IND),H		; Undocumented
+	RL	(IY+IND),L		; Undocumented
 	RL	A
 	RL	B
 	RL	C
@@ -593,7 +719,21 @@ Z80OPS:
 	RLA
 	RLC	(HL)
 	RLC	(IX+IND)
+	RLC	(IX+IND),A		; Undocumented
+	RLC	(IX+IND),B		; Undocumented
+	RLC	(IX+IND),C		; Undocumented
+	RLC	(IX+IND),D		; Undocumented
+	RLC	(IX+IND),E		; Undocumented
+	RLC	(IX+IND),H		; Undocumented
+	RLC	(IX+IND),L		; Undocumented
 	RLC	(IY+IND)
+	RLC	(IY+IND),A		; Undocumented
+	RLC	(IY+IND),B		; Undocumented
+	RLC	(IY+IND),C		; Undocumented
+	RLC	(IY+IND),D		; Undocumented
+	RLC	(IY+IND),E		; Undocumented
+	RLC	(IY+IND),H		; Undocumented
+	RLC	(IY+IND),L		; Undocumented
 	RLC	A
 	RLC	B
 	RLC	C
@@ -605,7 +745,21 @@ Z80OPS:
 	RLD
 	RR	(HL)
 	RR	(IX+IND)
+	RR	(IX+IND),A		; Undocumented
+	RR	(IX+IND),B		; Undocumented
+	RR	(IX+IND),C		; Undocumented
+	RR	(IX+IND),D		; Undocumented
+	RR	(IX+IND),E		; Undocumented
+	RR	(IX+IND),H		; Undocumented
+	RR	(IX+IND),L		; Undocumented
 	RR	(IY+IND)
+	RR	(IY+IND),A		; Undocumented
+	RR	(IY+IND),B		; Undocumented
+	RR	(IY+IND),C		; Undocumented
+	RR	(IY+IND),D		; Undocumented
+	RR	(IY+IND),E		; Undocumented
+	RR	(IY+IND),H		; Undocumented
+	RR	(IY+IND),L		; Undocumented
 	RR	A
 	RR	B
 	RR	C
@@ -616,7 +770,21 @@ Z80OPS:
 	RRA
 	RRC	(HL)
 	RRC	(IX+IND)
+	RRC	(IX+IND),A		; Undocumented
+	RRC	(IX+IND),B		; Undocumented
+	RRC	(IX+IND),C		; Undocumented
+	RRC	(IX+IND),D		; Undocumented
+	RRC	(IX+IND),E		; Undocumented
+	RRC	(IX+IND),H		; Undocumented
+	RRC	(IX+IND),L		; Undocumented
 	RRC	(IY+IND)
+	RRC	(IY+IND),A		; Undocumented
+	RRC	(IY+IND),B		; Undocumented
+	RRC	(IY+IND),C		; Undocumented
+	RRC	(IY+IND),D		; Undocumented
+	RRC	(IY+IND),E		; Undocumented
+	RRC	(IY+IND),H		; Undocumented
+	RRC	(IY+IND),L		; Undocumented
 	RRC	A
 	RRC	B
 	RRC	C
@@ -643,10 +811,10 @@ Z80OPS:
 	SBC	A,D
 	SBC	A,E
 	SBC	A,H
-	SBC	A,IXH
-	SBC	A,IXL
-	SBC	A,IYH
-	SBC	A,IYL
+	SBC	A,IXH			; Undocumented
+	SBC	A,IXL			; Undocumented
+	SBC	A,IYH			; Undocumented
+	SBC	A,IYL			; Undocumented
 	SBC	A,L
 	SBC	A,N
 	SBC	HL,BC
@@ -656,7 +824,21 @@ Z80OPS:
 	SCF
 	SET	0,(HL)
 	SET	0,(IX+IND)
+	SET	0,(IX+IND),A		; Undocumented
+	SET	0,(IX+IND),B		; Undocumented
+	SET	0,(IX+IND),C		; Undocumented
+	SET	0,(IX+IND),D		; Undocumented
+	SET	0,(IX+IND),E		; Undocumented
+	SET	0,(IX+IND),H		; Undocumented
+	SET	0,(IX+IND),L		; Undocumented
 	SET	0,(IY+IND)
+	SET	0,(IY+IND),A		; Undocumented
+	SET	0,(IY+IND),B		; Undocumented
+	SET	0,(IY+IND),C		; Undocumented
+	SET	0,(IY+IND),D		; Undocumented
+	SET	0,(IY+IND),E		; Undocumented
+	SET	0,(IY+IND),H		; Undocumented
+	SET	0,(IY+IND),L		; Undocumented
 	SET	0,A
 	SET	0,B
 	SET	0,C
@@ -666,7 +848,21 @@ Z80OPS:
 	SET	0,L
 	SET	1,(HL)
 	SET	1,(IX+IND)
+	SET	1,(IX+IND),A		; Undocumented
+	SET	1,(IX+IND),B		; Undocumented
+	SET	1,(IX+IND),C		; Undocumented
+	SET	1,(IX+IND),D		; Undocumented
+	SET	1,(IX+IND),E		; Undocumented
+	SET	1,(IX+IND),H		; Undocumented
+	SET	1,(IX+IND),L		; Undocumented
 	SET	1,(IY+IND)
+	SET	1,(IY+IND),A		; Undocumented
+	SET	1,(IY+IND),B		; Undocumented
+	SET	1,(IY+IND),C		; Undocumented
+	SET	1,(IY+IND),D		; Undocumented
+	SET	1,(IY+IND),E		; Undocumented
+	SET	1,(IY+IND),H		; Undocumented
+	SET	1,(IY+IND),L		; Undocumented
 	SET	1,A
 	SET	1,B
 	SET	1,C
@@ -676,7 +872,21 @@ Z80OPS:
 	SET	1,L
 	SET	2,(HL)
 	SET	2,(IX+IND)
+	SET	2,(IX+IND),A		; Undocumented
+	SET	2,(IX+IND),B		; Undocumented
+	SET	2,(IX+IND),C		; Undocumented
+	SET	2,(IX+IND),D		; Undocumented
+	SET	2,(IX+IND),E		; Undocumented
+	SET	2,(IX+IND),H		; Undocumented
+	SET	2,(IX+IND),L		; Undocumented
 	SET	2,(IY+IND)
+	SET	2,(IY+IND),A		; Undocumented
+	SET	2,(IY+IND),B		; Undocumented
+	SET	2,(IY+IND),C		; Undocumented
+	SET	2,(IY+IND),D		; Undocumented
+	SET	2,(IY+IND),E		; Undocumented
+	SET	2,(IY+IND),H		; Undocumented
+	SET	2,(IY+IND),L		; Undocumented
 	SET	2,A
 	SET	2,B
 	SET	2,C
@@ -686,7 +896,21 @@ Z80OPS:
 	SET	2,L
 	SET	3,(HL)
 	SET	3,(IX+IND)
+	SET	3,(IX+IND),A		; Undocumented
+	SET	3,(IX+IND),B		; Undocumented
+	SET	3,(IX+IND),C		; Undocumented
+	SET	3,(IX+IND),D		; Undocumented
+	SET	3,(IX+IND),E		; Undocumented
+	SET	3,(IX+IND),H		; Undocumented
+	SET	3,(IX+IND),L		; Undocumented
 	SET	3,(IY+IND)
+	SET	3,(IY+IND),A		; Undocumented
+	SET	3,(IY+IND),B		; Undocumented
+	SET	3,(IY+IND),C		; Undocumented
+	SET	3,(IY+IND),D		; Undocumented
+	SET	3,(IY+IND),E		; Undocumented
+	SET	3,(IY+IND),H		; Undocumented
+	SET	3,(IY+IND),L		; Undocumented
 	SET	3,A
 	SET	3,B
 	SET	3,C
@@ -696,7 +920,21 @@ Z80OPS:
 	SET	3,L
 	SET	4,(HL)
 	SET	4,(IX+IND)
+	SET	4,(IX+IND),A		; Undocumented
+	SET	4,(IX+IND),B		; Undocumented
+	SET	4,(IX+IND),C		; Undocumented
+	SET	4,(IX+IND),D		; Undocumented
+	SET	4,(IX+IND),E		; Undocumented
+	SET	4,(IX+IND),H		; Undocumented
+	SET	4,(IX+IND),L		; Undocumented
 	SET	4,(IY+IND)
+	SET	4,(IY+IND),A		; Undocumented
+	SET	4,(IY+IND),B		; Undocumented
+	SET	4,(IY+IND),C		; Undocumented
+	SET	4,(IY+IND),D		; Undocumented
+	SET	4,(IY+IND),E		; Undocumented
+	SET	4,(IY+IND),H		; Undocumented
+	SET	4,(IY+IND),L		; Undocumented
 	SET	4,A
 	SET	4,B
 	SET	4,C
@@ -706,7 +944,21 @@ Z80OPS:
 	SET	4,L
 	SET	5,(HL)
 	SET	5,(IX+IND)
+	SET	5,(IX+IND),A		; Undocumented
+	SET	5,(IX+IND),B		; Undocumented
+	SET	5,(IX+IND),C		; Undocumented
+	SET	5,(IX+IND),D		; Undocumented
+	SET	5,(IX+IND),E		; Undocumented
+	SET	5,(IX+IND),H		; Undocumented
+	SET	5,(IX+IND),L		; Undocumented
 	SET	5,(IY+IND)
+	SET	5,(IY+IND),A		; Undocumented
+	SET	5,(IY+IND),B		; Undocumented
+	SET	5,(IY+IND),C		; Undocumented
+	SET	5,(IY+IND),D		; Undocumented
+	SET	5,(IY+IND),E		; Undocumented
+	SET	5,(IY+IND),H		; Undocumented
+	SET	5,(IY+IND),L		; Undocumented
 	SET	5,A
 	SET	5,B
 	SET	5,C
@@ -716,7 +968,21 @@ Z80OPS:
 	SET	5,L
 	SET	6,(HL)
 	SET	6,(IX+IND)
+	SET	6,(IX+IND),A		; Undocumented
+	SET	6,(IX+IND),B		; Undocumented
+	SET	6,(IX+IND),C		; Undocumented
+	SET	6,(IX+IND),D		; Undocumented
+	SET	6,(IX+IND),E		; Undocumented
+	SET	6,(IX+IND),H		; Undocumented
+	SET	6,(IX+IND),L		; Undocumented
 	SET	6,(IY+IND)
+	SET	6,(IY+IND),A		; Undocumented
+	SET	6,(IY+IND),B		; Undocumented
+	SET	6,(IY+IND),C		; Undocumented
+	SET	6,(IY+IND),D		; Undocumented
+	SET	6,(IY+IND),E		; Undocumented
+	SET	6,(IY+IND),H		; Undocumented
+	SET	6,(IY+IND),L		; Undocumented
 	SET	6,A
 	SET	6,B
 	SET	6,C
@@ -726,7 +992,21 @@ Z80OPS:
 	SET	6,L
 	SET	7,(HL)
 	SET	7,(IX+IND)
+	SET	7,(IX+IND),A		; Undocumented
+	SET	7,(IX+IND),B		; Undocumented
+	SET	7,(IX+IND),C		; Undocumented
+	SET	7,(IX+IND),D		; Undocumented
+	SET	7,(IX+IND),E		; Undocumented
+	SET	7,(IX+IND),H		; Undocumented
+	SET	7,(IX+IND),L		; Undocumented
 	SET	7,(IY+IND)
+	SET	7,(IY+IND),A		; Undocumented
+	SET	7,(IY+IND),B		; Undocumented
+	SET	7,(IY+IND),C		; Undocumented
+	SET	7,(IY+IND),D		; Undocumented
+	SET	7,(IY+IND),E		; Undocumented
+	SET	7,(IY+IND),H		; Undocumented
+	SET	7,(IY+IND),L		; Undocumented
 	SET	7,A
 	SET	7,B
 	SET	7,C
@@ -736,7 +1016,21 @@ Z80OPS:
 	SET	7,L
 	SLA	(HL)
 	SLA	(IX+IND)
+	SLA	(IX+IND),A		; Undocumented
+	SLA	(IX+IND),B		; Undocumented
+	SLA	(IX+IND),C		; Undocumented
+	SLA	(IX+IND),D		; Undocumented
+	SLA	(IX+IND),E		; Undocumented
+	SLA	(IX+IND),H		; Undocumented
+	SLA	(IX+IND),L		; Undocumented
 	SLA	(IY+IND)
+	SLA	(IY+IND),A		; Undocumented
+	SLA	(IY+IND),B		; Undocumented
+	SLA	(IY+IND),C		; Undocumented
+	SLA	(IY+IND),D		; Undocumented
+	SLA	(IY+IND),E		; Undocumented
+	SLA	(IY+IND),H		; Undocumented
+	SLA	(IY+IND),L		; Undocumented
 	SLA	A
 	SLA	B
 	SLA	C
@@ -744,19 +1038,47 @@ Z80OPS:
 	SLA	E
 	SLA	H
 	SLA	L
-	SLL	(HL)
-	SLL	(IX+IND)
-	SLL	(IY+IND)
-	SLL	A
-	SLL	B
-	SLL	C
-	SLL	D
-	SLL	E
-	SLL	H
-	SLL	L
+	SLL	(HL)			; Undocumented
+	SLL	(IX+IND)		; Undocumented
+	SLL	(IX+IND),A		; Undocumented
+	SLL	(IX+IND),B		; Undocumented
+	SLL	(IX+IND),C		; Undocumented
+	SLL	(IX+IND),D		; Undocumented
+	SLL	(IX+IND),E		; Undocumented
+	SLL	(IX+IND),H		; Undocumented
+	SLL	(IX+IND),L		; Undocumented
+	SLL	(IY+IND)		; Undocumented
+	SLL	(IY+IND),A		; Undocumented
+	SLL	(IY+IND),B		; Undocumented
+	SLL	(IY+IND),C		; Undocumented
+	SLL	(IY+IND),D		; Undocumented
+	SLL	(IY+IND),E		; Undocumented
+	SLL	(IY+IND),H		; Undocumented
+	SLL	(IY+IND),L		; Undocumented
+	SLL	A			; Undocumented
+	SLL	B			; Undocumented
+	SLL	C			; Undocumented
+	SLL	D			; Undocumented
+	SLL	E			; Undocumented
+	SLL	H			; Undocumented
+	SLL	L			; Undocumented
 	SRA	(HL)
 	SRA	(IX+IND)
+	SRA	(IX+IND),A		; Undocumented
+	SRA	(IX+IND),B		; Undocumented
+	SRA	(IX+IND),C		; Undocumented
+	SRA	(IX+IND),D		; Undocumented
+	SRA	(IX+IND),E		; Undocumented
+	SRA	(IX+IND),H		; Undocumented
+	SRA	(IX+IND),L		; Undocumented
 	SRA	(IY+IND)
+	SRA	(IY+IND),A		; Undocumented
+	SRA	(IY+IND),B		; Undocumented
+	SRA	(IY+IND),C		; Undocumented
+	SRA	(IY+IND),D		; Undocumented
+	SRA	(IY+IND),E		; Undocumented
+	SRA	(IY+IND),H		; Undocumented
+	SRA	(IY+IND),L		; Undocumented
 	SRA	A
 	SRA	B
 	SRA	C
@@ -766,7 +1088,21 @@ Z80OPS:
 	SRA	L
 	SRL	(HL)
 	SRL	(IX+IND)
+	SRL	(IX+IND),A		; Undocumented
+	SRL	(IX+IND),B		; Undocumented
+	SRL	(IX+IND),C		; Undocumented
+	SRL	(IX+IND),D		; Undocumented
+	SRL	(IX+IND),E		; Undocumented
+	SRL	(IX+IND),H		; Undocumented
+	SRL	(IX+IND),L		; Undocumented
 	SRL	(IY+IND)
+	SRL	(IY+IND),A		; Undocumented
+	SRL	(IY+IND),B		; Undocumented
+	SRL	(IY+IND),C		; Undocumented
+	SRL	(IY+IND),D		; Undocumented
+	SRL	(IY+IND),E		; Undocumented
+	SRL	(IY+IND),H		; Undocumented
+	SRL	(IY+IND),L		; Undocumented
 	SRL	A
 	SRL	B
 	SRL	C
@@ -783,10 +1119,10 @@ Z80OPS:
 	SUB	D
 	SUB	E
 	SUB	H
-	SUB	IXH
-	SUB	IXL
-	SUB	IYH
-	SUB	IYL
+	SUB	IXH			; Undocumented
+	SUB	IXL			; Undocumented
+	SUB	IYH			; Undocumented
+	SUB	IYL			; Undocumented
 	SUB	L
 	SUB	N
 	XOR	(HL)
@@ -798,17 +1134,325 @@ Z80OPS:
 	XOR	D
 	XOR	E
 	XOR	H
-	XOR	IXH
-	XOR	IXL
-	XOR	IYH
-	XOR	IYL
+	XOR	IXH			; Undocumented
+	XOR	IXL			; Undocumented
+	XOR	IYH			; Undocumented
+	XOR	IYL			; Undocumented
 	XOR	L
 	XOR	N
 
 ; Rest of undocumented op-codes
-	DEFB	0EDH,063H		; LD (nn),HL
+	DEFB	0EDH,000H		; NOP
+	DEFB	0EDH,001H		; NOP
+	DEFB	0EDH,002H		; NOP
+	DEFB	0EDH,003H		; NOP
+	DEFB	0EDH,004H		; NOP
+	DEFB	0EDH,005H		; NOP
+	DEFB	0EDH,006H		; NOP
+	DEFB	0EDH,007H		; NOP
+	DEFB	0EDH,008H		; NOP
+	DEFB	0EDH,009H		; NOP
+	DEFB	0EDH,00AH		; NOP
+	DEFB	0EDH,00BH		; NOP
+	DEFB	0EDH,00CH		; NOP
+	DEFB	0EDH,00DH		; NOP
+	DEFB	0EDH,00EH		; NOP
+	DEFB	0EDH,00FH		; NOP
+	DEFB	0EDH,010H		; NOP
+	DEFB	0EDH,011H		; NOP
+	DEFB	0EDH,012H		; NOP
+	DEFB	0EDH,013H		; NOP
+	DEFB	0EDH,014H		; NOP
+	DEFB	0EDH,015H		; NOP
+	DEFB	0EDH,016H		; NOP
+	DEFB	0EDH,017H		; NOP
+	DEFB	0EDH,018H		; NOP
+	DEFB	0EDH,019H		; NOP
+	DEFB	0EDH,01AH		; NOP
+	DEFB	0EDH,01BH		; NOP
+	DEFB	0EDH,01CH		; NOP
+	DEFB	0EDH,01DH		; NOP
+	DEFB	0EDH,01EH		; NOP
+	DEFB	0EDH,01FH		; NOP
+	DEFB	0EDH,020H		; NOP
+	DEFB	0EDH,021H		; NOP
+	DEFB	0EDH,022H		; NOP
+	DEFB	0EDH,023H		; NOP
+	DEFB	0EDH,024H		; NOP
+	DEFB	0EDH,025H		; NOP
+	DEFB	0EDH,026H		; NOP
+	DEFB	0EDH,027H		; NOP
+	DEFB	0EDH,028H		; NOP
+	DEFB	0EDH,029H		; NOP
+	DEFB	0EDH,02AH		; NOP
+	DEFB	0EDH,02BH		; NOP
+	DEFB	0EDH,02CH		; NOP
+	DEFB	0EDH,02DH		; NOP
+	DEFB	0EDH,02EH		; NOP
+	DEFB	0EDH,02FH		; NOP
+	DEFB	0EDH,030H		; NOP
+	DEFB	0EDH,031H		; NOP
+	DEFB	0EDH,032H		; NOP
+	DEFB	0EDH,033H		; NOP
+	DEFB	0EDH,034H		; NOP
+	DEFB	0EDH,035H		; NOP
+	DEFB	0EDH,036H		; NOP
+	DEFB	0EDH,037H		; NOP
+	DEFB	0EDH,038H		; NOP
+	DEFB	0EDH,039H		; NOP
+	DEFB	0EDH,03AH		; NOP
+	DEFB	0EDH,03BH		; NOP
+	DEFB	0EDH,03CH		; NOP
+	DEFB	0EDH,03DH		; NOP
+	DEFB	0EDH,03EH		; NOP
+	DEFB	0EDH,03FH		; NOP
+	DEFB	0EDH,04CH		; NEG
+	DEFB	0EDH,04EH		; IM 0
+	DEFB	0EDH,054H		; NEG
+	DEFB	0EDH,055H		; RETN
+	DEFB	0EDH,05CH		; NEG
+	DEFB	0EDH,05DH		; RETI
+	DEFB	0EDH,063H		; LD (NN),HL
 	DEFW	NN
-	DEFB	0EDH,06BH		; LD HL,(nn)
+	DEFB	0EDH,064H		; NEG
+	DEFB	0EDH,065H		; RETN
+	DEFB	0EDH,066H		; IM 0
+	DEFB	0EDH,06BH		; LD HL,(NN)
 	DEFW	NN
+	DEFB	0EDH,06CH		; NEG
+	DEFB	0EDH,06DH		; RETI
+	DEFB	0EDH,06EH		; IM 0
+	DEFB	0EDH,074H		; NEG
+	DEFB	0EDH,075H		; RETN
+	DEFB	0EDH,076H		; IM 1
+	DEFB	0EDH,077H		; NOP
+	DEFB	0EDH,07CH		; NEG
+	DEFB	0EDH,07DH		; RETI
+	DEFB	0EDH,07EH		; IM 2
+	DEFB	0EDH,07FH		; NOP
+	DEFB	0EDH,080H		; NOP
+	DEFB	0EDH,081H		; NOP
+	DEFB	0EDH,082H		; NOP
+	DEFB	0EDH,083H		; NOP
+	DEFB	0EDH,084H		; NOP
+	DEFB	0EDH,085H		; NOP
+	DEFB	0EDH,086H		; NOP
+	DEFB	0EDH,087H		; NOP
+	DEFB	0EDH,088H		; NOP
+	DEFB	0EDH,089H		; NOP
+	DEFB	0EDH,08AH		; NOP
+	DEFB	0EDH,08BH		; NOP
+	DEFB	0EDH,08CH		; NOP
+	DEFB	0EDH,08DH		; NOP
+	DEFB	0EDH,08EH		; NOP
+	DEFB	0EDH,08FH		; NOP
+	DEFB	0EDH,090H		; NOP
+	DEFB	0EDH,091H		; NOP
+	DEFB	0EDH,092H		; NOP
+	DEFB	0EDH,093H		; NOP
+	DEFB	0EDH,094H		; NOP
+	DEFB	0EDH,095H		; NOP
+	DEFB	0EDH,096H		; NOP
+	DEFB	0EDH,097H		; NOP
+	DEFB	0EDH,098H		; NOP
+	DEFB	0EDH,099H		; NOP
+	DEFB	0EDH,09AH		; NOP
+	DEFB	0EDH,09BH		; NOP
+	DEFB	0EDH,09CH		; NOP
+	DEFB	0EDH,09DH		; NOP
+	DEFB	0EDH,09EH		; NOP
+	DEFB	0EDH,09FH		; NOP
+	DEFB	0EDH,0A4H		; NOP
+	DEFB	0EDH,0A5H		; NOP
+	DEFB	0EDH,0A6H		; NOP
+	DEFB	0EDH,0A7H		; NOP
+	DEFB	0EDH,0ACH		; NOP
+	DEFB	0EDH,0ADH		; NOP
+	DEFB	0EDH,0AEH		; NOP
+	DEFB	0EDH,0AFH		; NOP
+	DEFB	0EDH,0B4H		; NOP
+	DEFB	0EDH,0B5H		; NOP
+	DEFB	0EDH,0B6H		; NOP
+	DEFB	0EDH,0B7H		; NOP
+	DEFB	0EDH,0BCH		; NOP
+	DEFB	0EDH,0BDH		; NOP
+	DEFB	0EDH,0BEH		; NOP
+	DEFB	0EDH,0BFH		; NOP
+	DEFB	0EDH,0C0H		; NOP
+	DEFB	0EDH,0C1H		; NOP
+	DEFB	0EDH,0C2H		; NOP
+	DEFB	0EDH,0C3H		; NOP
+	DEFB	0EDH,0C4H		; NOP
+	DEFB	0EDH,0C5H		; NOP
+	DEFB	0EDH,0C6H		; NOP
+	DEFB	0EDH,0C7H		; NOP
+	DEFB	0EDH,0C8H		; NOP
+	DEFB	0EDH,0C9H		; NOP
+	DEFB	0EDH,0CAH		; NOP
+	DEFB	0EDH,0CBH		; NOP
+	DEFB	0EDH,0CCH		; NOP
+	DEFB	0EDH,0CDH		; NOP
+	DEFB	0EDH,0CEH		; NOP
+	DEFB	0EDH,0CFH		; NOP
+	DEFB	0EDH,0D0H		; NOP
+	DEFB	0EDH,0D1H		; NOP
+	DEFB	0EDH,0D2H		; NOP
+	DEFB	0EDH,0D3H		; NOP
+	DEFB	0EDH,0D4H		; NOP
+	DEFB	0EDH,0D5H		; NOP
+	DEFB	0EDH,0D6H		; NOP
+	DEFB	0EDH,0D7H		; NOP
+	DEFB	0EDH,0D8H		; NOP
+	DEFB	0EDH,0D9H		; NOP
+	DEFB	0EDH,0DAH		; NOP
+	DEFB	0EDH,0DBH		; NOP
+	DEFB	0EDH,0DCH		; NOP
+	DEFB	0EDH,0DDH		; NOP
+	DEFB	0EDH,0DEH		; NOP
+	DEFB	0EDH,0DFH		; NOP
+	DEFB	0EDH,0E0H		; NOP
+	DEFB	0EDH,0E1H		; NOP
+	DEFB	0EDH,0E2H		; NOP
+	DEFB	0EDH,0E3H		; NOP
+	DEFB	0EDH,0E4H		; NOP
+	DEFB	0EDH,0E5H		; NOP
+	DEFB	0EDH,0E6H		; NOP
+	DEFB	0EDH,0E7H		; NOP
+	DEFB	0EDH,0E8H		; NOP
+	DEFB	0EDH,0E9H		; NOP
+	DEFB	0EDH,0EAH		; NOP
+	DEFB	0EDH,0EBH		; NOP
+	DEFB	0EDH,0ECH		; NOP
+	DEFB	0EDH,0EDH		; NOP
+	DEFB	0EDH,0EEH		; NOP
+	DEFB	0EDH,0EFH		; NOP
+	DEFB	0EDH,0F0H		; NOP
+	DEFB	0EDH,0F1H		; NOP
+	DEFB	0EDH,0F2H		; NOP
+	DEFB	0EDH,0F3H		; NOP
+	DEFB	0EDH,0F4H		; NOP
+	DEFB	0EDH,0F5H		; NOP
+	DEFB	0EDH,0F6H		; NOP
+	DEFB	0EDH,0F7H		; NOP
+	DEFB	0EDH,0F8H		; NOP
+	DEFB	0EDH,0F9H		; NOP
+	DEFB	0EDH,0FAH		; NOP
+	DEFB	0EDH,0FBH		; NOP
+	DEFB	0EDH,0FCH		; NOP
+	DEFB	0EDH,0FDH		; NOP
+	DEFB	0EDH,0FEH		; NOP
+	DEFB	0EDH,0FFH		; NOP
+	DEFB	0DDH,0CBH,IND,040H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,IND,041H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,IND,042H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,IND,043H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,IND,044H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,IND,045H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,IND,047H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,IND,048H	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,IND,049H	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,IND,04AH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,IND,04BH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,IND,04CH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,IND,04DH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,IND,04FH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,IND,050H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,IND,051H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,IND,052H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,IND,053H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,IND,054H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,IND,055H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,IND,057H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,IND,058H	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,IND,059H	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,IND,05AH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,IND,05BH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,IND,05CH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,IND,05DH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,IND,05FH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,IND,060H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,IND,061H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,IND,062H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,IND,063H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,IND,064H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,IND,065H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,IND,067H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,IND,068H	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,IND,069H	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,IND,06AH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,IND,06BH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,IND,06CH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,IND,06DH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,IND,06FH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,IND,070H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,IND,071H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,IND,072H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,IND,073H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,IND,074H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,IND,075H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,IND,077H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,IND,078H	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,IND,079H	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,IND,07AH	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,IND,07BH	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,IND,07CH	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,IND,07DH	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,IND,07FH	; BIT 7,(IX+IND)
+	DEFB	0FDH,0CBH,IND,040H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,IND,041H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,IND,042H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,IND,043H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,IND,044H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,IND,045H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,IND,047H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,IND,048H	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,IND,049H	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,IND,04AH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,IND,04BH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,IND,04CH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,IND,04DH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,IND,04FH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,IND,050H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,IND,051H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,IND,052H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,IND,053H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,IND,054H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,IND,055H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,IND,057H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,IND,058H	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,IND,059H	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,IND,05AH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,IND,05BH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,IND,05CH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,IND,05DH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,IND,05FH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,IND,060H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,IND,061H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,IND,062H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,IND,063H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,IND,064H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,IND,065H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,IND,067H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,IND,068H	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,IND,069H	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,IND,06AH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,IND,06BH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,IND,06CH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,IND,06DH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,IND,06FH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,IND,070H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,IND,071H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,IND,072H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,IND,073H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,IND,074H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,IND,075H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,IND,077H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,IND,078H	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,IND,079H	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,IND,07AH	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,IND,07BH	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,IND,07CH	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,IND,07DH	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,IND,07FH	; BIT 7,(IY+IND)
 
 NN:	DEFS	2


### PR DESCRIPTION
1. Added remaining undocumented Z80 instructions to dis-/assembler.
2. Cleaned up and deduplicate code in z80arfun.c.
3. Fixed (IMHO) chk_v1 & chk_v2 functions and renamed them to chk_byte & chk_sbyte to make they purpose more clear
4. Bonus feature: added support for 8080 mode in the assembler since the simulator and disassembler already support it.
5. Added 8080opsall.asm to test dis-/assembler.
6. Increased version number of the assembler because of the many changes.
7. Added copyright notices and history to assembler.
8. Added copyright notice to disas.c.

Added second commit to fix some cosmetic stuff and typos.
To hide my own errors ;-) (checking thousands of lines of diffs before pushing makes my eyes bleed...),
I included cleanups for a file which I overlooked in my previous clean up.
