### PR TITLE
z80asm: reformat z80anum.c and make z80asm compile with -Wextra without warnings

### DIFF
--- a/z80asm/Makefile
+++ b/z80asm/Makefile
@@ -6,7 +6,7 @@ CC = gcc
 #CC = cc
 #CC = acc
 
-CFLAGS = -c -O3 -Wall -D_POSIX_C_SOURCE=200809L
+CFLAGS = -c -O3 -Wall -Wextra -D_POSIX_C_SOURCE=200809L
 #CFLAGS = -c -O
 
 LFLAGS =

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -13,81 +13,82 @@
 #include "z80a.h"
 #include "z80aglb.h"
 
-#define T_NODE  0
-#define T_VALUE 1
+#define T_NODE		0
+#define T_VALUE		1
 
 /* character classes */
-#define C_BIN  0x0001
-#define C_HEX  0x0002
-#define C_OCT  0x0004
-#define C_DEC  0x0008
-#define C_OPE  0x0010
-#define C_SPC  0x0020
-#define C_SYM  0x0040
+#define C_BIN		0x0001
+#define C_HEX		0x0002
+#define C_OCT		0x0004
+#define C_DEC		0x0008
+#define C_OPE		0x0010
+#define C_SPC		0x0020
+#define C_SYM		0x0040
 
 /* parser fsm states */
-#define S_OPE  0
-#define S_HEX  1
-#define S_OCT  2
-#define S_BIN  3
-#define S_DEC  4
-#define S_LIT  5
-#define S_SYM  6
+#define S_OPE		0
+#define S_HEX		1
+#define S_OCT		2
+#define S_BIN		3
+#define S_DEC		4
+#define S_LIT		5
+#define S_SYM		6
 
-#define SS_START  0
-#define SS_CONT   1
-#define SS_POST   2 
+#define SS_START	0
+#define SS_CONT		1
+#define SS_POST		2
 
-/* standard operators: '(', ')', '*', '/', '%', '+', '-', '|', '&', '^', '~' */
-/* other    operators: left shift '<', right shift '>', current position '$' */
-/* other    tokens:    end of parsing 'X', numerical value 'N' */
+/*
+ *	standard operators: '(', ')', '*', '/', '%', '+', '-', '|', '&', '^', '~'
+ *	other    operators: left shift '<', right shift '>', current position '$'
+ *	other    tokens:    end of parsing 'X', numerical value 'N'
+ */
 
 typedef struct node {
-  int   op:8;
-  int   left:8;
-  int   right:8;
-  int   flag:8;
-  int   value;
+	int op: 8;
+	int left: 8;
+	int right: 8;
+	int flag: 8;
+	int value;
 } Node;
 
+int getdot(void);
 int getsymvalue(char *);
-int getdot();
 
 extern struct sym *get_sym(char *);
 extern void asmerr(int);
 
-
 static int  mknode(int, int, int, int);
 static void parser_init(char *);
-static int  parse();
+static int  parse(void);
 static int  asctoi(char *);
-static int  expr_factor();
-/*static int  expr_term();*/
-static int  expr_simple();
-/*static int  expr_shift();*/
-/*static int  expr_and();*/
-/*static int  expr_xor();*/
-/*static int  expr_or();*/
-static int  expr();
+static int  expr_factor(void);
+/*static int  expr_term(void);*/
+static int  expr_simple(void);
+/*static int  expr_shift(void);*/
+/*static int  expr_and(void);*/
+/*static int  expr_xor(void);*/
+/*static int  expr_or(void);*/
+static int  expr(void);
 static int  evaluate(int);
-       void dump_nodes();
-       int  eval(char *);
 
+void dump_nodes(void);
+int  eval(char *);
 
+/*
+ *	precedence
+ *	operators	functions
+ *	+ - ~ (unary)	expr_factor
+ *	* / %		expr_term
+ *	+ -		expr_simple
+ *	< >		expr_shift
+ *	&		expr_and
+ *	^		expr_xor
+ *	|		expr_or
+ *	( )		expr
+ */
 
-/* precedence
-   operators        functions
-   + - ~ (unaire)   expr_factor
-   * /  %           expr_term
-   + -              expr_simple
-   < >              expr_shift
-   &                expr_and
-   ^                expr_xor
-   |                expr_or 
-   ( )              expr    
-*/
-
-#define MAXNODES 100
+#define MAXNODES	100
 
 static int   parsed_pos  = 0;
 static char *parsed_line = NULL;
@@ -99,623 +100,655 @@ static int   type;
 static int   value;
 static int   tok;
 
-static int mknode(int op, int flag, int p1, int p2) {
-  int  node;
+static int mknode(int op, int flag, int p1, int p2)
+{
+	int node;
 
-  if (curnode < MAXNODES) {
-    node = curnode;
-    curnode++;
-    nodes[node].op    = op;
-    nodes[node].flag  = flag;      
-    if (nodes[node].flag == T_NODE) {
-      nodes[node].left  = p1;  
-      nodes[node].right = p2;  
-      nodes[node].value = 0;
-    } else {
-      nodes[node].left  = 0;  
-      nodes[node].right = 0;  
-      nodes[node].value = p1;
-    }
-    return node;
-  }
-  return -1;
-}
-
-/* these 2 functions simulates the retieval */
-/* of a symbol or of the current position */
-int getdot() {
-  return pc;
-}
-
-int getsymvalue(char *str) {
-  struct sym *sp;
-  
-  if (strcasecmp(str, "$") == 0)
-    return getdot();
-  if (strlen(str) > symlen)
-    str[symlen] = '\0';
-  if ((sp = get_sym(str)) != NULL) 
-    return sp->sym_val;
-  else 
-    asmerr(E_UNDSYM);
-  return 0;
+	if (curnode < MAXNODES) {
+		node = curnode;
+		curnode++;
+		nodes[node].op    = op;
+		nodes[node].flag  = flag;
+		if (nodes[node].flag == T_NODE) {
+			nodes[node].left  = p1;
+			nodes[node].right = p2;
+			nodes[node].value = 0;
+		} else {
+			nodes[node].left  = 0;
+			nodes[node].right = 0;
+			nodes[node].value = p1;
+		}
+		return(node);
+	}
+	return(-1);
 }
 
 /*
- * strdup() and strcasecmp() is defined by POSIX only and not by any ANSI C
- * standard. So we need a substitute if compiling in non POSIX environment.
+ *	these two functions simulate the retieval
+ *	of a symbol or of the current position
  */
+
+int getdot(void)
+{
+	return(pc);
+}
+
+int getsymvalue(char *str)
+{
+	struct sym *sp;
+
+	if (strcasecmp(str, "$") == 0)
+		return(getdot());
+	if (strlen(str) > (unsigned) symlen)
+		str[symlen] = '\0';
+	if ((sp = get_sym(str)) != NULL)
+		return(sp->sym_val);
+	else
+		asmerr(E_UNDSYM);
+	return(0);
+}
+
+/*
+ *	strdup() and strcasecmp() is defined by POSIX only and not by
+ *	any ANSI C standard. So we need a substitute if compiling in
+ *	non POSIX environment.
+ */
+
 #ifndef _POSIX_C_SOURCE
 char *strdup(const char *s)
 {
 	size_t len = strlen(s) + 1;
 	char *p = malloc(len);
-	return p ? memcpy(p, s, len) : NULL;
+
+	return(p ? memcpy(p, s, len) : NULL);
 }
 
 int strcasecmp(unsigned char *s1, unsigned char *s2)
 {
-    register int c, d;
+	register int c, d;
 
-    for (;;) {
-	switch(c = *s1++ - (d = *s2++)) {
-	case 0:
-		if(!d)
-			break;
-		continue;
-	case ('A' - 'a'):
-		if((d < 'a') || (d > 'z'))
-			break;
-		continue;
-	case ('a' - 'A'):
-		if((d < 'A') || (d > 'Z'))
-			break;
-		continue;
+	for (;;) {
+		switch(c = *s1++ - (d = *s2++)) {
+		case 0:
+			if (!d)
+				break;
+			continue;
+		case ('A' - 'a'):
+			if ((d < 'a') || (d > 'z'))
+				break;
+			continue;
+		case ('a' - 'A'):
+			if ((d < 'A') || (d > 'Z'))
+				break;
+			continue;
+		}
+		return(c);
 	}
-	return(c);
-    }
 }
 #endif
 
-static void parser_init(char *str) {
-  static int initialized = 0;
-  int i;
+static void parser_init(char *str)
+{
+	static int initialized = 0;
+	int i;
 
-  parsed_pos = 0;
-  curnode = 1;
-  memset(&nodes[0], '\0', sizeof(nodes));
-  if (parsed_line) 
-    free(parsed_line);
-  parsed_line = strdup(str);
-  if (!initialized) {
-    memset(&charclass[0], '\0', sizeof(charclass));
-    for (i='a'; i<='z'; i++)
-      charclass[i] = charclass[i] | C_SYM;
-    for (i='A'; i<='Z'; i++)
-      charclass[i] = charclass[i] | C_SYM;
-    for (i='0'; i<='9'; i++)
-      charclass[i] = charclass[i] | C_DEC | C_HEX | C_SYM;
-    for (i='0'; i<='7'; i++)
-      charclass[i] |= C_OCT;
-    for (i='a'; i<='f'; i++)
-      charclass[i] |= C_HEX;
-    for (i='A'; i<='F'; i++)
-      charclass[i] |= C_HEX;
-    for (i='0'; i<='1'; i++)
-      charclass[i] |= C_BIN;
-    charclass['_']  |= C_SYM;
-    charclass['$']  |= C_SYM | C_OCT | C_HEX | C_BIN | C_DEC;
-    charclass['-']  |= C_OPE;
-    charclass['+']  |= C_OPE;
-    charclass['*']  |= C_OPE;
-    charclass['/']  |= C_OPE;
-    charclass['%']  |= C_OPE;
-    charclass['<']  |= C_OPE;
-    charclass['>']  |= C_OPE;
-    charclass['|']  |= C_OPE;
-    charclass['&']  |= C_OPE;
-    charclass['^']  |= C_OPE;
-    charclass['~']  |= C_OPE;
-    charclass['(']  |= C_OPE;
-    charclass[')']  |= C_OPE;
-    charclass[' ']  |= C_SPC;
-    charclass['\n'] |= C_SPC;
-    charclass['\r'] |= C_SPC;
-    charclass['\t'] |= C_SPC;
-    initialized = 1;
-  }
+	parsed_pos = 0;
+	curnode = 1;
+	memset(&nodes[0], '\0', sizeof(nodes));
+	if (parsed_line)
+		free(parsed_line);
+	parsed_line = strdup(str);
+	if (!initialized) {
+		memset(&charclass[0], '\0', sizeof(charclass));
+		for (i = 'a'; i <= 'z'; i++)
+			charclass[i] |= C_SYM;
+		for (i = 'A'; i <= 'Z'; i++)
+			charclass[i] |= C_SYM;
+		for (i = '0'; i <= '9'; i++)
+			charclass[i] |= C_DEC | C_HEX | C_SYM;
+		for (i = '0'; i <= '7'; i++)
+			charclass[i] |= C_OCT;
+		for (i = 'a'; i <= 'f'; i++)
+			charclass[i] |= C_HEX;
+		for (i = 'A'; i <= 'F'; i++)
+			charclass[i] |= C_HEX;
+		for (i = '0'; i <= '1'; i++)
+			charclass[i] |= C_BIN;
+		charclass['_']  |= C_SYM;
+		charclass['$']  |= C_SYM | C_OCT | C_HEX | C_BIN | C_DEC;
+		charclass['-']  |= C_OPE;
+		charclass['+']  |= C_OPE;
+		charclass['*']  |= C_OPE;
+		charclass['/']  |= C_OPE;
+		charclass['%']  |= C_OPE;
+		charclass['<']  |= C_OPE;
+		charclass['>']  |= C_OPE;
+		charclass['|']  |= C_OPE;
+		charclass['&']  |= C_OPE;
+		charclass['^']  |= C_OPE;
+		charclass['~']  |= C_OPE;
+		charclass['(']  |= C_OPE;
+		charclass[')']  |= C_OPE;
+		charclass[' ']  |= C_SPC;
+		charclass['\n'] |= C_SPC;
+		charclass['\r'] |= C_SPC;
+		charclass['\t'] |= C_SPC;
+		initialized = 1;
+	}
 }
 
-static int parse() {
-  int mark, start, state, sstate, index, quote, pcode; 
-  char symbol[256];
+static int parse(void)
+{
+	int mark, start, state, sstate, index, quote, pcode;
+	char symbol[256];
 
-  mark  = parsed_pos;
-  state = -1;
- again:  
-  parsed_pos = mark;
-  state++;
-  sstate = SS_START;
-  quote  = 0;  
-  index  = 0;  
-  code   = -1;
-  pcode  = 0;
-  value  = 0;
-  start  = 1;
-  while(1) {
-    pcode = code;
-  skip_spaces:
-    code = parsed_line[parsed_pos]; 
-    parsed_pos += (code) ? 1 : 0;
-    type = ((code < 128) ? charclass[code] : 0);
-    if ((quote == 0) && ((type & C_SPC) == C_SPC))
-      goto skip_spaces;
-    switch(state) {
-    case S_OPE:
-      if ((type & C_OPE) == C_OPE) 
-	return code;
-      goto again;
+	mark  = parsed_pos;
+	state = -1;
+ again:
+	parsed_pos = mark;
+	state++;
+	sstate = SS_START;
+	quote  = 0;
+	index  = 0;
+	code   = -1;
+	pcode  = 0;
+	value  = 0;
+	start  = 1;
+	while(1) {
+		pcode = code;
+	skip_spaces:
+		code = parsed_line[parsed_pos];
+		parsed_pos += (code) ? 1 : 0;
+		type = ((code < 128) ? charclass[code] : 0);
+		if ((quote == 0) && ((type & C_SPC) == C_SPC))
+			goto skip_spaces;
+		switch(state) {
+		case S_OPE:
+			if ((type & C_OPE) == C_OPE)
+				return(code);
+			goto again;
 
-    case S_HEX:
-      switch(sstate) {
-      	case SS_START:  /* initial condition */
-      	  if (!isdigit(code))
-	     goto again;  
-	  sstate = SS_CONT;   
-	  /* no break fall into next case */
-	  	  
-      	case SS_CONT:   /* building the value from digits */
-	  if ((type & C_HEX) == C_HEX) {
-      	    if (code == '$')  
-      	       continue;
-            value *= 16;
-            value += toupper(code) - ((code <= '9') ? '0' : '7');
-            index++;
-            continue;
-          } else
-	    if ((index > 0) && (toupper(code) == 'H')) {
-	      sstate = SS_POST;
-	      continue;
-	    }
-      	  break;
-      		
-      	case SS_POST:  /* post processing, parsing position adjustment */
-      	  if ((type & C_OPE) == C_OPE) {
-	     parsed_pos--;  	
-	     return 'N';
-      	  }
-      	  if (code == 0)
-      	     return 'N';   
-      	  break;   
-      }
-      goto again;
-      
-    case S_OCT:
-      switch(sstate) {
-        case SS_START:  /* initial condition */
-      	  if (!isdigit(code))
-	     goto again;  
-	  sstate = SS_CONT;   
-	  /* no break fall into next case */
+		case S_HEX:
+			switch(sstate) {
+			case SS_START:	/* initial condition */
+				if (!isdigit(code))
+					goto again;
+				sstate = SS_CONT;
+				/* fallthrough */
+			case SS_CONT:	/* building the value from digits */
+				if ((type & C_HEX) == C_HEX) {
+					if (code == '$')
+						continue;
+					value *= 16;
+					value += toupper(code)
+						 - ((code <= '9') ? '0' : '7');
+					index++;
+					continue;
+				} else if ((index > 0) && (toupper(code) == 'H')) {
+					sstate = SS_POST;
+					continue;
+				}
+				break;
+			case SS_POST:	/* post processing, parsing position adjustment */
+				if ((type & C_OPE) == C_OPE) {
+					parsed_pos--;
+					return('N');
+				}
+				if (code == 0)
+					return('N');
+				break;
+			}
+			goto again;
 
-        case SS_CONT:
-	  if ((type & C_OCT) == C_OCT) {
-      	    if (code == '$')  
-      	       continue;
-            value *= 8;
-            value += code - '0';
-            index++;
-            continue;
-         } else
-	    if ((index > 0) && (toupper(code) == 'O' || toupper(code) == 'Q')) {
-	      sstate = SS_POST;
-              continue;
-	    }
-          break;
-          
-        case SS_POST:
-      	  if ((type & C_OPE) == C_OPE) {
-	     parsed_pos--;  	
-	     return 'N';
-      	  }
-      	  if (code == 0)
-      	     return 'N';   
-      	  break;   
-      }
-      goto again;
+		case S_OCT:
+			switch(sstate) {
+			case SS_START:	/* initial condition */
+				if (!isdigit(code))
+					goto again;
+				sstate = SS_CONT;
+				/* fallthrough */
+			case SS_CONT:
+				if ((type & C_OCT) == C_OCT) {
+					if (code == '$')
+						continue;
+					value *= 8;
+					value += code - '0';
+					index++;
+					continue;
+				} else if ((index > 0) && (toupper(code) == 'O'
+							   || toupper(code) == 'Q')) {
+					sstate = SS_POST;
+					continue;
+				}
+				break;
+			case SS_POST:
+				if ((type & C_OPE) == C_OPE) {
+					parsed_pos--;
+					return('N');
+				}
+				if (code == 0)
+					return('N');
+				break;
+			}
+			goto again;
 
-    case S_BIN:
-      switch(sstate) {
-        case SS_START:  /* initial condition */
-      	  if (!isdigit(code))
-	     goto again;  
-	  sstate = SS_CONT;   
-	  /* no break fall into next case */
+		case S_BIN:
+			switch(sstate) {
+			case SS_START:	/* initial condition */
+				if (!isdigit(code))
+					goto again;
+				sstate = SS_CONT;
+				/* fallthrough */
+			case SS_CONT:
+				if ((type & C_BIN) == C_BIN) {
+					if (code == '$')
+						continue;
+					value *= 2;
+					value += code - '0';
+					index++;
+					continue;
+				} else if ((index > 0) && (toupper(code) == 'B')) {
+					sstate = SS_POST;
+					continue;
+				}
+				break;
+			case SS_POST:
+				if ((type & C_OPE) == C_OPE) {
+					parsed_pos--;
+					return('N');
+				}
+				if (code == 0)
+					return('N');
+				break;
+			}
+			goto again;
 
-        case SS_CONT:
-	  if ((type & C_BIN) == C_BIN) {
-      	    if (code == '$')  
-      	       continue;
-            value *= 2;
-            value += code - '0';
-            index++;
-            continue;
-         } else
-	    if ((index > 0) && (toupper(code) == 'B')) {
-	      sstate = SS_POST;
-              continue;
-	    }
-          break;
-          
-        case SS_POST:
-      	  if ((type & C_OPE) == C_OPE) {
-	     parsed_pos--;  	
-	     return 'N';
-      	  }
-      	  if (code == 0)
-      	     return 'N';   
-      	  break;   
-      }
-      goto again;
-      
-    case S_DEC:
-      switch(sstate) {
-        case SS_START:  /* initial condition */
-      	  if (!isdigit(code))
-	     goto again;  
-	  sstate = SS_CONT;   
-	  /* no break fall into next case */
+		case S_DEC:
+			switch(sstate) {
+			case SS_START:	/* initial condition */
+				if (!isdigit(code))
+					goto again;
+				sstate = SS_CONT;
+				/* fallthrough */
+			case SS_CONT:
+				if ((type & C_DEC) == C_DEC) {
+					if (code == '$')
+						continue;
+					value *= 10;
+					value += code - '0';
+					index++;
+					continue;
+				} if ((index > 0) && ((code == 0)
+						      || ((type & C_OPE) == C_OPE))) {
+					if ((type & C_OPE) == C_OPE)
+						parsed_pos--;
+					return('N');
+				}
+				break;
+			case SS_POST:
+				/* do nothing */
+				break;
+			}
+			goto again;
 
-        case SS_CONT:
-	  if ((type & C_DEC) == C_DEC) {
-      	    if (code == '$')  
-      	       continue;
-            value *= 10;
-            value += code - '0';
-            index++;
-            continue;
-         }
-         if ((index > 0) && ((code == 0) || ((type & C_OPE) == C_OPE))) {
-           if ((type & C_OPE) == C_OPE) 
-             parsed_pos--;
-           return 'N';
-         }
-         break;
+		case S_LIT:
+			if (quote == 0) {
+				if (code != '\'')
+					goto again;
+				quote = 1;
+				continue;
+			} else {
+				if (code == '\'') {
+					if (pcode != '\\') {
+						symbol[index] = '\0';
+						value = asctoi(symbol);
+						return('N');
+					} else
+						symbol[index++] = code;
+				} else
+					symbol[index++] = code;
+			}
+			break;
 
-        case SS_POST:
-          /* do nothing */
-          break;
-      }
-      goto again;
+		case S_SYM:
+			if (start && !(isalpha(code) || (code = '$') || (code == '_')))
+				goto again;
+			start = 0;
+			if ((type & C_SYM) == C_SYM) {
+				symbol[index++] = code;
+				continue;
+			}
+			if ((index > 0) && (((type & C_OPE) == C_OPE) || (code == 0))) {
+				symbol[index] = '\0';
+				value = getsymvalue(symbol);
+				if ((type & C_OPE) == C_OPE)
+					parsed_pos--;
+				return('N');
+			}
+			goto again;
 
-    case S_LIT:
-      if (quote == 0) {
-        if (code != '\'')
-          goto again;          
-        quote = 1;
-        continue;
-      } else {
-        if (code == '\'') { 
-          if (pcode != '\\') {
-            symbol[index] = '\0';
-            value = asctoi(symbol);
-            return 'N';
-          } else 
-            symbol[index++] = code;
-        } else {
-          symbol[index++] = code;
-        }
-      }
-      break;
-
-    case S_SYM:
-      if (start && !(isalpha(code) || (code = '$') || (code == '_')))
-	goto again;  
-      start = 0;
-      if ((type & C_SYM) == C_SYM) {
-        symbol[index++] = code;
-        continue;
-      }
-      if ((index > 0) && (((type & C_OPE) == C_OPE) || (code == 0))) {
-        symbol[index] = '\0';        
-        value = getsymvalue(symbol);
-        if ((type & C_OPE) == C_OPE) 
-          parsed_pos--;
-        return 'N';
-      }
-      goto again;
-      
-    default:
-      if (code == 0) 
-        return 'X';
-      asmerr(E_ILLOPE);
-      return 1;
-    }
-  }
+		default:
+			if (code == 0)
+				return('X');
+			asmerr(E_ILLOPE);
+			return(1);
+		}
+	}
 }
 
-static int asctoi(char *str) {
-  register int num;
-  
-  num = 0;
-  while (*str) {
-    num <<= 8;    
-    if (*str == '\\') {
-      str++;
-      switch(*str++) {
-      case 'a':  num |= 0x07; break;
-      case 'b':  num |= 0x08; break;
-      case 'f':  num |= 0x0c; break;
-      case 'n':  num |= 0x0a; break;
-      case 'r':  num |= 0x0d; break;
-      case 't':  num |= 0x09; break;
-      case 'v':  num |= 0x0b; break;
-      case '\\': num |= 0x5c; break;
-      case '\'': num |= 0x27; break;
-      case '"':  num |= 0x22; break;
-      case '?':  num |= 0x3f; break;
-      default:
-        break;
-      }
-    } else {
-      num |= (int) *str++;
-    }
-  }
-  return(num);
+static int asctoi(char *str)
+{
+	register int num;
+
+	num = 0;
+	while (*str) {
+		num <<= 8;
+		if (*str == '\\') {
+			str++;
+			switch(*str++) {
+			case 'a':
+				num |= 0x07;
+				break;
+			case 'b':
+				num |= 0x08;
+				break;
+			case 'f':
+				num |= 0x0c;
+				break;
+			case 'n':
+				num |= 0x0a;
+				break;
+			case 'r':
+				num |= 0x0d;
+				break;
+			case 't':
+				num |= 0x09;
+				break;
+			case 'v':
+				num |= 0x0b;
+				break;
+			case '\\':
+				num |= 0x5c;
+				break;
+			case '\'':
+				num |= 0x27;
+				break;
+			case '"':
+				num |= 0x22;
+				break;
+			case '?':
+				num |= 0x3f;
+				break;
+			default:
+				break;
+			}
+		} else
+			num |= (int) *str++;
+	}
+	return(num);
 }
 
-static int expr_factor() {
-  int n1, n2;
-  
-  switch(tok) {
-  case '(':  	
-    tok = parse();
-    n1 = expr();
-    tok = parse();
-    if (tok != ')') {
-      asmerr(E_MISPAR);
-      return 0;
-    }
-    return n1;
+static int expr_factor(void)
+{
+	int n1, n2;
 
-  case '~':
-    tok = parse();
-    n2 = expr_factor();
-    n1 = mknode('~', T_NODE, n2, 0);
-    return n1;
+	switch(tok) {
+	case '(':
+		tok = parse();
+		n1 = expr();
+		tok = parse();
+		if (tok != ')') {
+			asmerr(E_MISPAR);
+			return(0);
+		}
+		return(n1);
 
-  case '+':
-    tok = parse();
-    n2 = expr_factor();
-    n1 =  mknode('*', T_NODE, mknode('N', T_VALUE,  1, 0), n2);
-    return n1;
+	case '~':
+		tok = parse();
+		n2 = expr_factor();
+		n1 = mknode('~', T_NODE, n2, 0);
+		return(n1);
 
-  case '-':
-    tok = parse();
-    n2 = expr_factor();
-    n1 = mknode('*', T_NODE, mknode('N', T_VALUE, -1, 0), n2);
-    return n1;
-    
-  case 'N':
-    n1 = mknode('N', T_VALUE, value, 0);
-    return n1;
+	case '+':
+		tok = parse();
+		n2 = expr_factor();
+		n1 = mknode('*', T_NODE, mknode('N', T_VALUE, 1, 0), n2);
+		return(n1);
 
-  default :
-    asmerr(E_ILLOPE);
-    return 0;
-  }
+	case '-':
+		tok = parse();
+		n2 = expr_factor();
+		n1 = mknode('*', T_NODE, mknode('N', T_VALUE, -1, 0), n2);
+		return(n1);
+
+	case 'N':
+		n1 = mknode('N', T_VALUE, value, 0);
+		return(n1);
+
+	default:
+		asmerr(E_ILLOPE);
+		return(0);
+	}
 }
 
-static int expr_term() {
-  int n1, n2, t, mark;
+static int expr_term(void)
+{
+	int n1, n2, t, mark;
 
-  n1 = expr_factor();
-  while (1) {  
-    mark = parsed_pos;
-    tok = parse();
-    switch(tok) {
-    case '*':
-    case '/':
-    case '%':
-      t = tok;
-      mark = parsed_pos;
-      tok = parse();
-      n2 = expr_factor();
-      n1 = mknode(t, T_NODE, n1, n2);
-      continue;
+	n1 = expr_factor();
+	while (1) {
+		mark = parsed_pos;
+		tok = parse();
+		switch(tok) {
+		case '*':
+		case '/':
+		case '%':
+			t = tok;
+			mark = parsed_pos;
+			tok = parse();
+			n2 = expr_factor();
+			n1 = mknode(t, T_NODE, n1, n2);
+			continue;
 
-    default: 
-      parsed_pos = mark;
-      return n1;
-    }
-  }  
+		default:
+			parsed_pos = mark;
+			return(n1);
+		}
+	}
 }
 
-static int expr_simple() {
-  int n1, n2, t, mark;
+static int expr_simple(void)
+{
+	int n1, n2, t, mark;
 
-  n1 = expr_term();
-  while (1) {  
-    mark = parsed_pos;
-    tok = parse();
-    switch(tok) {
-    case '+':
-    case '-':
-      t = tok;
-      mark = parsed_pos;
-      tok = parse();
-      n2 = expr_term();
-      n1 = mknode(t, T_NODE, n1, n2);
-      continue;
+	n1 = expr_term();
+	while (1) {
+		mark = parsed_pos;
+		tok = parse();
+		switch(tok) {
+		case '+':
+		case '-':
+			t = tok;
+			mark = parsed_pos;
+			tok = parse();
+			n2 = expr_term();
+			n1 = mknode(t, T_NODE, n1, n2);
+			continue;
 
-    default: 
-      parsed_pos = mark;
-      return n1;
-    }
-  }  
+		default:
+			parsed_pos = mark;
+			return(n1);
+		}
+	}
 }
 
-static int expr_shift() {
-  int n1, n2, t, mark;
+static int expr_shift(void)
+{
+	int n1, n2, t, mark;
 
-  n1 = expr_simple();
-  while (1) {  
-    mark = parsed_pos;
-    tok = parse();
-    switch(tok) {
-    case '<':
-    case '>':
-      t = tok;
-      mark = parsed_pos;
-      tok = parse();
-      n2 = expr_simple();
-      n1 = mknode(t, T_NODE, n1, n2);
-      return n1; /* not associative */
-      continue;
+	n1 = expr_simple();
+	while (1) {
+		mark = parsed_pos;
+		tok = parse();
+		switch(tok) {
+		case '<':
+		case '>':
+			t = tok;
+			mark = parsed_pos;
+			tok = parse();
+			n2 = expr_simple();
+			n1 = mknode(t, T_NODE, n1, n2);
+			return(n1);	/* not associative */
 
-    default: 
-      parsed_pos = mark;
-      return n1;
-    }
-  }  
+		default:
+			parsed_pos = mark;
+			return(n1);
+		}
+	}
 }
 
-static int expr_and() {
-  int n1, n2, t, mark;
+static int expr_and(void)
+{
+	int n1, n2, t, mark;
 
-  n1 = expr_shift();
-  while (1) {  
-    mark = parsed_pos;
-    tok = parse();
-    switch(tok) {
-    case '&':
-      t = tok;
-      mark = parsed_pos;
-      tok = parse();
-      n2 = expr_shift();
-      n1 = mknode(t, T_NODE, n1, n2);
-      continue;
+	n1 = expr_shift();
+	while (1) {
+		mark = parsed_pos;
+		tok = parse();
+		switch(tok) {
+		case '&':
+			t = tok;
+			mark = parsed_pos;
+			tok = parse();
+			n2 = expr_shift();
+			n1 = mknode(t, T_NODE, n1, n2);
+			continue;
 
-    default: 
-      parsed_pos = mark;
-      return n1;
-    }
-  }  
+		default:
+			parsed_pos = mark;
+			return(n1);
+		}
+	}
 }
 
-static int expr_xor() {
-  int n1, n2, t, mark;
+static int expr_xor(void)
+{
+	int n1, n2, t, mark;
 
-  n1 = expr_and();
-  while (1) {  
-    mark = parsed_pos;
-    tok = parse();
-    switch(tok) {
-    case '^':
-      t = tok;
-      mark = parsed_pos;
-      tok = parse();
-      n2 = expr_and();
-      n1 = mknode(t, T_NODE, n1, n2);
-      continue;
+	n1 = expr_and();
+	while (1) {
+		mark = parsed_pos;
+		tok = parse();
+		switch(tok) {
+		case '^':
+			t = tok;
+			mark = parsed_pos;
+			tok = parse();
+			n2 = expr_and();
+			n1 = mknode(t, T_NODE, n1, n2);
+			continue;
 
-    default: 
-      parsed_pos = mark;
-      return n1;
-    }
-  }  
+		default:
+			parsed_pos = mark;
+			return(n1);
+		}
+	}
 }
 
-static int expr_or() {
-  int n1, n2, t, mark;
+static int expr_or(void)
+{
+	int n1, n2, t, mark;
 
-  n1 = expr_xor();
-  while (1) {  
-    mark = parsed_pos;
-    tok = parse();
-    switch(tok) {
-    case '|':
-      t = tok;
-      mark = parsed_pos;
-      tok = parse();
-      n2 = expr_xor();
-      n1 = mknode(t, T_NODE, n1, n2);
-      continue;
+	n1 = expr_xor();
+	while (1) {
+		mark = parsed_pos;
+		tok = parse();
+		switch(tok) {
+		case '|':
+			t = tok;
+			mark = parsed_pos;
+			tok = parse();
+			n2 = expr_xor();
+			n1 = mknode(t, T_NODE, n1, n2);
+			continue;
 
-    default: 
-      parsed_pos = mark;
-      return n1;
-    }
-  }  
+		default:
+			parsed_pos = mark;
+			return(n1);
+		}
+	}
 }
 
-static int expr() {
-  return expr_or();
+static int expr(void)
+{
+	return(expr_or());
 }
 
-static int evaluate(int node) {
-  int n1, n2;
+static int evaluate(int node)
+{
+	int n1, n2;
 
-  n1 = n2 = 0; /* to make the compiler happy */
-  if (nodes[node].flag == 0) {
-    if (nodes[node].left)
-      n1 = evaluate(nodes[node].left);
-    if (nodes[node].right)
-      n2 = evaluate(nodes[node].right);
-    switch(nodes[node].op) {
-    case '~':
-      return ~ n1;
-    case '-':
-      return n1 - n2;
-    case '+':
-      return n1 + n2;
-    case '*':
-      return n1 * n2;
-    case '/':
-      return n1 / n2;
-    case '%':
-      return n1 % n2;
-    case '<':
-      return n1 << n2;
-    case '>':
-      return n1 >> n2;
-    case '|':
-      return n1 | n2;
-    case '^':
-      return n1 ^ n2;
-    case '&':
-      return n1 & n2;
-    default: 
-      asmerr(E_ILLOPE);
-      return n1;
-    }
-  } else {
-    return nodes[node].value;
-  }
-}    
-
-void dump_nodes() {
-  int i;
-  
-  for (i=1; i < curnode; i++) {
-    if (nodes[i].flag == T_NODE)  	
-    	printf("%2d: NODE:  %c  left=%d  right=%d\n", 
-    		i, nodes[i].op, nodes[i].left, nodes[i].right);
-     else 		
-    	printf("%2d: VALUE: %c value=%d\n", 
-    		i, nodes[i].op, nodes[i].value);
-  }
+	n1 = n2 = 0;	/* to make the compiler happy */
+	if (nodes[node].flag == 0) {
+		if (nodes[node].left)
+			n1 = evaluate(nodes[node].left);
+		if (nodes[node].right)
+			n2 = evaluate(nodes[node].right);
+		switch(nodes[node].op) {
+		case '~':
+			return(~n1);
+		case '-':
+			return(n1 - n2);
+		case '+':
+			return(n1 + n2);
+		case '*':
+			return(n1 * n2);
+		case '/':
+			return(n1 / n2);
+		case '%':
+			return(n1 % n2);
+		case '<':
+			return(n1 << n2);
+		case '>':
+			return(n1 >> n2);
+		case '|':
+			return(n1 | n2);
+		case '^':
+			return(n1 ^ n2);
+		case '&':
+			return(n1 & n2);
+		default:
+			asmerr(E_ILLOPE);
+			return(n1);
+		}
+	} else
+		return(nodes[node].value);
 }
 
-int eval(char *str) {
-  int entry;
-  
-  parser_init(str);
-  tok = parse();  
-  entry = expr();
-/*  printf("entry=%d\n", entry); */
-/*  dump_nodes(); */
-  return evaluate(entry);
+void dump_nodes(void)
+{
+	int i;
+
+	for (i = 1; i < curnode; i++) {
+		if (nodes[i].flag == T_NODE)
+			printf("%2d: NODE:  %c  left=%d  right=%d\n",
+			       i, nodes[i].op, nodes[i].left, nodes[i].right);
+		else
+			printf("%2d: VALUE: %c value=%d\n",
+			       i, nodes[i].op, nodes[i].value);
+	}
+}
+
+int eval(char *str)
+{
+	int entry;
+
+	parser_init(str);
+	tok = parse();
+	entry = expr();
+/*	printf("entry=%d\n", entry); */
+/*	dump_nodes(); */
+	return(evaluate(entry));
 }
 
 /* from z80anum-orig.c */
@@ -726,12 +759,12 @@ int eval(char *str) {
  */
 int chk_byte(int i)
 {
-  if (i >= -128 && i <= 255)
-    return(i);
-  else {
-    asmerr(E_VALOUT);
-    return(0);
-  }
+	if (i >= -128 && i <= 255)
+		return(i);
+	else {
+		asmerr(E_VALOUT);
+		return(0);
+	}
 }
 
 /*
@@ -740,12 +773,10 @@ int chk_byte(int i)
  */
 int chk_sbyte(int i)
 {
-  if (i >= -128 && i <= 127)
-    return(i);
-  else {
-    asmerr(E_VALOUT);
-    return(0);
-  }
+	if (i >= -128 && i <= 127)
+		return(i);
+	else {
+		asmerr(E_VALOUT);
+		return(0);
+	}
 }
-
-

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -43,11 +43,15 @@ extern struct sym *get_sym(char *);
 extern int put_sym(char *, int);
 extern void put_label(void);
 
+#define UNUSED(x)	(void)(x)
+
 /*
  *	.8080 and .Z80
  */
 int op_pers(int new_pers, int dummy)
 {
+	UNUSED(dummy);
+
 	pers = &perstab[new_pers];
 	return(0);
 }
@@ -58,6 +62,9 @@ int op_pers(int new_pers, int dummy)
 int op_org(int dummy1, int dummy2)
 {
 	register int i;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
 
 	if (!gencode)
 		return(0);
@@ -85,6 +92,9 @@ int op_org(int dummy1, int dummy2)
  */
 int op_equ(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (!gencode)
 		return(0);
 	if (pass == 1) {		/* Pass 1 */
@@ -106,6 +116,9 @@ int op_equ(int dummy1, int dummy2)
  */
 int op_dl(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (!gencode)
 		return(0);
 	sd_flag = 1;
@@ -120,6 +133,9 @@ int op_dl(int dummy1, int dummy2)
  */
 int op_ds(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	register int val;
 
 	if (!gencode)
@@ -144,6 +160,9 @@ int op_db(int dummy1, int dummy2)
 	register int i;
 	register char *p;
 	register char *s;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
 
 	if (!gencode)
 		return(0);
@@ -189,6 +208,9 @@ int op_dm(int dummy1, int dummy2)
 	register int i;
 	register char *p;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (!gencode)
 		return(0);
 	i = 0;
@@ -221,6 +243,9 @@ int op_dw(int dummy1, int dummy2)
 	register int i, len, temp;
 	register char *p;
 	register char *s;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
 
 	if (!gencode)
 		return(0);
@@ -257,6 +282,8 @@ int op_misc(int op_code, int dummy)
 	static char fn[LENFN];
 	static int incnest;
 	static struct inc incl[INCNEST];
+
+	UNUSED(dummy);
 
 	if (!gencode)
 		return(0);
@@ -365,6 +392,8 @@ int op_cond(int op_code, int dummy)
 	register char *p, *p1, *p2;
 	static int condnest[IFNEST];
 
+	UNUSED(dummy);
+
 	switch(op_code) {
 	case 1:				/* IFDEF */
 		if (iflevel >= IFNEST) {
@@ -452,6 +481,8 @@ int op_cond(int op_code, int dummy)
  */
 int op_glob(int op_code, int dummy)
 {
+	UNUSED(dummy);
+
 	if (!gencode)
 		return(0);
 	sd_flag = 2;

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -133,10 +133,10 @@ int op_dl(int dummy1, int dummy2)
  */
 int op_ds(int dummy1, int dummy2)
 {
+	register int val;
+
 	UNUSED(dummy1);
 	UNUSED(dummy2);
-
-	register int val;
 
 	if (!gencode)
 		return(0);

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -44,11 +44,15 @@ extern void asmerr(int);
 extern int get_reg(char *);
 extern void put_label(void);
 
+#define UNUSED(x)	(void)(x)
+
 /*
  *	process 1byte opcodes without arguments
  */
 int op_1b(int b1, int dummy)
 {
+	UNUSED(dummy);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -74,6 +78,9 @@ int op_2b(int b1, int b2)
  */
 int op_im(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
@@ -104,6 +111,8 @@ int op_im(int dummy1, int dummy2)
 int op_pupo(int base_op, int dummy)
 {
 	register int len;
+
+	UNUSED(dummy);
 
 	if (pass == 1)
 		if (*label)
@@ -155,6 +164,9 @@ int op_ex(int dummy1, int dummy2)
 {
 	register int len;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -190,6 +202,9 @@ int op_call(int dummy1, int dummy2)
 {
 	register char *p1, *p2;
 	register int i;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
 
 	if (pass == 1) {		/* PASS 1 */
 		if (*label)
@@ -278,6 +293,9 @@ int op_rst(int dummy1, int dummy2)
 {
 	register int op;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
@@ -297,6 +315,9 @@ int op_rst(int dummy1, int dummy2)
  */
 int op_ret(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
@@ -344,6 +365,9 @@ int op_jp(int dummy1, int dummy2)
 {
 	register char *p1, *p2;
 	register int i, len;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
 
 	if (pass == 1)
 		if (*label)
@@ -469,6 +493,9 @@ int op_jr(int dummy1, int dummy2)
 {
 	register char *p1, *p2;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
@@ -518,6 +545,9 @@ int op_jr(int dummy1, int dummy2)
  */
 int op_djnz(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
@@ -535,6 +565,9 @@ int op_ld(int dummy1, int dummy2)
 {
 	register int len, op;
 	register char *p1, *p2;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
 
 	if (pass == 1)
 		if (*label)
@@ -1262,6 +1295,9 @@ int op_add(int dummy1, int dummy2)
 	register int len;
 	register char *p1, *p2;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -1403,6 +1439,9 @@ int op_adc(int dummy1, int dummy2)
 	register int len;
 	register char *p1, *p2;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -1436,6 +1475,9 @@ int op_adc(int dummy1, int dummy2)
  */
 int op_sub(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -1449,6 +1491,9 @@ int op_sbc(int dummy1, int dummy2)
 {
 	register int len;
 	register char *p1, *p2;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
 
 	if (pass == 1)
 		if (*label)
@@ -1620,6 +1665,9 @@ int op_decinc(int base_op, int base_op16)
  */
 int op_or(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -1631,6 +1679,9 @@ int op_or(int dummy1, int dummy2)
  */
 int op_xor(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -1642,6 +1693,9 @@ int op_xor(int dummy1, int dummy2)
  */
 int op_and(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -1653,6 +1707,9 @@ int op_and(int dummy1, int dummy2)
  */
 int op_cp(int dummy1, int dummy2)
 {
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -1741,6 +1798,8 @@ int op_rotshf(int base_op, int dummy)
 {
 	register char *p;
 	register int len, op;
+
+	UNUSED(dummy);
 
 	if (pass == 1)
 		if (*label)
@@ -1850,6 +1909,9 @@ int op_out(int dummy1, int dummy2)
 	register int op;
 	register char *p;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
@@ -1905,6 +1967,9 @@ int op_in(int dummy1, int dummy2)
 	register char *p1, *p2;
 	register int op;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
@@ -1956,6 +2021,8 @@ int op_trsbit(int base_op, int dummy)
 	register int len;
 	register int i;
 	register int op;
+
+	UNUSED(dummy);
 
 	len = 2;
 	i = 0;
@@ -2078,6 +2145,9 @@ int op8080_mov(int dummy1, int dummy2)
 	register char *p1, *p2;
 	register int op1, op2;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -2139,6 +2209,8 @@ int op8080_alu(int base_op, int dummy)
 {
 	register int op;
 
+	UNUSED(dummy);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -2170,6 +2242,8 @@ int op8080_alu(int base_op, int dummy)
 int op8080_decinc(int base_op, int dummy)
 {
 	register int op;
+
+	UNUSED(dummy);
 
 	if (pass == 1)
 		if (*label)
@@ -2203,6 +2277,8 @@ int op8080_reg16(int base_op, int dummy)
 {
 	register int op;
 
+	UNUSED(dummy);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -2233,6 +2309,8 @@ int op8080_regbd(int base_op, int dummy)
 {
 	register int op;
 
+	UNUSED(dummy);
+
 	if (pass == 1)
 		if (*label)
 			put_label();
@@ -2258,6 +2336,8 @@ int op8080_regbd(int base_op, int dummy)
 int op8080_imm(int base_op, int dummy)
 {
 	register int len;
+
+	UNUSED(dummy);
 
 	if (pass == 1)
 		if (*label)
@@ -2290,6 +2370,9 @@ int op8080_rst(int dummy1, int dummy2)
 {
 	register int op;
 
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
 	if (pass == 1) {		/* PASS 1 */
 		if (*label)
 			put_label();
@@ -2309,6 +2392,8 @@ int op8080_rst(int dummy1, int dummy2)
 int op8080_pupo(int base_op, int dummy)
 {
 	register int op;
+
+	UNUSED(dummy);
 
 	if (pass == 1)
 		if (*label)
@@ -2341,6 +2426,8 @@ int op8080_pupo(int base_op, int dummy)
 int op8080_addr(int base_op, int dummy)
 {
 	register int i, len;
+
+	UNUSED(dummy);
 
 	if (pass == 1)
 		if (*label)
@@ -2376,6 +2463,9 @@ int op8080_mvi(int dummy1, int dummy2)
 	register int len;
 	register char *p1, *p2;
 	register int op;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
 
 	if (pass == 1)
 		if (*label)
@@ -2435,6 +2525,9 @@ int op8080_lxi(int dummy1, int dummy2)
 	register int i, len;
 	register char *p1, *p2;
 	register int op;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
 
 	if (pass == 1)
 		if (*label)


### PR DESCRIPTION
Added an `(unsigned)` cast to a strlen comparison and changed functions without parameters
from `()` to `(void)` in z80anum.c. This accounts for the object code differences to the old version
of z80anum.c.