### PR TITLE
z80core: added remaining undocumented Z80 instructions

### DIFF
--- a/doc/CREDITS
+++ b/doc/CREDITS
@@ -50,3 +50,12 @@ For implementation of a BDOS-like interface for host file I/O.
 Fred Weigel <fred_weigel@hotmail.com>
 
 For the AM9511 emulation and 8080/Z80 software to use it.
+
+
+Thomas Eberhardt <sneakywumpus@gmail.com>
+
+For completing the implementation of the undocumented Z80 instructions,
+in the simulator, disassembler and assembler.
+For bug fixes to the refresh register implementation.
+For improving the faithfulness of the block instructions implementation.
+For adding 8080 support to the assembler.

--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -47,7 +47,7 @@ part of the system image, if the complete image won't fit on the system
 tracks.
 
 Option 8:
-Change default personality to 8080.
+Change default instruction set to 8080.
 
 Option u:
 Accept undocumented Z80 instructions.
@@ -107,6 +107,8 @@ Others:
 
 INCLUDE <filename>      - include another source file
 PRINT   <'string'>      - print string to stdout in pass one
+.8080                   - switch to 8080 instruction set
+.Z80                    - switch to Z80 instruction set
 
 
 Operator precedence for the node based parser from Didier Derny:

--- a/z80core/COPYING
+++ b/z80core/COPYING
@@ -1,4 +1,5 @@
 Copyright (c) 1987-2021 Udo Munk
+Copyright (c) 2022 Thomas Eberhardt
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/z80core/sim0.c
+++ b/z80core/sim0.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 1987-2022 Udo Munk
  * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2022 Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
@@ -383,7 +384,7 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 	} else {
 		strcpy(&confdir[0], CONFDIR);
 	}
-	
+
 	/* if option -r is used ROMS are there */
 	if (rompath[0] == 0) {
 		/* if not first try ./roms */

--- a/z80core/sim2.c
+++ b/z80core/sim2.c
@@ -136,10 +136,11 @@ static int op_tb4l(void), op_tb5l(void), op_tb6l(void), op_tb7l(void);
 static int op_tb0hl(void), op_tb1hl(void), op_tb2hl(void), op_tb3hl(void);
 static int op_tb4hl(void), op_tb5hl(void), op_tb6hl(void), op_tb7hl(void);
 
+static int op_undoc_slla(void);
 #ifdef Z80_UNDOC
-static int op_undoc_slla(void), op_undoc_sllb(void), op_undoc_sllc(void);
-static int op_undoc_slld(void), op_undoc_slle(void);
-static int op_undoc_sllh(void), op_undoc_slll(void), op_undoc_sllhl(void);
+static int op_undoc_sllb(void), op_undoc_sllc(void), op_undoc_slld(void);
+static int op_undoc_slle(void), op_undoc_sllh(void), op_undoc_slll(void);
+static int op_undoc_sllhl(void);
 #endif
 
 int op_cb_handel(void)

--- a/z80core/sim2.c
+++ b/z80core/sim2.c
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
+ * Copyright (C) 2022 by Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
+ * Copyright (C) 2022 by Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3

--- a/z80core/sim4.c
+++ b/z80core/sim4.c
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
+ * Copyright (C) 2022 by Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
@@ -89,6 +90,10 @@ static int op_oprld(void), op_oprrd(void);
 
 #ifdef Z80_UNDOC
 static int op_undoc_outc0(void), op_undoc_infic(void);
+static int op_undoc_nop(void);
+static int op_undoc_im0(void), op_undoc_im1(void), op_undoc_im2(void);
+static int op_undoc_reti(void), op_undoc_retn(void);
+static int op_undoc_neg(void);
 #endif
 
 int op_ed_handel(void)
@@ -96,70 +101,70 @@ int op_ed_handel(void)
 	register int t;
 
 	static int (*op_ed[256]) (void) = {
-		trap_ed,			/* 0x00 */
-		trap_ed,			/* 0x01 */
-		trap_ed,			/* 0x02 */
-		trap_ed,			/* 0x03 */
-		trap_ed,			/* 0x04 */
-		trap_ed,			/* 0x05 */
-		trap_ed,			/* 0x06 */
-		trap_ed,			/* 0x07 */
-		trap_ed,			/* 0x08 */
-		trap_ed,			/* 0x09 */
-		trap_ed,			/* 0x0a */
-		trap_ed,			/* 0x0b */
-		trap_ed,			/* 0x0c */
-		trap_ed,			/* 0x0d */
-		trap_ed,			/* 0x0e */
-		trap_ed,			/* 0x0f */
-		trap_ed,			/* 0x10 */
-		trap_ed,			/* 0x11 */
-		trap_ed,			/* 0x12 */
-		trap_ed,			/* 0x13 */
-		trap_ed,			/* 0x14 */
-		trap_ed,			/* 0x15 */
-		trap_ed,			/* 0x16 */
-		trap_ed,			/* 0x17 */
-		trap_ed,			/* 0x18 */
-		trap_ed,			/* 0x19 */
-		trap_ed,			/* 0x1a */
-		trap_ed,			/* 0x1b */
-		trap_ed,			/* 0x1c */
-		trap_ed,			/* 0x1d */
-		trap_ed,			/* 0x1e */
-		trap_ed,			/* 0x1f */
-		trap_ed,			/* 0x20 */
-		trap_ed,			/* 0x21 */
-		trap_ed,			/* 0x22 */
-		trap_ed,			/* 0x23 */
-		trap_ed,			/* 0x24 */
-		trap_ed,			/* 0x25 */
-		trap_ed,			/* 0x26 */
-		trap_ed,			/* 0x27 */
-		trap_ed,			/* 0x28 */
-		trap_ed,			/* 0x29 */
-		trap_ed,			/* 0x2a */
-		trap_ed,			/* 0x2b */
-		trap_ed,			/* 0x2c */
-		trap_ed,			/* 0x2d */
-		trap_ed,			/* 0x2e */
-		trap_ed,			/* 0x2f */
-		trap_ed,			/* 0x30 */
-		trap_ed,			/* 0x31 */
-		trap_ed,			/* 0x32 */
-		trap_ed,			/* 0x33 */
-		trap_ed,			/* 0x34 */
-		trap_ed,			/* 0x35 */
-		trap_ed,			/* 0x36 */
-		trap_ed,			/* 0x37 */
-		trap_ed,			/* 0x38 */
-		trap_ed,			/* 0x39 */
-		trap_ed,			/* 0x3a */
-		trap_ed,			/* 0x3b */
-		trap_ed,			/* 0x3c */
-		trap_ed,			/* 0x3d */
-		trap_ed,			/* 0x3e */
-		trap_ed,			/* 0x3f */
+		UNDOC(op_undoc_nop),		/* 0x00 */
+		UNDOC(op_undoc_nop),		/* 0x01 */
+		UNDOC(op_undoc_nop),		/* 0x02 */
+		UNDOC(op_undoc_nop),		/* 0x03 */
+		UNDOC(op_undoc_nop),		/* 0x04 */
+		UNDOC(op_undoc_nop),		/* 0x05 */
+		UNDOC(op_undoc_nop),		/* 0x06 */
+		UNDOC(op_undoc_nop),		/* 0x07 */
+		UNDOC(op_undoc_nop),		/* 0x08 */
+		UNDOC(op_undoc_nop),		/* 0x09 */
+		UNDOC(op_undoc_nop),		/* 0x0a */
+		UNDOC(op_undoc_nop),		/* 0x0b */
+		UNDOC(op_undoc_nop),		/* 0x0c */
+		UNDOC(op_undoc_nop),		/* 0x0d */
+		UNDOC(op_undoc_nop),		/* 0x0e */
+		UNDOC(op_undoc_nop),		/* 0x0f */
+		UNDOC(op_undoc_nop),		/* 0x10 */
+		UNDOC(op_undoc_nop),		/* 0x11 */
+		UNDOC(op_undoc_nop),		/* 0x12 */
+		UNDOC(op_undoc_nop),		/* 0x13 */
+		UNDOC(op_undoc_nop),		/* 0x14 */
+		UNDOC(op_undoc_nop),		/* 0x15 */
+		UNDOC(op_undoc_nop),		/* 0x16 */
+		UNDOC(op_undoc_nop),		/* 0x17 */
+		UNDOC(op_undoc_nop),		/* 0x18 */
+		UNDOC(op_undoc_nop),		/* 0x19 */
+		UNDOC(op_undoc_nop),		/* 0x1a */
+		UNDOC(op_undoc_nop),		/* 0x1b */
+		UNDOC(op_undoc_nop),		/* 0x1c */
+		UNDOC(op_undoc_nop),		/* 0x1d */
+		UNDOC(op_undoc_nop),		/* 0x1e */
+		UNDOC(op_undoc_nop),		/* 0x1f */
+		UNDOC(op_undoc_nop),		/* 0x20 */
+		UNDOC(op_undoc_nop),		/* 0x21 */
+		UNDOC(op_undoc_nop),		/* 0x22 */
+		UNDOC(op_undoc_nop),		/* 0x23 */
+		UNDOC(op_undoc_nop),		/* 0x24 */
+		UNDOC(op_undoc_nop),		/* 0x25 */
+		UNDOC(op_undoc_nop),		/* 0x26 */
+		UNDOC(op_undoc_nop),		/* 0x27 */
+		UNDOC(op_undoc_nop),		/* 0x28 */
+		UNDOC(op_undoc_nop),		/* 0x29 */
+		UNDOC(op_undoc_nop),		/* 0x2a */
+		UNDOC(op_undoc_nop),		/* 0x2b */
+		UNDOC(op_undoc_nop),		/* 0x2c */
+		UNDOC(op_undoc_nop),		/* 0x2d */
+		UNDOC(op_undoc_nop),		/* 0x2e */
+		UNDOC(op_undoc_nop),		/* 0x2f */
+		UNDOC(op_undoc_nop),		/* 0x30 */
+		UNDOC(op_undoc_nop),		/* 0x31 */
+		UNDOC(op_undoc_nop),		/* 0x32 */
+		UNDOC(op_undoc_nop),		/* 0x33 */
+		UNDOC(op_undoc_nop),		/* 0x34 */
+		UNDOC(op_undoc_nop),		/* 0x35 */
+		UNDOC(op_undoc_nop),		/* 0x36 */
+		UNDOC(op_undoc_nop),		/* 0x37 */
+		UNDOC(op_undoc_nop),		/* 0x38 */
+		UNDOC(op_undoc_nop),		/* 0x39 */
+		UNDOC(op_undoc_nop),		/* 0x3a */
+		UNDOC(op_undoc_nop),		/* 0x3b */
+		UNDOC(op_undoc_nop),		/* 0x3c */
+		UNDOC(op_undoc_nop),		/* 0x3d */
+		UNDOC(op_undoc_nop),		/* 0x3e */
+		UNDOC(op_undoc_nop),		/* 0x3f */
 		op_inbic,			/* 0x40 */
 		op_outcb,			/* 0x41 */
 		op_sbchb,			/* 0x42 */
@@ -172,186 +177,186 @@ int op_ed_handel(void)
 		op_outcc,			/* 0x49 */
 		op_adchb,			/* 0x4a */
 		op_ldbcinn,			/* 0x4b */
-		trap_ed,			/* 0x4c */
+		UNDOC(op_undoc_neg),		/* 0x4c */
 		op_reti,			/* 0x4d */
-		trap_ed,			/* 0x4e */
+		UNDOC(op_undoc_im0),		/* 0x4e */
 		op_ldra,			/* 0x4f */
 		op_indic,			/* 0x50 */
 		op_outcd,			/* 0x51 */
 		op_sbchd,			/* 0x52 */
 		op_ldinde,			/* 0x53 */
-		trap_ed,			/* 0x54 */
-		trap_ed,			/* 0x55 */
+		UNDOC(op_undoc_neg),		/* 0x54 */
+		UNDOC(op_undoc_retn),		/* 0x55 */
 		op_im1,				/* 0x56 */
 		op_ldai,			/* 0x57 */
 		op_ineic,			/* 0x58 */
 		op_outce,			/* 0x59 */
 		op_adchd,			/* 0x5a */
 		op_lddeinn,			/* 0x5b */
-		trap_ed,			/* 0x5c */
-		trap_ed,			/* 0x5d */
+		UNDOC(op_undoc_neg),		/* 0x5c */
+		UNDOC(op_undoc_reti),		/* 0x5d */
 		op_im2,				/* 0x5e */
 		op_ldar,			/* 0x5f */
 		op_inhic,			/* 0x60 */
 		op_outch,			/* 0x61 */
 		op_sbchh,			/* 0x62 */
 		op_ldinhl,			/* 0x63 */
-		trap_ed,			/* 0x64 */
-		trap_ed,			/* 0x65 */
-		trap_ed,			/* 0x66 */
+		UNDOC(op_undoc_neg),		/* 0x64 */
+		UNDOC(op_undoc_retn),		/* 0x65 */
+		UNDOC(op_undoc_im0),		/* 0x66 */
 		op_oprrd,			/* 0x67 */
 		op_inlic,			/* 0x68 */
 		op_outcl,			/* 0x69 */
 		op_adchh,			/* 0x6a */
 		op_ldhlinn,			/* 0x6b */
-		trap_ed,			/* 0x6c */
-		trap_ed,			/* 0x6d */
-		trap_ed,			/* 0x6e */
+		UNDOC(op_undoc_neg),		/* 0x6c */
+		UNDOC(op_undoc_reti),		/* 0x6d */
+		UNDOC(op_undoc_im0),		/* 0x6e */
 		op_oprld,			/* 0x6f */
 		UNDOC(op_undoc_infic),		/* 0x70 */
 		UNDOC(op_undoc_outc0),		/* 0x71 */
 		op_sbchs,			/* 0x72 */
 		op_ldinsp,			/* 0x73 */
-		trap_ed,			/* 0x74 */
-		trap_ed,			/* 0x75 */
-		trap_ed,			/* 0x76 */
-		trap_ed,			/* 0x77 */
+		UNDOC(op_undoc_neg),		/* 0x74 */
+		UNDOC(op_undoc_retn),		/* 0x75 */
+		UNDOC(op_undoc_im1),		/* 0x76 */
+		UNDOC(op_undoc_nop),		/* 0x77 */
 		op_inaic,			/* 0x78 */
 		op_outca,			/* 0x79 */
 		op_adchs,			/* 0x7a */
 		op_ldspinn,			/* 0x7b */
-		trap_ed,			/* 0x7c */
-		trap_ed,			/* 0x7d */
-		trap_ed,			/* 0x7e */
-		trap_ed,			/* 0x7f */
-		trap_ed,			/* 0x80 */
-		trap_ed,			/* 0x81 */
-		trap_ed,			/* 0x82 */
-		trap_ed,			/* 0x83 */
-		trap_ed,			/* 0x84 */
-		trap_ed,			/* 0x85 */
-		trap_ed,			/* 0x86 */
-		trap_ed,			/* 0x87 */
-		trap_ed,			/* 0x88 */
-		trap_ed,			/* 0x89 */
-		trap_ed,			/* 0x8a */
-		trap_ed,			/* 0x8b */
-		trap_ed,			/* 0x8c */
-		trap_ed,			/* 0x8d */
-		trap_ed,			/* 0x8e */
-		trap_ed,			/* 0x8f */
-		trap_ed,			/* 0x90 */
-		trap_ed,			/* 0x91 */
-		trap_ed,			/* 0x92 */
-		trap_ed,			/* 0x93 */
-		trap_ed,			/* 0x94 */
-		trap_ed,			/* 0x95 */
-		trap_ed,			/* 0x96 */
-		trap_ed,			/* 0x97 */
-		trap_ed,			/* 0x98 */
-		trap_ed,			/* 0x99 */
-		trap_ed,			/* 0x9a */
-		trap_ed,			/* 0x9b */
-		trap_ed,			/* 0x9c */
-		trap_ed,			/* 0x9d */
-		trap_ed,			/* 0x9e */
-		trap_ed,			/* 0x9f */
+		UNDOC(op_undoc_neg),		/* 0x7c */
+		UNDOC(op_undoc_reti),		/* 0x7d */
+		UNDOC(op_undoc_im2),		/* 0x7e */
+		UNDOC(op_undoc_nop),		/* 0x7f */
+		UNDOC(op_undoc_nop),		/* 0x80 */
+		UNDOC(op_undoc_nop),		/* 0x81 */
+		UNDOC(op_undoc_nop),		/* 0x82 */
+		UNDOC(op_undoc_nop),		/* 0x83 */
+		UNDOC(op_undoc_nop),		/* 0x84 */
+		UNDOC(op_undoc_nop),		/* 0x85 */
+		UNDOC(op_undoc_nop),		/* 0x86 */
+		UNDOC(op_undoc_nop),		/* 0x87 */
+		UNDOC(op_undoc_nop),		/* 0x88 */
+		UNDOC(op_undoc_nop),		/* 0x89 */
+		UNDOC(op_undoc_nop),		/* 0x8a */
+		UNDOC(op_undoc_nop),		/* 0x8b */
+		UNDOC(op_undoc_nop),		/* 0x8c */
+		UNDOC(op_undoc_nop),		/* 0x8d */
+		UNDOC(op_undoc_nop),		/* 0x8e */
+		UNDOC(op_undoc_nop),		/* 0x8f */
+		UNDOC(op_undoc_nop),		/* 0x90 */
+		UNDOC(op_undoc_nop),		/* 0x91 */
+		UNDOC(op_undoc_nop),		/* 0x92 */
+		UNDOC(op_undoc_nop),		/* 0x93 */
+		UNDOC(op_undoc_nop),		/* 0x94 */
+		UNDOC(op_undoc_nop),		/* 0x95 */
+		UNDOC(op_undoc_nop),		/* 0x96 */
+		UNDOC(op_undoc_nop),		/* 0x97 */
+		UNDOC(op_undoc_nop),		/* 0x98 */
+		UNDOC(op_undoc_nop),		/* 0x99 */
+		UNDOC(op_undoc_nop),		/* 0x9a */
+		UNDOC(op_undoc_nop),		/* 0x9b */
+		UNDOC(op_undoc_nop),		/* 0x9c */
+		UNDOC(op_undoc_nop),		/* 0x9d */
+		UNDOC(op_undoc_nop),		/* 0x9e */
+		UNDOC(op_undoc_nop),		/* 0x9f */
 		op_ldi,				/* 0xa0 */
 		op_cpi,				/* 0xa1 */
 		op_ini,				/* 0xa2 */
 		op_outi,			/* 0xa3 */
-		trap_ed,			/* 0xa4 */
-		trap_ed,			/* 0xa5 */
-		trap_ed,			/* 0xa6 */
-		trap_ed,			/* 0xa7 */
+		UNDOC(op_undoc_nop),		/* 0xa4 */
+		UNDOC(op_undoc_nop),		/* 0xa5 */
+		UNDOC(op_undoc_nop),		/* 0xa6 */
+		UNDOC(op_undoc_nop),		/* 0xa7 */
 		op_ldd,				/* 0xa8 */
 		op_cpdop,			/* 0xa9 */
 		op_ind,				/* 0xaa */
 		op_outd,			/* 0xab */
-		trap_ed,			/* 0xac */
-		trap_ed,			/* 0xad */
-		trap_ed,			/* 0xae */
-		trap_ed,			/* 0xaf */
+		UNDOC(op_undoc_nop),		/* 0xac */
+		UNDOC(op_undoc_nop),		/* 0xad */
+		UNDOC(op_undoc_nop),		/* 0xae */
+		UNDOC(op_undoc_nop),		/* 0xaf */
 		op_ldir,			/* 0xb0 */
 		op_cpir,			/* 0xb1 */
 		op_inir,			/* 0xb2 */
 		op_otir,			/* 0xb3 */
-		trap_ed,			/* 0xb4 */
-		trap_ed,			/* 0xb5 */
-		trap_ed,			/* 0xb6 */
-		trap_ed,			/* 0xb7 */
+		UNDOC(op_undoc_nop),		/* 0xb4 */
+		UNDOC(op_undoc_nop),		/* 0xb5 */
+		UNDOC(op_undoc_nop),		/* 0xb6 */
+		UNDOC(op_undoc_nop),		/* 0xb7 */
 		op_lddr,			/* 0xb8 */
 		op_cpdr,			/* 0xb9 */
 		op_indr,			/* 0xba */
 		op_otdr,			/* 0xbb */
-		trap_ed,			/* 0xbc */
-		trap_ed,			/* 0xbd */
-		trap_ed,			/* 0xbe */
-		trap_ed,			/* 0xbf */
-		trap_ed,			/* 0xc0 */
-		trap_ed,			/* 0xc1 */
-		trap_ed,			/* 0xc2 */
-		trap_ed,			/* 0xc3 */
-		trap_ed,			/* 0xc4 */
-		trap_ed,			/* 0xc5 */
-		trap_ed,			/* 0xc6 */
-		trap_ed,			/* 0xc7 */
-		trap_ed,			/* 0xc8 */
-		trap_ed,			/* 0xc9 */
-		trap_ed,			/* 0xca */
-		trap_ed,			/* 0xcb */
-		trap_ed,			/* 0xcc */
-		trap_ed,			/* 0xcd */
-		trap_ed,			/* 0xce */
-		trap_ed,			/* 0xcf */
-		trap_ed,			/* 0xd0 */
-		trap_ed,			/* 0xd1 */
-		trap_ed,			/* 0xd2 */
-		trap_ed,			/* 0xd3 */
-		trap_ed,			/* 0xd4 */
-		trap_ed,			/* 0xd5 */
-		trap_ed,			/* 0xd6 */
-		trap_ed,			/* 0xd7 */
-		trap_ed,			/* 0xd8 */
-		trap_ed,			/* 0xd9 */
-		trap_ed,			/* 0xda */
-		trap_ed,			/* 0xdb */
-		trap_ed,			/* 0xdc */
-		trap_ed,			/* 0xdd */
-		trap_ed,			/* 0xde */
-		trap_ed,			/* 0xdf */
-		trap_ed,			/* 0xe0 */
-		trap_ed,			/* 0xe1 */
-		trap_ed,			/* 0xe2 */
-		trap_ed,			/* 0xe3 */
-		trap_ed,			/* 0xe4 */
-		trap_ed,			/* 0xe5 */
-		trap_ed,			/* 0xe6 */
-		trap_ed,			/* 0xe7 */
-		trap_ed,			/* 0xe8 */
-		trap_ed,			/* 0xe9 */
-		trap_ed,			/* 0xea */
-		trap_ed,			/* 0xeb */
-		trap_ed,			/* 0xec */
-		trap_ed,			/* 0xed */
-		trap_ed,			/* 0xee */
-		trap_ed,			/* 0xef */
-		trap_ed,			/* 0xf0 */
-		trap_ed,			/* 0xf1 */
-		trap_ed,			/* 0xf2 */
-		trap_ed,			/* 0xf3 */
-		trap_ed,			/* 0xf4 */
-		trap_ed,			/* 0xf5 */
-		trap_ed,			/* 0xf6 */
-		trap_ed,			/* 0xf7 */
-		trap_ed,			/* 0xf8 */
-		trap_ed,			/* 0xf9 */
-		trap_ed,			/* 0xfa */
-		trap_ed,			/* 0xfb */
-		trap_ed,			/* 0xfc */
-		trap_ed,			/* 0xfd */
-		trap_ed,			/* 0xfe */
-		trap_ed				/* 0xff */
+		UNDOC(op_undoc_nop),		/* 0xbc */
+		UNDOC(op_undoc_nop),		/* 0xbd */
+		UNDOC(op_undoc_nop),		/* 0xbe */
+		UNDOC(op_undoc_nop),		/* 0xbf */
+		UNDOC(op_undoc_nop),		/* 0xc0 */
+		UNDOC(op_undoc_nop),		/* 0xc1 */
+		UNDOC(op_undoc_nop),		/* 0xc2 */
+		UNDOC(op_undoc_nop),		/* 0xc3 */
+		UNDOC(op_undoc_nop),		/* 0xc4 */
+		UNDOC(op_undoc_nop),		/* 0xc5 */
+		UNDOC(op_undoc_nop),		/* 0xc6 */
+		UNDOC(op_undoc_nop),		/* 0xc7 */
+		UNDOC(op_undoc_nop),		/* 0xc8 */
+		UNDOC(op_undoc_nop),		/* 0xc9 */
+		UNDOC(op_undoc_nop),		/* 0xca */
+		UNDOC(op_undoc_nop),		/* 0xcb */
+		UNDOC(op_undoc_nop),		/* 0xcc */
+		UNDOC(op_undoc_nop),		/* 0xcd */
+		UNDOC(op_undoc_nop),		/* 0xce */
+		UNDOC(op_undoc_nop),		/* 0xcf */
+		UNDOC(op_undoc_nop),		/* 0xd0 */
+		UNDOC(op_undoc_nop),		/* 0xd1 */
+		UNDOC(op_undoc_nop),		/* 0xd2 */
+		UNDOC(op_undoc_nop),		/* 0xd3 */
+		UNDOC(op_undoc_nop),		/* 0xd4 */
+		UNDOC(op_undoc_nop),		/* 0xd5 */
+		UNDOC(op_undoc_nop),		/* 0xd6 */
+		UNDOC(op_undoc_nop),		/* 0xd7 */
+		UNDOC(op_undoc_nop),		/* 0xd8 */
+		UNDOC(op_undoc_nop),		/* 0xd9 */
+		UNDOC(op_undoc_nop),		/* 0xda */
+		UNDOC(op_undoc_nop),		/* 0xdb */
+		UNDOC(op_undoc_nop),		/* 0xdc */
+		UNDOC(op_undoc_nop),		/* 0xdd */
+		UNDOC(op_undoc_nop),		/* 0xde */
+		UNDOC(op_undoc_nop),		/* 0xdf */
+		UNDOC(op_undoc_nop),		/* 0xe0 */
+		UNDOC(op_undoc_nop),		/* 0xe1 */
+		UNDOC(op_undoc_nop),		/* 0xe2 */
+		UNDOC(op_undoc_nop),		/* 0xe3 */
+		UNDOC(op_undoc_nop),		/* 0xe4 */
+		UNDOC(op_undoc_nop),		/* 0xe5 */
+		UNDOC(op_undoc_nop),		/* 0xe6 */
+		UNDOC(op_undoc_nop),		/* 0xe7 */
+		UNDOC(op_undoc_nop),		/* 0xe8 */
+		UNDOC(op_undoc_nop),		/* 0xe9 */
+		UNDOC(op_undoc_nop),		/* 0xea */
+		UNDOC(op_undoc_nop),		/* 0xeb */
+		UNDOC(op_undoc_nop),		/* 0xec */
+		UNDOC(op_undoc_nop),		/* 0xed */
+		UNDOC(op_undoc_nop),		/* 0xee */
+		UNDOC(op_undoc_nop),		/* 0xef */
+		UNDOC(op_undoc_nop),		/* 0xf0 */
+		UNDOC(op_undoc_nop),		/* 0xf1 */
+		UNDOC(op_undoc_nop),		/* 0xf2 */
+		UNDOC(op_undoc_nop),		/* 0xf3 */
+		UNDOC(op_undoc_nop),		/* 0xf4 */
+		UNDOC(op_undoc_nop),		/* 0xf5 */
+		UNDOC(op_undoc_nop),		/* 0xf6 */
+		UNDOC(op_undoc_nop),		/* 0xf7 */
+		UNDOC(op_undoc_nop),		/* 0xf8 */
+		UNDOC(op_undoc_nop),		/* 0xf9 */
+		UNDOC(op_undoc_nop),		/* 0xfa */
+		UNDOC(op_undoc_nop),		/* 0xfb */
+		UNDOC(op_undoc_nop),		/* 0xfc */
+		UNDOC(op_undoc_nop),		/* 0xfd */
+		UNDOC(op_undoc_nop),		/* 0xfe */
+		UNDOC(op_undoc_nop)		/* 0xff */
 	};
 
 #ifdef BUS_8080
@@ -1490,6 +1495,76 @@ static int op_undoc_infic(void)		/* IN F,(C) */
 	(tmp & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[tmp]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	return(12);
+}
+
+static int op_undoc_nop(void)		/* NOP */
+{
+	if (u_flag) {
+		trap_ed();
+		return(0);
+	}
+
+	return(8);
+}
+
+static int op_undoc_im0(void)		/* IM 0 */
+{
+	if (u_flag) {
+		trap_ed();
+		return(0);
+	}
+
+	return(op_im0());
+}
+
+static int op_undoc_im1(void)		/* IM 1 */
+{
+	if (u_flag) {
+		trap_ed();
+		return(0);
+	}
+
+	return(op_im1());
+}
+
+static int op_undoc_im2(void)		/* IM 2 */
+{
+	if (u_flag) {
+		trap_ed();
+		return(0);
+	}
+
+	return(op_im2());
+}
+
+static int op_undoc_reti(void)		/* RETI */
+{
+	if (u_flag) {
+		trap_ed();
+		return(0);
+	}
+
+	return(op_reti());
+}
+
+static int op_undoc_retn(void)		/* RETN */
+{
+	if (u_flag) {
+		trap_ed();
+		return(0);
+	}
+
+	return(op_retn());
+}
+
+static int op_undoc_neg(void)		/* NEG */
+{
+	if (u_flag) {
+		trap_ed();
+		return(0);
+	}
+
+	return(op_neg());
 }
 
 #endif

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
+ * Copyright (C) 2022 by Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3

--- a/z80core/sim6.c
+++ b/z80core/sim6.c
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
+ * Copyright (C) 2022 by Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
@@ -75,268 +76,336 @@ static int op_rlcixd(int), op_rrcixd(int), op_rlixd(int), op_rrixd(int);
 static int op_slaixd(int), op_sraixd(int), op_srlixd(int);
 
 #ifdef Z80_UNDOC
-static int op_undoc_sllixd(int);
+static int op_undoc_tb0ixd(int), op_undoc_tb1ixd(int), op_undoc_tb2ixd(int);
+static int op_undoc_tb3ixd(int), op_undoc_tb4ixd(int), op_undoc_tb5ixd(int);
+static int op_undoc_tb6ixd(int), op_undoc_tb7ixd(int);
+static int op_undoc_rb0ixda(int), op_undoc_rb1ixda(int), op_undoc_rb2ixda(int);
+static int op_undoc_rb3ixda(int), op_undoc_rb4ixda(int), op_undoc_rb5ixda(int);
+static int op_undoc_rb6ixda(int), op_undoc_rb7ixda(int);
+static int op_undoc_rb0ixdb(int), op_undoc_rb1ixdb(int), op_undoc_rb2ixdb(int);
+static int op_undoc_rb3ixdb(int), op_undoc_rb4ixdb(int), op_undoc_rb5ixdb(int);
+static int op_undoc_rb6ixdb(int), op_undoc_rb7ixdb(int);
+static int op_undoc_rb0ixdc(int), op_undoc_rb1ixdc(int), op_undoc_rb2ixdc(int);
+static int op_undoc_rb3ixdc(int), op_undoc_rb4ixdc(int), op_undoc_rb5ixdc(int);
+static int op_undoc_rb6ixdc(int), op_undoc_rb7ixdc(int);
+static int op_undoc_rb0ixdd(int), op_undoc_rb1ixdd(int), op_undoc_rb2ixdd(int);
+static int op_undoc_rb3ixdd(int), op_undoc_rb4ixdd(int), op_undoc_rb5ixdd(int);
+static int op_undoc_rb6ixdd(int), op_undoc_rb7ixdd(int);
+static int op_undoc_rb0ixde(int), op_undoc_rb1ixde(int), op_undoc_rb2ixde(int);
+static int op_undoc_rb3ixde(int), op_undoc_rb4ixde(int), op_undoc_rb5ixde(int);
+static int op_undoc_rb6ixde(int), op_undoc_rb7ixde(int);
+static int op_undoc_rb0ixdh(int), op_undoc_rb1ixdh(int), op_undoc_rb2ixdh(int);
+static int op_undoc_rb3ixdh(int), op_undoc_rb4ixdh(int), op_undoc_rb5ixdh(int);
+static int op_undoc_rb6ixdh(int), op_undoc_rb7ixdh(int);
+static int op_undoc_rb0ixdl(int), op_undoc_rb1ixdl(int), op_undoc_rb2ixdl(int);
+static int op_undoc_rb3ixdl(int), op_undoc_rb4ixdl(int), op_undoc_rb5ixdl(int);
+static int op_undoc_rb6ixdl(int), op_undoc_rb7ixdl(int);
+static int op_undoc_sb0ixda(int), op_undoc_sb1ixda(int), op_undoc_sb2ixda(int);
+static int op_undoc_sb3ixda(int), op_undoc_sb4ixda(int), op_undoc_sb5ixda(int);
+static int op_undoc_sb6ixda(int), op_undoc_sb7ixda(int);
+static int op_undoc_sb0ixdb(int), op_undoc_sb1ixdb(int), op_undoc_sb2ixdb(int);
+static int op_undoc_sb3ixdb(int), op_undoc_sb4ixdb(int), op_undoc_sb5ixdb(int);
+static int op_undoc_sb6ixdb(int), op_undoc_sb7ixdb(int);
+static int op_undoc_sb0ixdc(int), op_undoc_sb1ixdc(int), op_undoc_sb2ixdc(int);
+static int op_undoc_sb3ixdc(int), op_undoc_sb4ixdc(int), op_undoc_sb5ixdc(int);
+static int op_undoc_sb6ixdc(int), op_undoc_sb7ixdc(int);
+static int op_undoc_sb0ixdd(int), op_undoc_sb1ixdd(int), op_undoc_sb2ixdd(int);
+static int op_undoc_sb3ixdd(int), op_undoc_sb4ixdd(int), op_undoc_sb5ixdd(int);
+static int op_undoc_sb6ixdd(int), op_undoc_sb7ixdd(int);
+static int op_undoc_sb0ixde(int), op_undoc_sb1ixde(int), op_undoc_sb2ixde(int);
+static int op_undoc_sb3ixde(int), op_undoc_sb4ixde(int), op_undoc_sb5ixde(int);
+static int op_undoc_sb6ixde(int), op_undoc_sb7ixde(int);
+static int op_undoc_sb0ixdh(int), op_undoc_sb1ixdh(int), op_undoc_sb2ixdh(int);
+static int op_undoc_sb3ixdh(int), op_undoc_sb4ixdh(int), op_undoc_sb5ixdh(int);
+static int op_undoc_sb6ixdh(int), op_undoc_sb7ixdh(int);
+static int op_undoc_sb0ixdl(int), op_undoc_sb1ixdl(int), op_undoc_sb2ixdl(int);
+static int op_undoc_sb3ixdl(int), op_undoc_sb4ixdl(int), op_undoc_sb5ixdl(int);
+static int op_undoc_sb6ixdl(int), op_undoc_sb7ixdl(int);
+static int op_undoc_rlcixda(int), op_undoc_rlcixdb(int), op_undoc_rlcixdc(int);
+static int op_undoc_rlcixdd(int), op_undoc_rlcixde(int), op_undoc_rlcixdh(int);
+static int op_undoc_rlcixdl(int);
+static int op_undoc_rrcixda(int), op_undoc_rrcixdb(int), op_undoc_rrcixdc(int);
+static int op_undoc_rrcixdd(int), op_undoc_rrcixde(int), op_undoc_rrcixdh(int);
+static int op_undoc_rrcixdl(int);
+static int op_undoc_rlixda(int), op_undoc_rlixdb(int), op_undoc_rlixdc(int);
+static int op_undoc_rlixdd(int), op_undoc_rlixde(int), op_undoc_rlixdh(int);
+static int op_undoc_rlixdl(int);
+static int op_undoc_rrixda(int), op_undoc_rrixdb(int), op_undoc_rrixdc(int);
+static int op_undoc_rrixdd(int), op_undoc_rrixde(int), op_undoc_rrixdh(int);
+static int op_undoc_rrixdl(int);
+static int op_undoc_slaixda(int), op_undoc_slaixdb(int), op_undoc_slaixdc(int);
+static int op_undoc_slaixdd(int), op_undoc_slaixde(int), op_undoc_slaixdh(int);
+static int op_undoc_slaixdl(int);
+static int op_undoc_sraixda(int), op_undoc_sraixdb(int), op_undoc_sraixdc(int);
+static int op_undoc_sraixdd(int), op_undoc_sraixde(int), op_undoc_sraixdh(int);
+static int op_undoc_sraixdl(int);
+static int op_undoc_sllixda(int), op_undoc_sllixdb(int), op_undoc_sllixdc(int);
+static int op_undoc_sllixdd(int), op_undoc_sllixde(int), op_undoc_sllixdh(int);
+static int op_undoc_sllixdl(int), op_undoc_sllixd(int);
+static int op_undoc_srlixda(int), op_undoc_srlixdb(int), op_undoc_srlixdc(int);
+static int op_undoc_srlixdd(int), op_undoc_srlixde(int), op_undoc_srlixdh(int);
+static int op_undoc_srlixdl(int);
 #endif
 
 int op_ddcb_handel(void)
 {
 	static int (*op_ddcb[256]) () = {
-		trap_ddcb,			/* 0x00 */
-		trap_ddcb,			/* 0x01 */
-		trap_ddcb,			/* 0x02 */
-		trap_ddcb,			/* 0x03 */
-		trap_ddcb,			/* 0x04 */
-		trap_ddcb,			/* 0x05 */
+		UNDOC(op_undoc_rlcixdb),	/* 0x00 */
+		UNDOC(op_undoc_rlcixdc),	/* 0x01 */
+		UNDOC(op_undoc_rlcixdd),	/* 0x02 */
+		UNDOC(op_undoc_rlcixde),	/* 0x03 */
+		UNDOC(op_undoc_rlcixdh),	/* 0x04 */
+		UNDOC(op_undoc_rlcixdl),	/* 0x05 */
 		op_rlcixd,			/* 0x06 */
-		trap_ddcb,			/* 0x07 */
-		trap_ddcb,			/* 0x08 */
-		trap_ddcb,			/* 0x09 */
-		trap_ddcb,			/* 0x0a */
-		trap_ddcb,			/* 0x0b */
-		trap_ddcb,			/* 0x0c */
-		trap_ddcb,			/* 0x0d */
+		UNDOC(op_undoc_rlcixda),	/* 0x07 */
+		UNDOC(op_undoc_rrcixdb),	/* 0x08 */
+		UNDOC(op_undoc_rrcixdc),	/* 0x09 */
+		UNDOC(op_undoc_rrcixdd),	/* 0x0a */
+		UNDOC(op_undoc_rrcixde),	/* 0x0b */
+		UNDOC(op_undoc_rrcixdh),	/* 0x0c */
+		UNDOC(op_undoc_rrcixdl),	/* 0x0d */
 		op_rrcixd,			/* 0x0e */
-		trap_ddcb,			/* 0x0f */
-		trap_ddcb,			/* 0x10 */
-		trap_ddcb,			/* 0x11 */
-		trap_ddcb,			/* 0x12 */
-		trap_ddcb,			/* 0x13 */
-		trap_ddcb,			/* 0x14 */
-		trap_ddcb,			/* 0x15 */
+		UNDOC(op_undoc_rrcixda),	/* 0x0f */
+		UNDOC(op_undoc_rlixdb),		/* 0x10 */
+		UNDOC(op_undoc_rlixdc),		/* 0x11 */
+		UNDOC(op_undoc_rlixdd),		/* 0x12 */
+		UNDOC(op_undoc_rlixde),		/* 0x13 */
+		UNDOC(op_undoc_rlixdh),		/* 0x14 */
+		UNDOC(op_undoc_rlixdl),		/* 0x15 */
 		op_rlixd,			/* 0x16 */
-		trap_ddcb,			/* 0x17 */
-		trap_ddcb,			/* 0x18 */
-		trap_ddcb,			/* 0x19 */
-		trap_ddcb,			/* 0x1a */
-		trap_ddcb,			/* 0x1b */
-		trap_ddcb,			/* 0x1c */
-		trap_ddcb,			/* 0x1d */
+		UNDOC(op_undoc_rlixda),		/* 0x17 */
+		UNDOC(op_undoc_rrixdb),		/* 0x18 */
+		UNDOC(op_undoc_rrixdc),		/* 0x19 */
+		UNDOC(op_undoc_rrixdd),		/* 0x1a */
+		UNDOC(op_undoc_rrixde),		/* 0x1b */
+		UNDOC(op_undoc_rrixdh),		/* 0x1c */
+		UNDOC(op_undoc_rrixdl),		/* 0x1d */
 		op_rrixd,			/* 0x1e */
-		trap_ddcb,			/* 0x1f */
-		trap_ddcb,			/* 0x20 */
-		trap_ddcb,			/* 0x21 */
-		trap_ddcb,			/* 0x22 */
-		trap_ddcb,			/* 0x23 */
-		trap_ddcb,			/* 0x24 */
-		trap_ddcb,			/* 0x25 */
+		UNDOC(op_undoc_rrixda),		/* 0x1f */
+		UNDOC(op_undoc_slaixdb),	/* 0x20 */
+		UNDOC(op_undoc_slaixdc),	/* 0x21 */
+		UNDOC(op_undoc_slaixdd),	/* 0x22 */
+		UNDOC(op_undoc_slaixde),	/* 0x23 */
+		UNDOC(op_undoc_slaixdh),	/* 0x24 */
+		UNDOC(op_undoc_slaixdl),	/* 0x25 */
 		op_slaixd,			/* 0x26 */
-		trap_ddcb,			/* 0x27 */
-		trap_ddcb,			/* 0x28 */
-		trap_ddcb,			/* 0x29 */
-		trap_ddcb,			/* 0x2a */
-		trap_ddcb,			/* 0x2b */
-		trap_ddcb,			/* 0x2c */
-		trap_ddcb,			/* 0x2d */
+		UNDOC(op_undoc_slaixda),	/* 0x27 */
+		UNDOC(op_undoc_sraixdb),	/* 0x28 */
+		UNDOC(op_undoc_sraixdc),	/* 0x29 */
+		UNDOC(op_undoc_sraixdd),	/* 0x2a */
+		UNDOC(op_undoc_sraixde),	/* 0x2b */
+		UNDOC(op_undoc_sraixdh),	/* 0x2c */
+		UNDOC(op_undoc_sraixdl),	/* 0x2d */
 		op_sraixd,			/* 0x2e */
-		trap_ddcb,			/* 0x2f */
-		trap_ddcb,			/* 0x30 */
-		trap_ddcb,			/* 0x31 */
-		trap_ddcb,			/* 0x32 */
-		trap_ddcb,			/* 0x33 */
-		trap_ddcb,			/* 0x34 */
-		trap_ddcb,			/* 0x35 */
+		UNDOC(op_undoc_sraixda),	/* 0x2f */
+		UNDOC(op_undoc_sllixdb),	/* 0x30 */
+		UNDOC(op_undoc_sllixdc),	/* 0x31 */
+		UNDOC(op_undoc_sllixdd),	/* 0x32 */
+		UNDOC(op_undoc_sllixde),	/* 0x33 */
+		UNDOC(op_undoc_sllixdh),	/* 0x34 */
+		UNDOC(op_undoc_sllixdl),	/* 0x35 */
 		UNDOC(op_undoc_sllixd),		/* 0x36 */
-		trap_ddcb,			/* 0x37 */
-		trap_ddcb,			/* 0x38 */
-		trap_ddcb,			/* 0x39 */
-		trap_ddcb,			/* 0x3a */
-		trap_ddcb,			/* 0x3b */
-		trap_ddcb,			/* 0x3c */
-		trap_ddcb,			/* 0x3d */
+		UNDOC(op_undoc_sllixda),	/* 0x37 */
+		UNDOC(op_undoc_srlixdb),	/* 0x38 */
+		UNDOC(op_undoc_srlixdc),	/* 0x39 */
+		UNDOC(op_undoc_srlixdd),	/* 0x3a */
+		UNDOC(op_undoc_srlixde),	/* 0x3b */
+		UNDOC(op_undoc_srlixdh),	/* 0x3c */
+		UNDOC(op_undoc_srlixdl),	/* 0x3d */
 		op_srlixd,			/* 0x3e */
-		trap_ddcb,			/* 0x3f */
-		trap_ddcb,			/* 0x40 */
-		trap_ddcb,			/* 0x41 */
-		trap_ddcb,			/* 0x42 */
-		trap_ddcb,			/* 0x43 */
-		trap_ddcb,			/* 0x44 */
-		trap_ddcb,			/* 0x45 */
+		UNDOC(op_undoc_srlixda),	/* 0x3f */
+		UNDOC(op_undoc_tb0ixd),		/* 0x40 */
+		UNDOC(op_undoc_tb0ixd),		/* 0x41 */
+		UNDOC(op_undoc_tb0ixd),		/* 0x42 */
+		UNDOC(op_undoc_tb0ixd),		/* 0x43 */
+		UNDOC(op_undoc_tb0ixd),		/* 0x44 */
+		UNDOC(op_undoc_tb0ixd),		/* 0x45 */
 		op_tb0ixd,			/* 0x46 */
-		trap_ddcb,			/* 0x47 */
-		trap_ddcb,			/* 0x48 */
-		trap_ddcb,			/* 0x49 */
-		trap_ddcb,			/* 0x4a */
-		trap_ddcb,			/* 0x4b */
-		trap_ddcb,			/* 0x4c */
-		trap_ddcb,			/* 0x4d */
+		UNDOC(op_undoc_tb0ixd),		/* 0x47 */
+		UNDOC(op_undoc_tb1ixd),		/* 0x48 */
+		UNDOC(op_undoc_tb1ixd),		/* 0x49 */
+		UNDOC(op_undoc_tb1ixd),		/* 0x4a */
+		UNDOC(op_undoc_tb1ixd),		/* 0x4b */
+		UNDOC(op_undoc_tb1ixd),		/* 0x4c */
+		UNDOC(op_undoc_tb1ixd),		/* 0x4d */
 		op_tb1ixd,			/* 0x4e */
-		trap_ddcb,			/* 0x4f */
-		trap_ddcb,			/* 0x50 */
-		trap_ddcb,			/* 0x51 */
-		trap_ddcb,			/* 0x52 */
-		trap_ddcb,			/* 0x53 */
-		trap_ddcb,			/* 0x54 */
-		trap_ddcb,			/* 0x55 */
+		UNDOC(op_undoc_tb1ixd),		/* 0x4f */
+		UNDOC(op_undoc_tb2ixd),		/* 0x50 */
+		UNDOC(op_undoc_tb2ixd),		/* 0x51 */
+		UNDOC(op_undoc_tb2ixd),		/* 0x52 */
+		UNDOC(op_undoc_tb2ixd),		/* 0x53 */
+		UNDOC(op_undoc_tb2ixd),		/* 0x54 */
+		UNDOC(op_undoc_tb2ixd),		/* 0x55 */
 		op_tb2ixd,			/* 0x56 */
-		trap_ddcb,			/* 0x57 */
-		trap_ddcb,			/* 0x58 */
-		trap_ddcb,			/* 0x59 */
-		trap_ddcb,			/* 0x5a */
-		trap_ddcb,			/* 0x5b */
-		trap_ddcb,			/* 0x5c */
-		trap_ddcb,			/* 0x5d */
+		UNDOC(op_undoc_tb2ixd),		/* 0x57 */
+		UNDOC(op_undoc_tb3ixd),		/* 0x58 */
+		UNDOC(op_undoc_tb3ixd),		/* 0x59 */
+		UNDOC(op_undoc_tb3ixd),		/* 0x5a */
+		UNDOC(op_undoc_tb3ixd),		/* 0x5b */
+		UNDOC(op_undoc_tb3ixd),		/* 0x5c */
+		UNDOC(op_undoc_tb3ixd),		/* 0x5d */
 		op_tb3ixd,			/* 0x5e */
-		trap_ddcb,			/* 0x5f */
-		trap_ddcb,			/* 0x60 */
-		trap_ddcb,			/* 0x61 */
-		trap_ddcb,			/* 0x62 */
-		trap_ddcb,			/* 0x63 */
-		trap_ddcb,			/* 0x64 */
-		trap_ddcb,			/* 0x65 */
+		UNDOC(op_undoc_tb3ixd),		/* 0x5f */
+		UNDOC(op_undoc_tb4ixd),		/* 0x60 */
+		UNDOC(op_undoc_tb4ixd),		/* 0x61 */
+		UNDOC(op_undoc_tb4ixd),		/* 0x62 */
+		UNDOC(op_undoc_tb4ixd),		/* 0x63 */
+		UNDOC(op_undoc_tb4ixd),		/* 0x64 */
+		UNDOC(op_undoc_tb4ixd),		/* 0x65 */
 		op_tb4ixd,			/* 0x66 */
-		trap_ddcb,			/* 0x67 */
-		trap_ddcb,			/* 0x68 */
-		trap_ddcb,			/* 0x69 */
-		trap_ddcb,			/* 0x6a */
-		trap_ddcb,			/* 0x6b */
-		trap_ddcb,			/* 0x6c */
-		trap_ddcb,			/* 0x6d */
+		UNDOC(op_undoc_tb4ixd),		/* 0x67 */
+		UNDOC(op_undoc_tb5ixd),		/* 0x68 */
+		UNDOC(op_undoc_tb5ixd),		/* 0x69 */
+		UNDOC(op_undoc_tb5ixd),		/* 0x6a */
+		UNDOC(op_undoc_tb5ixd),		/* 0x6b */
+		UNDOC(op_undoc_tb5ixd),		/* 0x6c */
+		UNDOC(op_undoc_tb5ixd),		/* 0x6d */
 		op_tb5ixd,			/* 0x6e */
-		trap_ddcb,			/* 0x6f */
-		trap_ddcb,			/* 0x70 */
-		trap_ddcb,			/* 0x71 */
-		trap_ddcb,			/* 0x72 */
-		trap_ddcb,			/* 0x73 */
-		trap_ddcb,			/* 0x74 */
-		trap_ddcb,			/* 0x75 */
+		UNDOC(op_undoc_tb5ixd),		/* 0x6f */
+		UNDOC(op_undoc_tb6ixd),		/* 0x70 */
+		UNDOC(op_undoc_tb6ixd),		/* 0x71 */
+		UNDOC(op_undoc_tb6ixd),		/* 0x72 */
+		UNDOC(op_undoc_tb6ixd),		/* 0x73 */
+		UNDOC(op_undoc_tb6ixd),		/* 0x74 */
+		UNDOC(op_undoc_tb6ixd),		/* 0x75 */
 		op_tb6ixd,			/* 0x76 */
-		trap_ddcb,			/* 0x77 */
-		trap_ddcb,			/* 0x78 */
-		trap_ddcb,			/* 0x79 */
-		trap_ddcb,			/* 0x7a */
-		trap_ddcb,			/* 0x7b */
-		trap_ddcb,			/* 0x7c */
-		trap_ddcb,			/* 0x7d */
+		UNDOC(op_undoc_tb6ixd),		/* 0x77 */
+		UNDOC(op_undoc_tb7ixd),		/* 0x78 */
+		UNDOC(op_undoc_tb7ixd),		/* 0x79 */
+		UNDOC(op_undoc_tb7ixd),		/* 0x7a */
+		UNDOC(op_undoc_tb7ixd),		/* 0x7b */
+		UNDOC(op_undoc_tb7ixd),		/* 0x7c */
+		UNDOC(op_undoc_tb7ixd),		/* 0x7d */
 		op_tb7ixd,			/* 0x7e */
-		trap_ddcb,			/* 0x7f */
-		trap_ddcb,			/* 0x80 */
-		trap_ddcb,			/* 0x81 */
-		trap_ddcb,			/* 0x82 */
-		trap_ddcb,			/* 0x83 */
-		trap_ddcb,			/* 0x84 */
-		trap_ddcb,			/* 0x85 */
+		UNDOC(op_undoc_tb7ixd),		/* 0x7f */
+		UNDOC(op_undoc_rb0ixdb),	/* 0x80 */
+		UNDOC(op_undoc_rb0ixdc),	/* 0x81 */
+		UNDOC(op_undoc_rb0ixdd),	/* 0x82 */
+		UNDOC(op_undoc_rb0ixde),	/* 0x83 */
+		UNDOC(op_undoc_rb0ixdh),	/* 0x84 */
+		UNDOC(op_undoc_rb0ixdl),	/* 0x85 */
 		op_rb0ixd,			/* 0x86 */
-		trap_ddcb,			/* 0x87 */
-		trap_ddcb,			/* 0x88 */
-		trap_ddcb,			/* 0x89 */
-		trap_ddcb,			/* 0x8a */
-		trap_ddcb,			/* 0x8b */
-		trap_ddcb,			/* 0x8c */
-		trap_ddcb,			/* 0x8d */
+		UNDOC(op_undoc_rb0ixda),	/* 0x87 */
+		UNDOC(op_undoc_rb1ixdb),	/* 0x88 */
+		UNDOC(op_undoc_rb1ixdc),	/* 0x89 */
+		UNDOC(op_undoc_rb1ixdd),	/* 0x8a */
+		UNDOC(op_undoc_rb1ixde),	/* 0x8b */
+		UNDOC(op_undoc_rb1ixdh),	/* 0x8c */
+		UNDOC(op_undoc_rb1ixdl),	/* 0x8d */
 		op_rb1ixd,			/* 0x8e */
-		trap_ddcb,			/* 0x8f */
-		trap_ddcb,			/* 0x90 */
-		trap_ddcb,			/* 0x91 */
-		trap_ddcb,			/* 0x92 */
-		trap_ddcb,			/* 0x93 */
-		trap_ddcb,			/* 0x94 */
-		trap_ddcb,			/* 0x95 */
+		UNDOC(op_undoc_rb1ixda),	/* 0x8f */
+		UNDOC(op_undoc_rb2ixdb),	/* 0x90 */
+		UNDOC(op_undoc_rb2ixdc),	/* 0x91 */
+		UNDOC(op_undoc_rb2ixdd),	/* 0x92 */
+		UNDOC(op_undoc_rb2ixde),	/* 0x93 */
+		UNDOC(op_undoc_rb2ixdh),	/* 0x94 */
+		UNDOC(op_undoc_rb2ixdl),	/* 0x95 */
 		op_rb2ixd,			/* 0x96 */
-		trap_ddcb,			/* 0x97 */
-		trap_ddcb,			/* 0x98 */
-		trap_ddcb,			/* 0x99 */
-		trap_ddcb,			/* 0x9a */
-		trap_ddcb,			/* 0x9b */
-		trap_ddcb,			/* 0x9c */
-		trap_ddcb,			/* 0x9d */
+		UNDOC(op_undoc_rb2ixda),	/* 0x97 */
+		UNDOC(op_undoc_rb3ixdb),	/* 0x98 */
+		UNDOC(op_undoc_rb3ixdc),	/* 0x99 */
+		UNDOC(op_undoc_rb3ixdd),	/* 0x9a */
+		UNDOC(op_undoc_rb3ixde),	/* 0x9b */
+		UNDOC(op_undoc_rb3ixdh),	/* 0x9c */
+		UNDOC(op_undoc_rb3ixdl),	/* 0x9d */
 		op_rb3ixd,			/* 0x9e */
-		trap_ddcb,			/* 0x9f */
-		trap_ddcb,			/* 0xa0 */
-		trap_ddcb,			/* 0xa1 */
-		trap_ddcb,			/* 0xa2 */
-		trap_ddcb,			/* 0xa3 */
-		trap_ddcb,			/* 0xa4 */
-		trap_ddcb,			/* 0xa5 */
+		UNDOC(op_undoc_rb3ixda),	/* 0x9f */
+		UNDOC(op_undoc_rb4ixdb),	/* 0xa0 */
+		UNDOC(op_undoc_rb4ixdc),	/* 0xa1 */
+		UNDOC(op_undoc_rb4ixdd),	/* 0xa2 */
+		UNDOC(op_undoc_rb4ixde),	/* 0xa3 */
+		UNDOC(op_undoc_rb4ixdh),	/* 0xa4 */
+		UNDOC(op_undoc_rb4ixdl),	/* 0xa5 */
 		op_rb4ixd,			/* 0xa6 */
-		trap_ddcb,			/* 0xa7 */
-		trap_ddcb,			/* 0xa8 */
-		trap_ddcb,			/* 0xa9 */
-		trap_ddcb,			/* 0xaa */
-		trap_ddcb,			/* 0xab */
-		trap_ddcb,			/* 0xac */
-		trap_ddcb,			/* 0xad */
+		UNDOC(op_undoc_rb4ixda),	/* 0xa7 */
+		UNDOC(op_undoc_rb5ixdb),	/* 0xa8 */
+		UNDOC(op_undoc_rb5ixdc),	/* 0xa9 */
+		UNDOC(op_undoc_rb5ixdd),	/* 0xaa */
+		UNDOC(op_undoc_rb5ixde),	/* 0xab */
+		UNDOC(op_undoc_rb5ixdh),	/* 0xac */
+		UNDOC(op_undoc_rb5ixdl),	/* 0xad */
 		op_rb5ixd,			/* 0xae */
-		trap_ddcb,			/* 0xaf */
-		trap_ddcb,			/* 0xb0 */
-		trap_ddcb,			/* 0xb1 */
-		trap_ddcb,			/* 0xb2 */
-		trap_ddcb,			/* 0xb3 */
-		trap_ddcb,			/* 0xb4 */
-		trap_ddcb,			/* 0xb5 */
+		UNDOC(op_undoc_rb5ixda),	/* 0xaf */
+		UNDOC(op_undoc_rb6ixdb),	/* 0xb0 */
+		UNDOC(op_undoc_rb6ixdc),	/* 0xb1 */
+		UNDOC(op_undoc_rb6ixdd),	/* 0xb2 */
+		UNDOC(op_undoc_rb6ixde),	/* 0xb3 */
+		UNDOC(op_undoc_rb6ixdh),	/* 0xb4 */
+		UNDOC(op_undoc_rb6ixdl),	/* 0xb5 */
 		op_rb6ixd,			/* 0xb6 */
-		trap_ddcb,			/* 0xb7 */
-		trap_ddcb,			/* 0xb8 */
-		trap_ddcb,			/* 0xb9 */
-		trap_ddcb,			/* 0xba */
-		trap_ddcb,			/* 0xbb */
-		trap_ddcb,			/* 0xbc */
-		trap_ddcb,			/* 0xbd */
+		UNDOC(op_undoc_rb6ixda),	/* 0xb7 */
+		UNDOC(op_undoc_rb7ixdb),	/* 0xb8 */
+		UNDOC(op_undoc_rb7ixdc),	/* 0xb9 */
+		UNDOC(op_undoc_rb7ixdd),	/* 0xba */
+		UNDOC(op_undoc_rb7ixde),	/* 0xbb */
+		UNDOC(op_undoc_rb7ixdh),	/* 0xbc */
+		UNDOC(op_undoc_rb7ixdl),	/* 0xbd */
 		op_rb7ixd,			/* 0xbe */
-		trap_ddcb,			/* 0xbf */
-		trap_ddcb,			/* 0xc0 */
-		trap_ddcb,			/* 0xc1 */
-		trap_ddcb,			/* 0xc2 */
-		trap_ddcb,			/* 0xc3 */
-		trap_ddcb,			/* 0xc4 */
-		trap_ddcb,			/* 0xc5 */
+		UNDOC(op_undoc_rb7ixda),	/* 0xbf */
+		UNDOC(op_undoc_sb0ixdb),	/* 0xc0 */
+		UNDOC(op_undoc_sb0ixdc),	/* 0xc1 */
+		UNDOC(op_undoc_sb0ixdd),	/* 0xc2 */
+		UNDOC(op_undoc_sb0ixde),	/* 0xc3 */
+		UNDOC(op_undoc_sb0ixdh),	/* 0xc4 */
+		UNDOC(op_undoc_sb0ixdl),	/* 0xc5 */
 		op_sb0ixd,			/* 0xc6 */
-		trap_ddcb,			/* 0xc7 */
-		trap_ddcb,			/* 0xc8 */
-		trap_ddcb,			/* 0xc9 */
-		trap_ddcb,			/* 0xca */
-		trap_ddcb,			/* 0xcb */
-		trap_ddcb,			/* 0xcc */
-		trap_ddcb,			/* 0xcd */
+		UNDOC(op_undoc_sb0ixda),	/* 0xc7 */
+		UNDOC(op_undoc_sb1ixdb),	/* 0xc8 */
+		UNDOC(op_undoc_sb1ixdc),	/* 0xc9 */
+		UNDOC(op_undoc_sb1ixdd),	/* 0xca */
+		UNDOC(op_undoc_sb1ixde),	/* 0xcb */
+		UNDOC(op_undoc_sb1ixdh),	/* 0xcc */
+		UNDOC(op_undoc_sb1ixdl),	/* 0xcd */
 		op_sb1ixd,			/* 0xce */
-		trap_ddcb,			/* 0xcf */
-		trap_ddcb,			/* 0xd0 */
-		trap_ddcb,			/* 0xd1 */
-		trap_ddcb,			/* 0xd2 */
-		trap_ddcb,			/* 0xd3 */
-		trap_ddcb,			/* 0xd4 */
-		trap_ddcb,			/* 0xd5 */
+		UNDOC(op_undoc_sb1ixda),	/* 0xcf */
+		UNDOC(op_undoc_sb2ixdb),	/* 0xd0 */
+		UNDOC(op_undoc_sb2ixdc),	/* 0xd1 */
+		UNDOC(op_undoc_sb2ixdd),	/* 0xd2 */
+		UNDOC(op_undoc_sb2ixde),	/* 0xd3 */
+		UNDOC(op_undoc_sb2ixdh),	/* 0xd4 */
+		UNDOC(op_undoc_sb2ixdl),	/* 0xd5 */
 		op_sb2ixd,			/* 0xd6 */
-		trap_ddcb,			/* 0xd7 */
-		trap_ddcb,			/* 0xd8 */
-		trap_ddcb,			/* 0xd9 */
-		trap_ddcb,			/* 0xda */
-		trap_ddcb,			/* 0xdb */
-		trap_ddcb,			/* 0xdc */
-		trap_ddcb,			/* 0xdd */
+		UNDOC(op_undoc_sb2ixda),	/* 0xd7 */
+		UNDOC(op_undoc_sb3ixdb),	/* 0xd8 */
+		UNDOC(op_undoc_sb3ixdc),	/* 0xd9 */
+		UNDOC(op_undoc_sb3ixdd),	/* 0xda */
+		UNDOC(op_undoc_sb3ixde),	/* 0xdb */
+		UNDOC(op_undoc_sb3ixdh),	/* 0xdc */
+		UNDOC(op_undoc_sb3ixdl),	/* 0xdd */
 		op_sb3ixd,			/* 0xde */
-		trap_ddcb,			/* 0xdf */
-		trap_ddcb,			/* 0xe0 */
-		trap_ddcb,			/* 0xe1 */
-		trap_ddcb,			/* 0xe2 */
-		trap_ddcb,			/* 0xe3 */
-		trap_ddcb,			/* 0xe4 */
-		trap_ddcb,			/* 0xe5 */
+		UNDOC(op_undoc_sb3ixda),	/* 0xdf */
+		UNDOC(op_undoc_sb4ixdb),	/* 0xe0 */
+		UNDOC(op_undoc_sb4ixdc),	/* 0xe1 */
+		UNDOC(op_undoc_sb4ixdd),	/* 0xe2 */
+		UNDOC(op_undoc_sb4ixde),	/* 0xe3 */
+		UNDOC(op_undoc_sb4ixdh),	/* 0xe4 */
+		UNDOC(op_undoc_sb4ixdl),	/* 0xe5 */
 		op_sb4ixd,			/* 0xe6 */
-		trap_ddcb,			/* 0xe7 */
-		trap_ddcb,			/* 0xe8 */
-		trap_ddcb,			/* 0xe9 */
-		trap_ddcb,			/* 0xea */
-		trap_ddcb,			/* 0xeb */
-		trap_ddcb,			/* 0xec */
-		trap_ddcb,			/* 0xed */
+		UNDOC(op_undoc_sb4ixda),	/* 0xe7 */
+		UNDOC(op_undoc_sb5ixdb),	/* 0xe8 */
+		UNDOC(op_undoc_sb5ixdc),	/* 0xe9 */
+		UNDOC(op_undoc_sb5ixdd),	/* 0xea */
+		UNDOC(op_undoc_sb5ixde),	/* 0xeb */
+		UNDOC(op_undoc_sb5ixdh),	/* 0xec */
+		UNDOC(op_undoc_sb5ixdl),	/* 0xed */
 		op_sb5ixd,			/* 0xee */
-		trap_ddcb,			/* 0xef */
-		trap_ddcb,			/* 0xf0 */
-		trap_ddcb,			/* 0xf1 */
-		trap_ddcb,			/* 0xf2 */
-		trap_ddcb,			/* 0xf3 */
-		trap_ddcb,			/* 0xf4 */
-		trap_ddcb,			/* 0xf5 */
+		UNDOC(op_undoc_sb5ixda),	/* 0xef */
+		UNDOC(op_undoc_sb6ixdb),	/* 0xf0 */
+		UNDOC(op_undoc_sb6ixdc),	/* 0xf1 */
+		UNDOC(op_undoc_sb6ixdd),	/* 0xf2 */
+		UNDOC(op_undoc_sb6ixde),	/* 0xf3 */
+		UNDOC(op_undoc_sb6ixdh),	/* 0xf4 */
+		UNDOC(op_undoc_sb6ixdl),	/* 0xf5 */
 		op_sb6ixd,			/* 0xf6 */
-		trap_ddcb,			/* 0xf7 */
-		trap_ddcb,			/* 0xf8 */
-		trap_ddcb,			/* 0xf9 */
-		trap_ddcb,			/* 0xfa */
-		trap_ddcb,			/* 0xfb */
-		trap_ddcb,			/* 0xfc */
-		trap_ddcb,			/* 0xfd */
+		UNDOC(op_undoc_sb6ixda),	/* 0xf7 */
+		UNDOC(op_undoc_sb7ixdb),	/* 0xf8 */
+		UNDOC(op_undoc_sb7ixdc),	/* 0xf9 */
+		UNDOC(op_undoc_sb7ixdd),	/* 0xfa */
+		UNDOC(op_undoc_sb7ixde),	/* 0xfb */
+		UNDOC(op_undoc_sb7ixdh),	/* 0xfc */
+		UNDOC(op_undoc_sb7ixdl),	/* 0xfd */
 		op_sb7ixd,			/* 0xfe */
-		trap_ddcb			/* 0xff */
+		UNDOC(op_undoc_sb7ixda)		/* 0xff */
 	};
 
 	register int d;
@@ -673,6 +742,2557 @@ static int op_srlixd(int data)		/* SRL (IX+d) */
 
 #ifdef Z80_UNDOC
 
+static int op_undoc_tb0ixd(int data)	/* BIT 0,(IX+d) */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	return(op_tb0ixd(data));
+}
+
+static int op_undoc_tb1ixd(int data)	/* BIT 1,(IX+d) */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	return(op_tb1ixd(data));
+}
+
+static int op_undoc_tb2ixd(int data)	/* BIT 2,(IX+d) */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	return(op_tb2ixd(data));
+}
+
+static int op_undoc_tb3ixd(int data)	/* BIT 3,(IX+d) */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	return(op_tb3ixd(data));
+}
+
+static int op_undoc_tb4ixd(int data)	/* BIT 4,(IX+d) */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	return(op_tb4ixd(data));
+}
+
+static int op_undoc_tb5ixd(int data)	/* BIT 5,(IX+d) */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	return(op_tb5ixd(data));
+}
+
+static int op_undoc_tb6ixd(int data)	/* BIT 6,(IX+d) */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	return(op_tb6ixd(data));
+}
+
+static int op_undoc_tb7ixd(int data)	/* BIT 7,(IX+d) */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	return(op_tb7ixd(data));
+}
+
+static int op_undoc_rb0ixda(int data)	/* RES 0,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) & ~1;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_rb1ixda(int data)	/* RES 1,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) & ~2;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_rb2ixda(int data)	/* RES 2,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) & ~4;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_rb3ixda(int data)	/* RES 3,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) & ~8;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_rb4ixda(int data)	/* RES 4,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) & ~16;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_rb5ixda(int data)	/* RES 5,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) & ~32;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_rb6ixda(int data)	/* RES 6,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) & ~64;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_rb7ixda(int data)	/* RES 7,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) & ~128;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_rb0ixdb(int data)	/* RES 0,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) & ~1;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_rb1ixdb(int data)	/* RES 1,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) & ~2;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_rb2ixdb(int data)	/* RES 2,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) & ~4;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_rb3ixdb(int data)	/* RES 3,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) & ~8;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_rb4ixdb(int data)	/* RES 4,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) & ~16;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_rb5ixdb(int data)	/* RES 5,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) & ~32;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_rb6ixdb(int data)	/* RES 6,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) & ~64;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_rb7ixdb(int data)	/* RES 7,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) & ~128;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_rb0ixdc(int data)	/* RES 0,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) & ~1;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_rb1ixdc(int data)	/* RES 1,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) & ~2;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_rb2ixdc(int data)	/* RES 2,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) & ~4;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_rb3ixdc(int data)	/* RES 3,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) & ~8;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_rb4ixdc(int data)	/* RES 4,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) & ~16;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_rb5ixdc(int data)	/* RES 5,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) & ~32;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_rb6ixdc(int data)	/* RES 6,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) & ~64;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_rb7ixdc(int data)	/* RES 7,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) & ~128;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_rb0ixdd(int data)	/* RES 0,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) & ~1;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_rb1ixdd(int data)	/* RES 1,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) & ~2;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_rb2ixdd(int data)	/* RES 2,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) & ~4;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_rb3ixdd(int data)	/* RES 3,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) & ~8;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_rb4ixdd(int data)	/* RES 4,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) & ~16;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_rb5ixdd(int data)	/* RES 5,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) & ~32;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_rb6ixdd(int data)	/* RES 6,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) & ~64;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_rb7ixdd(int data)	/* RES 7,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) & ~128;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_rb0ixde(int data)	/* RES 0,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) & ~1;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_rb1ixde(int data)	/* RES 1,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) & ~2;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_rb2ixde(int data)	/* RES 2,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) & ~4;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_rb3ixde(int data)	/* RES 3,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) & ~8;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_rb4ixde(int data)	/* RES 4,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) & ~16;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_rb5ixde(int data)	/* RES 5,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) & ~32;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_rb6ixde(int data)	/* RES 6,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) & ~64;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_rb7ixde(int data)	/* RES 7,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) & ~128;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_rb0ixdh(int data)	/* RES 0,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) & ~1;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_rb1ixdh(int data)	/* RES 1,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) & ~2;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_rb2ixdh(int data)	/* RES 2,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) & ~4;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_rb3ixdh(int data)	/* RES 3,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) & ~8;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_rb4ixdh(int data)	/* RES 4,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) & ~16;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_rb5ixdh(int data)	/* RES 5,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) & ~32;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_rb6ixdh(int data)	/* RES 6,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) & ~64;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_rb7ixdh(int data)	/* RES 7,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) & ~128;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_rb0ixdl(int data)	/* RES 0,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) & ~1;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_rb1ixdl(int data)	/* RES 1,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) & ~2;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_rb2ixdl(int data)	/* RES 2,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) & ~4;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_rb3ixdl(int data)	/* RES 3,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) & ~8;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_rb4ixdl(int data)	/* RES 4,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) & ~16;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_rb5ixdl(int data)	/* RES 5,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) & ~32;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_rb6ixdl(int data)	/* RES 6,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) & ~64;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_rb7ixdl(int data)	/* RES 7,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) & ~128;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_sb0ixda(int data)	/* SET 0,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) | 1;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_sb1ixda(int data)	/* SET 1,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) | 2;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_sb2ixda(int data)	/* SET 2,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) | 4;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_sb3ixda(int data)	/* SET 3,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) | 8;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_sb4ixda(int data)	/* SET 4,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) | 16;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_sb5ixda(int data)	/* SET 5,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) | 32;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_sb6ixda(int data)	/* SET 6,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) | 64;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_sb7ixda(int data)	/* SET 7,(IX+d),A */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	A = memrdr(IX + data) | 128;
+	memwrt(IX + data, A);
+	return(23);
+}
+
+static int op_undoc_sb0ixdb(int data)	/* SET 0,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) | 1;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_sb1ixdb(int data)	/* SET 1,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) | 2;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_sb2ixdb(int data)	/* SET 2,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) | 4;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_sb3ixdb(int data)	/* SET 3,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) | 8;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_sb4ixdb(int data)	/* SET 4,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) | 16;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_sb5ixdb(int data)	/* SET 5,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) | 32;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_sb6ixdb(int data)	/* SET 6,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) | 64;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_sb7ixdb(int data)	/* SET 7,(IX+d),B */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	B = memrdr(IX + data) | 128;
+	memwrt(IX + data, B);
+	return(23);
+}
+
+static int op_undoc_sb0ixdc(int data)	/* SET 0,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) | 1;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_sb1ixdc(int data)	/* SET 1,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) | 2;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_sb2ixdc(int data)	/* SET 2,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) | 4;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_sb3ixdc(int data)	/* SET 3,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) | 8;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_sb4ixdc(int data)	/* SET 4,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) | 16;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_sb5ixdc(int data)	/* SET 5,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) | 32;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_sb6ixdc(int data)	/* SET 6,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) | 64;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_sb7ixdc(int data)	/* SET 7,(IX+d),C */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	C = memrdr(IX + data) | 128;
+	memwrt(IX + data, C);
+	return(23);
+}
+
+static int op_undoc_sb0ixdd(int data)	/* SET 0,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) | 1;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_sb1ixdd(int data)	/* SET 1,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) | 2;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_sb2ixdd(int data)	/* SET 2,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) | 4;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_sb3ixdd(int data)	/* SET 3,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) | 8;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_sb4ixdd(int data)	/* SET 4,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) | 16;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_sb5ixdd(int data)	/* SET 5,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) | 32;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_sb6ixdd(int data)	/* SET 6,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) | 64;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_sb7ixdd(int data)	/* SET 7,(IX+d),D */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	D = memrdr(IX + data) | 128;
+	memwrt(IX + data, D);
+	return(23);
+}
+
+static int op_undoc_sb0ixde(int data)	/* SET 0,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) | 1;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_sb1ixde(int data)	/* SET 1,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) | 2;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_sb2ixde(int data)	/* SET 2,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) | 4;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_sb3ixde(int data)	/* SET 3,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) | 8;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_sb4ixde(int data)	/* SET 4,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) | 16;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_sb5ixde(int data)	/* SET 5,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) | 32;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_sb6ixde(int data)	/* SET 6,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) | 64;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_sb7ixde(int data)	/* SET 7,(IX+d),E */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	E = memrdr(IX + data) | 128;
+	memwrt(IX + data, E);
+	return(23);
+}
+
+static int op_undoc_sb0ixdh(int data)	/* SET 0,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) | 1;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_sb1ixdh(int data)	/* SET 1,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) | 2;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_sb2ixdh(int data)	/* SET 2,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) | 4;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_sb3ixdh(int data)	/* SET 3,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) | 8;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_sb4ixdh(int data)	/* SET 4,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) | 16;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_sb5ixdh(int data)	/* SET 5,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) | 32;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_sb6ixdh(int data)	/* SET 6,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) | 64;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_sb7ixdh(int data)	/* SET 7,(IX+d),H */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	H = memrdr(IX + data) | 128;
+	memwrt(IX + data, H);
+	return(23);
+}
+
+static int op_undoc_sb0ixdl(int data)	/* SET 0,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) | 1;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_sb1ixdl(int data)	/* SET 1,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) | 2;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_sb2ixdl(int data)	/* SET 2,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) | 4;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_sb3ixdl(int data)	/* SET 3,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) | 8;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_sb4ixdl(int data)	/* SET 4,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) | 16;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_sb5ixdl(int data)	/* SET 5,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) | 32;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_sb6ixdl(int data)	/* SET 6,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) | 64;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_sb7ixdl(int data)	/* SET 7,(IX+d),L */
+{
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	L = memrdr(IX + data) | 128;
+	memwrt(IX + data, L);
+	return(23);
+}
+
+static int op_undoc_rlcixda(int data)	/* RLC (IX+d),A */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	A = memrdr(addr);
+	i = A & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A <<= 1;
+	if (i) A |= 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlcixdb(int data)	/* RLC (IX+d),B */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	B = memrdr(addr);
+	i = B & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B <<= 1;
+	if (i) B |= 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlcixdc(int data)	/* RLC (IX+d),C */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	C = memrdr(addr);
+	i = C & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C <<= 1;
+	if (i) C |= 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlcixdd(int data)	/* RLC (IX+d),D */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	D = memrdr(addr);
+	i = D & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D <<= 1;
+	if (i) D |= 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlcixde(int data)	/* RLC (IX+d),E */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	E = memrdr(addr);
+	i = E & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E <<= 1;
+	if (i) E |= 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlcixdh(int data)	/* RLC (IX+d),H */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	H = memrdr(addr);
+	i = H & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H <<= 1;
+	if (i) H |= 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlcixdl(int data)	/* RLC (IX+d),L */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	L = memrdr(addr);
+	i = L & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L <<= 1;
+	if (i) L |= 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrcixda(int data)	/* RRC (IX+d),A */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	A = memrdr(addr);
+	i = A & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A >>= 1;
+	if (i) A |= 128;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrcixdb(int data)	/* RRC (IX+d),B */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	B = memrdr(addr);
+	i = B & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B >>= 1;
+	if (i) B |= 128;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrcixdc(int data)	/* RRC (IX+d),C */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	C = memrdr(addr);
+	i = C & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C >>= 1;
+	if (i) C |= 128;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrcixdd(int data)	/* RRC (IX+d),D */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	D = memrdr(addr);
+	i = D & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D >>= 1;
+	if (i) D |= 128;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrcixde(int data)	/* RRC (IX+d),E */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	E = memrdr(addr);
+	i = E & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E >>= 1;
+	if (i) E |= 128;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrcixdh(int data)	/* RRC (IX+d),H */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	H = memrdr(addr);
+	i = H & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H >>= 1;
+	if (i) H |= 128;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrcixdl(int data)	/* RRC (IX+d),L */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	L = memrdr(addr);
+	i = L & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L >>= 1;
+	if (i) L |= 128;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlixda(int data)	/* RL (IX+d),A */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	A = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A <<= 1;
+	if (old_c_flag) A |= 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlixdb(int data)	/* RL (IX+d),B */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	B = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B <<= 1;
+	if (old_c_flag) B |= 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlixdc(int data)	/* RL (IX+d),C */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	C = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C <<= 1;
+	if (old_c_flag) C |= 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlixdd(int data)	/* RL (IX+d),D */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	D = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D <<= 1;
+	if (old_c_flag) D |= 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlixde(int data)	/* RL (IX+d),E */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	E = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E <<= 1;
+	if (old_c_flag) E |= 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlixdh(int data)	/* RL (IX+d),H */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	H = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H <<= 1;
+	if (old_c_flag) H |= 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlixdl(int data)	/* RL (IX+d),L */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	L = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L <<= 1;
+	if (old_c_flag) L |= 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrixda(int data)	/* RR (IX+d),A */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	A = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(A & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A >>= 1;
+	if (old_c_flag) A |= 128;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrixdb(int data)	/* RR (IX+d),B */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	B = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(B & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B >>= 1;
+	if (old_c_flag) B |= 128;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrixdc(int data)	/* RR (IX+d),C */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	C = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(C & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C >>= 1;
+	if (old_c_flag) C |= 128;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrixdd(int data)	/* RR (IX+d),D */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	D = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(D & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D >>= 1;
+	if (old_c_flag) D |= 128;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrixde(int data)	/* RR (IX+d),E */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	E = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(E & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E >>= 1;
+	if (old_c_flag) E |= 128;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrixdh(int data)	/* RR (IX+d),H */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	H = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(H & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H >>= 1;
+	if (old_c_flag) H |= 128;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrixdl(int data)	/* RR (IX+d),L */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	L = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(L & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L >>= 1;
+	if (old_c_flag) L |= 128;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaixda(int data)	/* SLA (IX+d),A */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	A = memrdr(addr);
+	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A <<= 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaixdb(int data)	/* SLA (IX+d),B */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	B = memrdr(addr);
+	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B <<= 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaixdc(int data)	/* SLA (IX+d),C */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	C = memrdr(addr);
+	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C <<= 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaixdd(int data)	/* SLA (IX+d),D */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	D = memrdr(addr);
+	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D <<= 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaixde(int data)	/* SLA (IX+d),E */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	E = memrdr(addr);
+	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E <<= 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaixdh(int data)	/* SLA (IX+d),H */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	H = memrdr(addr);
+	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H <<= 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaixdl(int data)	/* SLA (IX+d),L */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	L = memrdr(addr);
+	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L <<= 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraixda(int data)	/* SRA (IX+d),A */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	A = memrdr(addr);
+	i = A & 128;
+	(A & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = (A >> 1) | i;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraixdb(int data)	/* SRA (IX+d),B */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	B = memrdr(addr);
+	i = B & 128;
+	(B & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B = (B >> 1) | i;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraixdc(int data)	/* SRA (IX+d),C */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	C = memrdr(addr);
+	i = C & 128;
+	(C & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C = (C >> 1) | i;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraixdd(int data)	/* SRA (IX+d),D */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	D = memrdr(addr);
+	i = D & 128;
+	(D & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D = (D >> 1) | i;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraixde(int data)	/* SRA (IX+d),E */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	E = memrdr(addr);
+	i = E & 128;
+	(E & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E = (E >> 1) | i;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraixdh(int data)	/* SRA (IX+d),H */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	H = memrdr(addr);
+	i = H & 128;
+	(H & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H = (H >> 1) | i;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraixdl(int data)	/* SRA (IX+d),L */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	L = memrdr(addr);
+	i = L & 128;
+	(L & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L = (L >> 1) | i;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sllixda(int data)	/* SLL (IX+d),A */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	A = memrdr(addr);
+	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = (A << 1) | 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sllixdb(int data)	/* SLL (IX+d),B */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	B = memrdr(addr);
+	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B = (B << 1) | 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sllixdc(int data)	/* SLL (IX+d),C */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	C = memrdr(addr);
+	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C = (C << 1) | 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sllixdd(int data)	/* SLL (IX+d),D */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	D = memrdr(addr);
+	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D = (D << 1) | 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sllixde(int data)	/* SLL (IX+d),E */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	E = memrdr(addr);
+	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E = (E << 1) | 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sllixdh(int data)	/* SLL (IX+d),H */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	H = memrdr(addr);
+	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H = (H << 1) | 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sllixdl(int data)	/* SLL (IX+d),L */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	L = memrdr(addr);
+	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L = (L << 1) | 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
 static int op_undoc_sllixd(int data)	/* SLL (IX+d) */
 {
 	register BYTE P;
@@ -692,6 +3312,153 @@ static int op_undoc_sllixd(int data)	/* SLL (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srlixda(int data)	/* SRL (IX+d),A */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	A = memrdr(addr);
+	(A & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A >>= 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srlixdb(int data)	/* SRL (IX+d),B */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	B = memrdr(addr);
+	(B & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B >>= 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srlixdc(int data)	/* SRL (IX+d),C */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	C = memrdr(addr);
+	(C & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C >>= 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srlixdd(int data)	/* SRL (IX+d),D */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	D = memrdr(addr);
+	(D & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D >>= 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srlixde(int data)	/* SRL (IX+d),E */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	E = memrdr(addr);
+	(E & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E >>= 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srlixdh(int data)	/* SRL (IX+d),H */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	H = memrdr(addr);
+	(H & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H >>= 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srlixdl(int data)	/* SRL (IX+d),L */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_ddcb();
+		return(0);
+	}
+
+	addr = IX + data;
+	L = memrdr(addr);
+	(L & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L >>= 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	return(23);
 }
 

--- a/z80core/sim7.c
+++ b/z80core/sim7.c
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
+ * Copyright (C) 2022 by Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
@@ -75,268 +76,336 @@ static int op_rlciyd(int), op_rrciyd(int), op_rliyd(int), op_rriyd(int);
 static int op_slaiyd(int), op_sraiyd(int), op_srliyd(int);
 
 #ifdef Z80_UNDOC
-static int op_undoc_slliyd(int);
+static int op_undoc_tb0iyd(int), op_undoc_tb1iyd(int), op_undoc_tb2iyd(int);
+static int op_undoc_tb3iyd(int), op_undoc_tb4iyd(int), op_undoc_tb5iyd(int);
+static int op_undoc_tb6iyd(int), op_undoc_tb7iyd(int);
+static int op_undoc_rb0iyda(int), op_undoc_rb1iyda(int), op_undoc_rb2iyda(int);
+static int op_undoc_rb3iyda(int), op_undoc_rb4iyda(int), op_undoc_rb5iyda(int);
+static int op_undoc_rb6iyda(int), op_undoc_rb7iyda(int);
+static int op_undoc_rb0iydb(int), op_undoc_rb1iydb(int), op_undoc_rb2iydb(int);
+static int op_undoc_rb3iydb(int), op_undoc_rb4iydb(int), op_undoc_rb5iydb(int);
+static int op_undoc_rb6iydb(int), op_undoc_rb7iydb(int);
+static int op_undoc_rb0iydc(int), op_undoc_rb1iydc(int), op_undoc_rb2iydc(int);
+static int op_undoc_rb3iydc(int), op_undoc_rb4iydc(int), op_undoc_rb5iydc(int);
+static int op_undoc_rb6iydc(int), op_undoc_rb7iydc(int);
+static int op_undoc_rb0iydd(int), op_undoc_rb1iydd(int), op_undoc_rb2iydd(int);
+static int op_undoc_rb3iydd(int), op_undoc_rb4iydd(int), op_undoc_rb5iydd(int);
+static int op_undoc_rb6iydd(int), op_undoc_rb7iydd(int);
+static int op_undoc_rb0iyde(int), op_undoc_rb1iyde(int), op_undoc_rb2iyde(int);
+static int op_undoc_rb3iyde(int), op_undoc_rb4iyde(int), op_undoc_rb5iyde(int);
+static int op_undoc_rb6iyde(int), op_undoc_rb7iyde(int);
+static int op_undoc_rb0iydh(int), op_undoc_rb1iydh(int), op_undoc_rb2iydh(int);
+static int op_undoc_rb3iydh(int), op_undoc_rb4iydh(int), op_undoc_rb5iydh(int);
+static int op_undoc_rb6iydh(int), op_undoc_rb7iydh(int);
+static int op_undoc_rb0iydl(int), op_undoc_rb1iydl(int), op_undoc_rb2iydl(int);
+static int op_undoc_rb3iydl(int), op_undoc_rb4iydl(int), op_undoc_rb5iydl(int);
+static int op_undoc_rb6iydl(int), op_undoc_rb7iydl(int);
+static int op_undoc_sb0iyda(int), op_undoc_sb1iyda(int), op_undoc_sb2iyda(int);
+static int op_undoc_sb3iyda(int), op_undoc_sb4iyda(int), op_undoc_sb5iyda(int);
+static int op_undoc_sb6iyda(int), op_undoc_sb7iyda(int);
+static int op_undoc_sb0iydb(int), op_undoc_sb1iydb(int), op_undoc_sb2iydb(int);
+static int op_undoc_sb3iydb(int), op_undoc_sb4iydb(int), op_undoc_sb5iydb(int);
+static int op_undoc_sb6iydb(int), op_undoc_sb7iydb(int);
+static int op_undoc_sb0iydc(int), op_undoc_sb1iydc(int), op_undoc_sb2iydc(int);
+static int op_undoc_sb3iydc(int), op_undoc_sb4iydc(int), op_undoc_sb5iydc(int);
+static int op_undoc_sb6iydc(int), op_undoc_sb7iydc(int);
+static int op_undoc_sb0iydd(int), op_undoc_sb1iydd(int), op_undoc_sb2iydd(int);
+static int op_undoc_sb3iydd(int), op_undoc_sb4iydd(int), op_undoc_sb5iydd(int);
+static int op_undoc_sb6iydd(int), op_undoc_sb7iydd(int);
+static int op_undoc_sb0iyde(int), op_undoc_sb1iyde(int), op_undoc_sb2iyde(int);
+static int op_undoc_sb3iyde(int), op_undoc_sb4iyde(int), op_undoc_sb5iyde(int);
+static int op_undoc_sb6iyde(int), op_undoc_sb7iyde(int);
+static int op_undoc_sb0iydh(int), op_undoc_sb1iydh(int), op_undoc_sb2iydh(int);
+static int op_undoc_sb3iydh(int), op_undoc_sb4iydh(int), op_undoc_sb5iydh(int);
+static int op_undoc_sb6iydh(int), op_undoc_sb7iydh(int);
+static int op_undoc_sb0iydl(int), op_undoc_sb1iydl(int), op_undoc_sb2iydl(int);
+static int op_undoc_sb3iydl(int), op_undoc_sb4iydl(int), op_undoc_sb5iydl(int);
+static int op_undoc_sb6iydl(int), op_undoc_sb7iydl(int);
+static int op_undoc_rlciyda(int), op_undoc_rlciydb(int), op_undoc_rlciydc(int);
+static int op_undoc_rlciydd(int), op_undoc_rlciyde(int), op_undoc_rlciydh(int);
+static int op_undoc_rlciydl(int);
+static int op_undoc_rrciyda(int), op_undoc_rrciydb(int), op_undoc_rrciydc(int);
+static int op_undoc_rrciydd(int), op_undoc_rrciyde(int), op_undoc_rrciydh(int);
+static int op_undoc_rrciydl(int);
+static int op_undoc_rliyda(int), op_undoc_rliydb(int), op_undoc_rliydc(int);
+static int op_undoc_rliydd(int), op_undoc_rliyde(int), op_undoc_rliydh(int);
+static int op_undoc_rliydl(int);
+static int op_undoc_rriyda(int), op_undoc_rriydb(int), op_undoc_rriydc(int);
+static int op_undoc_rriydd(int), op_undoc_rriyde(int), op_undoc_rriydh(int);
+static int op_undoc_rriydl(int);
+static int op_undoc_slaiyda(int), op_undoc_slaiydb(int), op_undoc_slaiydc(int);
+static int op_undoc_slaiydd(int), op_undoc_slaiyde(int), op_undoc_slaiydh(int);
+static int op_undoc_slaiydl(int);
+static int op_undoc_sraiyda(int), op_undoc_sraiydb(int), op_undoc_sraiydc(int);
+static int op_undoc_sraiydd(int), op_undoc_sraiyde(int), op_undoc_sraiydh(int);
+static int op_undoc_sraiydl(int);
+static int op_undoc_slliyda(int), op_undoc_slliydb(int), op_undoc_slliydc(int);
+static int op_undoc_slliydd(int), op_undoc_slliyde(int), op_undoc_slliydh(int);
+static int op_undoc_slliydl(int), op_undoc_slliyd(int);
+static int op_undoc_srliyda(int), op_undoc_srliydb(int), op_undoc_srliydc(int);
+static int op_undoc_srliydd(int), op_undoc_srliyde(int), op_undoc_srliydh(int);
+static int op_undoc_srliydl(int);
 #endif
 
 int op_fdcb_handel(void)
 {
 	static int (*op_fdcb[256]) () = {
-		trap_fdcb,			/* 0x00 */
-		trap_fdcb,			/* 0x01 */
-		trap_fdcb,			/* 0x02 */
-		trap_fdcb,			/* 0x03 */
-		trap_fdcb,			/* 0x04 */
-		trap_fdcb,			/* 0x05 */
+		UNDOC(op_undoc_rlciydb),	/* 0x00 */
+		UNDOC(op_undoc_rlciydc),	/* 0x01 */
+		UNDOC(op_undoc_rlciydd),	/* 0x02 */
+		UNDOC(op_undoc_rlciyde),	/* 0x03 */
+		UNDOC(op_undoc_rlciydh),	/* 0x04 */
+		UNDOC(op_undoc_rlciydl),	/* 0x05 */
 		op_rlciyd,			/* 0x06 */
-		trap_fdcb,			/* 0x07 */
-		trap_fdcb,			/* 0x08 */
-		trap_fdcb,			/* 0x09 */
-		trap_fdcb,			/* 0x0a */
-		trap_fdcb,			/* 0x0b */
-		trap_fdcb,			/* 0x0c */
-		trap_fdcb,			/* 0x0d */
+		UNDOC(op_undoc_rlciyda),	/* 0x07 */
+		UNDOC(op_undoc_rrciydb),	/* 0x08 */
+		UNDOC(op_undoc_rrciydc),	/* 0x09 */
+		UNDOC(op_undoc_rrciydd),	/* 0x0a */
+		UNDOC(op_undoc_rrciyde),	/* 0x0b */
+		UNDOC(op_undoc_rrciydh),	/* 0x0c */
+		UNDOC(op_undoc_rrciydl),	/* 0x0d */
 		op_rrciyd,			/* 0x0e */
-		trap_fdcb,			/* 0x0f */
-		trap_fdcb,			/* 0x10 */
-		trap_fdcb,			/* 0x11 */
-		trap_fdcb,			/* 0x12 */
-		trap_fdcb,			/* 0x13 */
-		trap_fdcb,			/* 0x14 */
-		trap_fdcb,			/* 0x15 */
+		UNDOC(op_undoc_rrciyda),	/* 0x0f */
+		UNDOC(op_undoc_rliydb),		/* 0x10 */
+		UNDOC(op_undoc_rliydc),		/* 0x11 */
+		UNDOC(op_undoc_rliydd),		/* 0x12 */
+		UNDOC(op_undoc_rliyde),		/* 0x13 */
+		UNDOC(op_undoc_rliydh),		/* 0x14 */
+		UNDOC(op_undoc_rliydl),		/* 0x15 */
 		op_rliyd,			/* 0x16 */
-		trap_fdcb,			/* 0x17 */
-		trap_fdcb,			/* 0x18 */
-		trap_fdcb,			/* 0x19 */
-		trap_fdcb,			/* 0x1a */
-		trap_fdcb,			/* 0x1b */
-		trap_fdcb,			/* 0x1c */
-		trap_fdcb,			/* 0x1d */
+		UNDOC(op_undoc_rliyda),		/* 0x17 */
+		UNDOC(op_undoc_rriydb),		/* 0x18 */
+		UNDOC(op_undoc_rriydc),		/* 0x19 */
+		UNDOC(op_undoc_rriydd),		/* 0x1a */
+		UNDOC(op_undoc_rriyde),		/* 0x1b */
+		UNDOC(op_undoc_rriydh),		/* 0x1c */
+		UNDOC(op_undoc_rriydl),		/* 0x1d */
 		op_rriyd,			/* 0x1e */
-		trap_fdcb,			/* 0x1f */
-		trap_fdcb,			/* 0x20 */
-		trap_fdcb,			/* 0x21 */
-		trap_fdcb,			/* 0x22 */
-		trap_fdcb,			/* 0x23 */
-		trap_fdcb,			/* 0x24 */
-		trap_fdcb,			/* 0x25 */
+		UNDOC(op_undoc_rriyda),		/* 0x1f */
+		UNDOC(op_undoc_slaiydb),	/* 0x20 */
+		UNDOC(op_undoc_slaiydc),	/* 0x21 */
+		UNDOC(op_undoc_slaiydd),	/* 0x22 */
+		UNDOC(op_undoc_slaiyde),	/* 0x23 */
+		UNDOC(op_undoc_slaiydh),	/* 0x24 */
+		UNDOC(op_undoc_slaiydl),	/* 0x25 */
 		op_slaiyd,			/* 0x26 */
-		trap_fdcb,			/* 0x27 */
-		trap_fdcb,			/* 0x28 */
-		trap_fdcb,			/* 0x29 */
-		trap_fdcb,			/* 0x2a */
-		trap_fdcb,			/* 0x2b */
-		trap_fdcb,			/* 0x2c */
-		trap_fdcb,			/* 0x2d */
+		UNDOC(op_undoc_slaiyda),	/* 0x27 */
+		UNDOC(op_undoc_sraiydb),	/* 0x28 */
+		UNDOC(op_undoc_sraiydc),	/* 0x29 */
+		UNDOC(op_undoc_sraiydd),	/* 0x2a */
+		UNDOC(op_undoc_sraiyde),	/* 0x2b */
+		UNDOC(op_undoc_sraiydh),	/* 0x2c */
+		UNDOC(op_undoc_sraiydl),	/* 0x2d */
 		op_sraiyd,			/* 0x2e */
-		trap_fdcb,			/* 0x2f */
-		trap_fdcb,			/* 0x30 */
-		trap_fdcb,			/* 0x31 */
-		trap_fdcb,			/* 0x32 */
-		trap_fdcb,			/* 0x33 */
-		trap_fdcb,			/* 0x34 */
-		trap_fdcb,			/* 0x35 */
+		UNDOC(op_undoc_sraiyda),	/* 0x2f */
+		UNDOC(op_undoc_slliydb),	/* 0x30 */
+		UNDOC(op_undoc_slliydc),	/* 0x31 */
+		UNDOC(op_undoc_slliydd),	/* 0x32 */
+		UNDOC(op_undoc_slliyde),	/* 0x33 */
+		UNDOC(op_undoc_slliydh),	/* 0x34 */
+		UNDOC(op_undoc_slliydl),	/* 0x35 */
 		UNDOC(op_undoc_slliyd),		/* 0x36 */
-		trap_fdcb,			/* 0x37 */
-		trap_fdcb,			/* 0x38 */
-		trap_fdcb,			/* 0x39 */
-		trap_fdcb,			/* 0x3a */
-		trap_fdcb,			/* 0x3b */
-		trap_fdcb,			/* 0x3c */
-		trap_fdcb,			/* 0x3d */
+		UNDOC(op_undoc_slliyda),	/* 0x37 */
+		UNDOC(op_undoc_srliydb),	/* 0x38 */
+		UNDOC(op_undoc_srliydc),	/* 0x39 */
+		UNDOC(op_undoc_srliydd),	/* 0x3a */
+		UNDOC(op_undoc_srliyde),	/* 0x3b */
+		UNDOC(op_undoc_srliydh),	/* 0x3c */
+		UNDOC(op_undoc_srliydl),	/* 0x3d */
 		op_srliyd,			/* 0x3e */
-		trap_fdcb,			/* 0x3f */
-		trap_fdcb,			/* 0x40 */
-		trap_fdcb,			/* 0x41 */
-		trap_fdcb,			/* 0x42 */
-		trap_fdcb,			/* 0x43 */
-		trap_fdcb,			/* 0x44 */
-		trap_fdcb,			/* 0x45 */
+		UNDOC(op_undoc_srliyda),	/* 0x3f */
+		UNDOC(op_undoc_tb0iyd),		/* 0x40 */
+		UNDOC(op_undoc_tb0iyd),		/* 0x41 */
+		UNDOC(op_undoc_tb0iyd),		/* 0x42 */
+		UNDOC(op_undoc_tb0iyd),		/* 0x43 */
+		UNDOC(op_undoc_tb0iyd),		/* 0x44 */
+		UNDOC(op_undoc_tb0iyd),		/* 0x45 */
 		op_tb0iyd,			/* 0x46 */
-		trap_fdcb,			/* 0x47 */
-		trap_fdcb,			/* 0x48 */
-		trap_fdcb,			/* 0x49 */
-		trap_fdcb,			/* 0x4a */
-		trap_fdcb,			/* 0x4b */
-		trap_fdcb,			/* 0x4c */
-		trap_fdcb,			/* 0x4d */
+		UNDOC(op_undoc_tb0iyd),		/* 0x47 */
+		UNDOC(op_undoc_tb1iyd),		/* 0x48 */
+		UNDOC(op_undoc_tb1iyd),		/* 0x49 */
+		UNDOC(op_undoc_tb1iyd),		/* 0x4a */
+		UNDOC(op_undoc_tb1iyd),		/* 0x4b */
+		UNDOC(op_undoc_tb1iyd),		/* 0x4c */
+		UNDOC(op_undoc_tb1iyd),		/* 0x4d */
 		op_tb1iyd,			/* 0x4e */
-		trap_fdcb,			/* 0x4f */
-		trap_fdcb,			/* 0x50 */
-		trap_fdcb,			/* 0x51 */
-		trap_fdcb,			/* 0x52 */
-		trap_fdcb,			/* 0x53 */
-		trap_fdcb,			/* 0x54 */
-		trap_fdcb,			/* 0x55 */
+		UNDOC(op_undoc_tb1iyd),		/* 0x4f */
+		UNDOC(op_undoc_tb2iyd),		/* 0x50 */
+		UNDOC(op_undoc_tb2iyd),		/* 0x51 */
+		UNDOC(op_undoc_tb2iyd),		/* 0x52 */
+		UNDOC(op_undoc_tb2iyd),		/* 0x53 */
+		UNDOC(op_undoc_tb2iyd),		/* 0x54 */
+		UNDOC(op_undoc_tb2iyd),		/* 0x55 */
 		op_tb2iyd,			/* 0x56 */
-		trap_fdcb,			/* 0x57 */
-		trap_fdcb,			/* 0x58 */
-		trap_fdcb,			/* 0x59 */
-		trap_fdcb,			/* 0x5a */
-		trap_fdcb,			/* 0x5b */
-		trap_fdcb,			/* 0x5c */
-		trap_fdcb,			/* 0x5d */
+		UNDOC(op_undoc_tb2iyd),		/* 0x57 */
+		UNDOC(op_undoc_tb3iyd),		/* 0x58 */
+		UNDOC(op_undoc_tb3iyd),		/* 0x59 */
+		UNDOC(op_undoc_tb3iyd),		/* 0x5a */
+		UNDOC(op_undoc_tb3iyd),		/* 0x5b */
+		UNDOC(op_undoc_tb3iyd),		/* 0x5c */
+		UNDOC(op_undoc_tb3iyd),		/* 0x5d */
 		op_tb3iyd,			/* 0x5e */
-		trap_fdcb,			/* 0x5f */
-		trap_fdcb,			/* 0x60 */
-		trap_fdcb,			/* 0x61 */
-		trap_fdcb,			/* 0x62 */
-		trap_fdcb,			/* 0x63 */
-		trap_fdcb,			/* 0x64 */
-		trap_fdcb,			/* 0x65 */
+		UNDOC(op_undoc_tb3iyd),		/* 0x5f */
+		UNDOC(op_undoc_tb4iyd),		/* 0x60 */
+		UNDOC(op_undoc_tb4iyd),		/* 0x61 */
+		UNDOC(op_undoc_tb4iyd),		/* 0x62 */
+		UNDOC(op_undoc_tb4iyd),		/* 0x63 */
+		UNDOC(op_undoc_tb4iyd),		/* 0x64 */
+		UNDOC(op_undoc_tb4iyd),		/* 0x65 */
 		op_tb4iyd,			/* 0x66 */
-		trap_fdcb,			/* 0x67 */
-		trap_fdcb,			/* 0x68 */
-		trap_fdcb,			/* 0x69 */
-		trap_fdcb,			/* 0x6a */
-		trap_fdcb,			/* 0x6b */
-		trap_fdcb,			/* 0x6c */
-		trap_fdcb,			/* 0x6d */
+		UNDOC(op_undoc_tb4iyd),		/* 0x67 */
+		UNDOC(op_undoc_tb5iyd),		/* 0x68 */
+		UNDOC(op_undoc_tb5iyd),		/* 0x69 */
+		UNDOC(op_undoc_tb5iyd),		/* 0x6a */
+		UNDOC(op_undoc_tb5iyd),		/* 0x6b */
+		UNDOC(op_undoc_tb5iyd),		/* 0x6c */
+		UNDOC(op_undoc_tb5iyd),		/* 0x6d */
 		op_tb5iyd,			/* 0x6e */
-		trap_fdcb,			/* 0x6f */
-		trap_fdcb,			/* 0x70 */
-		trap_fdcb,			/* 0x71 */
-		trap_fdcb,			/* 0x72 */
-		trap_fdcb,			/* 0x73 */
-		trap_fdcb,			/* 0x74 */
-		trap_fdcb,			/* 0x75 */
+		UNDOC(op_undoc_tb5iyd),		/* 0x6f */
+		UNDOC(op_undoc_tb6iyd),		/* 0x70 */
+		UNDOC(op_undoc_tb6iyd),		/* 0x71 */
+		UNDOC(op_undoc_tb6iyd),		/* 0x72 */
+		UNDOC(op_undoc_tb6iyd),		/* 0x73 */
+		UNDOC(op_undoc_tb6iyd),		/* 0x74 */
+		UNDOC(op_undoc_tb6iyd),		/* 0x75 */
 		op_tb6iyd,			/* 0x76 */
-		trap_fdcb,			/* 0x77 */
-		trap_fdcb,			/* 0x78 */
-		trap_fdcb,			/* 0x79 */
-		trap_fdcb,			/* 0x7a */
-		trap_fdcb,			/* 0x7b */
-		trap_fdcb,			/* 0x7c */
-		trap_fdcb,			/* 0x7d */
+		UNDOC(op_undoc_tb6iyd),		/* 0x77 */
+		UNDOC(op_undoc_tb7iyd),		/* 0x78 */
+		UNDOC(op_undoc_tb7iyd),		/* 0x79 */
+		UNDOC(op_undoc_tb7iyd),		/* 0x7a */
+		UNDOC(op_undoc_tb7iyd),		/* 0x7b */
+		UNDOC(op_undoc_tb7iyd),		/* 0x7c */
+		UNDOC(op_undoc_tb7iyd),		/* 0x7d */
 		op_tb7iyd,			/* 0x7e */
-		trap_fdcb,			/* 0x7f */
-		trap_fdcb,			/* 0x80 */
-		trap_fdcb,			/* 0x81 */
-		trap_fdcb,			/* 0x82 */
-		trap_fdcb,			/* 0x83 */
-		trap_fdcb,			/* 0x84 */
-		trap_fdcb,			/* 0x85 */
+		UNDOC(op_undoc_tb7iyd),		/* 0x7f */
+		UNDOC(op_undoc_rb0iydb),	/* 0x80 */
+		UNDOC(op_undoc_rb0iydc),	/* 0x81 */
+		UNDOC(op_undoc_rb0iydd),	/* 0x82 */
+		UNDOC(op_undoc_rb0iyde),	/* 0x83 */
+		UNDOC(op_undoc_rb0iydh),	/* 0x84 */
+		UNDOC(op_undoc_rb0iydl),	/* 0x85 */
 		op_rb0iyd,			/* 0x86 */
-		trap_fdcb,			/* 0x87 */
-		trap_fdcb,			/* 0x88 */
-		trap_fdcb,			/* 0x89 */
-		trap_fdcb,			/* 0x8a */
-		trap_fdcb,			/* 0x8b */
-		trap_fdcb,			/* 0x8c */
-		trap_fdcb,			/* 0x8d */
+		UNDOC(op_undoc_rb0iyda),	/* 0x87 */
+		UNDOC(op_undoc_rb1iydb),	/* 0x88 */
+		UNDOC(op_undoc_rb1iydc),	/* 0x89 */
+		UNDOC(op_undoc_rb1iydd),	/* 0x8a */
+		UNDOC(op_undoc_rb1iyde),	/* 0x8b */
+		UNDOC(op_undoc_rb1iydh),	/* 0x8c */
+		UNDOC(op_undoc_rb1iydl),	/* 0x8d */
 		op_rb1iyd,			/* 0x8e */
-		trap_fdcb,			/* 0x8f */
-		trap_fdcb,			/* 0x90 */
-		trap_fdcb,			/* 0x91 */
-		trap_fdcb,			/* 0x92 */
-		trap_fdcb,			/* 0x93 */
-		trap_fdcb,			/* 0x94 */
-		trap_fdcb,			/* 0x95 */
+		UNDOC(op_undoc_rb1iyda),	/* 0x8f */
+		UNDOC(op_undoc_rb2iydb),	/* 0x90 */
+		UNDOC(op_undoc_rb2iydc),	/* 0x91 */
+		UNDOC(op_undoc_rb2iydd),	/* 0x92 */
+		UNDOC(op_undoc_rb2iyde),	/* 0x93 */
+		UNDOC(op_undoc_rb2iydh),	/* 0x94 */
+		UNDOC(op_undoc_rb2iydl),	/* 0x95 */
 		op_rb2iyd,			/* 0x96 */
-		trap_fdcb,			/* 0x97 */
-		trap_fdcb,			/* 0x98 */
-		trap_fdcb,			/* 0x99 */
-		trap_fdcb,			/* 0x9a */
-		trap_fdcb,			/* 0x9b */
-		trap_fdcb,			/* 0x9c */
-		trap_fdcb,			/* 0x9d */
+		UNDOC(op_undoc_rb2iyda),	/* 0x97 */
+		UNDOC(op_undoc_rb3iydb),	/* 0x98 */
+		UNDOC(op_undoc_rb3iydc),	/* 0x99 */
+		UNDOC(op_undoc_rb3iydd),	/* 0x9a */
+		UNDOC(op_undoc_rb3iyde),	/* 0x9b */
+		UNDOC(op_undoc_rb3iydh),	/* 0x9c */
+		UNDOC(op_undoc_rb3iydl),	/* 0x9d */
 		op_rb3iyd,			/* 0x9e */
-		trap_fdcb,			/* 0x9f */
-		trap_fdcb,			/* 0xa0 */
-		trap_fdcb,			/* 0xa1 */
-		trap_fdcb,			/* 0xa2 */
-		trap_fdcb,			/* 0xa3 */
-		trap_fdcb,			/* 0xa4 */
-		trap_fdcb,			/* 0xa5 */
+		UNDOC(op_undoc_rb3iyda),	/* 0x9f */
+		UNDOC(op_undoc_rb4iydb),	/* 0xa0 */
+		UNDOC(op_undoc_rb4iydc),	/* 0xa1 */
+		UNDOC(op_undoc_rb4iydd),	/* 0xa2 */
+		UNDOC(op_undoc_rb4iyde),	/* 0xa3 */
+		UNDOC(op_undoc_rb4iydh),	/* 0xa4 */
+		UNDOC(op_undoc_rb4iydl),	/* 0xa5 */
 		op_rb4iyd,			/* 0xa6 */
-		trap_fdcb,			/* 0xa7 */
-		trap_fdcb,			/* 0xa8 */
-		trap_fdcb,			/* 0xa9 */
-		trap_fdcb,			/* 0xaa */
-		trap_fdcb,			/* 0xab */
-		trap_fdcb,			/* 0xac */
-		trap_fdcb,			/* 0xad */
+		UNDOC(op_undoc_rb4iyda),	/* 0xa7 */
+		UNDOC(op_undoc_rb5iydb),	/* 0xa8 */
+		UNDOC(op_undoc_rb5iydc),	/* 0xa9 */
+		UNDOC(op_undoc_rb5iydd),	/* 0xaa */
+		UNDOC(op_undoc_rb5iyde),	/* 0xab */
+		UNDOC(op_undoc_rb5iydh),	/* 0xac */
+		UNDOC(op_undoc_rb5iydl),	/* 0xad */
 		op_rb5iyd,			/* 0xae */
-		trap_fdcb,			/* 0xaf */
-		trap_fdcb,			/* 0xb0 */
-		trap_fdcb,			/* 0xb1 */
-		trap_fdcb,			/* 0xb2 */
-		trap_fdcb,			/* 0xb3 */
-		trap_fdcb,			/* 0xb4 */
-		trap_fdcb,			/* 0xb5 */
+		UNDOC(op_undoc_rb5iyda),	/* 0xaf */
+		UNDOC(op_undoc_rb6iydb),	/* 0xb0 */
+		UNDOC(op_undoc_rb6iydc),	/* 0xb1 */
+		UNDOC(op_undoc_rb6iydd),	/* 0xb2 */
+		UNDOC(op_undoc_rb6iyde),	/* 0xb3 */
+		UNDOC(op_undoc_rb6iydh),	/* 0xb4 */
+		UNDOC(op_undoc_rb6iydl),	/* 0xb5 */
 		op_rb6iyd,			/* 0xb6 */
-		trap_fdcb,			/* 0xb7 */
-		trap_fdcb,			/* 0xb8 */
-		trap_fdcb,			/* 0xb9 */
-		trap_fdcb,			/* 0xba */
-		trap_fdcb,			/* 0xbb */
-		trap_fdcb,			/* 0xbc */
-		trap_fdcb,			/* 0xbd */
+		UNDOC(op_undoc_rb6iyda),	/* 0xb7 */
+		UNDOC(op_undoc_rb7iydb),	/* 0xb8 */
+		UNDOC(op_undoc_rb7iydc),	/* 0xb9 */
+		UNDOC(op_undoc_rb7iydd),	/* 0xba */
+		UNDOC(op_undoc_rb7iyde),	/* 0xbb */
+		UNDOC(op_undoc_rb7iydh),	/* 0xbc */
+		UNDOC(op_undoc_rb7iydl),	/* 0xbd */
 		op_rb7iyd,			/* 0xbe */
-		trap_fdcb,			/* 0xbf */
-		trap_fdcb,			/* 0xc0 */
-		trap_fdcb,			/* 0xc1 */
-		trap_fdcb,			/* 0xc2 */
-		trap_fdcb,			/* 0xc3 */
-		trap_fdcb,			/* 0xc4 */
-		trap_fdcb,			/* 0xc5 */
+		UNDOC(op_undoc_rb7iyda),	/* 0xbf */
+		UNDOC(op_undoc_sb0iydb),	/* 0xc0 */
+		UNDOC(op_undoc_sb0iydc),	/* 0xc1 */
+		UNDOC(op_undoc_sb0iydd),	/* 0xc2 */
+		UNDOC(op_undoc_sb0iyde),	/* 0xc3 */
+		UNDOC(op_undoc_sb0iydh),	/* 0xc4 */
+		UNDOC(op_undoc_sb0iydl),	/* 0xc5 */
 		op_sb0iyd,			/* 0xc6 */
-		trap_fdcb,			/* 0xc7 */
-		trap_fdcb,			/* 0xc8 */
-		trap_fdcb,			/* 0xc9 */
-		trap_fdcb,			/* 0xca */
-		trap_fdcb,			/* 0xcb */
-		trap_fdcb,			/* 0xcc */
-		trap_fdcb,			/* 0xcd */
+		UNDOC(op_undoc_sb0iyda),	/* 0xc7 */
+		UNDOC(op_undoc_sb1iydb),	/* 0xc8 */
+		UNDOC(op_undoc_sb1iydc),	/* 0xc9 */
+		UNDOC(op_undoc_sb1iydd),	/* 0xca */
+		UNDOC(op_undoc_sb1iyde),	/* 0xcb */
+		UNDOC(op_undoc_sb1iydh),	/* 0xcc */
+		UNDOC(op_undoc_sb1iydl),	/* 0xcd */
 		op_sb1iyd,			/* 0xce */
-		trap_fdcb,			/* 0xcf */
-		trap_fdcb,			/* 0xd0 */
-		trap_fdcb,			/* 0xd1 */
-		trap_fdcb,			/* 0xd2 */
-		trap_fdcb,			/* 0xd3 */
-		trap_fdcb,			/* 0xd4 */
-		trap_fdcb,			/* 0xd5 */
+		UNDOC(op_undoc_sb1iyda),	/* 0xcf */
+		UNDOC(op_undoc_sb2iydb),	/* 0xd0 */
+		UNDOC(op_undoc_sb2iydc),	/* 0xd1 */
+		UNDOC(op_undoc_sb2iydd),	/* 0xd2 */
+		UNDOC(op_undoc_sb2iyde),	/* 0xd3 */
+		UNDOC(op_undoc_sb2iydh),	/* 0xd4 */
+		UNDOC(op_undoc_sb2iydl),	/* 0xd5 */
 		op_sb2iyd,			/* 0xd6 */
-		trap_fdcb,			/* 0xd7 */
-		trap_fdcb,			/* 0xd8 */
-		trap_fdcb,			/* 0xd9 */
-		trap_fdcb,			/* 0xda */
-		trap_fdcb,			/* 0xdb */
-		trap_fdcb,			/* 0xdc */
-		trap_fdcb,			/* 0xdd */
+		UNDOC(op_undoc_sb2iyda),	/* 0xd7 */
+		UNDOC(op_undoc_sb3iydb),	/* 0xd8 */
+		UNDOC(op_undoc_sb3iydc),	/* 0xd9 */
+		UNDOC(op_undoc_sb3iydd),	/* 0xda */
+		UNDOC(op_undoc_sb3iyde),	/* 0xdb */
+		UNDOC(op_undoc_sb3iydh),	/* 0xdc */
+		UNDOC(op_undoc_sb3iydl),	/* 0xdd */
 		op_sb3iyd,			/* 0xde */
-		trap_fdcb,			/* 0xdf */
-		trap_fdcb,			/* 0xe0 */
-		trap_fdcb,			/* 0xe1 */
-		trap_fdcb,			/* 0xe2 */
-		trap_fdcb,			/* 0xe3 */
-		trap_fdcb,			/* 0xe4 */
-		trap_fdcb,			/* 0xe5 */
+		UNDOC(op_undoc_sb3iyda),	/* 0xdf */
+		UNDOC(op_undoc_sb4iydb),	/* 0xe0 */
+		UNDOC(op_undoc_sb4iydc),	/* 0xe1 */
+		UNDOC(op_undoc_sb4iydd),	/* 0xe2 */
+		UNDOC(op_undoc_sb4iyde),	/* 0xe3 */
+		UNDOC(op_undoc_sb4iydh),	/* 0xe4 */
+		UNDOC(op_undoc_sb4iydl),	/* 0xe5 */
 		op_sb4iyd,			/* 0xe6 */
-		trap_fdcb,			/* 0xe7 */
-		trap_fdcb,			/* 0xe8 */
-		trap_fdcb,			/* 0xe9 */
-		trap_fdcb,			/* 0xea */
-		trap_fdcb,			/* 0xeb */
-		trap_fdcb,			/* 0xec */
-		trap_fdcb,			/* 0xed */
+		UNDOC(op_undoc_sb4iyda),	/* 0xe7 */
+		UNDOC(op_undoc_sb5iydb),	/* 0xe8 */
+		UNDOC(op_undoc_sb5iydc),	/* 0xe9 */
+		UNDOC(op_undoc_sb5iydd),	/* 0xea */
+		UNDOC(op_undoc_sb5iyde),	/* 0xeb */
+		UNDOC(op_undoc_sb5iydh),	/* 0xec */
+		UNDOC(op_undoc_sb5iydl),	/* 0xed */
 		op_sb5iyd,			/* 0xee */
-		trap_fdcb,			/* 0xef */
-		trap_fdcb,			/* 0xf0 */
-		trap_fdcb,			/* 0xf1 */
-		trap_fdcb,			/* 0xf2 */
-		trap_fdcb,			/* 0xf3 */
-		trap_fdcb,			/* 0xf4 */
-		trap_fdcb,			/* 0xf5 */
+		UNDOC(op_undoc_sb5iyda),	/* 0xef */
+		UNDOC(op_undoc_sb6iydb),	/* 0xf0 */
+		UNDOC(op_undoc_sb6iydc),	/* 0xf1 */
+		UNDOC(op_undoc_sb6iydd),	/* 0xf2 */
+		UNDOC(op_undoc_sb6iyde),	/* 0xf3 */
+		UNDOC(op_undoc_sb6iydh),	/* 0xf4 */
+		UNDOC(op_undoc_sb6iydl),	/* 0xf5 */
 		op_sb6iyd,			/* 0xf6 */
-		trap_fdcb,			/* 0xf7 */
-		trap_fdcb,			/* 0xf8 */
-		trap_fdcb,			/* 0xf9 */
-		trap_fdcb,			/* 0xfa */
-		trap_fdcb,			/* 0xfb */
-		trap_fdcb,			/* 0xfc */
-		trap_fdcb,			/* 0xfd */
+		UNDOC(op_undoc_sb6iyda),	/* 0xf7 */
+		UNDOC(op_undoc_sb7iydb),	/* 0xf8 */
+		UNDOC(op_undoc_sb7iydc),	/* 0xf9 */
+		UNDOC(op_undoc_sb7iydd),	/* 0xfa */
+		UNDOC(op_undoc_sb7iyde),	/* 0xfb */
+		UNDOC(op_undoc_sb7iydh),	/* 0xfc */
+		UNDOC(op_undoc_sb7iydl),	/* 0xfd */
 		op_sb7iyd,			/* 0xfe */
-		trap_fdcb			/* 0xff */
+		UNDOC(op_undoc_sb7iyda)		/* 0xff */
 	};
 
 	register int d;
@@ -673,6 +742,2557 @@ static int op_srliyd(int data)		/* SRL (IY+d) */
 
 #ifdef Z80_UNDOC
 
+static int op_undoc_tb0iyd(int data)	/* BIT 0,(IY+d) */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	return(op_tb0iyd(data));
+}
+
+static int op_undoc_tb1iyd(int data)	/* BIT 1,(IY+d) */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	return(op_tb1iyd(data));
+}
+
+static int op_undoc_tb2iyd(int data)	/* BIT 2,(IY+d) */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	return(op_tb2iyd(data));
+}
+
+static int op_undoc_tb3iyd(int data)	/* BIT 3,(IY+d) */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	return(op_tb3iyd(data));
+}
+
+static int op_undoc_tb4iyd(int data)	/* BIT 4,(IY+d) */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	return(op_tb4iyd(data));
+}
+
+static int op_undoc_tb5iyd(int data)	/* BIT 5,(IY+d) */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	return(op_tb5iyd(data));
+}
+
+static int op_undoc_tb6iyd(int data)	/* BIT 6,(IY+d) */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	return(op_tb6iyd(data));
+}
+
+static int op_undoc_tb7iyd(int data)	/* BIT 7,(IY+d) */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	return(op_tb7iyd(data));
+}
+
+static int op_undoc_rb0iyda(int data)	/* RES 0,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) & ~1;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_rb1iyda(int data)	/* RES 1,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) & ~2;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_rb2iyda(int data)	/* RES 2,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) & ~4;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_rb3iyda(int data)	/* RES 3,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) & ~8;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_rb4iyda(int data)	/* RES 4,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) & ~16;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_rb5iyda(int data)	/* RES 5,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) & ~32;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_rb6iyda(int data)	/* RES 6,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) & ~64;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_rb7iyda(int data)	/* RES 7,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) & ~128;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_rb0iydb(int data)	/* RES 0,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) & ~1;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_rb1iydb(int data)	/* RES 1,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) & ~2;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_rb2iydb(int data)	/* RES 2,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) & ~4;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_rb3iydb(int data)	/* RES 3,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) & ~8;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_rb4iydb(int data)	/* RES 4,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) & ~16;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_rb5iydb(int data)	/* RES 5,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) & ~32;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_rb6iydb(int data)	/* RES 6,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) & ~64;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_rb7iydb(int data)	/* RES 7,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) & ~128;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_rb0iydc(int data)	/* RES 0,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) & ~1;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_rb1iydc(int data)	/* RES 1,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) & ~2;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_rb2iydc(int data)	/* RES 2,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) & ~4;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_rb3iydc(int data)	/* RES 3,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) & ~8;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_rb4iydc(int data)	/* RES 4,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) & ~16;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_rb5iydc(int data)	/* RES 5,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) & ~32;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_rb6iydc(int data)	/* RES 6,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) & ~64;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_rb7iydc(int data)	/* RES 7,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) & ~128;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_rb0iydd(int data)	/* RES 0,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) & ~1;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_rb1iydd(int data)	/* RES 1,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) & ~2;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_rb2iydd(int data)	/* RES 2,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) & ~4;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_rb3iydd(int data)	/* RES 3,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) & ~8;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_rb4iydd(int data)	/* RES 4,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) & ~16;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_rb5iydd(int data)	/* RES 5,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) & ~32;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_rb6iydd(int data)	/* RES 6,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) & ~64;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_rb7iydd(int data)	/* RES 7,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) & ~128;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_rb0iyde(int data)	/* RES 0,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) & ~1;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_rb1iyde(int data)	/* RES 1,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) & ~2;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_rb2iyde(int data)	/* RES 2,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) & ~4;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_rb3iyde(int data)	/* RES 3,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) & ~8;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_rb4iyde(int data)	/* RES 4,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) & ~16;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_rb5iyde(int data)	/* RES 5,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) & ~32;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_rb6iyde(int data)	/* RES 6,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) & ~64;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_rb7iyde(int data)	/* RES 7,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) & ~128;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_rb0iydh(int data)	/* RES 0,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) & ~1;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_rb1iydh(int data)	/* RES 1,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) & ~2;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_rb2iydh(int data)	/* RES 2,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) & ~4;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_rb3iydh(int data)	/* RES 3,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) & ~8;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_rb4iydh(int data)	/* RES 4,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) & ~16;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_rb5iydh(int data)	/* RES 5,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) & ~32;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_rb6iydh(int data)	/* RES 6,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) & ~64;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_rb7iydh(int data)	/* RES 7,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) & ~128;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_rb0iydl(int data)	/* RES 0,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) & ~1;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_rb1iydl(int data)	/* RES 1,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) & ~2;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_rb2iydl(int data)	/* RES 2,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) & ~4;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_rb3iydl(int data)	/* RES 3,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) & ~8;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_rb4iydl(int data)	/* RES 4,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) & ~16;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_rb5iydl(int data)	/* RES 5,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) & ~32;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_rb6iydl(int data)	/* RES 6,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) & ~64;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_rb7iydl(int data)	/* RES 7,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) & ~128;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_sb0iyda(int data)	/* SET 0,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) | 1;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_sb1iyda(int data)	/* SET 1,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) | 2;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_sb2iyda(int data)	/* SET 2,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) | 4;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_sb3iyda(int data)	/* SET 3,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) | 8;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_sb4iyda(int data)	/* SET 4,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) | 16;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_sb5iyda(int data)	/* SET 5,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) | 32;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_sb6iyda(int data)	/* SET 6,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) | 64;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_sb7iyda(int data)	/* SET 7,(IY+d),A */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	A = memrdr(IY + data) | 128;
+	memwrt(IY + data, A);
+	return(23);
+}
+
+static int op_undoc_sb0iydb(int data)	/* SET 0,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) | 1;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_sb1iydb(int data)	/* SET 1,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) | 2;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_sb2iydb(int data)	/* SET 2,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) | 4;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_sb3iydb(int data)	/* SET 3,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) | 8;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_sb4iydb(int data)	/* SET 4,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) | 16;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_sb5iydb(int data)	/* SET 5,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) | 32;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_sb6iydb(int data)	/* SET 6,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) | 64;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_sb7iydb(int data)	/* SET 7,(IY+d),B */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	B = memrdr(IY + data) | 128;
+	memwrt(IY + data, B);
+	return(23);
+}
+
+static int op_undoc_sb0iydc(int data)	/* SET 0,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) | 1;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_sb1iydc(int data)	/* SET 1,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) | 2;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_sb2iydc(int data)	/* SET 2,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) | 4;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_sb3iydc(int data)	/* SET 3,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) | 8;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_sb4iydc(int data)	/* SET 4,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) | 16;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_sb5iydc(int data)	/* SET 5,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) | 32;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_sb6iydc(int data)	/* SET 6,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) | 64;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_sb7iydc(int data)	/* SET 7,(IY+d),C */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	C = memrdr(IY + data) | 128;
+	memwrt(IY + data, C);
+	return(23);
+}
+
+static int op_undoc_sb0iydd(int data)	/* SET 0,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) | 1;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_sb1iydd(int data)	/* SET 1,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) | 2;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_sb2iydd(int data)	/* SET 2,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) | 4;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_sb3iydd(int data)	/* SET 3,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) | 8;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_sb4iydd(int data)	/* SET 4,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) | 16;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_sb5iydd(int data)	/* SET 5,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) | 32;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_sb6iydd(int data)	/* SET 6,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) | 64;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_sb7iydd(int data)	/* SET 7,(IY+d),D */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	D = memrdr(IY + data) | 128;
+	memwrt(IY + data, D);
+	return(23);
+}
+
+static int op_undoc_sb0iyde(int data)	/* SET 0,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) | 1;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_sb1iyde(int data)	/* SET 1,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) | 2;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_sb2iyde(int data)	/* SET 2,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) | 4;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_sb3iyde(int data)	/* SET 3,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) | 8;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_sb4iyde(int data)	/* SET 4,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) | 16;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_sb5iyde(int data)	/* SET 5,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) | 32;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_sb6iyde(int data)	/* SET 6,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) | 64;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_sb7iyde(int data)	/* SET 7,(IY+d),E */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	E = memrdr(IY + data) | 128;
+	memwrt(IY + data, E);
+	return(23);
+}
+
+static int op_undoc_sb0iydh(int data)	/* SET 0,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) | 1;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_sb1iydh(int data)	/* SET 1,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) | 2;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_sb2iydh(int data)	/* SET 2,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) | 4;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_sb3iydh(int data)	/* SET 3,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) | 8;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_sb4iydh(int data)	/* SET 4,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) | 16;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_sb5iydh(int data)	/* SET 5,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) | 32;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_sb6iydh(int data)	/* SET 6,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) | 64;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_sb7iydh(int data)	/* SET 7,(IY+d),H */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	H = memrdr(IY + data) | 128;
+	memwrt(IY + data, H);
+	return(23);
+}
+
+static int op_undoc_sb0iydl(int data)	/* SET 0,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) | 1;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_sb1iydl(int data)	/* SET 1,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) | 2;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_sb2iydl(int data)	/* SET 2,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) | 4;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_sb3iydl(int data)	/* SET 3,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) | 8;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_sb4iydl(int data)	/* SET 4,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) | 16;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_sb5iydl(int data)	/* SET 5,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) | 32;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_sb6iydl(int data)	/* SET 6,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) | 64;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_sb7iydl(int data)	/* SET 7,(IY+d),L */
+{
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	L = memrdr(IY + data) | 128;
+	memwrt(IY + data, L);
+	return(23);
+}
+
+static int op_undoc_rlciyda(int data)	/* RLC (IY+d),A */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	A = memrdr(addr);
+	i = A & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A <<= 1;
+	if (i) A |= 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlciydb(int data)	/* RLC (IY+d),B */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	B = memrdr(addr);
+	i = B & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B <<= 1;
+	if (i) B |= 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlciydc(int data)	/* RLC (IY+d),C */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	C = memrdr(addr);
+	i = C & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C <<= 1;
+	if (i) C |= 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlciydd(int data)	/* RLC (IY+d),D */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	D = memrdr(addr);
+	i = D & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D <<= 1;
+	if (i) D |= 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlciyde(int data)	/* RLC (IY+d),E */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	E = memrdr(addr);
+	i = E & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E <<= 1;
+	if (i) E |= 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlciydh(int data)	/* RLC (IY+d),H */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	H = memrdr(addr);
+	i = H & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H <<= 1;
+	if (i) H |= 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rlciydl(int data)	/* RLC (IY+d),L */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	L = memrdr(addr);
+	i = L & 128;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L <<= 1;
+	if (i) L |= 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrciyda(int data)	/* RRC (IY+d),A */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	A = memrdr(addr);
+	i = A & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A >>= 1;
+	if (i) A |= 128;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrciydb(int data)	/* RRC (IY+d),B */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	B = memrdr(addr);
+	i = B & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B >>= 1;
+	if (i) B |= 128;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrciydc(int data)	/* RRC (IY+d),C */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	C = memrdr(addr);
+	i = C & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C >>= 1;
+	if (i) C |= 128;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrciydd(int data)	/* RRC (IY+d),D */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	D = memrdr(addr);
+	i = D & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D >>= 1;
+	if (i) D |= 128;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrciyde(int data)	/* RRC (IY+d),E */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	E = memrdr(addr);
+	i = E & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E >>= 1;
+	if (i) E |= 128;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrciydh(int data)	/* RRC (IY+d),H */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	H = memrdr(addr);
+	i = H & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H >>= 1;
+	if (i) H |= 128;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rrciydl(int data)	/* RRC (IY+d),L */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	L = memrdr(addr);
+	i = L & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L >>= 1;
+	if (i) L |= 128;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rliyda(int data)	/* RL (IY+d),A */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	A = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A <<= 1;
+	if (old_c_flag) A |= 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rliydb(int data)	/* RL (IY+d),B */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	B = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B <<= 1;
+	if (old_c_flag) B |= 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rliydc(int data)	/* RL (IY+d),C */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	C = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C <<= 1;
+	if (old_c_flag) C |= 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rliydd(int data)	/* RL (IY+d),D */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	D = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D <<= 1;
+	if (old_c_flag) D |= 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rliyde(int data)	/* RL (IY+d),E */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	E = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E <<= 1;
+	if (old_c_flag) E |= 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rliydh(int data)	/* RL (IY+d),H */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	H = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H <<= 1;
+	if (old_c_flag) H |= 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rliydl(int data)	/* RL (IY+d),L */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	L = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L <<= 1;
+	if (old_c_flag) L |= 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rriyda(int data)	/* RR (IY+d),A */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	A = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(A & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A >>= 1;
+	if (old_c_flag) A |= 128;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rriydb(int data)	/* RR (IY+d),B */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	B = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(B & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B >>= 1;
+	if (old_c_flag) B |= 128;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rriydc(int data)	/* RR (IY+d),C */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	C = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(C & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C >>= 1;
+	if (old_c_flag) C |= 128;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rriydd(int data)	/* RR (IY+d),D */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	D = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(D & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D >>= 1;
+	if (old_c_flag) D |= 128;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rriyde(int data)	/* RR (IY+d),E */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	E = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(E & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E >>= 1;
+	if (old_c_flag) E |= 128;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rriydh(int data)	/* RR (IY+d),H */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	H = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(H & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H >>= 1;
+	if (old_c_flag) H |= 128;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_rriydl(int data)	/* RR (IY+d),L */
+{
+	WORD addr;
+	int old_c_flag;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	L = memrdr(addr);
+	old_c_flag = F & C_FLAG;
+	(L & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L >>= 1;
+	if (old_c_flag) L |= 128;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaiyda(int data)	/* SLA (IY+d),A */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	A = memrdr(addr);
+	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A <<= 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaiydb(int data)	/* SLA (IY+d),B */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	B = memrdr(addr);
+	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B <<= 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaiydc(int data)	/* SLA (IY+d),C */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	C = memrdr(addr);
+	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C <<= 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaiydd(int data)	/* SLA (IY+d),D */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	D = memrdr(addr);
+	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D <<= 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaiyde(int data)	/* SLA (IY+d),E */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	E = memrdr(addr);
+	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E <<= 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaiydh(int data)	/* SLA (IY+d),H */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	H = memrdr(addr);
+	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H <<= 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slaiydl(int data)	/* SLA (IY+d),L */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	L = memrdr(addr);
+	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L <<= 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraiyda(int data)	/* SRA (IY+d),A */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	A = memrdr(addr);
+	i = A & 128;
+	(A & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = (A >> 1) | i;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraiydb(int data)	/* SRA (IY+d),B */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	B = memrdr(addr);
+	i = B & 128;
+	(B & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B = (B >> 1) | i;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraiydc(int data)	/* SRA (IY+d),C */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	C = memrdr(addr);
+	i = C & 128;
+	(C & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C = (C >> 1) | i;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraiydd(int data)	/* SRA (IY+d),D */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	D = memrdr(addr);
+	i = D & 128;
+	(D & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D = (D >> 1) | i;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraiyde(int data)	/* SRA (IY+d),E */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	E = memrdr(addr);
+	i = E & 128;
+	(E & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E = (E >> 1) | i;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraiydh(int data)	/* SRA (IY+d),H */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	H = memrdr(addr);
+	i = H & 128;
+	(H & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H = (H >> 1) | i;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_sraiydl(int data)	/* SRA (IY+d),L */
+{
+	WORD addr;
+	int i;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	L = memrdr(addr);
+	i = L & 128;
+	(L & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L = (L >> 1) | i;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slliyda(int data)	/* SLL (IY+d),A */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	A = memrdr(addr);
+	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = (A << 1) | 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slliydb(int data)	/* SLL (IY+d),B */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	B = memrdr(addr);
+	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B = (B << 1) | 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slliydc(int data)	/* SLL (IY+d),C */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	C = memrdr(addr);
+	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C = (C << 1) | 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slliydd(int data)	/* SLL (IY+d),D */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	D = memrdr(addr);
+	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D = (D << 1) | 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slliyde(int data)	/* SLL (IY+d),E */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	E = memrdr(addr);
+	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E = (E << 1) | 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slliydh(int data)	/* SLL (IY+d),H */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	H = memrdr(addr);
+	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H = (H << 1) | 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_slliydl(int data)	/* SLL (IY+d),L */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	L = memrdr(addr);
+	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L = (L << 1) | 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
 static int op_undoc_slliyd(int data)	/* SLL (IY+d) */
 {
 	register BYTE P;
@@ -692,6 +3312,153 @@ static int op_undoc_slliyd(int data)	/* SLL (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srliyda(int data)	/* SRL (IY+d),A */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	A = memrdr(addr);
+	(A & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A >>= 1;
+	memwrt(addr, A);
+	F &= ~(H_FLAG | N_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srliydb(int data)	/* SRL (IY+d),B */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	B = memrdr(addr);
+	(B & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	B >>= 1;
+	memwrt(addr, B);
+	F &= ~(H_FLAG | N_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srliydc(int data)	/* SRL (IY+d),C */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	C = memrdr(addr);
+	(C & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	C >>= 1;
+	memwrt(addr, C);
+	F &= ~(H_FLAG | N_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srliydd(int data)	/* SRL (IY+d),D */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	D = memrdr(addr);
+	(D & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	D >>= 1;
+	memwrt(addr, D);
+	F &= ~(H_FLAG | N_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srliyde(int data)	/* SRL (IY+d),E */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	E = memrdr(addr);
+	(E & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	E >>= 1;
+	memwrt(addr, E);
+	F &= ~(H_FLAG | N_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srliydh(int data)	/* SRL (IY+d),H */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	H = memrdr(addr);
+	(H & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H >>= 1;
+	memwrt(addr, H);
+	F &= ~(H_FLAG | N_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	return(23);
+}
+
+static int op_undoc_srliydl(int data)	/* SRL (IY+d),L */
+{
+	WORD addr;
+
+	if (u_flag) {
+		trap_fdcb();
+		return(0);
+	}
+
+	addr = IY + data;
+	L = memrdr(addr);
+	(L & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	L >>= 1;
+	memwrt(addr, L);
+	F &= ~(H_FLAG | N_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	return(23);
 }
 

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 1987-2021 Udo Munk
  * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2022 Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 1987-2021 Udo Munk
  * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2022 Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3


### PR DESCRIPTION
1. Added rest of 0xed undocumented instructions, all mirrors of documented ones.
2. Added rest of 0x[df]d 0xcb undocumented instructions. The BIT instructions are just mirrored.
3. Added copyright to files with functional changes by me, and also to COPYING to indicate that I put my changes under the same terms.
4. Added myself to CREDITS, to save the project leader some work.
5. Removed one lonely TAB character.

This completes the implementation of the undocumented instructions. All op-code planes are now completely covered.

Please feel free to change the wording in CREDITS.