### PR TITLE
z80core: further improvements to refresh register accuracy

### DIFF
--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -476,6 +476,7 @@ void cpu_z80(void)
 			PC = 0x66;
 			int_nmi = 0;
 			t += 11;
+			R++;		/* increment refresh register */
 		}
 
 		if (int_int) {		/* maskable interrupt */
@@ -575,6 +576,7 @@ void cpu_z80(void)
 #ifdef FRONTPANEL
 			m1_step = 1;
 #endif
+			R++;		/* increment refresh register */
 		}
 leave:
 
@@ -582,6 +584,8 @@ leave:
 		/* M1 opcode fetch */
 		cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
 #endif
+
+		R++;			/* increment refresh register */
 
 		int_protection = 0;
 		states = (*op_sim[memrdr(PC++)]) (); /* execute next opcode */
@@ -605,7 +609,6 @@ leave:
 			}
 		}
 
-		R++;			/* increment refresh register */
 		T += states;	/* increment CPU clock */
 
 					/* do runtime measurement */

--- a/z80core/sim2.c
+++ b/z80core/sim2.c
@@ -417,9 +417,9 @@ int op_cb_handel(void)
 	fp_sampleLightGroup(0, 0);
 #endif
 
-	t = (*op_cb[memrdr(PC++)]) ();	/* execute next opcode */
-
 	R++;				/* increment refresh register */
+
+	t = (*op_cb[memrdr(PC++)]) ();	/* execute next opcode */
 
 	return(t);
 }

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -384,9 +384,9 @@ int op_dd_handel(void)
 	fp_sampleLightGroup(0, 0);
 #endif
 
-	t = (*op_dd[memrdr(PC++)]) ();	/* execute next opcode */
-
 	R++;				/* increment refresh register */
+
+	t = (*op_dd[memrdr(PC++)]) ();	/* execute next opcode */
 
 	return(t);
 }

--- a/z80core/sim4.c
+++ b/z80core/sim4.c
@@ -370,9 +370,9 @@ int op_ed_handel(void)
 	fp_sampleLightGroup(0, 0);
 #endif
 
-	t = (*op_ed[memrdr(PC++)]) ();	/* execute next opcode */
-
 	R++;				/* increment refresh register */
+
+	t = (*op_ed[memrdr(PC++)]) ();	/* execute next opcode */
 
 	return(t);
 }

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -384,9 +384,9 @@ int op_fd_handel(void)
 	fp_sampleLightGroup(0, 0);
 #endif
 
-	t = (*op_fd[memrdr(PC++)]) ();	/* execute next opcode */
-
 	R++;				/* increment refresh register */
+
+	t = (*op_fd[memrdr(PC++)]) ();	/* execute next opcode */
 
 	return(t);
 }


### PR DESCRIPTION
All described in "The Undocumented Z80 Documented"

1. R needs to be incremented before instructions are executed. (really only affects "LD A,R")
2. Taking any interrupt increments R