### PR TITLE
z80asm: seperate pseudo ops from opcodes, other small stuff

### DIFF
--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -75,9 +75,9 @@ struct ope {
 };
 
 /*
- *	structure personality
+ *	structure operations set
  */
-struct pers {
+struct opset {
 	int no_opcodes;		/* number of opcode entries */
 	struct opc *opctab;	/* opcode table */
 	int no_operands;	/* number of operand entries */
@@ -148,11 +148,11 @@ struct inc {
 #define NOREG		99	/* operand isn't register */
 
 /*
- *	definitions of personalities
+ *	definitions of operations sets
  */
-#define	NUMPERS		2	/* number of personalities */
-#define PERSZ80		0	/* Z80 personality */
-#define PERS8080	1	/* 8080 personality */
+#define OPSET_PSD	0	/* pseudo ops */
+#define OPSET_Z80	1	/* Z80 opcodes */
+#define OPSET_8080	2	/* 8080 opcodes */
 
 /*
  *	definitions of error numbers for error messages in listfile

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -45,6 +45,7 @@ int  list_flag,			/* flag for option -l */
      undoc_flag,		/* flag for option -u */
      ver_flag,			/* flag for option -v */
      dump_flag,			/* flag for option -x */
+     opset = OPSET_Z80,		/* current operations set (default Z80) */
      pc,			/* program counter */
      pass,			/* processed pass */
      iflevel,			/* IF nesting level */
@@ -58,8 +59,8 @@ int  list_flag,			/* flag for option -l */
 				/* = 3: address from <sd_val>, no data */
 				/* = 4: suppress whole line */
      sd_val,			/* output value for PSEUDO opcodes */
-     prg_adr,			/* start address of program */
-     prg_flag,			/* flag for prg_adr valid */
+     prg_addr,			/* start address of program */
+     prg_flag,			/* flag for prg_addr valid */
      out_form = OUTDEF,		/* format of object file */
      symlen = SYMLEN,		/* max. symbol length */
      symsize;			/* size of symarray */
@@ -79,6 +80,3 @@ unsigned
 struct sym
      *symtab[HASHSIZE],		/* symbol table */
      **symarray;		/* sorted symbol table */
-
-struct pers
-     *pers;			/* current personality */

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -41,6 +41,7 @@ extern int	list_flag,
 		undoc_flag,
 		ver_flag,
 		dump_flag,
+		opset,
 		pc,
 		pass,
 		iflevel,
@@ -49,7 +50,7 @@ extern int	list_flag,
 		errnum,
 		sd_flag,
 		sd_val,
-		prg_adr,
+		prg_addr,
 		prg_flag,
 		out_form,
 		symlen,
@@ -69,5 +70,4 @@ extern unsigned	c_line,
 extern struct sym *symtab[],
 		  **symarray;
 
-extern struct pers perstab[],
-		   *pers;
+extern struct opset opsettab[];

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -105,7 +105,6 @@ int main(int argc, char *argv[])
  */
 void init(void)
 {
-	pers = &perstab[PERSZ80];
 	errfp = stdout;
 }
 
@@ -182,7 +181,7 @@ void options(int argc, char *argv[])
 					fatal(F_OUTMEM, "symbols");
 				break;
 			case '8':
-				pers = &perstab[PERS8080];
+				opset = OPSET_8080;
 				break;
 			case 'u':
 				undoc_flag = 1;

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -168,7 +168,7 @@ int strcasecmp(unsigned char *s1, unsigned char *s2)
 	register int c, d;
 
 	for (;;) {
-		switch(c = *s1++ - (d = *s2++)) {
+		switch (c = *s1++ - (d = *s2++)) {
 		case 0:
 			if (!d)
 				break;
@@ -244,7 +244,7 @@ static int parse(void)
 
 	mark  = parsed_pos;
 	state = -1;
- again:
+again:
 	parsed_pos = mark;
 	state++;
 	sstate = SS_START;
@@ -254,7 +254,7 @@ static int parse(void)
 	pcode  = 0;
 	value  = 0;
 	start  = 1;
-	while(1) {
+	while (1) {
 		pcode = code;
 	skip_spaces:
 		code = parsed_line[parsed_pos];
@@ -262,14 +262,14 @@ static int parse(void)
 		type = ((code < 128) ? charclass[code] : 0);
 		if ((quote == 0) && ((type & C_SPC) == C_SPC))
 			goto skip_spaces;
-		switch(state) {
+		switch (state) {
 		case S_OPE:
 			if ((type & C_OPE) == C_OPE)
 				return(code);
 			goto again;
 
 		case S_HEX:
-			switch(sstate) {
+			switch (sstate) {
 			case SS_START:	/* initial condition */
 				if (!isdigit(code))
 					goto again;
@@ -301,7 +301,7 @@ static int parse(void)
 			goto again;
 
 		case S_OCT:
-			switch(sstate) {
+			switch (sstate) {
 			case SS_START:	/* initial condition */
 				if (!isdigit(code))
 					goto again;
@@ -333,7 +333,7 @@ static int parse(void)
 			goto again;
 
 		case S_BIN:
-			switch(sstate) {
+			switch (sstate) {
 			case SS_START:	/* initial condition */
 				if (!isdigit(code))
 					goto again;
@@ -364,7 +364,7 @@ static int parse(void)
 			goto again;
 
 		case S_DEC:
-			switch(sstate) {
+			switch (sstate) {
 			case SS_START:	/* initial condition */
 				if (!isdigit(code))
 					goto again;
@@ -445,7 +445,7 @@ static int asctoi(char *str)
 		num <<= 8;
 		if (*str == '\\') {
 			str++;
-			switch(*str++) {
+			switch (*str++) {
 			case 'a':
 				num |= 0x07;
 				break;
@@ -492,7 +492,7 @@ static int expr_factor(void)
 {
 	int n1, n2;
 
-	switch(tok) {
+	switch (tok) {
 	case '(':
 		tok = parse();
 		n1 = expr();
@@ -539,7 +539,7 @@ static int expr_term(void)
 	while (1) {
 		mark = parsed_pos;
 		tok = parse();
-		switch(tok) {
+		switch (tok) {
 		case '*':
 		case '/':
 		case '%':
@@ -565,7 +565,7 @@ static int expr_simple(void)
 	while (1) {
 		mark = parsed_pos;
 		tok = parse();
-		switch(tok) {
+		switch (tok) {
 		case '+':
 		case '-':
 			t = tok;
@@ -590,7 +590,7 @@ static int expr_shift(void)
 	while (1) {
 		mark = parsed_pos;
 		tok = parse();
-		switch(tok) {
+		switch (tok) {
 		case '<':
 		case '>':
 			t = tok;
@@ -615,7 +615,7 @@ static int expr_and(void)
 	while (1) {
 		mark = parsed_pos;
 		tok = parse();
-		switch(tok) {
+		switch (tok) {
 		case '&':
 			t = tok;
 			mark = parsed_pos;
@@ -639,7 +639,7 @@ static int expr_xor(void)
 	while (1) {
 		mark = parsed_pos;
 		tok = parse();
-		switch(tok) {
+		switch (tok) {
 		case '^':
 			t = tok;
 			mark = parsed_pos;
@@ -663,7 +663,7 @@ static int expr_or(void)
 	while (1) {
 		mark = parsed_pos;
 		tok = parse();
-		switch(tok) {
+		switch (tok) {
 		case '|':
 			t = tok;
 			mark = parsed_pos;
@@ -694,7 +694,7 @@ static int evaluate(int node)
 			n1 = evaluate(nodes[node].left);
 		if (nodes[node].right)
 			n2 = evaluate(nodes[node].right);
-		switch(nodes[node].op) {
+		switch (nodes[node].op) {
 		case '~':
 			return(~n1);
 		case '-':

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -99,7 +99,7 @@ void lst_attl(void)
 /*
  *	print one line into listfile, if -l option set
  */
-void lst_line(int val, int opcount)
+void lst_line(int val, int op_cnt)
 {
 	register int i;
 
@@ -128,19 +128,19 @@ void lst_line(int val, int opcount)
 		fatal(F_INTERN, "invalid listflag for function lst_line");
 		break;
 	}
-	if (opcount >= 1)
+	if (op_cnt >= 1)
 		fprintf(lstfp, "%02x ", ops[0] & 0xff);
 	else
 		fprintf(lstfp, "   ");
-	if (opcount >= 2)
+	if (op_cnt >= 2)
 		fprintf(lstfp, "%02x ", ops[1] & 0xff);
 	else
 		fprintf(lstfp, "   ");
-	if (opcount >= 3)
+	if (op_cnt >= 3)
 		fprintf(lstfp, "%02x ", ops[2] & 0xff);
 	else
 		fprintf(lstfp, "   ");
-	if (opcount >= 4)
+	if (op_cnt >= 4)
 		fprintf(lstfp, "%02x ", ops[3] & 0xff);
 	else
 		fprintf(lstfp, "   ");
@@ -154,11 +154,11 @@ no_data:
 	}
 	sd_flag = 0;
 	p_line++;
-	if (opcount > 4 && sd_flag == 0) {
-		opcount -= 4;
+	if (op_cnt > 4 && sd_flag == 0) {
+		op_cnt -= 4;
 		i = 4;
 		sd_val = val;
-		while (opcount > 0) {
+		while (op_cnt > 0) {
 			if (p_line >= ppl) {
 				lst_header();
 				lst_attl();
@@ -166,19 +166,19 @@ no_data:
 			s_line++;
 			sd_val += 4;
 			fprintf(lstfp, "%04x  ", sd_val & 0xffff);
-			if (opcount-- > 0)
+			if (op_cnt-- > 0)
 				fprintf(lstfp, "%02x ", ops[i++] & 0xff);
 			else
 				fprintf(lstfp, "   ");
-			if (opcount-- > 0)
+			if (op_cnt-- > 0)
 				fprintf(lstfp, "%02x ", ops[i++] & 0xff);
 			else
 				fprintf(lstfp, "   ");
-			if (opcount-- > 0)
+			if (op_cnt-- > 0)
 				fprintf(lstfp, "%02x ", ops[i++] & 0xff);
 			else
 				fprintf(lstfp, "   ");
-			if (opcount-- > 0)
+			if (op_cnt-- > 0)
 				fprintf(lstfp, "%02x ", ops[i++] & 0xff);
 			else
 				fprintf(lstfp, "   ");
@@ -289,19 +289,19 @@ void obj_end(void)
 /*
  *	write opcodes in ops[] into object file
  */
-void obj_writeb(int opcount)
+void obj_writeb(int op_cnt)
 {
 	register int i;
 
 	switch (out_form) {
 	case OUTBIN:
-		fwrite(ops, 1, opcount, objfp);
+		fwrite(ops, 1, op_cnt, objfp);
 		break;
 	case OUTMOS:
-		fwrite(ops, 1, opcount, objfp);
+		fwrite(ops, 1, op_cnt, objfp);
 		break;
 	case OUTHEX:
-		for (i = 0; opcount; opcount--) {
+		for (i = 0; op_cnt; op_cnt--) {
 			if (hex_cnt >= MAXHEX)
 				flush_hex();
 			hex_buf[hex_cnt++] = ops[i++];

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -38,7 +38,7 @@ extern void asmerr(int);
 
 /*
  *	binary search in sorted table opctab of opset and OPSET_PSD
- *	search opset first since pseudo ops are less common
+ *	search opset first since pseudo ops occur less often
  *
  *	Input: pointer to string with opcode
  *


### PR DESCRIPTION
1. Seperate pseudo ops from opcodes to make it easier to add new ones
2. Add a few pseudo op aliases, and two simple new ones: DEFC DEFZ
3. Refactor the Z80 CB opcodes code
4. Improve Z80 IN and OUT syntax checks
5. Anglicize some variables and strings
6. Clean-up my clean-up of z80anum.c
7. Some small reformatting