### PR TITLE
z80asm: fix check_sbyte to cover complete byte two complement's number range

### DIFF
--- a/z80asm/z80anum-orig.c
+++ b/z80asm/z80anum-orig.c
@@ -293,12 +293,12 @@ int strval(char *str)
 }
 
 /*
- *	check value for range -256 < value < 256
+ *	check value for range -257 < value < 256
  *	Output: value if in range, otherwise 0 and error message
  */
 int chk_byte(int i)
 {
-	if (i >= -255 && i <= 255)
+	if (i >= -256 && i <= 255)
 		return(i);
 	else {
 		asmerr(E_VALOUT);

--- a/z80asm/z80anum-orig.c
+++ b/z80asm/z80anum-orig.c
@@ -307,12 +307,12 @@ int chk_byte(int i)
 }
 
 /*
- *	check value for range -128 < value < 128
+ *	check value for range -129 < value < 128
  *	Output: value if in range, otherwise 0 and error message
  */
 int chk_sbyte(int i)
 {
-	if (i >= -127 && i <= 127)
+	if (i >= -128 && i <= 127)
 		return(i);
 	else {
 		asmerr(E_VALOUT);

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -768,12 +768,12 @@ int chk_byte(int i)
 }
 
 /*
- *	check value for range -128 < value < 128
+ *	check value for range -129 < value < 128
  *	Output: value if in range, otherwise 0 and error message
  */
 int chk_sbyte(int i)
 {
-	if (i >= -127 && i <= 127)
+	if (i >= -128 && i <= 127)
 		return(i);
 	else {
 		asmerr(E_VALOUT);

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -754,12 +754,12 @@ int eval(char *str)
 /* from z80anum-orig.c */
 
 /*
- *	check value for range -256 < value < 256
+ *	check value for range -257 < value < 256
  *	Output: value if in range, otherwise 0 and error message
  */
 int chk_byte(int i)
 {
-	if (i >= -255 && i <= 255)
+	if (i >= -256 && i <= 255)
 		return(i);
 	else {
 		asmerr(E_VALOUT);


### PR DESCRIPTION
`check_sbyte()` should accept -128, since this is inside the two complement's range.
Also accept -256..255 for `check_byte()` as, for example, specified by Intel
in their 8080/8085 Assembly Language Programming Manual.

That is check_byte accepts all 256 values for both positive and negative values,
and check_sbyte accepts all 256 values for two's complement values.

Sorry for getting this wrong in my previous commit.