### PR TITLE
z80asm: clean up and bug fix in the new expression parser

### DIFF
--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -45,8 +45,8 @@
 #define COMMENT		';'	/* inline comment character */
 #define LINCOM		'*'	/* comment line if in column 1 */
 #define LABSEP		':'	/* label separator */
-#define STRSEP		'\''	/* string separator */
-#define STRSEP2		'"'	/* the other string separator */
+#define STRDEL		'\''	/* string delimiter */
+#define STRDEL2		'"'	/* the other string delimiter */
 #define ENDFILE		"END"	/* end of source */
 #define MAXFN		512	/* max. no. source files */
 #define MAXLINE		128	/* max. line length source */
@@ -184,7 +184,7 @@ struct inc {
 #define E_UNDSYM	5	/* undefined symbol */
 #define E_VALOUT	6	/* value out of bounds */
 #define E_MISPAR	7	/* missing paren */
-#define E_MISSEP	8	/* missing string separator */
+#define E_MISDEL	8	/* missing string delimiter */
 #define E_MEMOVR	9	/* memory override (ORG) */
 #define E_MISIFF	10	/* missing IF at ELSE or ENDIF */
 #define E_IFNEST	11	/* to many IF's nested */
@@ -194,7 +194,7 @@ struct inc {
 #define E_ORGPHS	15	/* invalid ORG in .PHASE block */
 #define E_MISPHS	16	/* missing .PHASE at .DEPHASE */
 #define E_DIVBY0	17	/* division by zero */
-#define E_RADIX		18	/* invalid radix */
+#define E_INVEXP	18	/* invalid expression */
 
 /*
  *	definition of fatal errors

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -531,7 +531,7 @@ comment:
 /*
  *	get operand into s from source line l
  *	converts to upper case
- *	strings inside of 's are copied without changes
+ *	delimited strings are copied without changes
  */
 char *get_arg(char *s, char *l)
 {
@@ -554,7 +554,7 @@ char *get_arg(char *s, char *l)
 				*s++ = ' ';
 			continue;
 		}
-		if ((*l != STRSEP) && (*l != STRSEP2)) {
+		if ((*l != STRDEL) && (*l != STRDEL2)) {
 			*s++ = toupper((unsigned char) *l++);
 			continue;
 		}

--- a/z80asm/z80anum-orig.c
+++ b/z80asm/z80anum-orig.c
@@ -94,11 +94,11 @@ int eval(char *s)
 			val = eval(word);
 			continue;
 		}
-		if (*s == STRSEP) {
+		if (*s == STRDEL) {
 			s++;
-			while (*s != STRSEP) {
+			while (*s != STRDEL) {
 				if (*s == '\n' || *s == '\0') {
-					asmerr(E_MISSEP);
+					asmerr(E_MISDEL);
 					goto sep_error;
 				}
 				*p++ = *s++;

--- a/z80asm/z80anum-orig.c
+++ b/z80asm/z80anum-orig.c
@@ -99,12 +99,12 @@ int eval(char *s)
 			while (*s != STRDEL) {
 				if (*s == '\n' || *s == '\0') {
 					asmerr(E_MISDEL);
-					goto sep_error;
+					goto delim_error;
 				}
 				*p++ = *s++;
 			}
 			s++;
-sep_error:
+delim_error:
 			*p = '\0';
 			val = strval(word);
 			continue;
@@ -176,7 +176,7 @@ sep_error:
 			goto eval_break;
 		}
 	}
-	eval_break:
+eval_break:
 	return(val);
 }
 

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -55,10 +55,10 @@ static char *errmsg[] = {		/* error messages for asmerr() */
 	"missing ENDIF",		/* 12 */
 	"INCLUDE nesting to deep",	/* 13 */
 	".PHASE can not be nested",	/* 14 */
-	"invalid ORG in .PHASE block",	/* 15 */
+	"ORG in .PHASE block",		/* 15 */
 	"missing .PHASE",		/* 16 */
 	"division by zero",		/* 17 */
-	"invalid .RADIX"		/* 18 */
+	"invalid expression"		/* 18 */
 };
 
 static int seq_flag;			/* flag for sequential ORG */

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -150,7 +150,7 @@ int op_radix(int dummy1, int dummy2)
 
 	i = eval(operand);
 	if (i < 2 || i > 16)
-		asmerr(E_RADIX);
+		asmerr(E_VALOUT);
 	else
 		radix = i;
 	sd_flag = 2;
@@ -230,14 +230,14 @@ int op_db(int dummy1, int dummy2)
 	p = operand;
 	while (*p) {
 		j = 0;
-		if (*p == STRSEP || *p == STRSEP2) {
+		if (*p == STRDEL || *p == STRDEL2) {
 			s = p + 1;
 			while (1) {
 				/* check for double delim */
 				if ((*s == *p) && (*++s != *p))
 					break;
 				if (*s == '\n' || *s == '\0') {
-					asmerr(E_MISSEP);
+					asmerr(E_MISDEL);
 					goto sep_error;
 				}
 				ops[i++] = *s++;
@@ -286,8 +286,8 @@ int op_dm(int op_code, int dummy)
 
 	i = 0;
 	p = operand;
-	if (*p != STRSEP && *p != STRSEP2) {
-		asmerr(E_MISSEP);
+	if (*p != STRDEL && *p != STRDEL2) {
+		asmerr(E_MISDEL);
 		return(0);
 	}
 	p++;
@@ -296,7 +296,7 @@ int op_dm(int op_code, int dummy)
 		if ((*p == *operand) && (*++p != *operand))
 			break;
 		if (*p == '\n' || *p == '\0') {
-			asmerr(E_MISSEP);
+			asmerr(E_MISDEL);
 			break;
 		}
 		ops[i++] = *p++;
@@ -389,7 +389,7 @@ int op_misc(int op_code, int dummy)
 	case 5:				/* PRINT */
 		if (pass == 1) {
 			p = operand;
-			if (*p == STRSEP || *p == STRSEP2) {
+			if (*p == STRDEL || *p == STRDEL2) {
 				p++;
 				while (1) {
 					/* check for double delim */
@@ -398,7 +398,7 @@ int op_misc(int op_code, int dummy)
 						break;
 					if (*p == '\0') {
 						putchar('\n');
-						asmerr(E_MISSEP);
+						asmerr(E_MISDEL);
 						return(0);
 					}
 					putchar(*p++);
@@ -463,14 +463,14 @@ int op_misc(int op_code, int dummy)
 				p++;	/* ignore TITLE */
 			while (isspace((unsigned char) *p))
 				p++;	/* ignore white space until text */
-			if (*p == STRSEP || *p == STRSEP2) {
+			if (*p == STRDEL || *p == STRDEL2) {
 				s = p + 1;
 				while (1) {
 					/* check for double delim */
 					if ((*s == *p) && (*++s != *p))
 						break;
 					if (*s == '\n') {
-						asmerr(E_MISSEP);
+						asmerr(E_MISDEL);
 						break;
 					}
 					*d++ = *s++;

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -238,7 +238,7 @@ int op_db(int dummy1, int dummy2)
 					break;
 				if (*s == '\n' || *s == '\0') {
 					asmerr(E_MISDEL);
-					goto sep_error;
+					goto delim_error;
 				}
 				ops[i++] = *s++;
 				if (i >= OPCARRAY)
@@ -270,7 +270,7 @@ int op_db(int dummy1, int dummy2)
 		if (*p == ',')
 			p++;
 	}
-sep_error:
+delim_error:
 	return(i);
 }
 


### PR DESCRIPTION
String separator => string delimiter.

Lexical scanning really attracts goto's. Looks actually cleaner now.

Use new error message for invalid expression.

Bug fix: X'h' constants need to be upcased, since they are inside strings.
