### PR TITLE
remove isxdigit macro and use correct type cast for ctype function arguments

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -130,9 +130,5 @@ struct softbreak {			/* structure of a breakpoint */
 };
 #endif
 
-#ifndef isxdigit
-#define isxdigit(c) ((c<='f'&&c>='a')||(c<='F'&&c>='A')||(c<='9'&&c>='0'))
-#endif
-
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -157,10 +157,6 @@ struct softbreak {			/* structure of a breakpoint */
 };
 #endif
 
-#ifndef isxdigit
-#define isxdigit(c) ((c<='f'&&c>='a')||(c<='F'&&c>='A')||(c<='9'&&c>='0'))
-#endif
-
 /*
  *	Structure for the disk images
  */

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -150,9 +150,5 @@ struct softbreak {			/* structure of a breakpoint */
 };
 #endif
 
-#ifndef isxdigit
-#define isxdigit(c) ((c<='f'&&c>='a')||(c<='F'&&c>='A')||(c<='9'&&c>='0'))
-#endif
-
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -144,9 +144,5 @@ struct softbreak {			/* structure of a breakpoint */
 };
 #endif
 
-#ifndef isxdigit
-#define isxdigit(c) ((c<='f'&&c>='a')||(c<='F'&&c>='A')||(c<='9'&&c>='0'))
-#endif
-
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -117,9 +117,5 @@ struct softbreak {			/* structure of a breakpoint */
 };
 #endif
 
-#ifndef isxdigit
-#define isxdigit(c) ((c<='f'&&c>='a')||(c<='F'&&c>='A')||(c<='9'&&c>='0'))
-#endif
-
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)

--- a/mosteksim/srcsim/simctl.c
+++ b/mosteksim/srcsim/simctl.c
@@ -91,7 +91,7 @@ void mon(void)
 			putchar('\n');
 			goto next;
 		}
-		switch (tolower(*cmd)) {
+		switch (tolower((unsigned char) *cmd)) {
 		case '\n':
 			do_step();
 			break;
@@ -189,7 +189,7 @@ static void do_trace(char *s)
 {
 	register int count, i;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == '\0')
 		count = 20;
@@ -229,9 +229,9 @@ static void do_go(char *s)
 	printf("Type CTRL-\\ to halt emulation\n\n");
 	set_unix_terminal();
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
-	if (isxdigit((int)*s))
+	if (isxdigit((unsigned char) *s))
 		PC = exatoi(s);
 	cont:
 	cpu_state = CONTIN_RUN;
@@ -312,9 +312,9 @@ static void do_dump(char *s)
 	register int i, j;
 	BYTE c;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
-	if (isxdigit((int)*s))
+	if (isxdigit((unsigned char) *s))
 		wrk_ram = mem_base() + exatoi(s) - exatoi(s) % 16;
 	printf("Adr    ");
 	for (i = 0; i < 16; i++)
@@ -343,9 +343,9 @@ static void do_list(char *s)
 {
 	register int i;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
-	if (isxdigit((int)*s))
+	if (isxdigit((unsigned char) *s))
 		wrk_ram = mem_base() + exatoi(s);
 	for (i = 0; i < 10; i++) {
 		printf("%04x - ", (unsigned int)(wrk_ram - mem_base()));
@@ -362,9 +362,9 @@ static void do_modify(char *s)
 {
 	static char nv[LENCMD];
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
-	if (isxdigit((int)*s))
+	if (isxdigit((unsigned char) *s))
 		wrk_ram = mem_base() + exatoi(s);
 	for (;;) {
 		printf("%04x = %02x : ", (unsigned int)(wrk_ram - mem_base()),
@@ -376,7 +376,7 @@ static void do_modify(char *s)
 				wrk_ram = mem_base();
 			continue;
 		}
-		if (!isxdigit((int)nv[0]))
+		if (!isxdigit((unsigned char) nv[0]))
 			break;
 		*wrk_ram++ = exatoi(nv);
 		if (wrk_ram > mem_base() + 65535)
@@ -393,7 +393,7 @@ static void do_fill(char *s)
 	register int i;
 	register BYTE val;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	p = mem_base() + exatoi(s);
 	while (*s != ',' && *s != '\0')
@@ -428,7 +428,7 @@ static void do_move(char *s)
 	register int count;
 
 	
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	p1 = mem_base() + exatoi(s);
 	while (*s != ',' && *s != '\0')
@@ -465,12 +465,12 @@ static void do_port(char *s)
 	static char nv[LENCMD];
 	extern BYTE io_out(BYTE, BYTE, BYTE), io_in(BYTE, BYTE);
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	port = exatoi(s);
 	printf("%02x = %02x : ", port, io_in(port, 0));
 	fgets(nv, sizeof(nv), stdin);
-	if (isxdigit((int)*nv))
+	if (isxdigit((unsigned char) *nv))
 		io_out(port, 0, (BYTE) exatoi(nv));
 }
 
@@ -481,7 +481,7 @@ static void do_reg(char *s)
 {
 	static char nv[LENCMD];
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == '\0') {
 		print_head();
@@ -694,7 +694,7 @@ static void do_break(char *s)
 				       soft[i].sb_passcount);
 		return;
 	}
-	if (isxdigit((int)*s)) {
+	if (isxdigit((unsigned char) *s)) {
 		i = atoi(s++);
 		if (i >= SBSIZE) {
 			printf("breakpoint %d not available\n", i);
@@ -705,7 +705,7 @@ static void do_break(char *s)
 		if (sb_next == SBSIZE)
 			sb_next = 0;
 	}
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == 'c') {
 		*(mem_base() + soft[i].sb_adr) = soft[i].sb_oldopc;
@@ -717,7 +717,7 @@ static void do_break(char *s)
 	soft[i].sb_adr = exatoi(s);
 	soft[i].sb_oldopc = *(mem_base() + soft[i].sb_adr);
 	*(mem_base() + soft[i].sb_adr) = 0x76;
-	while (!iscntrl((int)*s) && !ispunct((int)*s))
+	while (!iscntrl((unsigned char) *s) && !ispunct((unsigned char) *s))
 		s++;
 	if (*s != ',')
 		soft[i].sb_pass = 1;
@@ -739,7 +739,7 @@ static void do_hist(char *s)
 #else
 	int i, l, b, e, c, sa;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	switch (*s) {
 	case 'c':
@@ -755,7 +755,7 @@ static void do_hist(char *s)
 		e = h_next;
 		b = (h_flag) ? h_next + 1 : 0;
 		l = 0;
-		while (isspace((int)*s))
+		while (isspace((unsigned char) *s))
 			s++;
 		if (*s)
 			sa = exatoi(s);
@@ -786,7 +786,7 @@ static void do_hist(char *s)
 				printf("q = quit, else continue: ");
 				c = getkey();
 				putchar('\n');
-				if (toupper(c) == 'Q')
+				if (toupper((unsigned char) c) == 'Q')
 					break;
 			}
 		}
@@ -805,7 +805,7 @@ static void do_count(char *s)
 	puts("Sorry, no t-state count available");
 	puts("Please recompile with WANT_TIM defined in sim.h");
 #else
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == '\0') {
 		puts("start  stop  status  T-states");

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -27,7 +27,7 @@
 #define LENFN		2048	/* max. filename length */
 #define READA		"r"	/* file open mode read ascii */
 #define WRITEA		"w"	/* file open mode write ascii */
-#define WRITEB		"w"	/* file open mode write binary */
+#define WRITEB		"wb"	/* file open mode write binary */
 
 /*
  *	various constants

--- a/z80asm/z80anum-orig.c
+++ b/z80asm/z80anum-orig.c
@@ -23,11 +23,6 @@
 #include "z80a.h"
 #include "z80aglb.h"
 
-#ifndef isxdigit
-#define isxdigit(c) (isdigit(c) || (((c) >= 'a') && ((c) <= 'f'))	\
-				|| (((c) >= 'A') && ((c) <= 'F')))
-#endif
-
 /*
  *	definitions of operator symbols for expression parser
  */

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -28,11 +28,6 @@
 #include "z80a.h"
 #include "z80aglb.h"
 
-#ifndef isxdigit
-#define isxdigit(c) (isdigit(c) || (((c) >= 'a') && ((c) <= 'f'))	\
-				|| (((c) >= 'A') && ((c) <= 'F')))
-#endif
-
 int expr(int *);
 
 /* z80aout.c */

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -81,12 +81,12 @@ int exatoi(char *str)
 {
 	register int num = 0;
 
-	while (isxdigit((int)*str)) {
+	while (isxdigit((unsigned char) *str)) {
 		num *= 16;
 		if (*str <= '9')
 			num += *str - '0';
 		else
-			num += toupper((int)*str) - '7';
+			num += toupper((unsigned char) *str) - '7';
 		str++;
 	}
 	return(num);
@@ -178,7 +178,7 @@ int load_file(char *s, BYTE pstart, WORD psize)
 	BYTE d;
 	int fd;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	while (*s != ',' && *s != '\n' && *s != '\0')
 		*pfn++ = *s++;
@@ -289,7 +289,7 @@ static int load_hex(char *fn, BYTE pstart, WORD psize)
 
 	while (fgets(&buf[0], BUFSIZE, fd) != NULL) {
 		s = &buf[0];
-		while (isspace((int)*s))
+		while (isspace((unsigned char) *s))
 			s++;
 		if (*s != ':')
 			continue;

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -154,9 +154,5 @@ struct softbreak {			/* structure of a breakpoint */
 };
 #endif
 
-#ifndef isxdigit
-#define isxdigit(c) ((c<='f'&&c>='a')||(c<='F'&&c>='A')||(c<='9'&&c>='0'))
-#endif
-
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -155,9 +155,5 @@ struct softbreak {			/* structure of a breakpoint */
 };
 #endif
 
-#ifndef isxdigit
-#define isxdigit(c) ((c<='f'&&c>='a')||(c<='F'&&c>='A')||(c<='9'&&c>='0'))
-#endif
-
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)

--- a/z80sim/srcsim/simctl.c
+++ b/z80sim/srcsim/simctl.c
@@ -122,7 +122,7 @@ void mon(void)
 			putchar('\n');
 			goto next;
 		}
-		switch (tolower(*cmd)) {
+		switch (tolower((unsigned char) *cmd)) {
 		case '\n':
 			do_step();
 			break;
@@ -220,7 +220,7 @@ static void do_trace(char *s)
 {
 	register int count, i;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == '\0')
 		count = 20;
@@ -257,9 +257,9 @@ static void do_trace(char *s)
  */
 static void do_go(char *s)
 {
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
-	if (isxdigit((int)*s))
+	if (isxdigit((unsigned char) *s))
 		PC = exatoi(s);
 	cont:
 	cpu_state = CONTIN_RUN;
@@ -336,9 +336,9 @@ static void do_dump(char *s)
 	register int i, j;
 	BYTE c;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
-	if (isxdigit((int)*s))
+	if (isxdigit((unsigned char) *s))
 		wrk_ram = mem_base() + exatoi(s) - exatoi(s) % 16;
 	printf("Adr    ");
 	for (i = 0; i < 16; i++)
@@ -367,9 +367,9 @@ static void do_list(char *s)
 {
 	register int i;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
-	if (isxdigit((int)*s))
+	if (isxdigit((unsigned char) *s))
 		wrk_ram = mem_base() + exatoi(s);
 	for (i = 0; i < 10; i++) {
 		printf("%04x - ", (unsigned int)(wrk_ram - mem_base()));
@@ -384,9 +384,9 @@ static void do_modify(char *s)
 {
 	static char nv[LENCMD];
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
-	if (isxdigit((int)*s))
+	if (isxdigit((unsigned char) *s))
 		wrk_ram = mem_base() + exatoi(s);
 	for (;;) {
 		printf("%04x = %02x : ", (unsigned int)(wrk_ram - mem_base()),
@@ -398,7 +398,7 @@ static void do_modify(char *s)
 				wrk_ram = mem_base();
 			continue;
 		}
-		if (!isxdigit((int)nv[0]))
+		if (!isxdigit((unsigned char) nv[0]))
 			break;
 		*wrk_ram++ = exatoi(nv);
 		if (wrk_ram > mem_base() + 65535)
@@ -415,7 +415,7 @@ static void do_fill(char *s)
 	register int i;
 	register BYTE val;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	p = mem_base() + exatoi(s);
 	while (*s != ',' && *s != '\0')
@@ -450,7 +450,7 @@ static void do_move(char *s)
 	register int count;
 
 	
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	p1 = mem_base() + exatoi(s);
 	while (*s != ',' && *s != '\0')
@@ -487,12 +487,12 @@ static void do_port(char *s)
 	static char nv[LENCMD];
 	extern BYTE io_out(BYTE, BYTE, BYTE), io_in(BYTE, BYTE);
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	port = exatoi(s);
 	printf("%02x = %02x : ", port, io_in(port, 0));
 	fgets(nv, sizeof(nv), stdin);
-	if (isxdigit((int)*nv))
+	if (isxdigit((unsigned char) *nv))
 		io_out(port, 0, (BYTE) exatoi(nv));
 }
 
@@ -503,7 +503,7 @@ static void do_reg(char *s)
 {
 	static char nv[LENCMD];
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == '\0') {
 		print_head();
@@ -716,7 +716,7 @@ static void do_break(char *s)
 				       soft[i].sb_passcount);
 		return;
 	}
-	if (isxdigit((int)*s)) {
+	if (isxdigit((unsigned char) *s)) {
 		i = atoi(s++);
 		if (i >= SBSIZE) {
 			printf("breakpoint %d not available\n", i);
@@ -727,7 +727,7 @@ static void do_break(char *s)
 		if (sb_next == SBSIZE)
 			sb_next = 0;
 	}
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == 'c') {
 		*(mem_base() + soft[i].sb_adr) = soft[i].sb_oldopc;
@@ -739,7 +739,7 @@ static void do_break(char *s)
 	soft[i].sb_adr = exatoi(s);
 	soft[i].sb_oldopc = *(mem_base() + soft[i].sb_adr);
 	*(mem_base() + soft[i].sb_adr) = 0x76;
-	while (!iscntrl((int)*s) && !ispunct((int)*s))
+	while (!iscntrl((unsigned char) *s) && !ispunct((unsigned char) *s))
 		s++;
 	if (*s != ',')
 		soft[i].sb_pass = 1;
@@ -761,7 +761,7 @@ static void do_hist(char *s)
 #else
 	int i, l, b, e, c, sa;
 
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	switch (*s) {
 	case 'c':
@@ -777,7 +777,7 @@ static void do_hist(char *s)
 		e = h_next;
 		b = (h_flag) ? h_next + 1 : 0;
 		l = 0;
-		while (isspace((int)*s))
+		while (isspace((unsigned char) *s))
 			s++;
 		if (*s)
 			sa = exatoi(s);
@@ -808,7 +808,7 @@ static void do_hist(char *s)
 				printf("q = quit, else continue: ");
 				c = getkey();
 				putchar('\n');
-				if (toupper(c) == 'Q')
+				if (toupper((unsigned char) c) == 'Q')
 					break;
 			}
 		}
@@ -827,7 +827,7 @@ static void do_count(char *s)
 	puts("Sorry, no t-state count available");
 	puts("Please recompile with WANT_TIM defined in sim.h");
 #else
-	while (isspace((int)*s))
+	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == '\0') {
 		puts("start  stop  status  T-states");


### PR DESCRIPTION
isxdigit has been part of the C standard since 1989.
