### PR TITLE
z80asm: never define label when gencode is 0

### DIFF
--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -326,9 +326,9 @@ int p1_line(void)
 		return(0);
 	if (*opcode) {
 		if ((op = search_op(opcode)) != NULL) {
+			if (gencode && *label && (op->op_type != OP_SET))
+				put_label();
 			if (gencode || (op->op_type == OP_COND)) {
-				if ((op->op_type != OP_SET) && *label)
-					put_label();
 				i = (*op->op_fun)(op->op_c1, op->op_c2);
 				pc += i;
 				rpc += i;


### PR DESCRIPTION
Previously only the pseudo-ops .PHASE, DEFS, DEFB, DEFM, and DEFW
would call put_label() if a label was present. I relaxed this, in my changes to drive put_label()
with the opcode table, to every pseudo-op except DEFL and EQU, but unintentionally
allowed put_label() calls for IF & co. when gencode is 0.