### PR TITLE
z80asm: don't hardcode END pseudo-op, use op_type and check optional argument

### DIFF
--- a/cromemcosim/roms/z1mon-1.4.lis
+++ b/cromemcosim/roms/z1mon-1.4.lis
@@ -1,4 +1,4 @@
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 1
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 1
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -63,7 +63,7 @@ ffe7                  49     49 DUHL2	EQU	-25			;(FFE7)
                       58     58 ;
                       59     59 ; ENTER THE MONITOR FROM RESET.
                       60     60 ; COLD START ENTRY. INITIALIZES THE UART
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 2
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 2
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -128,7 +128,7 @@ e02b  d3 52          112    112 	OUT	(BCMNDP),A		;RESET DEVICE B
                      118    118 ; PUSH CARRIAGE-RETURN TO SELECT THE PROPER BAUD
                      119    119 ; RATE FOR THE CURRENT TERMINAL. (THE MAXIMUM
                      120    120 ; NUMBER OF CARRIAGE-RETURNS REQUIRED IS FOUR.)
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 3
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 3
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -193,7 +193,7 @@ e061  ed b8          177    177 	LDDR
                      178    178 ;
 e063  13             179    179 	INC	DE			;-> UHL,LO ON SYS STK
 e064  eb             180    180 	EX	DE,HL
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 4
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 4
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -258,7 +258,7 @@ e0aa  2b             237    237 	DEC	HL
 e0ab  56             238    238 	LD	D,(HL)
 e0ac  2b             239    239 	DEC	HL
 e0ad  5e             240    240 	LD	E,(HL)
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 5
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 5
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -323,7 +323,7 @@ e0ea  18 b4          294    294 ESCPE:	JR	CLBP			;CLEAR ANY BRKPTS
                      298    298 ; IS NOT ON A 1K (400H) BOUNDARY, OR IF SWATH
                      299    299 ; WIDTH IS NOT A MULTIPLE OF 1K.
                      300    300 ;
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 6
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 6
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -388,7 +388,7 @@ e12f  cc 0f e2       357    357 	CALL	Z,PMSG
 e132  fe 3c          358    358 	CP	'<'			;RECURSIVE CALL
 e134  20 0b          359    359 	JR	NZ,PC3			;ON CMND?
 e136  f1             360    360 	POP	AF
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 7
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 7
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -453,7 +453,7 @@ e166  cd a5 e1       416    416 VERIF:	CALL	L3NCR			;GET 3	OPERANDS
                      418    418 ; COMPARES TWO AREAS OF MEMORY. ENTER WITH
                      419    419 ; SOURCE IN HL, DESTINATION IN DE & COUNT
                      420    420 ; IN BC. ALTERS ALL REGISTERS.
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 8
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 8
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -518,7 +518,7 @@ e1a5  cd 8b e1       471    471 L3NCR: CALL	LD2N
                      478    478 ; DE & HL. FINISHES WITH A CRLF.
                      479    479 ;
 e1a8  cd ae e1       480    480 L1NCR: CALL	GNHL	        	 ;SKIP SPACES, LOAD HL
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 9
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 9
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -583,7 +583,7 @@ e1dc  c9             531    531 	RET
                      538    538 ;
 e1dd  97             539    539 SKSG0:	SUB	A
                      540    540 ;
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 10
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 10
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -648,7 +648,7 @@ e20e  c9             589    589 	RET
 e20f  f5             598    598 PMSG:	PUSH	AF			;SAVE
 e210  7e             599    599 PS1:	LD	A,(HL)
 e211  23             600    600 	INC	HL
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 11
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 11
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -713,7 +713,7 @@ e24c  23             657    657 	INC  	HL  	 		;BUMP BPSP
 e24d  eb             658    658 	EX   	DE,HL   	 	;DE = BPSP, HL= BP ADDR
 e24e  ed a0          659    659 	LDI
 e250  2b             660    660 	DEC  	HL
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 12
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 12
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -778,7 +778,7 @@ e28b  f1             717    717 	POP	AF
 e28c  c9             718    718 	RET
                      719    719 
                      720    720 
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 13
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 13
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -843,7 +843,7 @@ e2c6  18 f0          776    776 	JR	SM1
                      778    778 ;
 e2c8  47             779    779 SUBR:	LD	B,A
 e2c9  cd 44 e1       780    780 	CALL	GCHR
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 14
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 14
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -908,7 +908,7 @@ e32f  28 a4          837    837 	JR	Z,SR3	   		;IF H, LOOP.
 e331  c9             838    838 	RET		    		;IT IS H'. DONE.
                      839    839 
                      840    840 
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 15
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 15
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -973,7 +973,7 @@ e372  c9             895    895 	RET
                      898    898 ; COMMAND
                      899    899 ; READ BINARY INPUT FROM DATA PORT
                      900    900 ;
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 16
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 16
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -1038,7 +1038,7 @@ e3ab  0a 00 80       956    957 LFNN:	DEFB	LF,0,0 | 80H
                      957    958 ;
                      958    959 ;
 e3ae  ba             959    960 PRMPT:	DEFB	(':' | 80H)
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 17
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 17
 Source file: z1mon-1.4.asm
 Title:       
 
@@ -1103,13 +1103,13 @@ e3f0  0d 0d 43 52   1016   1017 HEAD:	DEFB	CR,CR, 'CROMEMCO ZM1.',('4' | 80H)
 e3f4  4f 4d 45 4d   1016   1018
 e3f8  43 4f 20 5a   1016   1019
 e3fc  4d 31 2e b4   1016   1020
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 18
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 18
 Source file: z1mon-1.4.asm
 Title:       
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 e400                1017   1021 	END	CSTART
-Z80-Assembler	Release 1.11-dev	Tue Oct  4 11:33:07 2022	Page 19
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:25:22 2022	Page 19
 Source file: z1mon-1.4.asm
 Title:       Symbol table
 
@@ -1119,7 +1119,7 @@ BCMNDP   0052 	BPARLP   0054 	BPMRK    000b 	BPSTOR   0016
 CASE     0000 	CHKIN    e00e 	CL1      e0a4 	CL2      e0b3 	
 CLBP     e0a0 	CMND     e0be 	CMND1    e0c2 	COM1     e051 	
 COM3     e082 	COM4     e08b 	COMMON   e04a 	CR       000d 	
-CRF      0007 	CRLF     e14d 	CRM      0080 	CSTART   e000*	
+CRF      0007 	CRLF     e14d 	CRM      0080 	CSTART   e000 	
 DATA     0001 	DAV      0040 	DISPL    e28d 	DM2      e29a 	
 DSPM     e292*	DSPM1    e295 	DUAF     fffd 	DUAF2    ffed 	
 DUBC     fffb 	DUBC2    ffeb*	DUDE     fff9 	DUDE2    ffe9*	

--- a/imsaisim/roms/basic4k.lis
+++ b/imsaisim/roms/basic4k.lis
@@ -1,4 +1,4 @@
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 1
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 1
 Source file: basic4k.asm
 Title:       
 
@@ -63,7 +63,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                       58     58 ;SHIFT THE LOW ORDER 4 BITS OF REG A TO THE HIGH 4 BITS
                       59     59 ;
 0020  e6 0f           60     60       AND   0FH              ;ISOLATE LOW 4
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 2
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 2
 Source file: basic4k.asm
 Title:       
 
@@ -128,7 +128,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                      118    118 ;     LD    A,17H            ;CMND: DTR, ENABLE TRNS, & RCVR,
 004b  3e 37          119    119       LD    A,37H            ;**UM**
                      120    120 ;     OUT   (TTY-1),A        ;WRITE TO SIO
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 3
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 3
 Source file: basic4k.asm
 Title:       
 
@@ -193,7 +193,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 00a1  eb             178    178       EX    DE,HL            ;FLIP/FLOP
 00a2  70             179    179       LD    (HL),B           ;PUT LO LINE
 00a3  23             180    180       INC   HL               ;POINT NEXT
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 4
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 4
 Source file: basic4k.asm
 Title:       
 
@@ -258,7 +258,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0102  09             238    238       ADD   HL,BC            ;DISP LEN OF INSERT
 0103  22 1a 11       239    239       LD    (PROGE),HL       ;UPDATE END POINT
 0106  c1             240    240       POP   BC               ;GET ADDR
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 5
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 5
 Source file: basic4k.asm
 Title:       
 
@@ -323,7 +323,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 016a  c3 a2 01       298    298       JP    IMMD             ;GO IMMEDIATE
                      299    299 *HEADING IMSAI 8080 4K BASIC
 016d                 300    300 RUNIT EQU   $
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 6
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 6
 Source file: basic4k.asm
 Title:       
 
@@ -388,7 +388,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 01c4  c2 c1 01       358    358       JP    NZ,NOJMP         ;BRIF NOT
 01c7  13             359    359       INC   DE               ;POINT NEXT
 01c8  13             360    360       INC   DE               ;DITTO
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 7
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 7
 Source file: basic4k.asm
 Title:       
 
@@ -453,7 +453,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 020d  23             418    418       INC   HL               ;POINT NEXT BYTE
 020e  7e             419    419       LD    A,(HL)           ;GET LOW LINE NUMBER
 020f  2b             420    420       DEC   HL               ;POINT BACK
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 8
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 8
 Source file: basic4k.asm
 Title:       
 
@@ -518,7 +518,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0267  ca 57 02       478    478       JP    Z,PR4            ;BRIF IT IS
 026a  fe 2c          479    479       CP    ','              ;TEST IF COMMA
 026c  ca 87 02       480    480       JP    Z,PR7            ;BRIF IT IS
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 9
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 9
 Source file: basic4k.asm
 Title:       
 
@@ -583,7 +583,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 02d4  22 57 10       538    538       LD    (ADDR1),HL       ;SAVE ADDR
 02d7  f7             539    539       RST   RST6             ;GO STORE THE VALUE
 02d8  e1             540    540       POP   HL               ;RESTORE POINTER TO STMT
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 10
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 10
 Source file: basic4k.asm
 Title:       
 
@@ -648,7 +648,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 034a  d2 85 0e       598    598       JP    NC,FOERR         ;ERROR IF MORE THAN 8 OPEN FOR/NEXT
 034d  32 6e 10       599    599       LD    (FORNE),A        ;PUT IN TABLE
 0350  72             600    600       LD    (HL),D           ;STORE IT
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 11
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 11
 Source file: basic4k.asm
 Title:       
 
@@ -713,7 +713,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 03ab  f7             658    658       RST   RST6             ;SAVE IT
 03ac  e1             659    659       POP   HL               ;RESTORE HL
 03ad  af             660    660       XOR   A                ;CLEAR A
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 12
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 12
 Source file: basic4k.asm
 Title:       
 
@@ -778,7 +778,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                      718    718 ;
 041a  cd 2f 0f       719    719       CALL  VAR              ;NEXT MUST BE VARIABLE NAME
 041d  fe 3d          720    720       CP    '='              ;TEST FOR EQUAL SIGN
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 13
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 13
 Source file: basic4k.asm
 Title:       
 
@@ -843,7 +843,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0475  cd cb 07       778    778       CALL  FSUB             ;SUBTRACT TO VALUE
 0478  cd 9e 09       779    779       CALL  FTEST            ;GET SIGN OF DIFFERENCE
 047b  ca 93 04       780    780       JP    Z,NXTZR          ;BRIF ZERO
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 14
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 14
 Source file: basic4k.asm
 Title:       
 
@@ -908,7 +908,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 04df  e1             838    838       POP   HL               ;RESTORE STMT POINTER
 04e0  cf             839    839       RST   RST1             ;SKIP SPACES
 04e1  fe 2c          840    840       CP    ','              ;TEST FOR COMMA
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 15
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 15
 Source file: basic4k.asm
 Title:       
 
@@ -973,7 +973,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0544                 898    898 FIN   EQU   $
                      899    899 ;
                      900    900 ;FLOATING POINT INPUT CONVERSION ROUTINE
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 16
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 16
 Source file: basic4k.asm
 Title:       
 
@@ -1038,7 +1038,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 05a4  3c             958    958       INC   A                ;PLUS ONE
 05a5  1f             959    959       RRA                    ;DIVIDE BY TWO
 05a6  e6 0f          960    960       AND   0FH              ;MASK OFF UNUSED BITS
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 17
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 17
 Source file: basic4k.asm
 Title:       
 
@@ -1103,7 +1103,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 05ff  78            1018   1018       LD    A,B              ;GET EXPONENT
 0600  e6 7f         1019   1019       AND   7FH              ;TURN OFF HIGH BIT
 0602  b6            1020   1020       OR    (HL)             ;OR IN MANTISSA SIGN
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 18
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 18
 Source file: basic4k.asm
 Title:       
 
@@ -1168,7 +1168,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 064b  79            1078   1078       LD    A,C              ;RELOAD EXPONENT BYTE
 064c  f6 c0         1079   1079       OR    0C0H             ;SET ALL ON
 064e  2f            1080   1080       CPL                    ;COMPLEMENT ACC
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 19
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 19
 Source file: basic4k.asm
 Title:       
 
@@ -1233,7 +1233,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 06a5  fe 2e         1138   1138 FOX4  CP    '.'              ;TEST FOR TRAILING DOT
 06a7  c0            1139   1139       RET   NZ               ;RETURN IF NOT
 06a8  36 20         1140   1140       LD    (HL),' '         ;SPACE IT OUT
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 20
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 20
 Source file: basic4k.asm
 Title:       
 
@@ -1298,7 +1298,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 06fa  f0            1198   1198       RET   P                ;RETURN IF FACC > ADDER
 06fb  c3 28 00      1199   1199       JP    RST5             ;ELSE, ADDER > FACC
 06fe  f5            1200   1200 FADD4 PUSH  AF               ;SAVE DIFFERENCE
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 21
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 21
 Source file: basic4k.asm
 Title:       
 
@@ -1363,7 +1363,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0762  21 32 10      1258   1258       LD    HL,FTEMP+4       ;POINT TEMP2 AREA
 0765  06 04         1259   1259       LD    B,4              ;PREPARE TO SAVE ACC
 0767  cd 60 0e      1260   1260       CALL  COPYD            ;GO COPY
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 22
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 22
 Source file: basic4k.asm
 Title:       
 
@@ -1428,7 +1428,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 07c6  b0            1318   1318       OR    B                ;PLUS SAVED SIGN
 07c7  77            1319   1319       LD    (HL),A           ;PUT BACK
 07c8  c3 90 07      1320   1320       JP    FNORM            ;GO NORMALIZE
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 23
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 23
 Source file: basic4k.asm
 Title:       
 
@@ -1493,7 +1493,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0815  88            1378   1378       ADC   A,B              ;ADD EXPONENTS TOGETHER
 0816  cd 8f 09      1379   1379       CALL  FOVUN            ;GO SEE IF OVERFLOW/UNDERFLOW
 0819  e6 7f         1380   1380       AND   7FH              ;TURN OFF SIGN
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 24
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 24
 Source file: basic4k.asm
 Title:       
 
@@ -1558,7 +1558,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0880  7e            1438   1438       LD    A,(HL)           ;GET MSD PAIR
 0881  e6 f0         1439   1439       AND   0F0H             ;ISOLATE LEFT HALF
 0883  c2 b1 08      1440   1440       JP    NZ,FMUX3         ;BRIF NORMALIZED
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 25
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 25
 Source file: basic4k.asm
 Title:       
 
@@ -1623,7 +1623,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 08d8  ca 71 0e      1498   1498       JP    Z,OVERR          ;DIVISION BY ZERO = ERROR
 08db  7e            1499   1499       LD    A,(HL)           ;LOAD EXPONENT OF DIVISOR
 08dc  cd ac 09      1500   1500       CALL  FEXP             ;GO GET EXPON
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 26
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 26
 Source file: basic4k.asm
 Title:       
 
@@ -1688,7 +1688,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 093f  47            1558   1558       LD    B,A              ;SAVE IT
 0940  2b            1559   1559       DEC   HL               ;POINT NEXT
 0941  0d            1560   1560       DEC   C                ;DECR CTR
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 27
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 27
 Source file: basic4k.asm
 Title:       
 
@@ -1753,7 +1753,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                     1618   1618 ;
                     1619   1619 ;EXPAND EXPONENT INTO 8 BINARY BITS
                     1620   1620 ;
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 28
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 28
 Source file: basic4k.asm
 Title:       
 
@@ -1818,7 +1818,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                     1678   1678 ;
 09e4  7e            1679   1679       LD    A,(HL)           ;GET A BYTE
 09e5  5f            1680   1680       LD    E,A              ;SAVE IT
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 29
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 29
 Source file: basic4k.asm
 Title:       
 
@@ -1883,7 +1883,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0a19  32 2a 10      1738   1738       LD    (FACC),A         ;SET THE SIGN & EXPONENT
 0a1c  c9            1739   1739       RET                    ;RETURN
                     1740   1740 *HEADING IMSAI 8080 4K BASIC
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 30
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 30
 Source file: basic4k.asm
 Title:       
 
@@ -1948,7 +1948,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0a6c  21 42 10      1798   1798       LD    HL,ORIGS         ;GET ORIGINAL NUMBER
 0a6f  cd cb 07      1799   1799       CALL  FSUB             ;SUBTRACT FROM PREV**2
 0a72  cd 9e 09      1800   1800       CALL  FTEST            ;GET SIGN OF DIFFERENCE
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 31
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 31
 Source file: basic4k.asm
 Title:       
 
@@ -2013,7 +2013,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0ade  36 7f         1858   1858       LD    (HL),7FH         ;DEFAULT . XXXXXX
 0ae0  23            1859   1859       INC   HL               ;POINT MSD
 0ae1  46            1860   1860       LD    B,(HL)           ;LOAD IT
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 32
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 32
 Source file: basic4k.asm
 Title:       
 
@@ -2078,7 +2078,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0b3e  c3 d2 0b      1918   1918       JP    LOOKO            ;GO LOOK FOR OPCODE
 0b41  cd e4 0e      1919   1919 LDFN  CALL  ALPHA            ;GO SEE IF FUNCTION
 0b44  c2 2e 0b      1920   1920       JP    NZ,LDVR1         ;BRIF IT'S NOT
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 33
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 33
 Source file: basic4k.asm
 Title:       
 
@@ -2143,7 +2143,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0bb2  23            1978   1978       INC   HL               ;POINT NEXT
 0bb3  e5            1979   1979       PUSH  HL               ;SAVE HL
 0bb4  c3 97 0b      1980   1980       JP    LDFNC            ;GO AS IF FUNCTION
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 34
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 34
 Source file: basic4k.asm
 Title:       
 
@@ -2208,7 +2208,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0c27  e1            2038   2038       POP   HL               ;GET STMT POINTER
 0c28  23            2039   2039       INC   HL               ;POINT NEXT
 0c29  c3 fe 0a      2040   2040       JP    LOOKD            ;NEXT IS DATA
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 35
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 35
 Source file: basic4k.asm
 Title:       
 
@@ -2273,7 +2273,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0c82  21 00 00      2098   2098       LD    HL,0             ;LOAD ZERO TO HL
 0c85  e5            2099   2099       PUSH  HL               ;GET BLOCK OF
 0c86  e5            2100   2100       PUSH  HL               ;4 BYTES
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 36
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 36
 Source file: basic4k.asm
 Title:       
 
@@ -2338,7 +2338,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0ce6  b7            2158   2158       OR    A                ;TEST IT
 0ce7  c8            2159   2159       RET   Z                ;RETURN IF ZERO
 0ce8  d1            2160   2160 EV7   POP   DE               ;RETURN 2 BYTES
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 37
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 37
 Source file: basic4k.asm
 Title:       
 
@@ -2403,7 +2403,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0d48  d6 03         2218   2218       SUB   3                ;MINUS THREE
 0d4a  47            2219   2219       LD    B,A              ;SAVE
 0d4b  cd bb 0e      2220   2220       CALL  SQUIS            ;GO COMPRESS
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 38
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 38
 Source file: basic4k.asm
 Title:       
 
@@ -2468,7 +2468,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0da6  3a 61 10      2278   2278       LD    A,(OUTSW)        ;GET OUTPUT SWITCH
 0da9  b7            2279   2279       OR    A                ;TEST IF OFF
 0daa  c2 b7 0d      2280   2280       JP    NZ,TOUT2         ;BRIF NOT
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 39
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 39
 Source file: basic4k.asm
 Title:       
 
@@ -2533,7 +2533,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0dfd  c2 06 0e      2338   2338       JP    NZ,OUT2          ;BRIF NOT
 0e00  cd b9 0d      2339   2339       CALL  CRLF             ;LINE FEED
 0e03  c3 15 0e      2340   2340       JP    OUT4             ;CONTINUE
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 40
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 40
 Source file: basic4k.asm
 Title:       
 
@@ -2598,7 +2598,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0e4e  c9            2398   2398       RET                    ;RETURN
                     2399   2399 ;
                     2400   2400 ;
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 41
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 41
 Source file: basic4k.asm
 Title:       
 
@@ -2663,7 +2663,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0e81  01 41 44      2458   2458 DAERR LD    BC,'DA'          ;OUT OF DATA
 0e84  df            2459   2459       RST   RST3
 0e85  01 4f 46      2460   2460 FOERR LD    BC,'FO'          ;MORE THAN 8 NESTED FOR/NEXT OR
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 42
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 42
 Source file: basic4k.asm
 Title:       
 
@@ -2728,7 +2728,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                     2518   2518 ;
 0ec4                2519   2519 GTEMP EQU   $
                     2520   2520 ;
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 43
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 43
 Source file: basic4k.asm
 Title:       
 
@@ -2793,7 +2793,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0ef1  fe 3a         2578   2578       CP    '9'+1            ;TEST IF 9 OR LESS
 0ef3  d0            2579   2579       RET   NC               ;RETURN IF NOT NUMERIC
 0ef4  bf            2580   2580       CP    A                ;SET Z
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 44
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 44
 Source file: basic4k.asm
 Title:       
 
@@ -2858,7 +2858,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                     2638   2638 ;
                     2639   2639 ;
                     2640   2640 ;TEST (HL) FOR A VARIABLE NAME
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 45
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 45
 Source file: basic4k.asm
 Title:       
 
@@ -2923,7 +2923,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
 0f8e  46 4f 52      2698   2698 FORLI DEFM  'FOR'
 0f91  00            2699   2699       DEFB  0
 0f92  ba 02         2700   2700       DEFW  FOR
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 46
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 46
 Source file: basic4k.asm
 Title:       
 
@@ -2988,7 +2988,7 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                     2755   2758 ;TTY   EQU   1                ;DEVICE ADDRESS FOR TERMINAL
 0002                2756   2759 TTY   EQU   2                ;**UM**
 1000                2757   2760 NULLI DEFS  2
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 47
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 47
 Source file: basic4k.asm
 Title:       
 
@@ -3031,12 +3031,12 @@ LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                     2793   2796 ;
                     2794   2797 ;
 111d                2795   2798       END   BASIC
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 48
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 48
 Source file: basic4k.asm
-Title:       Symboltable
+Title:       Symbol table
 
 ABS      0a04 	ABSLI    0f6f 	ADDR1    1057 	ADDR2    1059*	
-ADDR3    105b 	ALPHA    0ee4 	BASIC    0000*	BEGPR    111d 	
+ADDR3    105b 	ALPHA    0ee4 	BASIC    0000 	BEGPR    111d 	
 COLUM    1063 	COMP2    0e66 	CONTI    0049 	CONTO    0e44 	
 CONTX    01a3*	COPYD    0e60 	COPYH    0e57 	CR1      0d8b 	
 CRLF     0db9 	DAERR    0e81 	DASTM    1068 	DATAB    1118 	
@@ -3097,9 +3097,9 @@ OP1L2    0c14 	OP1L3    0c18 	OP2      0c2c 	OP2A     0c33
 OP3      0c41 	ORIGS    1042 	OUT1     0df7 	OUT2     0e06 	
 OUT4     0e15 	OUTSW    1061 	OVERR    0e71 	PACK     0e8d 	
 PARCT    1054 	PK1      0e96 	PK3      0eaa 	PR1      0237 	
-Z80-Assembler	Release 1.9	Wed May 16 19:58:15 2018	Page 49
+Z80-Assembler	Release 1.11-dev	Fri Oct  7 00:22:35 2022	Page 49
 Source file: basic4k.asm
-Title:       Symboltable
+Title:       Symbol table
 
 PR2      0240 	PR3      0246*	PR4      0257 	PR5      0261 	
 PR6      0266 	PR7      0287 	PR8      02ad 	PRINT    0233 	

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -47,7 +47,6 @@
 #define LABSEP		':'	/* label separator */
 #define STRDEL		'\''	/* string delimiter */
 #define STRDEL2		'"'	/* the other string delimiter */
-#define ENDFILE		"END"	/* end of source */
 #define MAXFN		512	/* max. no. source files */
 #define MAXLINE		128	/* max. line length source */
 #define PLENGTH		65	/* default lines/page in listing */
@@ -115,6 +114,7 @@ struct inc {
 #define OP_UNDOC	1	/* undocumented opcode */
 #define OP_COND		2	/* concerns conditional assembly */
 #define OP_SET		3	/* assigns value to label */
+#define OP_END		4	/* end of source */
 
 /*
  *	definition of operand symbols

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -322,8 +322,6 @@ int p1_line(void)
 	p = get_label(label, p);
 	p = get_opcode(opcode, p);
 	p = get_arg(operand, p);
-	if (gencode && strcmp(opcode, ENDFILE) == 0)
-		return(0);
 	if (*opcode) {
 		if ((op = search_op(opcode)) != NULL) {
 			if (gencode && *label && (op->op_type != OP_SET))
@@ -332,6 +330,8 @@ int p1_line(void)
 				i = (*op->op_fun)(op->op_c1, op->op_c2);
 				pc += i;
 				rpc += i;
+				if (op->op_type == OP_END)
+					return(0);
 			}
 		} else
 			asmerr(E_ILLOPC);
@@ -404,19 +404,16 @@ int p2_line(void)
 	p = get_label(label, p);
 	p = get_opcode(opcode, p);
 	p = get_arg(operand, p);
-	if (gencode && strcmp(opcode, ENDFILE) == 0) {
-		lst_line(pc, 0);
-		return(0);
-	}
 	if (*opcode) {
 		op = search_op(opcode);
-		if (gencode || (op->op_type == OP_COND))
+		if (gencode || (op->op_type == OP_COND)) {
 			op_count = (*op->op_fun)(op->op_c1, op->op_c2);
-		if (gencode) {
 			lst_line(pc, op_count);
 			obj_writeb(op_count);
 			pc += op_count;
 			rpc += op_count;
+			if (op->op_type == OP_END)
+				return(0);
 		} else {
 			sd_flag = 2;
 			lst_line(0, 0);

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -33,7 +33,7 @@ extern int op_opset(int, int), op_org(int, int), op_phase(int, int);
 extern int op_dephase(int, int), op_radix(int, int), op_equ(int, int);
 extern int op_dl(int, int), op_ds(int, int), op_db(int, int), op_dm(int, int);
 extern int op_dw(int, int), op_misc(int, int), op_cond(int, int);
-extern int op_glob(int, int);
+extern int op_glob(int, int), op_end(int, int);
 
 /* z80arfun.c */
 extern int op_1b(int, int), op_2b(int, int), op_im(int, int);
@@ -49,7 +49,7 @@ extern int op8080_addr(int, int), op8080_mvi(int, int), op8080_lxi(int, int);
 
 /*
  *	pseudo op table:
- *	includes entries for all common pseudo ops other than END
+ *	includes entries for all common pseudo ops
  *	must be sorted in ascending order!
  */
 struct opc opctab_psd[] = {
@@ -73,6 +73,7 @@ struct opc opctab_psd[] = {
 	{ "DW",		op_dw,		0,	0,	0	 },
 	{ "EJECT",	op_misc,	1,	0,	0	 },
 	{ "ELSE",	op_cond,	98,	0,	OP_COND	 },
+	{ "END",	op_end,		0,	0,	OP_END	 },
 	{ "ENDC",	op_cond,	99,	0,	OP_COND	 },
 	{ "ENDIF",	op_cond,	99,	0,	OP_COND	 },
 	{ "ENT",	op_glob,	2,	0,	0	 },

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -218,9 +218,10 @@ int op_ds(int dummy1, int dummy2)
 				*p2++ = *p++;
 			*p2 = '\0';
 			cnt = eval(tmp);
-			val = eval(p1 + 1);
-			if (pass == 2)
+			if (pass == 2) {
+				val = eval(p1 + 1);
 				obj_fill_value(cnt, val);
+			}
 		} else {
 			cnt = eval(operand);
 			if (pass == 2)
@@ -636,5 +637,18 @@ int op_glob(int op_code, int dummy)
 		fatal(F_INTERN, "invalid opcode for function op_glob");
 		break;
 	}
+	return(0);
+}
+
+/*
+ *	END
+ */
+int op_end(int dummy1, int dummy2)
+{
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
+	if (pass == 2 && *operand)
+		(void) eval(operand);
 	return(0);
 }


### PR DESCRIPTION
Also update listings, because the END argument causes a previously unused label to be referenced.

Change DEFS to evaluate second parameter only during pass 2.