### PR TITLE
z80asm: fix non-seq, detect code before ORG, ad_mode needs reset, UNUSED moved

### DIFF
--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -5,9 +5,7 @@ z80asm -f{b|m|h} -s[n|a] -e<num> -h<num> -x -8 -u -v
 
 A maximum of 512 source files is allowed. If the file name of a source
 doesn't have an extension the default extension ".asm" will be appended.
-Source files have a maximum path length of 2048 characters. For relative
-paths an extension must be specified, because z80asm assumes, that the
-part after the last '.' of a path is an extension!
+Source files have a maximum path length of 2048 characters.
 
 Option f:
 Format of the output file:

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -28,6 +28,7 @@
 #define READA		"r"	/* file open mode read ascii */
 #define WRITEA		"w"	/* file open mode write ascii */
 #define WRITEB		"wb"	/* file open mode write binary */
+#define PATHSEP		'/'	/* directory separator in paths */
 
 /*
  *	various constants

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -203,6 +203,7 @@ struct inc {
 #define E_MISPHS	16	/* missing .PHASE at .DEPHASE */
 #define E_DIVBY0	17	/* division by zero */
 #define E_INVEXP	18	/* invalid expression */
+#define E_BFRORG	19	/* code before first ORG (binary output) */
 
 /*
  *	definition of fatal errors

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -214,3 +214,8 @@ struct inc {
 #define F_FOPEN		3	/* can't open file */
 #define F_INTERN	4	/* internal error */
 #define F_HEXLEN	5	/* hex record length out of range */
+
+/*
+ *	macro for declaring unused function parameters
+ */
+#define UNUSED(x)	(void)(x)

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -434,7 +434,11 @@ void open_o_files(char *source)
 
 	if (*objfn == '\0')
 		strcpy(objfn, source);
-	if ((p = strrchr(objfn, '.')) != NULL) {
+	if ((p = strrchr(objfn, PATHSEP)))
+		p++;
+	else
+		p = objfn;
+	if ((p = strrchr(p, '.')) != NULL) {
 		if (out_form == OUTHEX)
 			strcpy(p, OBJEXTHEX);
 		else
@@ -455,7 +459,11 @@ void open_o_files(char *source)
 	if (list_flag) {
 		if (*lstfn == '\0')
 			strcpy(lstfn, source);
-		if ((p = strrchr(lstfn, '.')) != NULL)
+		if ((p = strrchr(lstfn, PATHSEP)))
+			p++;
+		else
+			p = lstfn;
+		if ((p = strrchr(p, '.')) != NULL)
 			strcpy(p, LSTEXT);
 		else
 			strcat(lstfn, LSTEXT);
@@ -479,7 +487,11 @@ void get_fn(char *dest, char *src, char *ext)
 	while ((i++ < LENFN) && (*sp != '\0'))
 		*dp++ = *sp++;
 	*dp = '\0';
-	if ((strrchr(dest, '.') == NULL)
+	if ((dp = strrchr(dest, PATHSEP)))
+		dp++;
+	else
+		dp = dest;
+	if ((strrchr(dp, '.') == NULL)
 	    && (strlen(dest) <= (LENFN - strlen(ext))))
 		strcat(dest, ext);
 }

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -349,6 +349,7 @@ void pass2(void)
 	rpc = pc = 0;
 	phs_flag = 0;
 	fi = 0;
+	ad_mode = AD_STD;
 	if (ver_flag)
 		puts("Pass 2");
 	obj_header();
@@ -404,8 +405,8 @@ int p2_line(void)
 		op = search_op(opcode);
 		if (gencode || (op->op_type == OP_COND)) {
 			op_count = (*op->op_fun)(op->op_c1, op->op_c2);
-			lst_line(pc, op_count);
 			obj_writeb(op_count);
+			lst_line(pc, op_count);
 			pc += op_count;
 			rpc += op_count;
 			if (op->op_type == OP_END)

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -53,8 +53,6 @@ extern void obj_fill_value(int, int);
 extern struct sym *get_sym(char *);
 extern int put_sym(char *, int);
 
-#define UNUSED(x)	(void)(x)
-
 /*
  *	.8080 and .Z80
  */

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -51,8 +51,6 @@ extern int chk_sbyte(int);
 /* z80atab.c */
 extern int get_reg(char *);
 
-#define UNUSED(x)	(void)(x)
-
 /*
  *	process 1byte opcodes without arguments
  */


### PR DESCRIPTION
1. Fixed non-sequential code detection. Flag wasn't initialized.
   Just reversed it...
2. There was another problem with binary output files when there
   is code generated before the first ORG, which sets the load address.
   You'll get an error during assembly now, when this happens.
   The object file produced should still be valid, it just won't
   contain any code from before the first ORG address.
3. ad_mode needs to be reset at the start of pass 2 since pseudo-ops
   set it regardless of the current pass. And because lst_line() isn't
   called during pass 1, ad_mode won't be reset to AD_STD.
4. moved UNUSED macro to z80a.h
5. forgot to mention: moved lst_line() after obj_writeb(), so that error
   messages from obj_writeb() will be shown on the correct source line.
6. make file name extensions manipulation work with paths