### PR TITLE
z80asm: use copy_arg() in DEFS, check for missing .DEPHASE, some re-org

### DIFF
--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -69,7 +69,7 @@ Pseudo Operations:
 Definition of symbols and allocation of memory:
 
 	 ORG    <expression>    - set program address
-<symbol> .PHASE <expression>    - set logical program counter
+         .PHASE <expression>    - set logical program counter
 	 .DEPHASE               - end of logical phase block
 <symbol> EQU    <expression>    - define constant symbol
 <symbol> DEFL   <expression>    - define variable symbol

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -206,6 +206,7 @@ struct inc {
 #define E_INVEXP	18	/* invalid expression */
 #define E_BFRORG	19	/* code before first ORG (binary output) */
 #define E_ILLLBL	20	/* illegal label */
+#define E_MISDPH	21	/* missing .DEPHASE */
 
 /*
  *	definition of fatal errors

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -261,7 +261,6 @@ void pass1(void)
 	pass = 1;
 	radix = 10;
 	rpc = pc = 0;
-	phs_flag = 0;
 	fi = 0;
 	if (ver_flag)
 		puts("Pass 1");
@@ -295,6 +294,8 @@ void p1_file(char *fn)
 	while (p1_line())
 		;
 	fclose(srcfp);
+	if (phs_flag)
+		asmerr(E_MISDPH);
 	if (iflevel)
 		asmerr(E_MISEIF);
 }
@@ -351,7 +352,6 @@ void pass2(void)
 	pass = 2;
 	radix = 10;
 	rpc = pc = 0;
-	phs_flag = 0;
 	ad_mode = AD_STD;
 	fi = 0;
 	if (ver_flag)

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -29,11 +29,10 @@
 #include "z80a.h"
 
 /* z80apfun.c */
-extern int op_opset(int, int), op_org(int, int), op_phase(int, int);
-extern int op_dephase(int, int), op_radix(int, int), op_equ(int, int);
-extern int op_dl(int, int), op_ds(int, int), op_db(int, int), op_dw(int, int);
-extern int op_misc(int, int), op_cond(int, int), op_glob(int, int);
-extern int op_end(int, int);
+extern int op_opset(int, int), op_org(int, int), op_radix(int, int);
+extern int op_equ(int, int), op_dl(int, int), op_ds(int, int), op_db(int, int);
+extern int op_dw(int, int), op_misc(int, int), op_cond(int, int);
+extern int op_glob(int, int), op_end(int, int);
 
 /* z80arfun.c */
 extern int op_1b(int, int), op_2b(int, int), op_im(int, int);
@@ -54,8 +53,8 @@ extern int op8080_addr(int, int), op8080_mvi(int, int), op8080_lxi(int, int);
  */
 struct opc opctab_psd[] = {
 	{ ".8080",	op_opset,	1,	0,	OP_NOLBL },
-	{ ".DEPHASE",	op_dephase,	0,	0,	OP_NOLBL },
-	{ ".PHASE",	op_phase,	0,	0,	OP_NOLBL },
+	{ ".DEPHASE",	op_org,		3,	0,	OP_NOLBL },
+	{ ".PHASE",	op_org,		2,	0,	OP_NOLBL },
 	{ ".RADIX",	op_radix,	0,	0,	OP_NOLBL },
 	{ ".Z80",	op_opset,	2,	0,	OP_NOLBL },
 	{ "ABS",	op_glob,	3,	0,	OP_NOLBL },
@@ -102,7 +101,7 @@ struct opc opctab_psd[] = {
 	{ "INCLUDE",	op_misc,	6,	0,	OP_NOLBL | OP_NOPRE },
 	{ "LIST",	op_misc,	2,	0,	OP_NOLBL },
 	{ "NOLIST",	op_misc,	3,	0,	OP_NOLBL },
-	{ "ORG",	op_org,		0,	0,	OP_NOLBL },
+	{ "ORG",	op_org,		1,	0,	OP_NOLBL },
 	{ "PAGE",	op_misc,	4,	0,	OP_NOLBL },
 	{ "PRINT",	op_misc,	5,	0,	OP_NOLBL | OP_NOPRE },
 	{ "PUBLIC",	op_glob,	2,	0,	OP_NOLBL },

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -52,11 +52,11 @@ extern int op8080_addr(int, int), op8080_mvi(int, int), op8080_lxi(int, int);
  *	must be sorted in ascending order!
  */
 struct opc opctab_psd[] = {
-	{ ".8080",	op_opset,	1,	0,	OP_NOLBL },
+	{ ".8080",	op_opset,	2,	0,	OP_NOLBL },
 	{ ".DEPHASE",	op_org,		3,	0,	OP_NOLBL },
 	{ ".PHASE",	op_org,		2,	0,	OP_NOLBL },
 	{ ".RADIX",	op_radix,	0,	0,	OP_NOLBL },
-	{ ".Z80",	op_opset,	2,	0,	OP_NOLBL },
+	{ ".Z80",	op_opset,	1,	0,	OP_NOLBL },
 	{ "ABS",	op_glob,	3,	0,	OP_NOLBL },
 	{ "ASEG",	op_glob,	3,	0,	OP_NOLBL },
 	{ "ASET",	op_dl,		0,	0,	OP_SET	 },

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -62,7 +62,8 @@ static char *errmsg[] = {		/* error messages for asmerr() */
 	"division by zero",		/* 17 */
 	"invalid expression",		/* 18 */
 	"object code before ORG",	/* 19 */
-	"illegal label"			/* 20 */
+	"illegal label",		/* 20 */
+	"missing .DEPHASE"		/* 21 */
 };
 
 /*

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -63,11 +63,11 @@ int op_opset(int op_code, int dummy)
 
 	ad_mode = AD_NONE;
 	switch (op_code) {
-	case 1:				/* .8080 */
-		opset = OPSET_8080;
-		break;
-	case 2:				/* .Z80 */
+	case 1:				/* .Z80 */
 		opset = OPSET_Z80;
+		break;
+	case 2:				/* .8080 */
+		opset = OPSET_8080;
 		break;
 	default:
 		fatal(F_INTERN, "invalid opcode for function op_opset");

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -76,65 +76,49 @@ int op_opset(int op_code, int dummy)
 }
 
 /*
- *	ORG
+ *	ORG, .PHASE, .DEPHASE
  */
-int op_org(int dummy1, int dummy2)
+int op_org(int op_code, int dummy)
 {
 	register int i;
 
-	UNUSED(dummy1);
-	UNUSED(dummy2);
+	UNUSED(dummy);
 
-	if (phs_flag) {
-		asmerr(E_ORGPHS);
-		return(0);
-	}
-	i = eval(operand);
-	if (pass == 1) {		/* PASS 1 */
-		if (!load_flag) {
-			load_addr = i;
-			load_flag = 1;
+	ad_mode = AD_NONE;
+	switch (op_code) {
+	case 1:				/* ORG */
+		if (phs_flag) {
+			asmerr(E_ORGPHS);
+			return(0);
 		}
-	} else {			/* PASS 2 */
-		obj_org(i);
-		ad_mode = AD_NONE;
-	}
-	rpc = pc = i;
-	return(0);
-}
-
-/*
- *	.PHASE
- */
-int op_phase(int dummy1, int dummy2)
-{
-	UNUSED(dummy1);
-	UNUSED(dummy2);
-
-	if (phs_flag)
-		asmerr(E_PHSNEST);
-	else {
-		phs_flag = 1;
-		pc = eval(operand);
-		ad_mode = AD_NONE;
-	}
-	return(0);
-}
-
-/*
- *	.DEPHASE
- */
-int op_dephase(int dummy1, int dummy2)
-{
-	UNUSED(dummy1);
-	UNUSED(dummy2);
-
-	if (!phs_flag)
-		asmerr(E_MISPHS);
-	else {
-		phs_flag = 0;
-		pc = rpc;
-		ad_mode = AD_NONE;
+		i = eval(operand);
+		if (pass == 1) {	/* PASS 1 */
+			if (!load_flag) {
+				load_addr = i;
+				load_flag = 1;
+			}
+		} else			/* PASS 2 */
+			obj_org(i);
+		rpc = pc = i;
+		break;
+	case 2:				/* .PHASE */
+		if (phs_flag)
+			asmerr(E_PHSNEST);
+		else {
+			phs_flag = 1;
+			pc = eval(operand);
+		}
+		break;
+	case 3:				/* .DEPHASE */
+		if (!phs_flag)
+			asmerr(E_MISPHS);
+		else {
+			phs_flag = 0;
+			pc = rpc;
+		}
+		break;
+	default:
+		fatal(F_INTERN, "invalid opcode for function op_org");
 	}
 	return(0);
 }
@@ -149,12 +133,12 @@ int op_radix(int dummy1, int dummy2)
 	UNUSED(dummy1);
 	UNUSED(dummy2);
 
+	ad_mode = AD_NONE;
 	i = eval(operand);
 	if (i < 2 || i > 16)
 		asmerr(E_VALOUT);
 	else
 		radix = i;
-	ad_mode = AD_NONE;
 	return(0);
 }
 
@@ -200,31 +184,29 @@ int op_dl(int dummy1, int dummy2)
  */
 int op_ds(int dummy1, int dummy2)
 {
-	register char *p, *p1, *p2;
+	register char *p;
 	register int count, value;
 
 	UNUSED(dummy1);
 	UNUSED(dummy2);
 
+	ad_mode = AD_ADDR;
+	ad_addr = pc;
 	p = operand;
 	if (*p == '\0')
 		asmerr(E_MISOPE);
 	else {
-		ad_addr = pc;
-		ad_mode = AD_ADDR;
-		if ((p1 = strchr(operand, ',')) != NULL) {
-			p2 = tmp;
-			while (*p != ',')
-				*p2++ = *p++;
-			*p2 = '\0';
-			count = eval(tmp);
-			if (pass == 2) {
-				value = eval(p1 + 1);
-				obj_fill_value(count, value);
-			}
-		} else {
-			count = eval(operand);
-			if (pass == 2)
+		p = copy_arg(tmp, p, NULL);
+		count = eval(tmp);
+		if (pass == 2) {
+			if (*p++ == ',') {
+				if (*p == '\0')
+					asmerr(E_MISOPE);
+				else {
+					value = eval(p);
+					obj_fill_value(count, value);
+				}
+			} else
 				obj_fill(count);
 		}
 		pc += count;
@@ -385,8 +367,8 @@ int op_misc(int op_code, int dummy)
 		incnest++;
 		p = operand;
 		d = fn;
-		while(!isspace((unsigned char) *p) && *p != COMMENT
-						   && *p != '\0')
+		while (!isspace((unsigned char) *p) && *p != COMMENT
+						    && *p != '\0')
 			*d++ = *p++;
 		*d = '\0';
 		if (pass == 1) {	/* PASS 1 */
@@ -394,7 +376,6 @@ int op_misc(int op_code, int dummy)
 				printf("   Include %s\n", fn);
 			p1_file(fn);
 		} else {		/* PASS 2 */
-			ad_mode = AD_NONE;
 			lst_line(0, 0);
 			if (ver_flag)
 				printf("   Include %s\n", fn);


### PR DESCRIPTION
1. Forgot to convert op_ds() to use copy_arg()
2. It is now an error to leave out .DEPHASE
3. Put ORG, .PHASE and .DEPHASE in one function. They belong together.
4. Always set ad_mode at beginning when possible (nearly all pseudo ops already did this)