### PR TITLE
z80sim: removed mem_base() and wrk_addr, reworked disassembler

### DIFF
--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -1080,7 +1080,6 @@ void exit_io(void)
  */
 void reset_system(void)
 {
-	extern BYTE *wrk_ram;
 	register int i;
 
 	/* reset hardware */
@@ -1100,7 +1099,6 @@ void reset_system(void)
 
 	/* reset CPU */
 	reset_cpu();
-	wrk_ram	= mem_base();
 
 	/* reboot */
 	boot(1);

--- a/cpmsim/srcsim/memory.h
+++ b/cpmsim/srcsim/memory.h
@@ -126,14 +126,3 @@ static inline BYTE getmem(WORD addr)
 	else
 		return(*(memory[selbnk] + addr));
 }
-
-/*
- * return memory base pointer for the simulation frame
- *
- * iosim.c still has a dependency on this
- * 
- */
-static inline BYTE *mem_base(void)
-{
-	return(memory[0]);
-}

--- a/iodevices/cromemco-88ccc.c
+++ b/iodevices/cromemco-88ccc.c
@@ -84,7 +84,6 @@ static void *store_image(void *arg)
 					for (j = 0; j < FIELDSIZE; j++) {
 						dma_write(dma_addr + (i * FIELDSIZE) + j, buffer[j]);
 					}
-					/* memcpy(mem_base() + dma_addr + (i * FIELDSIZE), buffer, len); */
 				}
 			}
 		} else {

--- a/mosteksim/srcsim/memory.h
+++ b/mosteksim/srcsim/memory.h
@@ -55,11 +55,3 @@ static inline BYTE getmem(WORD addr)
 {
 	return(memory[addr]);
 }
-
-/*
- * return memory base pointer for the simulation frame
- *
- * simctl.c still has a dependency on this
- * 
- */
-#define mem_base() (&memory[0])

--- a/mosteksim/srcsim/simctl.c
+++ b/mosteksim/srcsim/simctl.c
@@ -15,7 +15,7 @@
  */
 
 /*
- *	This module is an ICE type user interface to debug Z80 programs
+ *	This module is an ICE type user interface to debug Z80/8080 programs
  *	on a host system.
  */
 
@@ -36,7 +36,7 @@
 #include "../../iodevices/unix_terminal.h"
 
 extern void cpu_z80(void), cpu_8080(void);
-extern void disass(unsigned char **, int);
+extern void disass(int, WORD *);
 extern int exatoi(char *);
 extern int getkey(void);
 extern void int_on(void), int_off(void);
@@ -65,7 +65,7 @@ static void do_unix(char *);
 static void do_help(void);
 static void cpu_err_msg(void);
 
-extern BYTE *wrk_ram;
+static WORD wrk_addr;
 extern struct termios old_term;
 
 /*
@@ -76,6 +76,8 @@ void mon(void)
 {
 	register int eoj = 1;
 	static char cmd[LENCMD];
+
+	wrk_addr = PC;
 
 	tcgetattr(0, &old_term);
 
@@ -161,7 +163,7 @@ void mon(void)
  */
 static void do_step(void)
 {
-	BYTE *p;
+	WORD a;
 
 	cpu_state = SINGLE_STEP;
 	cpu_error = NONE;
@@ -178,8 +180,9 @@ static void do_step(void)
 	cpu_err_msg();
 	print_head();
 	print_reg();
-	p = mem_base() + PC;
-	disass(&p, PC);
+	a = PC;
+	disass(cpu, &a);
+	wrk_addr = PC;
 }
 
 /*
@@ -282,7 +285,7 @@ static int handel_break(void)
 	break_address = PC - 1;		/* store adr of breakpoint */
 	cpu_error = NONE;		/* HALT was a breakpoint */
 	PC--;				/* substitute HALT opcode by */
-	*(mem_base() + PC) = soft[i].sb_oldopc;	/* original opcode */
+	putmem(PC, soft[i].sb_oldopc);	/* original opcode */
 	cpu_state = SINGLE_STEP;	/* and execute it */
 	switch(cpu) {
 	case Z80:
@@ -292,7 +295,7 @@ static int handel_break(void)
 		cpu_8080();
 		break;
 	}
-	*(mem_base() + soft[i].sb_adr) = 0x76; /* restore HALT opcode again */
+	putmem(soft[i].sb_adr, 0x76);	/* restore HALT opcode again */
 	soft[i].sb_passcount++;		/* increment passcounter */
 	if (soft[i].sb_passcount != soft[i].sb_pass)
 		return(1);		/* pass not reached, continue */
@@ -315,22 +318,18 @@ static void do_dump(char *s)
 	while (isspace((unsigned char) *s))
 		s++;
 	if (isxdigit((unsigned char) *s))
-		wrk_ram = mem_base() + exatoi(s) - exatoi(s) % 16;
+		wrk_addr = exatoi(s) - exatoi(s) % 16;
 	printf("Adr    ");
 	for (i = 0; i < 16; i++)
 		printf("%02x ", i);
 	puts(" ASCII");
 	for (i = 0; i < 16; i++) {
-		printf("%04x - ", (unsigned int)(wrk_ram - mem_base()));
-		for (j = 0; j < 16; j++) {
-			printf("%02x ", *wrk_ram);
-			wrk_ram++;
-			if (wrk_ram > mem_base() + 65535)
-				wrk_ram = mem_base();
-		}
+		printf("%04x - ", (unsigned int) wrk_addr);
+		for (j = 0; j < 16; j++)
+			printf("%02x ", getmem(wrk_addr++));
 		putchar('\t');
 		for (j = -16; j < 0; j++)
-			printf("%c", ((c = *(wrk_ram + j)) >= ' ' && c <= 0x7f)
+			printf("%c", ((c = getmem(wrk_addr + j)) >= ' ' && c <= 0x7f)
 			       ? c : '.');
 		putchar('\n');
 	}
@@ -346,12 +345,10 @@ static void do_list(char *s)
 	while (isspace((unsigned char) *s))
 		s++;
 	if (isxdigit((unsigned char) *s))
-		wrk_ram = mem_base() + exatoi(s);
+		wrk_addr = exatoi(s);
 	for (i = 0; i < 10; i++) {
-		printf("%04x - ", (unsigned int)(wrk_ram - mem_base()));
-		disass(&wrk_ram, wrk_ram - mem_base());
-		if (wrk_ram > mem_base() + 65535)
-			wrk_ram = mem_base();
+		printf("%04x - ", (unsigned int) wrk_addr);
+		disass(cpu, &wrk_addr);
 	}
 }
 
@@ -365,22 +362,18 @@ static void do_modify(char *s)
 	while (isspace((unsigned char) *s))
 		s++;
 	if (isxdigit((unsigned char) *s))
-		wrk_ram = mem_base() + exatoi(s);
+		wrk_addr = exatoi(s);
 	for (;;) {
-		printf("%04x = %02x : ", (unsigned int)(wrk_ram - mem_base()),
-		       *wrk_ram);
+		printf("%04x = %02x : ", (unsigned int) wrk_addr,
+		       getmem(wrk_addr));
 		fgets(nv, sizeof(nv), stdin);
 		if (nv[0] == '\n') {
-			wrk_ram++;
-			if (wrk_ram > mem_base() + 65535)
-				wrk_ram = mem_base();
+			wrk_addr++;
 			continue;
 		}
 		if (!isxdigit((unsigned char) nv[0]))
 			break;
-		*wrk_ram++ = exatoi(nv);
-		if (wrk_ram > mem_base() + 65535)
-			wrk_ram = mem_base();
+		putmem(wrk_addr++, exatoi(nv));
 	}
 }
 
@@ -389,13 +382,13 @@ static void do_modify(char *s)
  */
 static void do_fill(char *s)
 {
-	register BYTE *p;
+	register WORD a;
 	register int i;
 	register BYTE val;
 
 	while (isspace((unsigned char) *s))
 		s++;
-	p = mem_base() + exatoi(s);
+	a = exatoi(s);
 	while (*s != ',' && *s != '\0')
 		s++;
 	if (*s) {
@@ -412,11 +405,8 @@ static void do_fill(char *s)
 		puts("value missing");
 		return;
 	}
-	while (i--) {
-		*p++ = val;
-		if (p > mem_base() + 65535)
-			p = mem_base();
-	}
+	while (i--)
+		putmem(a++, val);
 }
 
 /*
@@ -424,17 +414,17 @@ static void do_fill(char *s)
  */
 static void do_move(char *s)
 {
-	register BYTE *p1, *p2;
+	register WORD a1, a2;
 	register int count;
 
 	
 	while (isspace((unsigned char) *s))
 		s++;
-	p1 = mem_base() + exatoi(s);
+	a1 = exatoi(s);
 	while (*s != ',' && *s != '\0')
 		s++;
 	if (*s) {
-		p2 = mem_base() + exatoi(++s);
+		a2 = exatoi(++s);
 	} else {
 		puts("to missing");
 		return;
@@ -447,13 +437,8 @@ static void do_move(char *s)
 		puts("count missing");
 		return;
 	}
-	while (count--) {
-		*p2++ = *p1++;
-		if (p1 > mem_base() + 65535)
-			p1 = mem_base();
-		if (p2 > mem_base() + 65535)
-			p2 = mem_base();
-	}
+	while (count--)
+		putmem(a2++, getmem(a1++));
 }
 
 /*
@@ -708,15 +693,15 @@ static void do_break(char *s)
 	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == 'c') {
-		*(mem_base() + soft[i].sb_adr) = soft[i].sb_oldopc;
+		putmem(soft[i].sb_adr, soft[i].sb_oldopc);
 		memset((char *) &soft[i], 0, sizeof(struct softbreak));
 		return;
 	}
 	if (soft[i].sb_pass)
-		*(mem_base() + soft[i].sb_adr) = soft[i].sb_oldopc;
+		putmem(soft[i].sb_adr, soft[i].sb_oldopc);
 	soft[i].sb_adr = exatoi(s);
-	soft[i].sb_oldopc = *(mem_base() + soft[i].sb_adr);
-	*(mem_base() + soft[i].sb_adr) = 0x76;
+	soft[i].sb_oldopc = getmem(soft[i].sb_adr);
+	putmem(soft[i].sb_adr, 0x76);
 	while (!iscntrl((unsigned char) *s) && !ispunct((unsigned char) *s))
 		s++;
 	if (*s != ',')
@@ -841,13 +826,14 @@ static void do_clock(void)
 	BYTE save[3];
 	static struct sigaction newact;
 	static struct itimerval tim;
+	char *s = NULL;
 
-	save[0] = *(mem_base() + 0x0000); /* save memory locations */
-	save[1] = *(mem_base() + 0x0001); /* 0000H - 0002H */
-	save[2] = *(mem_base() + 0x0002);
-	*(mem_base() + 0x0000) = 0xc3;	/* store opcode JP 0000H at address */
-	*(mem_base() + 0x0001) = 0x00;	/* 0000H */
-	*(mem_base() + 0x0002) = 0x00;
+	save[0] = getmem(0x0000);	/* save memory locations */
+	save[1] = getmem(0x0001);	/* 0000H - 0002H */
+	save[2] = getmem(0x0002);
+	putmem(0x0000, 0xc3);		/* store opcode JP 0000H at address */
+	putmem(0x0001, 0x00);		/* 0000H */
+	putmem(0x0002, 0x00);
 	PC = 0;				/* set PC to this code */
 	R = 0L;				/* clear refresh register */
 	cpu_state = CONTIN_RUN;		/* initialise CPU */
@@ -864,19 +850,22 @@ static void do_clock(void)
 	switch(cpu) {			/* start CPU */
 	case Z80:
 		cpu_z80();
+		s = "JP";
 		break;
 	case I8080:
 		cpu_8080();
+		s = "JMP";
 		break;
 	}
 	newact.sa_handler = SIG_DFL;	/* reset timer interrupt handler */
 	sigaction(SIGALRM, &newact, NULL);
-	*(mem_base() + 0x0000) = save[0]; /* restore memory locations */
-	*(mem_base() + 0x0001) = save[1]; /* 0000H - 0002H */
-	*(mem_base() + 0x0002) = save[2];
-	if (cpu_error == NONE)
+	putmem(0x0000, save[0]);	/* restore memory locations */
+	putmem(0x0001, save[1]);	/* 0000H - 0002H */
+	putmem(0x0002, save[2]);
+	if (cpu_error == NONE) {
+		printf("CPU executed %ld %s instructions in 3 seconds\n", R, s);
 		printf("clock frequency = %5.2f Mhz\n", ((float) R) / 300000.0);
-	else
+	} else
 		puts("Interrupted by user");
 }
 
@@ -990,19 +979,22 @@ static void cpu_err_msg(void)
 		break;
 	case OPTRAP1:
 		printf("Op-code trap at %04x: %02x\n", PC - 1,
-		       *(mem_base() + PC - 1));
+		       getmem(PC - 1));
 		break;
 	case OPTRAP2:
 		printf("Op-code trap at %04x: %02x %02x\n", PC - 2,
-		       *(mem_base() + PC - 2), *(mem_base() + PC - 1));
+		       getmem(PC - 2), getmem(PC - 1));
 		break;
 	case OPTRAP4:
 		printf("Op-code trap at %04x: %02x %02x %02x %02x\n",
-		       PC - 4, *(mem_base() + PC - 4), *(mem_base() + PC - 3),
-		       *(mem_base() + PC - 2), *(mem_base() + PC - 1));
+		       PC - 4, getmem(PC - 4), getmem(PC - 3),
+		       getmem(PC - 2), getmem(PC - 1));
 		break;
 	case USERINT:
 		puts("User Interrupt");
+		break;
+	case INTERROR:
+		printf("Unsupported bus data during INT: %02x\n", int_data);
 		break;
 	case POWEROFF:
 		break;

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -66,8 +66,8 @@ extern void a_sort_sym(int);
 
 static char *errmsg[] = {		/* error messages for fatal() */
 	"out of memory: %s",		/* 0 */
-	"usage: z80asm -f{b|m|h} -s[n|a] -e<num> -h<num> -x -8 -u -v\n\
-              -o<file> -l[<file>] -d<symbol> ... <file> ...", /* 1 */
+	"usage: z80asm -f{b|m|h} -s[n|a] -e<num> -h<num> -x -8 -u -v\n"
+	"              -o<file> -l[<file>] -d<symbol> ... <file> ...", /* 1 */
 	"Assembly halted",		/* 2 */
 	"can't open file %s",		/* 3 */
 	"internal error: %s",		/* 4 */

--- a/z80core/sim0.c
+++ b/z80core/sim0.c
@@ -243,7 +243,8 @@ int main(int argc, char *argv[])
 #endif
 
 #ifdef HAS_BANKED_ROM
-			case 'R':	/* enable banked ROM for machines that implement it */
+			case 'R':	/* enable banked ROM for machines
+					   that implement it */
 				R_flag = 1;
 				break;
 #endif
@@ -265,7 +266,8 @@ int main(int argc, char *argv[])
 
 usage:
 
-				printf("usage:\t%s -z -8 -s -l -i -u %s-m val -f freq -x filename", pn, rom);
+				printf("usage:\t%s -z -8 -s -l -i -u %s-m val "
+				       "-f freq -x filename", pn, rom);
 #ifdef HAS_DISKS
 				printf(" -d diskpath");
 #endif
@@ -311,7 +313,8 @@ usage:
 				puts("\t     ./conf/system.conf");
 				printf("\t     %s/system.conf\n", CONFDIR);
 #if MAXMEMSECT > 0
-				printf("\t-M = use config file memory section val (1-%d)\n", MAXMEMSECT);
+				printf("\t-M = use config file memory "
+				       "section val (1-%d)\n", MAXMEMSECT);
 #endif
 #endif
 #ifdef HAS_BANKED_ROM
@@ -360,13 +363,15 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 		printf(", CPU doesn't execute undocumented instructions\n");
 #else
 		if (u_flag)
-			printf(", CPU doesn't execute undocumented instructions\n");
+			printf(", CPU doesn't execute undocumented "
+			       "instructions\n");
 		else
 			printf(", CPU executes undocumented instructions\n");
 #endif
 	} else {
 		if (u_flag)
-			printf(", CPU doesn't execute undocumented instructions\n");
+			printf(", CPU doesn't execute undocumented "
+			       "instructions\n");
 		else
 			printf(", CPU executes undocumented instructions\n");
 	}
@@ -407,7 +412,7 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 		if (load_core())
 			return(1);
 	} else if (x_flag) { 	/* OR load memory from file */
-		if (load_file(xfn, 0, 0)) /* (..., 0, 0) don't care where it loads */
+		if (load_file(xfn, 0, 0)) /* don't care where it loads */
 			return(1);
 	}
 

--- a/z80core/sim0.c
+++ b/z80core/sim0.c
@@ -81,8 +81,6 @@ extern void int_on(void), int_off(void), mon(void);
 extern void init_io(void), exit_io(void);
 extern int exatoi(char *);
 
-BYTE *wrk_ram;			/* work pointer for the memory */
-
 int main(int argc, char *argv[])
 {
 	register char *s, *p;

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -194,12 +194,6 @@ int load_file(char *s, BYTE pstart, WORD psize)
 		return(1);
 	}
 
-	//TODO: What is this? We need to remove references to wrk_ram and mem_base()
-	// if (*s == ',')
-	// 	wrk_ram = mem_base() + exatoi(++s);
-	// else
-	// 	wrk_ram = NULL;
-
 	read(fd, (char *) &d, 1);	/* read first byte of file */
 	close(fd);
 
@@ -304,8 +298,6 @@ static int load_hex(char *fn, BYTE pstart, WORD psize)
 		count += (*s <= '9') ? (*s - '0')
 				     : (*s - 'A' + 10);
 		s++;
-		if (count == 0)
-			break;
 		addr = (*s <= '9') ? (*s - '0') << 4
 				   : (*s - 'A' + 10) << 4;
 		s++;
@@ -319,6 +311,14 @@ static int load_hex(char *fn, BYTE pstart, WORD psize)
 		addr += (*s <= '9') ? (*s - '0')
 				    : (*s - 'A' + 10);
 		s++;
+		data = (*s <= '9') ? (*s - '0') << 4
+				   : (*s - 'A' + 10) << 4;
+		s++;
+		data += (*s <= '9') ? (*s - '0')
+				    : (*s - 'A' + 10);
+		s++;
+		if (data == 1)
+			break;
 
 		if (psize) {
 			if (addr < (pstart << 8) || (addr + count - 1) >= ((pstart + psize) << 8)) {
@@ -331,7 +331,6 @@ static int load_hex(char *fn, BYTE pstart, WORD psize)
 			saddr = addr;
 		if (addr >= eaddr)
 			eaddr = addr + count - 1;
-		s += 2;
 		for (i = 0; i < count; i++) {
 			data = (*s <= '9') ? (*s - '0') << 4
 					   : (*s - 'A' + 10) << 4;
@@ -345,13 +344,14 @@ static int load_hex(char *fn, BYTE pstart, WORD psize)
 
 	fclose(fd);
 
+	PC = addr ? addr : saddr;
+
 	count = eaddr - saddr + 1;
 	LOG(TAG, "Loader statistics for file %s:\r\n", fn);
 	LOG(TAG, "START : %04XH\r\n", saddr);
 	LOG(TAG, "END   : %04XH\r\n", eaddr);
+	LOG(TAG, "PC    : %04XH\r\n", PC);
 	LOG(TAG, "LOADED: %04XH (%d)\r\n\r\n", count & 0xffff, count & 0xffff);
-
-	PC = saddr;
 
 	return(0);
 }

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -197,7 +197,8 @@ int load_file(char *s, BYTE pstart, WORD psize)
 	read(fd, (char *) &d, 1);	/* read first byte of file */
 	close(fd);
 
-	LOGD(TAG, "LOAD in Range: %04Xh - %04Xh", pstart << 8, (pstart+psize)<<8);
+	LOGD(TAG, "LOAD in Range: %04Xh - %04Xh",
+	     pstart << 8, (pstart + psize) << 8);
 
 	if (d == 0xff) {		/* Mostek header ? */
 		return(load_mos(fn, pstart, psize));
@@ -231,7 +232,9 @@ static int load_mos(char *fn, BYTE pstart, WORD psize)
 	laddr = (fileb[2] << 8) + fileb[1];
 
 	if (psize && laddr < (pstart << 8)) {
-		LOGW(TAG, "tried to load mos file outside expected address range. Address: %04X", laddr);
+		LOGW(TAG, "tried to load mos file outside "
+		     "expected address range. "
+		     "Address: %04X", laddr);
 		return(1);
 	}
 
@@ -239,7 +242,9 @@ static int load_mos(char *fn, BYTE pstart, WORD psize)
 	for (i = laddr; i < 65536; i++) {
 		if (read(fd, fileb, 1) == 1) {
 			if (psize && i >= ((pstart + psize) << 8)) {
-				LOGW(TAG, "tried to load mos file outside expected address range. Address: %04X", i);
+				LOGW(TAG, "tried to load mos file outside "
+				     "expected address range. "
+				     "Address: %04X", i);
 				return(1);
 			}
 			count++;
@@ -321,8 +326,11 @@ static int load_hex(char *fn, BYTE pstart, WORD psize)
 			break;
 
 		if (psize) {
-			if (addr < (pstart << 8) || (addr + count - 1) >= ((pstart + psize) << 8)) {
-				LOGW(TAG, "tried to load hex record outside expected address range. Address: %04X-%04X", addr, addr+count);
+			if (addr < (pstart << 8)
+			    || (addr + count - 1) >= ((pstart + psize) << 8)) {
+				LOGW(TAG, "tried to load hex record outside "
+				     "expected address range. "
+				     "Address: %04X-%04X", addr, addr+count);
 				return(1);
 			}
 		}

--- a/z80sim/srcsim/disas.c
+++ b/z80sim/srcsim/disas.c
@@ -4,7 +4,7 @@
  * Copyright (C) 1989-2021 by Udo Munk
  * Parts Copyright (C) 2008 by Justin Clancy
  * 8080 disassembler Copyright (C) 2018 by Christophe Staiesse
- * Copyright (c) 2022 Thomas Eberhardt
+ * Copyright (c) 2022 by Thomas Eberhardt
  *
  * History:
  * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
@@ -51,29 +51,32 @@
 #include <stdio.h>
 #include <string.h>
 #include "sim.h"
+#include "memory.h"
+
+#define UNUSED(x)	(void)(x)
 
 /*
  *	Forward declarations
  */
-static int opout(char *, char **);
-static int nout(char *, unsigned char **);
-static int iout(char *, unsigned char **);
-static int rout(char *, char **);
-static int nnout(char *, unsigned char **);
-static int inout(char *, unsigned char **);
-static int cbop(char *, unsigned char **);
-static int edop(char *, unsigned char **);
-static int ddfd(char *, unsigned char **);
+static int opout(char *, WORD);
+static int nout(char *, WORD);
+static int iout(char *, WORD);
+static int rout(char *, WORD);
+static int nnout(char *, WORD);
+static int inout(char *, WORD);
+static int cbop(char *, WORD);
+static int edop(char *, WORD);
+static int ddfd(char *, WORD);
 
 /*
  *	Op-code tables
  */
 struct opt {
-	int (*fun) ();
+	int (*fun) (char *, WORD);
 	char *text;
 };
 
-static struct opt optabz80[256] = {
+static struct opt optabz80_01[64] = {
 	{ opout,  "NOP"			},	/* 0x00 */
 	{ nnout,  "LD\tBC,"		},	/* 0x01 */
 	{ opout,  "LD\t(BC),A"		},	/* 0x02 */
@@ -137,135 +140,10 @@ static struct opt optabz80[256] = {
 	{ opout,  "INC\tA"		},	/* 0x3c */
 	{ opout,  "DEC\tA"		},	/* 0x3d */
 	{ nout,   "LD\tA,"		},	/* 0x3e */
-	{ opout,  "CCF"			},	/* 0x3f */
-	{ opout,  "LD\tB,B"		},	/* 0x40 */
-	{ opout,  "LD\tB,C"		},	/* 0x41 */
-	{ opout,  "LD\tB,D"		},	/* 0x42 */
-	{ opout,  "LD\tB,E"		},	/* 0x43 */
-	{ opout,  "LD\tB,H"		},	/* 0x44 */
-	{ opout,  "LD\tB,L"		},	/* 0x45 */
-	{ opout,  "LD\tB,(HL)"		},	/* 0x46 */
-	{ opout,  "LD\tB,A"		},	/* 0x47 */
-	{ opout,  "LD\tC,B"		},	/* 0x48 */
-	{ opout,  "LD\tC,C"		},	/* 0x49 */
-	{ opout,  "LD\tC,D"		},	/* 0x4a */
-	{ opout,  "LD\tC,E"		},	/* 0x4b */
-	{ opout,  "LD\tC,H"		},	/* 0x4c */
-	{ opout,  "LD\tC,L"		},	/* 0x4d */
-	{ opout,  "LD\tC,(HL)"		},	/* 0x4e */
-	{ opout,  "LD\tC,A"		},	/* 0x4f */
-	{ opout,  "LD\tD,B"		},	/* 0x50 */
-	{ opout,  "LD\tD,C"		},	/* 0x51 */
-	{ opout,  "LD\tD,D"		},	/* 0x52 */
-	{ opout,  "LD\tD,E"		},	/* 0x53 */
-	{ opout,  "LD\tD,H"		},	/* 0x54 */
-	{ opout,  "LD\tD,L"		},	/* 0x55 */
-	{ opout,  "LD\tD,(HL)"		},	/* 0x56 */
-	{ opout,  "LD\tD,A"		},	/* 0x57 */
-	{ opout,  "LD\tE,B"		},	/* 0x58 */
-	{ opout,  "LD\tE,C"		},	/* 0x59 */
-	{ opout,  "LD\tE,D"		},	/* 0x5a */
-	{ opout,  "LD\tE,E"		},	/* 0x5b */
-	{ opout,  "LD\tE,H"		},	/* 0x5c */
-	{ opout,  "LD\tE,L"		},	/* 0x5d */
-	{ opout,  "LD\tE,(HL)"		},	/* 0x5e */
-	{ opout,  "LD\tE,A"		},	/* 0x5f */
-	{ opout,  "LD\tH,B"		},	/* 0x60 */
-	{ opout,  "LD\tH,C"		},	/* 0x61 */
-	{ opout,  "LD\tH,D"		},	/* 0x62 */
-	{ opout,  "LD\tH,E"		},	/* 0x63 */
-	{ opout,  "LD\tH,H"		},	/* 0x64 */
-	{ opout,  "LD\tH,L"		},	/* 0x65 */
-	{ opout,  "LD\tH,(HL)"		},	/* 0x66 */
-	{ opout,  "LD\tH,A"		},	/* 0x67 */
-	{ opout,  "LD\tL,B"		},	/* 0x68 */
-	{ opout,  "LD\tL,C"		},	/* 0x69 */
-	{ opout,  "LD\tL,D"		},	/* 0x6a */
-	{ opout,  "LD\tL,E"		},	/* 0x6b */
-	{ opout,  "LD\tL,H"		},	/* 0x6c */
-	{ opout,  "LD\tL,L"		},	/* 0x6d */
-	{ opout,  "LD\tL,(HL)"		},	/* 0x6e */
-	{ opout,  "LD\tL,A"		},	/* 0x6f */
-	{ opout,  "LD\t(HL),B"		},	/* 0x70 */
-	{ opout,  "LD\t(HL),C"		},	/* 0x71 */
-	{ opout,  "LD\t(HL),D"		},	/* 0x72 */
-	{ opout,  "LD\t(HL),E"		},	/* 0x73 */
-	{ opout,  "LD\t(HL),H"		},	/* 0x74 */
-	{ opout,  "LD\t(HL),L"		},	/* 0x75 */
-	{ opout,  "HALT"		},	/* 0x76 */
-	{ opout,  "LD\t(HL),A"		},	/* 0x77 */
-	{ opout,  "LD\tA,B"		},	/* 0x78 */
-	{ opout,  "LD\tA,C"		},	/* 0x79 */
-	{ opout,  "LD\tA,D"		},	/* 0x7a */
-	{ opout,  "LD\tA,E"		},	/* 0x7b */
-	{ opout,  "LD\tA,H"		},	/* 0x7c */
-	{ opout,  "LD\tA,L"		},	/* 0x7d */
-	{ opout,  "LD\tA,(HL)"		},	/* 0x7e */
-	{ opout,  "LD\tA,A"		},	/* 0x7f */
-	{ opout,  "ADD\tA,B"		},	/* 0x80 */
-	{ opout,  "ADD\tA,C"		},	/* 0x81 */
-	{ opout,  "ADD\tA,D"		},	/* 0x82 */
-	{ opout,  "ADD\tA,E"		},	/* 0x83 */
-	{ opout,  "ADD\tA,H"		},	/* 0x84 */
-	{ opout,  "ADD\tA,L"		},	/* 0x85 */
-	{ opout,  "ADD\tA,(HL)"		},	/* 0x86 */
-	{ opout,  "ADD\tA,A"		},	/* 0x87 */
-	{ opout,  "ADC\tA,B"		},	/* 0x88 */
-	{ opout,  "ADC\tA,C"		},	/* 0x89 */
-	{ opout,  "ADC\tA,D"		},	/* 0x8a */
-	{ opout,  "ADC\tA,E"		},	/* 0x8b */
-	{ opout,  "ADC\tA,H"		},	/* 0x8c */
-	{ opout,  "ADC\tA,L"		},	/* 0x8d */
-	{ opout,  "ADC\tA,(HL)"		},	/* 0x8e */
-	{ opout,  "ADC\tA,A"		},	/* 0x8f */
-	{ opout,  "SUB\tB"		},	/* 0x90 */
-	{ opout,  "SUB\tC"		},	/* 0x91 */
-	{ opout,  "SUB\tD"		},	/* 0x92 */
-	{ opout,  "SUB\tE"		},	/* 0x93 */
-	{ opout,  "SUB\tH"		},	/* 0x94 */
-	{ opout,  "SUB\tL"		},	/* 0x95 */
-	{ opout,  "SUB\t(HL)"		},	/* 0x96 */
-	{ opout,  "SUB\tA"		},	/* 0x97 */
-	{ opout,  "SBC\tA,B"		},	/* 0x98 */
-	{ opout,  "SBC\tA,C"		},	/* 0x99 */
-	{ opout,  "SBC\tA,D"		},	/* 0x9a */
-	{ opout,  "SBC\tA,E"		},	/* 0x9b */
-	{ opout,  "SBC\tA,H"		},	/* 0x9c */
-	{ opout,  "SBC\tA,L"		},	/* 0x9d */
-	{ opout,  "SBC\tA,(HL)"		},	/* 0x9e */
-	{ opout,  "SBC\tA,A"		},	/* 0x9f */
-	{ opout,  "AND\tB"		},	/* 0xa0 */
-	{ opout,  "AND\tC"		},	/* 0xa1 */
-	{ opout,  "AND\tD"		},	/* 0xa2 */
-	{ opout,  "AND\tE"		},	/* 0xa3 */
-	{ opout,  "AND\tH"		},	/* 0xa4 */
-	{ opout,  "AND\tL"		},	/* 0xa5 */
-	{ opout,  "AND\t(HL)"		},	/* 0xa6 */
-	{ opout,  "AND\tA"		},	/* 0xa7 */
-	{ opout,  "XOR\tB"		},	/* 0xa8 */
-	{ opout,  "XOR\tC"		},	/* 0xa9 */
-	{ opout,  "XOR\tD"		},	/* 0xaa */
-	{ opout,  "XOR\tE"		},	/* 0xab */
-	{ opout,  "XOR\tH"		},	/* 0xac */
-	{ opout,  "XOR\tL"		},	/* 0xad */
-	{ opout,  "XOR\t(HL)"		},	/* 0xae */
-	{ opout,  "XOR\tA"		},	/* 0xaf */
-	{ opout,  "OR\tB"		},	/* 0xb0 */
-	{ opout,  "OR\tC"		},	/* 0xb1 */
-	{ opout,  "OR\tD"		},	/* 0xb2 */
-	{ opout,  "OR\tE"		},	/* 0xb3 */
-	{ opout,  "OR\tH"		},	/* 0xb4 */
-	{ opout,  "OR\tL"		},	/* 0xb5 */
-	{ opout,  "OR\t(HL)"		},	/* 0xb6 */
-	{ opout,  "OR\tA"		},	/* 0xb7 */
-	{ opout,  "CP\tB"		},	/* 0xb8 */
-	{ opout,  "CP\tC"		},	/* 0xb9 */
-	{ opout,  "CP\tD"		},	/* 0xba */
-	{ opout,  "CP\tE"		},	/* 0xbb */
-	{ opout,  "CP\tH"		},	/* 0xbc */
-	{ opout,  "CP\tL"		},	/* 0xbd */
-	{ opout,  "CP\t(HL)"		},	/* 0xbe */
-	{ opout,  "CP\tA"		},	/* 0xbf */
+	{ opout,  "CCF"			}	/* 0x3f */
+};
+
+static struct opt optabz80_67[64] = {
 	{ opout,  "RET\tNZ"		},	/* 0xc0 */
 	{ opout,  "POP\tBC"		},	/* 0xc1 */
 	{ nnout,  "JP\tNZ,"		},	/* 0xc2 */
@@ -332,7 +210,109 @@ static struct opt optabz80[256] = {
 	{ opout,  "RST\t38"		}	/* 0xff */
 };
 
-static struct opt optabi8080[256] = {
+static struct opt optabed_23[64] = {
+	{ opout,  "IN\tB,(C)"		},	/* 0x40 */
+	{ opout,  "OUT\t(C),B"		},	/* 0x41 */
+	{ opout,  "SBC\tHL,BC"		},	/* 0x42 */
+	{ inout,  "LD\t(%04X),BC"	},	/* 0x43 */
+	{ opout,  "NEG"			},	/* 0x44 */
+	{ opout,  "RETN"		},	/* 0x45 */
+	{ opout,  "IM\t0"		},	/* 0x46 */
+	{ opout,  "LD\tI,A"		},	/* 0x47 */
+	{ opout,  "IN\tC,(C)"		},	/* 0x48 */
+	{ opout,  "OUT\t(C),C"		},	/* 0x49 */
+	{ opout,  "ADC\tHL,BC"		},	/* 0x4a */
+	{ inout,  "LD\tBC,(%04X)"	},	/* 0x4b */
+	{ opout,  "NEG*"		},	/* 0x4c */ /* undocumented */
+	{ opout,  "RETI"		},	/* 0x4d */
+	{ opout,  "IM*\t0"		},	/* 0x4e */ /* undocumented */
+	{ opout,  "LD\tR,A"		},	/* 0x4f */
+	{ opout,  "IN\tD,(C)"		},	/* 0x50 */
+	{ opout,  "OUT\t(C),D"		},	/* 0x51 */
+	{ opout,  "SBC\tHL,DE"		},	/* 0x52 */
+	{ inout,  "LD\t(%04X),DE"	},	/* 0x53 */
+	{ opout,  "NEG*"		},	/* 0x54 */ /* undocumented */
+	{ opout,  "RETN*"		},	/* 0x55 */ /* undocumented */
+	{ opout,  "IM\t1"		},	/* 0x56 */
+	{ opout,  "LD\tA,I"		},	/* 0x57 */
+	{ opout,  "IN\tE,(C)"		},	/* 0x58 */
+	{ opout,  "OUT\t(C),E"		},	/* 0x59 */
+	{ opout,  "ADC\tHL,DE"		},	/* 0x5a */
+	{ inout,  "LD\tDE,(%04X)"	},	/* 0x5b */
+	{ opout,  "NEG*"		},	/* 0x5c */ /* undocumented */
+	{ opout,  "RETI*"		},	/* 0x5d */ /* undocumented */
+	{ opout,  "IM\t2"		},	/* 0x5e */
+	{ opout,  "LD\tA,R"		},	/* 0x5f */
+	{ opout,  "IN\tH,(C)"		},	/* 0x60 */
+	{ opout,  "OUT\t(C),H"		},	/* 0x61 */
+	{ opout,  "SBC\tHL,HL"		},	/* 0x62 */
+	{ inout,  "LD*\t(%04X),HL"	},	/* 0x63 */ /* undocumented */
+	{ opout,  "NEG*"		},	/* 0x64 */ /* undocumented */
+	{ opout,  "RETN*"		},	/* 0x65 */ /* undocumented */
+	{ opout,  "IM*\t0"		},	/* 0x66 */ /* undocumented */
+	{ opout,  "RRD"			},	/* 0x67 */
+	{ opout,  "IN\tL,(C)"		},	/* 0x68 */
+	{ opout,  "OUT\t(C),L"		},	/* 0x69 */
+	{ opout,  "ADC\tHL,HL"		},	/* 0x6a */
+	{ inout,  "LD*\tHL,(%04X)"	},	/* 0x6b */ /* undocumented */
+	{ opout,  "NEG*"		},	/* 0x6c */ /* undocumented */
+	{ opout,  "RETI*"		},	/* 0x6d */ /* undocumented */
+	{ opout,  "IM*\t0"		},	/* 0x6e */ /* undocumented */
+	{ opout,  "RLD"			},	/* 0x6f */
+	{ opout,  "IN*\tF,(C)"		},	/* 0x70 */ /* undocumented */
+	{ opout,  "OUT*\t(C),0"		},	/* 0x71 */ /* undocumented */
+	{ opout,  "SBC\tHL,SP"		},	/* 0x72 */
+	{ inout,  "LD\t(%04X),SP"	},	/* 0x73 */
+	{ opout,  "NEG*"		},	/* 0x74 */ /* undocumented */
+	{ opout,  "RETN*"		},	/* 0x75 */ /* undocumented */
+	{ opout,  "IM*\t1"		},	/* 0x76 */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0x77 */ /* undocumented */
+	{ opout,  "IN\tA,(C)"		},	/* 0x78 */
+	{ opout,  "OUT\t(C),A"		},	/* 0x79 */
+	{ opout,  "ADC\tHL,SP"		},	/* 0x7a */
+	{ inout,  "LD\tSP,(%04X)"	},	/* 0x7b */
+	{ opout,  "NEG*"		},	/* 0x7c */ /* undocumented */
+	{ opout,  "RETI*"		},	/* 0x7d */ /* undocumented */
+	{ opout,  "IM*\t2"		},	/* 0x7e */ /* undocumented */
+	{ opout,  "NOP*"		}	/* 0x7f */ /* undocumented */
+};
+
+static struct opt optabed_5[32] = {
+	{ opout,  "LDI"			},	/* 0xa0 */
+	{ opout,  "CPI"			},	/* 0xa1 */
+	{ opout,  "INI"			},	/* 0xa2 */
+	{ opout,  "OUTI"		},	/* 0xa3 */
+	{ opout,  "NOP*"		},	/* 0xa4 */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xa5 */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xa6 */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xa7 */ /* undocumented */
+	{ opout,  "LDD"			},	/* 0xa8 */
+	{ opout,  "CPD"			},	/* 0xa9 */
+	{ opout,  "IND"			},	/* 0xaa */
+	{ opout,  "OUTD"		},	/* 0xab */
+	{ opout,  "NOP*"		},	/* 0xac */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xad */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xae */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xaf */ /* undocumented */
+	{ opout,  "LDIR"		},	/* 0xb0 */
+	{ opout,  "CPIR"		},	/* 0xb1 */
+	{ opout,  "INIR"		},	/* 0xb2 */
+	{ opout,  "OTIR"		},	/* 0xb3 */
+	{ opout,  "NOP*"		},	/* 0xb4 */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xb5 */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xb6 */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xb7 */ /* undocumented */
+	{ opout,  "LDDR"		},	/* 0xb8 */
+	{ opout,  "CPDR"		},	/* 0xb9 */
+	{ opout,  "INDR"		},	/* 0xba */
+	{ opout,  "OTDR"		},	/* 0xbb */
+	{ opout,  "NOP*"		},	/* 0xbc */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xbd */ /* undocumented */
+	{ opout,  "NOP*"		},	/* 0xbe */ /* undocumented */
+	{ opout,  "NOP*"		}	/* 0xbf */ /* undocumented */
+};
+
+static struct opt optabi8080_01[64] = {
 	{ opout,  "NOP"			},	/* 0x00 */
 	{ nnout,  "LXI\tB,"		},	/* 0x01 */
 	{ opout,  "STAX\tB"		},	/* 0x02 */
@@ -396,135 +376,10 @@ static struct opt optabi8080[256] = {
 	{ opout,  "INR\tA"		},	/* 0x3c */
 	{ opout,  "DCR\tA"		},	/* 0x3d */
 	{ nout,   "MVI\tA,"		},	/* 0x3e */
-	{ opout,  "CMC"			},	/* 0x3f */
-	{ opout,  "MOV\tB,B"		},	/* 0x40 */
-	{ opout,  "MOV\tB,C"		},	/* 0x41 */
-	{ opout,  "MOV\tB,D"		},	/* 0x42 */
-	{ opout,  "MOV\tB,E"		},	/* 0x43 */
-	{ opout,  "MOV\tB,H"		},	/* 0x44 */
-	{ opout,  "MOV\tB,L"		},	/* 0x45 */
-	{ opout,  "MOV\tB,M"		},	/* 0x46 */
-	{ opout,  "MOV\tB,A"		},	/* 0x47 */
-	{ opout,  "MOV\tC,B"		},	/* 0x48 */
-	{ opout,  "MOV\tC,C"		},	/* 0x49 */
-	{ opout,  "MOV\tC,D"		},	/* 0x4a */
-	{ opout,  "MOV\tC,E"		},	/* 0x4b */
-	{ opout,  "MOV\tC,H"		},	/* 0x4c */
-	{ opout,  "MOV\tC,L"		},	/* 0x4d */
-	{ opout,  "MOV\tC,M"		},	/* 0x4e */
-	{ opout,  "MOV\tC,A"		},	/* 0x4f */
-	{ opout,  "MOV\tD,B"		},	/* 0x50 */
-	{ opout,  "MOV\tD,C"		},	/* 0x51 */
-	{ opout,  "MOV\tD,D"		},	/* 0x52 */
-	{ opout,  "MOV\tD,E"		},	/* 0x53 */
-	{ opout,  "MOV\tD,H"		},	/* 0x54 */
-	{ opout,  "MOV\tD,L"		},	/* 0x55 */
-	{ opout,  "MOV\tD,M"		},	/* 0x56 */
-	{ opout,  "MOV\tD,A"		},	/* 0x57 */
-	{ opout,  "MOV\tE,B"		},	/* 0x58 */
-	{ opout,  "MOV\tE,C"		},	/* 0x59 */
-	{ opout,  "MOV\tE,D"		},	/* 0x5a */
-	{ opout,  "MOV\tE,E"		},	/* 0x5b */
-	{ opout,  "MOV\tE,H"		},	/* 0x5c */
-	{ opout,  "MOV\tE,L"		},	/* 0x5d */
-	{ opout,  "MOV\tE,M"		},	/* 0x5e */
-	{ opout,  "MOV\tE,A"		},	/* 0x5f */
-	{ opout,  "MOV\tH,B"		},	/* 0x60 */
-	{ opout,  "MOV\tH,C"		},	/* 0x61 */
-	{ opout,  "MOV\tH,D"		},	/* 0x62 */
-	{ opout,  "MOV\tH,E"		},	/* 0x63 */
-	{ opout,  "MOV\tH,H"		},	/* 0x64 */
-	{ opout,  "MOV\tH,L"		},	/* 0x65 */
-	{ opout,  "MOV\tH,M"		},	/* 0x66 */
-	{ opout,  "MOV\tH,A"		},	/* 0x67 */
-	{ opout,  "MOV\tL,B"		},	/* 0x68 */
-	{ opout,  "MOV\tL,C"		},	/* 0x69 */
-	{ opout,  "MOV\tL,D"		},	/* 0x6a */
-	{ opout,  "MOV\tL,E"		},	/* 0x6b */
-	{ opout,  "MOV\tL,H"		},	/* 0x6c */
-	{ opout,  "MOV\tL,L"		},	/* 0x6d */
-	{ opout,  "MOV\tL,M"		},	/* 0x6e */
-	{ opout,  "MOV\tL,A"		},	/* 0x6f */
-	{ opout,  "MOV\tM,B"		},	/* 0x70 */
-	{ opout,  "MOV\tM,C"		},	/* 0x71 */
-	{ opout,  "MOV\tM,D"		},	/* 0x72 */
-	{ opout,  "MOV\tM,E"		},	/* 0x73 */
-	{ opout,  "MOV\tM,H"		},	/* 0x74 */
-	{ opout,  "MOV\tM,L"		},	/* 0x75 */
-	{ opout,  "HLT"			},	/* 0x76 */
-	{ opout,  "MOV\tM,A"		},	/* 0x77 */
-	{ opout,  "MOV\tA,B"		},	/* 0x78 */
-	{ opout,  "MOV\tA,C"		},	/* 0x79 */
-	{ opout,  "MOV\tA,D"		},	/* 0x7a */
-	{ opout,  "MOV\tA,E"		},	/* 0x7b */
-	{ opout,  "MOV\tA,H"		},	/* 0x7c */
-	{ opout,  "MOV\tA,L"		},	/* 0x7d */
-	{ opout,  "MOV\tA,M"		},	/* 0x7e */
-	{ opout,  "MOV\tA,A"		},	/* 0x7f */
-	{ opout,  "ADD\tB"		},	/* 0x80 */
-	{ opout,  "ADD\tC"		},	/* 0x81 */
-	{ opout,  "ADD\tD"		},	/* 0x82 */
-	{ opout,  "ADD\tE"		},	/* 0x83 */
-	{ opout,  "ADD\tH"		},	/* 0x84 */
-	{ opout,  "ADD\tL"		},	/* 0x85 */
-	{ opout,  "ADD\tM"		},	/* 0x86 */
-	{ opout,  "ADD\tA"		},	/* 0x87 */
-	{ opout,  "ADC\tB"		},	/* 0x88 */
-	{ opout,  "ADC\tC"		},	/* 0x89 */
-	{ opout,  "ADC\tD"		},	/* 0x8a */
-	{ opout,  "ADC\tE"		},	/* 0x8b */
-	{ opout,  "ADC\tH"		},	/* 0x8c */
-	{ opout,  "ADC\tL"		},	/* 0x8d */
-	{ opout,  "ADC\tM"		},	/* 0x8e */
-	{ opout,  "ADC\tA"		},	/* 0x8f */
-	{ opout,  "SUB\tB"		},	/* 0x90 */
-	{ opout,  "SUB\tC"		},	/* 0x91 */
-	{ opout,  "SUB\tD"		},	/* 0x92 */
-	{ opout,  "SUB\tE"		},	/* 0x93 */
-	{ opout,  "SUB\tH"		},	/* 0x94 */
-	{ opout,  "SUB\tL"		},	/* 0x95 */
-	{ opout,  "SUB\tM"		},	/* 0x96 */
-	{ opout,  "SUB\tA"		},	/* 0x97 */
-	{ opout,  "SBB\tB"		},	/* 0x98 */
-	{ opout,  "SBB\tC"		},	/* 0x99 */
-	{ opout,  "SBB\tD"		},	/* 0x9a */
-	{ opout,  "SBB\tE"		},	/* 0x9b */
-	{ opout,  "SBB\tH"		},	/* 0x9c */
-	{ opout,  "SBB\tL"		},	/* 0x9d */
-	{ opout,  "SBB\tM"		},	/* 0x9e */
-	{ opout,  "SBB\tA"		},	/* 0x9f */
-	{ opout,  "ANA\tB"		},	/* 0xa0 */
-	{ opout,  "ANA\tC"		},	/* 0xa1 */
-	{ opout,  "ANA\tD"		},	/* 0xa2 */
-	{ opout,  "ANA\tE"		},	/* 0xa3 */
-	{ opout,  "ANA\tH"		},	/* 0xa4 */
-	{ opout,  "ANA\tL"		},	/* 0xa5 */
-	{ opout,  "ANA\tM"		},	/* 0xa6 */
-	{ opout,  "ANA\tA"		},	/* 0xa7 */
-	{ opout,  "XRA\tB"		},	/* 0xa8 */
-	{ opout,  "XRA\tC"		},	/* 0xa9 */
-	{ opout,  "XRA\tD"		},	/* 0xaa */
-	{ opout,  "XRA\tE"		},	/* 0xab */
-	{ opout,  "XRA\tH"		},	/* 0xac */
-	{ opout,  "XRA\tL"		},	/* 0xad */
-	{ opout,  "XRA\tM"		},	/* 0xae */
-	{ opout,  "XRA\tA"		},	/* 0xaf */
-	{ opout,  "ORA\tB"		},	/* 0xb0 */
-	{ opout,  "ORA\tC"		},	/* 0xb1 */
-	{ opout,  "ORA\tD"		},	/* 0xb2 */
-	{ opout,  "ORA\tE"		},	/* 0xb3 */
-	{ opout,  "ORA\tH"		},	/* 0xb4 */
-	{ opout,  "ORA\tL"		},	/* 0xb5 */
-	{ opout,  "ORA\tM"		},	/* 0xb6 */
-	{ opout,  "ORA\tA"		},	/* 0xb7 */
-	{ opout,  "CMP\tB"		},	/* 0xb8 */
-	{ opout,  "CMP\tC"		},	/* 0xb9 */
-	{ opout,  "CMP\tD"		},	/* 0xba */
-	{ opout,  "CMP\tE"		},	/* 0xbb */
-	{ opout,  "CMP\tH"		},	/* 0xbc */
-	{ opout,  "CMP\tL"		},	/* 0xbd */
-	{ opout,  "CMP\tM"		},	/* 0xbe */
-	{ opout,  "CMP\tA"		},	/* 0xbf */
+	{ opout,  "CMC"			}	/* 0x3f */
+};
+
+static struct opt optabi8080_67[64] = {
 	{ opout,  "RNZ"			},	/* 0xc0 */
 	{ opout,  "POP\tB"		},	/* 0xc1 */
 	{ nnout,  "JNZ\t"		},	/* 0xc2 */
@@ -591,11 +446,21 @@ static struct opt optabi8080[256] = {
 	{ opout,  "RST\t7"		}	/* 0xff */
 };
 
-static int addr;
-static char *unknown = "???";
-static char *reg[] = { "B", "C", "D", "E", "H", "L", "(HL)", "A" };
-static char *regix = "IX";
-static char *regiy = "IY";
+static char *reg[]	   = { "B", "C", "D", "E", "H", "L", "(HL)", "A" };
+static char *regix[]	   = { "B", "C", "D", "E", "IXH", "IXL", "IX", "A" };
+static char *regiy[]	   = { "B", "C", "D", "E", "IYH", "IYL", "IY", "A" };
+static char *aluins[]	   = {"ADD\tA,", "ADC\tA,", "SUB\t", "SBC\tA,",
+			      "AND\t", "XOR\t", "OR\t", "CP\t"};
+static char *aluinsu[]	   = {"ADD*\tA,", "ADC*\tA,", "SUB*\t", "SBC*\tA,",
+			      "AND*\t", "XOR*\t", "OR*\t", "CP*\t"};
+static char *rsins[]	   = {"RLC", "RRC", "RL", "RR",
+			      "SLA", "SRA", "SLL*", "SRL"};
+static char *rsinsu[]	   = {"RLC*", "RRC*", "RL*", "RR*",
+			      "SLA*", "SRA*", "SLL*", "SRL*"};
+static char *bitins[]	   = {"", "BIT", "RES", "SET"};
+static char *regi8080[]	   = { "B", "C", "D", "E", "H", "L", "M", "A" };
+static char *aluinsi8080[] = {"ADD", "ADC", "SUB", "SBB",
+			      "ANA", "XRA", "ORA", "CMP"};
 
 /* globals for passing disassembled code to anyone else who's interested */
 
@@ -604,25 +469,26 @@ char Opcode_Str[64];
 
 /* Set up machine code hex in Opcode_Str for disassembly */
 
-static void get_opcodes(unsigned char **p, int len)
+static void get_opcodes(WORD addr, int len)
 {
+  
 	switch (len) {
 	case 1:
-		sprintf(Opcode_Str, "%02X         ", (**p & 0xff));
+		sprintf(Opcode_Str, "%02X         ", getmem(addr));
 		break;
 	case 2:
 		sprintf(Opcode_Str, "%02X %02X      ",
-			(**p & 0xff), *(*p + 1) & 0xff);
+			getmem(addr), getmem(addr + 1));
 		break;
 	case 3:
 		sprintf(Opcode_Str, "%02X %02X %02X   ",
-			(**p & 0xff), *(*p + 1) & 0xff,
-			*(*p + 2) & 0xff);
+			getmem(addr), getmem(addr + 1),
+			getmem(addr + 2));
 		break;
 	case 4:
 		sprintf(Opcode_Str, "%02X %02X %02X %02X",
-			(**p & 0xff), *(*p + 1) & 0xff,
-			*(*p + 2) & 0xff, *(*p + 3) & 0xff);
+			getmem(addr), getmem(addr + 1),
+			getmem(addr + 2), getmem(addr + 3));
 		break;
 	default:
 		sprintf(Opcode_Str, "xx OW OW xx");
@@ -631,897 +497,349 @@ static void get_opcodes(unsigned char **p, int len)
 
 /*
  *	The function disass() is the only global function of
- *	this module. The first argument is a pointer to a
- *	unsigned char pointer, which points to the op-code
- *	to disassemble. The output of the disassembly goes
- *	to stdout, terminated by a newline. After the
- *	disassembly the pointer to the op-code will be
- *	increased by the size of the op-code, so that
+ *	this module. The first argument specifies the
+ *	instruction set to use. The second argument is a
+ *	pointer to a WORD, which hold the address of the
+ *	op-code to disassemble. The output of the disassembly
+ *	goes to stdout, terminated by a newline. After the
+ *	disassembly the pointer to the address of the op-code
+ *	will be increased by the size of the op-code, so that
  *	disass() can be called again.
- *	The second argument is the (Z80) address of the
- *	op-code to disassemble. It is used to calculate the
- *	destination address of relative jumps.
  *
- *	At most four bytes will be read from the buffer.
+ *	At most four bytes will be read from memory using
+ *	getmem().
  *
- *	To handle memory wrap around from high memory to low
- *	memory addresses, set base to a non-null pointer
- *	designating the base of a 64K memory block. *p should
- *	point into this block.
  */
-void disass(int cpu, unsigned char **p, int adr, unsigned char *base)
+void disass(int cpu, WORD *addr)
 {
-	register int len;
-	unsigned char buf[4];
-	size_t ofs;
-	int i;
+	register BYTE op;
+	register int len = 1;
+	struct opt *optp;
 
-	addr = adr;
-
-	if (base != NULL) {
-		ofs = *p - base;
-		for (i = 0; i < 4; i++)
-			buf[i] = base[(ofs + i) & 0xffff];
-		*p = buf;
+	op = getmem(*addr);
+	if (cpu == Z80) {
+		if (op < 0x40) {
+			optp = &optabz80_01[op];
+			len = (*optp->fun)(optp->text, *addr);
+		} else if (op < 0x80) {
+			if (op == 0x76)
+				strcpy(Disass_Str, "HALT");
+			else
+				sprintf(Disass_Str, "LD\t%s,%s",
+					reg[(op >> 3) & 7], reg[op & 7]);
+		} else if (op < 0xc0)
+			sprintf(Disass_Str, "%s%s",
+				aluins[(op >> 3) & 7], reg[op & 7]);
+		else {
+			optp = &optabz80_67[op & 0x3f];
+			len = (*optp->fun)(optp->text, *addr);
+		}
+	} else {
+		if (op < 0x40) {
+			optp = &optabi8080_01[op];
+			len = (*optp->fun)(optp->text, *addr);
+		} else if (op < 0x80) {
+			if (op == 0x76)
+				strcpy(Disass_Str, "HLT");
+			else
+				sprintf(Disass_Str, "MOV\t%s,%s",
+					regi8080[(op >> 3) & 7],
+					regi8080[op & 7]);
+		} else if (op < 0xc0)
+			sprintf(Disass_Str, "%s\t%s",
+				aluinsi8080[(op >> 3) & 7],
+				regi8080[op & 7]);
+		else {
+			optp = &optabi8080_67[op & 0x3f];
+			len = (*optp->fun)(optp->text, *addr);
+		}
 	}
 
-	if (cpu == Z80)
-		len = (*optabz80[**p].fun) (optabz80[**p].text, p);
-	else
-		len = (*optabi8080[**p].fun) (optabi8080[**p].text, p);
-
-	get_opcodes(p, len);
+	get_opcodes(*addr, len);
 #ifndef WANT_GUI
 	fputs(Opcode_Str, stdout);
 	putchar('\t');
 	fputs(Disass_Str, stdout);
+	putchar('\n');
 #endif
 
-	if (base != NULL)
-		*p = base + ((ofs + len) & 0xffff);
-	else
-		*p += len;
+	*addr += len;
 }
 
 /*
  *	disassemble 1 byte op-codes
  */
-static int opout(char *s, char **p)
+static int opout(char *s, WORD a)
 {
-	p = p;	/* to avoid compiler warning */
+	UNUSED(a);
 
-	sprintf(Disass_Str, "%s\n", s);
+	strcpy(Disass_Str, s);
 	return(1);
 }
 
 /*
  *	disassemble 2 byte op-codes of type "Op n"
  */
-static int nout(char *s, unsigned char **p)
+static int nout(char *s, WORD a)
 {
-	sprintf(Disass_Str, "%s%02X\n", s, *(*p + 1));
+	sprintf(Disass_Str, "%s%02X", s, getmem(a + 1));
 	return(2);
 }
 
 /*
  *	disassemble 2 byte op-codes with indirect addressing
  */
-static int iout(char *s, unsigned char **p)
+static int iout(char *s, WORD a)
 {
-	sprintf(Disass_Str, s, *(*p + 1));
-	strcat(Disass_Str, "\n");
+	sprintf(Disass_Str, s, getmem(a + 1));
 	return(2);
 }
 
 /*
  *	disassemble 2 byte op-codes with relative addressing
  */
-static int rout(char *s, char **p)
+static int rout(char *s, WORD a)
 {
-	sprintf(Disass_Str, "%s%04X\n", s, (addr + *(*p + 1) + 2) & 0xffff);
+	sprintf(Disass_Str, "%s%04X", s, a + (signed char) getmem(a + 1) + 2);
 	return(2);
 }
 
 /*
  *	disassemble 3 byte op-codes of type "Op nn"
  */
-static int nnout(char *s, unsigned char **p)
+static int nnout(char *s, WORD a)
 {
 	register int i;
 
-	i = *(*p + 1) + (*(*p + 2) << 8);
-	sprintf(Disass_Str, "%s%04X\n", s, i);
+	i = getmem(a + 1) + (getmem(a + 2) << 8);
+	sprintf(Disass_Str, "%s%04X", s, i);
 	return(3);
 }
 
 /*
  *	disassemble 3 byte op-codes with indirect addressing
  */
-static int inout(char *s, unsigned char **p)
+static int inout(char *s, WORD a)
 {
 	register int i;
 
-	i = *(*p + 1) + (*(*p + 2) << 8);
+	i = getmem(a + 1) + (getmem(a + 2) << 8);
 	sprintf(Disass_Str, s, i);
-	strcat(Disass_Str, "\n");
 	return(3);
 }
 
 /*
  *	disassemble multi byte op-codes with prefix 0xcb
  */
-static int cbop(char *s, unsigned char **p)
+static int cbop(char *s, WORD a)
 {
-	register int b2;
+	register BYTE b2;
 
-	s = s;	/* to avoid compiler warning */
+	UNUSED(s);
 
-	b2 = *(*p + 1);
-	if (b2 >= 0x00 && b2 <= 0x07) {
-		sprintf(Disass_Str, "RLC\t%s\n",
-			reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0x08 && b2 <= 0x0f) {
-		sprintf(Disass_Str, "RRC\t%s\n",
-			reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0x10 && b2 <= 0x17) {
-		sprintf(Disass_Str, "RL\t%s\n",
-			reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0x18 && b2 <= 0x1f) {
-		sprintf(Disass_Str, "RR\t%s\n",
-			reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0x20 && b2 <= 0x27) {
-		sprintf(Disass_Str, "SLA\t%s\n",
-			reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0x28 && b2 <= 0x2f) {
-		sprintf(Disass_Str, "SRA\t%s\n",
-			reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0x30 && b2 <= 0x37) {		/* undocumented */
-		sprintf(Disass_Str, "SLL*\t%s\n",
-			reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0x38 && b2 <= 0x3f) {
-		sprintf(Disass_Str, "SRL\t%s\n",
-			reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0x40 && b2 <= 0x7f) {
-		sprintf(Disass_Str, "BIT\t%c,%s\n",
-			((b2 >> 3) & 7) + '0', reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0x80 && b2 <= 0xbf) {
-		sprintf(Disass_Str, "RES\t%c,%s\n",
-			((b2 >> 3) & 7) + '0', reg[b2 & 7]);
-		return(2);
-	}
-	if (b2 >= 0xc0) {
-		sprintf(Disass_Str, "SET\t%c,%s\n",
-			((b2 >> 3) & 7) + '0', reg[b2 & 7]);
-		return(2);
-	}
-	sprintf(Disass_Str, "%s\n", unknown);
+	b2 = getmem(a + 1);
+	if (b2 < 0x40)
+		sprintf(Disass_Str, "%s\t%s",
+			rsins[b2 >> 3], reg[b2 & 7]);
+	else
+		sprintf(Disass_Str, "%s\t%c,%s",
+			bitins[b2 >> 6], ((b2 >> 3) & 7) + '0', reg[b2 & 7]);
 	return(2);
 }
 
 /*
  *	disassemble multi byte op-codes with prefix 0xed
  */
-static int edop(char *s, unsigned char **p)
+static int edop(char *s, WORD a)
 {
-	register int b2, i;
-	int len = 2;
+	register BYTE b2;
+	int len = 1;
 
-	s = s;	/* to avoid compiler warning */
+	UNUSED(s);
 
-	Disass_Str[0] = 0;
-	b2 = *(*p + 1);
-	switch (b2) {
-	case 0x40:
-		strcat(Disass_Str, "IN\tB,(C)\n");
-		break;
-	case 0x41:
-		strcat(Disass_Str, "OUT\t(C),B\n");
-		break;
-	case 0x42:
-		strcat(Disass_Str, "SBC\tHL,BC\n");
-		break;
-	case 0x43:
-		i = *(*p + 2) + (*(*p + 3) << 8);
-		sprintf(Disass_Str, "LD\t(%04X),BC\n", i);
-		len = 4;
-		break;
-	case 0x44:
-		strcat(Disass_Str, "NEG\n");
-		break;
-	case 0x45:
-		strcat(Disass_Str, "RETN\n");
-		break;
-	case 0x46:
-		strcat(Disass_Str, "IM\t0\n");
-		break;
-	case 0x47:
-		strcat(Disass_Str, "LD\tI,A\n");
-		break;
-	case 0x48:
-		strcat(Disass_Str, "IN\tC,(C)\n");
-		break;
-	case 0x49:
-		strcat(Disass_Str, "OUT\t(C),C\n");
-		break;
-	case 0x4a:
-		strcat(Disass_Str, "ADC\tHL,BC\n");
-		break;
-	case 0x4b:
-		i = *(*p + 2) + (*(*p + 3) << 8);
-		sprintf(Disass_Str, "LD\tBC,(%04X)\n", i);
-		len = 4;
-		break;
-	case 0x4c:				/* undocumented */
-	case 0x54:				/* undocumented */
-	case 0x5c:				/* undocumented */
-	case 0x64:				/* undocumented */
-	case 0x6c:				/* undocumented */
-	case 0x74:				/* undocumented */
-	case 0x7c:				/* undocumented */
-		strcat(Disass_Str, "NEG*\n");
-		break;
-	case 0x4d:
-		strcat(Disass_Str, "RETI\n");
-		break;
-	case 0x4e:				/* undocumented */
-	case 0x66:				/* undocumented */
-	case 0x6e:				/* undocumented */
-		strcat(Disass_Str, "IM*\t0\n");
-		break;
-	case 0x4f:
-		strcat(Disass_Str, "LD\tR,A\n");
-		break;
-	case 0x50:
-		strcat(Disass_Str, "IN\tD,(C)\n");
-		break;
-	case 0x51:
-		strcat(Disass_Str, "OUT\t(C),D\n");
-		break;
-	case 0x52:
-		strcat(Disass_Str, "SBC\tHL,DE\n");
-		break;
-	case 0x53:
-		i = *(*p + 2) + (*(*p + 3) << 8);
-		sprintf(Disass_Str, "LD\t(%04X),DE\n", i);
-		len = 4;
-		break;
-	case 0x55:				/* undocumented */
-	case 0x65:				/* undocumented */
-	case 0x75:				/* undocumented */
-		strcat(Disass_Str, "RETN*\n");
-		break;
-	case 0x5d:				/* undocumented */
-	case 0x6d:				/* undocumented */
-	case 0x7d:				/* undocumented */
-		strcat(Disass_Str, "RETI*\n");
-		break;
-	case 0x56:
-		strcat(Disass_Str, "IM\t1\n");
-		break;
-	case 0x57:
-		strcat(Disass_Str, "LD\tA,I\n");
-		break;
-	case 0x58:
-		strcat(Disass_Str, "IN\tE,(C)\n");
-		break;
-	case 0x59:
-		strcat(Disass_Str, "OUT\t(C),E\n");
-		break;
-	case 0x5a:
-		strcat(Disass_Str, "ADC\tHL,DE\n");
-		break;
-	case 0x5b:
-		i = *(*p + 2) + (*(*p + 3) << 8);
-		sprintf(Disass_Str, "LD\tDE,(%04X)\n", i);
-		len = 4;
-		break;
-	case 0x5e:
-		strcat(Disass_Str, "IM\t2\n");
-		break;
-	case 0x5f:
-		strcat(Disass_Str, "LD\tA,R\n");
-		break;
-	case 0x60:
-		strcat(Disass_Str, "IN\tH,(C)\n");
-		break;
-	case 0x61:
-		strcat(Disass_Str, "OUT\t(C),H\n");
-		break;
-	case 0x62:
-		strcat(Disass_Str, "SBC\tHL,HL\n");
-		break;
-	case 0x63:				/* undocumented */
-		i = *(*p + 2) + (*(*p + 3) << 8);
-		sprintf(Disass_Str, "LD*\t(%04X),HL\n", i);
-		len = 4;
-		break;
-	case 0x67:
-		strcat(Disass_Str, "RRD\n");
-		break;
-	case 0x68:
-		strcat(Disass_Str, "IN\tL,(C)\n");
-		break;
-	case 0x69:
-		strcat(Disass_Str, "OUT\t(C),L\n");
-		break;
-	case 0x6a:
-		strcat(Disass_Str, "ADC\tHL,HL\n");
-		break;
-	case 0x6b:				/* undocumented */
-		i = *(*p + 2) + (*(*p + 3) << 8);
-		sprintf(Disass_Str, "LD*\tHL,(%04X)\n", i);
-		len = 4;
-		break;
-	case 0x6f:
-		strcat(Disass_Str, "RLD\n");
-		break;
-	case 0x70:				/* undocumented */
-		strcat(Disass_Str, "IN*\tF,(C)\n");
-		break;
-	case 0x71:				/* undocumented */
-		strcat(Disass_Str, "OUT*\t(C),0\n");
-		break;
-	case 0x72:
-		strcat(Disass_Str, "SBC\tHL,SP\n");
-		break;
-	case 0x73:
-		i = *(*p + 2) + (*(*p + 3) << 8);
-		sprintf(Disass_Str, "LD\t(%04X),SP\n", i);
-		len = 4;
-		break;
-	case 0x76:				/* undocumented */
-		strcat(Disass_Str, "IM*\t1\n");
-		break;
-	case 0x78:
-		strcat(Disass_Str, "IN\tA,(C)\n");
-		break;
-	case 0x79:
-		strcat(Disass_Str, "OUT\t(C),A\n");
-		break;
-	case 0x7a:
-		strcat(Disass_Str, "ADC\tHL,SP\n");
-		break;
-	case 0x7b:
-		i = *(*p + 2) + (*(*p + 3) << 8);
-		sprintf(Disass_Str, "LD\tSP,(%04X)\n", i);
-		len = 4;
-		break;
-	case 0x7e:				/* undocumented */
-		strcat(Disass_Str, "IM*\t2\n");
-		break;
-	case 0xa0:
-		strcat(Disass_Str, "LDI\n");
-		break;
-	case 0xa1:
-		strcat(Disass_Str, "CPI\n");
-		break;
-	case 0xa2:
-		strcat(Disass_Str, "INI\n");
-		break;
-	case 0xa3:
-		strcat(Disass_Str, "OUTI\n");
-		break;
-	case 0xa8:
-		strcat(Disass_Str, "LDD\n");
-		break;
-	case 0xa9:
-		strcat(Disass_Str, "CPD\n");
-		break;
-	case 0xaa:
-		strcat(Disass_Str, "IND\n");
-		break;
-	case 0xab:
-		strcat(Disass_Str, "OUTD\n");
-		break;
-	case 0xb0:
-		strcat(Disass_Str, "LDIR\n");
-		break;
-	case 0xb1:
-		strcat(Disass_Str, "CPIR\n");
-		break;
-	case 0xb2:
-		strcat(Disass_Str, "INIR\n");
-		break;
-	case 0xb3:
-		strcat(Disass_Str, "OTIR\n");
-		break;
-	case 0xb8:
-		strcat(Disass_Str, "LDDR\n");
-		break;
-	case 0xb9:
-		strcat(Disass_Str, "CPDR\n");
-		break;
-	case 0xba:
-		strcat(Disass_Str, "INDR\n");
-		break;
-	case 0xbb:
-		strcat(Disass_Str, "OTDR\n");
-		break;
-	default:				/* undocumented */
-		strcat(Disass_Str, "NOP*\n");
-	}
-	return(len);
+	b2 = getmem(a + 1);
+	if (b2 < 0x40)					/* undocumented */
+		strcpy(Disass_Str, "NOP*");
+	else if (b2 < 0x80) {
+		b2 &= 0x3f;
+		len = (*optabed_23[b2].fun)(optabed_23[b2].text, a + 1);
+	} else if (b2 < 0xa0)				/* undocumented */
+		strcpy(Disass_Str, "NOP*");
+	else if (b2 < 0xc0) {
+		b2 &= 0x1f;
+		len = (*optabed_5[b2].fun)(optabed_5[b2].text, a + 1);
+	} else						/* undocumented */
+		strcpy(Disass_Str, "NOP*");
+	return(len + 1);
 }
 
 /*
  *	disassemble multi byte op-codes with prefix 0xdd and 0xfd
  */
-static int ddfd(char *s, unsigned char **p)
+static int ddfd(char *s, WORD a)
 {
-	register int b2, b4;
-	register char *ireg;
-	int len = 3;
+	register BYTE b2, b4;
+	register int r1, r2;
+	register char **ireg;
 
-	s = s;	/* to avoid compiler warning */
+	UNUSED(s);
 
-	if (**p == 0xdd)
+	if (getmem(a) == 0xdd)
 		ireg = regix;
 	else
 		ireg = regiy;
-	b2 = *(*p + 1);
-	if (b2 >= 0x70 && b2 <= 0x77 && b2 != 0x76) {
-		sprintf(Disass_Str, "LD\t(%s+%02X),%s\n", ireg, *(*p + 2),
-			reg[b2 & 7]);
-		return(3);
-	}
-	switch (b2) {
-	case 0x09:
-		sprintf(Disass_Str, "ADD\t%s,BC\n", ireg);
-		len = 2;
-		break;
-	case 0x19:
-		sprintf(Disass_Str, "ADD\t%s,DE\n", ireg);
-		len = 2;
-		break;
-	case 0x21:
-		sprintf(Disass_Str, "LD\t%s,%04X\n", ireg, *(*p + 2) + (*(*p + 3) << 8));
-		len = 4;
-		break;
-	case 0x22:
-		sprintf(Disass_Str, "LD\t(%04X),%s\n", *(*p + 2) + (*(*p + 3) << 8), ireg);
-		len = 4;
-		break;
-	case 0x23:
-		sprintf(Disass_Str, "INC\t%s\n", ireg);
-		len = 2;
-		break;
-	case 0x24:				/* undocumented */
-		sprintf(Disass_Str, "INC*\t%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x25:				/* undocumented */
-		sprintf(Disass_Str, "DEC*\t%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x26:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sH,%02X\n", ireg, *(*p + 2));
-		break;
-	case 0x29:
-		if (**p == 0xdd)
-			sprintf(Disass_Str, "ADD\tIX,IX\n");
-		else
-			sprintf(Disass_Str, "ADD\tIY,IY\n");
-		len = 2;
-		break;
-	case 0x2a:
-		sprintf(Disass_Str, "LD\t%s,(%04X)\n", ireg, *(*p + 2) + (*(*p + 3) << 8));
-		len = 4;
-		break;
-	case 0x2b:
-		sprintf(Disass_Str, "DEC\t%s\n", ireg);
-		len = 2;
-		break;
-	case 0x2c:				/* undocumented */
-		sprintf(Disass_Str, "INC*\t%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x2d:				/* undocumented */
-		sprintf(Disass_Str, "DEC*\t%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x2e:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sL,%02X\n", ireg, *(*p + 2));
-		break;
-	case 0x34:
-		sprintf(Disass_Str, "INC\t(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x35:
-		sprintf(Disass_Str, "DEC\t(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x36:
-		sprintf(Disass_Str, "LD\t(%s+%02X),%02X\n", ireg, *(*p + 2), *(*p + 3));
-		len = 4;
-		break;
-	case 0x39:
-		sprintf(Disass_Str, "ADD\t%s,SP\n", ireg);
-		len = 2;
-		break;
-	case 0x44:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tB,%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x45:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tB,%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x46:
-		sprintf(Disass_Str, "LD\tB,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x4c:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tC,%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x4d:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tC,%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x4e:
-		sprintf(Disass_Str, "LD\tC,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x54:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tD,%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x55:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tD,%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x56:
-		sprintf(Disass_Str, "LD\tD,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x5c:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tE,%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x5d:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tE,%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x5e:
-		sprintf(Disass_Str, "LD\tE,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x60:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sH,B\n", ireg);
-		len = 2;
-		break;
-	case 0x61:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sH,C\n", ireg);
-		len = 2;
-		break;
-	case 0x62:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sH,D\n", ireg);
-		len = 2;
-		break;
-	case 0x63:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sH,E\n", ireg);
-		len = 2;
-		break;
-	case 0x64:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sH,%sH\n", ireg, ireg);
-		len = 2;
-		break;
-	case 0x65:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sH,%sL\n", ireg, ireg);
-		len = 2;
-		break;
-	case 0x66:
-		sprintf(Disass_Str, "LD\tH,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x67:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sH,A\n", ireg);
-		len = 2;
-		break;
-	case 0x68:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sL,B\n", ireg);
-		len = 2;
-		break;
-	case 0x69:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sL,C\n", ireg);
-		len = 2;
-		break;
-	case 0x6a:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sL,D\n", ireg);
-		len = 2;
-		break;
-	case 0x6b:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sL,E\n", ireg);
-		len = 2;
-		break;
-	case 0x6c:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sL,%sH\n", ireg, ireg);
-		len = 2;
-		break;
-	case 0x6d:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sL,%sL\n", ireg, ireg);
-		len = 2;
-		break;
-	case 0x6e:
-		sprintf(Disass_Str, "LD\tL,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x6f:				/* undocumented */
-		sprintf(Disass_Str, "LD*\t%sL,A\n", ireg);
-		len = 2;
-		break;
-	case 0x7c:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tA,%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x7d:				/* undocumented */
-		sprintf(Disass_Str, "LD*\tA,%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x7e:
-		sprintf(Disass_Str, "LD\tA,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x84:				/* undocumented */
-		sprintf(Disass_Str, "ADD*\tA,%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x85:				/* undocumented */
-		sprintf(Disass_Str, "ADD*\tA,%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x86:
-		sprintf(Disass_Str, "ADD\tA,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x8c:				/* undocumented */
-		sprintf(Disass_Str, "ADC*\tA,%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x8d:				/* undocumented */
-		sprintf(Disass_Str, "ADC*\tA,%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x8e:
-		sprintf(Disass_Str, "ADC\tA,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x94:				/* undocumented */
-		sprintf(Disass_Str, "SUB*\t%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x95:				/* undocumented */
-		sprintf(Disass_Str, "SUB*\t%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x96:
-		sprintf(Disass_Str, "SUB\t(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0x9c:				/* undocumented */
-		sprintf(Disass_Str, "SBC*\tA,%sH\n", ireg);
-		len = 2;
-		break;
-	case 0x9d:				/* undocumented */
-		sprintf(Disass_Str, "SBC*\tA,%sL\n", ireg);
-		len = 2;
-		break;
-	case 0x9e:
-		sprintf(Disass_Str, "SBC\tA,(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0xa4:				/* undocumented */
-		sprintf(Disass_Str, "AND*\t%sH\n", ireg);
-		len = 2;
-		break;
-	case 0xa5:				/* undocumented */
-		sprintf(Disass_Str, "AND*\t%sL\n", ireg);
-		len = 2;
-		break;
-	case 0xa6:
-		sprintf(Disass_Str, "AND\t(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0xac:				/* undocumented */
-		sprintf(Disass_Str, "XOR*\t%sH\n", ireg);
-		len = 2;
-		break;
-	case 0xad:				/* undocumented */
-		sprintf(Disass_Str, "XOR*\t%sL\n", ireg);
-		len = 2;
-		break;
-	case 0xae:
-		sprintf(Disass_Str, "XOR\t(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0xb4:				/* undocumented */
-		sprintf(Disass_Str, "OR*\t%sH\n", ireg);
-		len = 2;
-		break;
-	case 0xb5:				/* undocumented */
-		sprintf(Disass_Str, "OR*\t%sL\n", ireg);
-		len = 2;
-		break;
-	case 0xb6:
-		sprintf(Disass_Str, "OR\t(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0xbc:				/* undocumented */
-		sprintf(Disass_Str, "CP*\t%sH\n", ireg);
-		len = 2;
-		break;
-	case 0xbd:				/* undocumented */
-		sprintf(Disass_Str, "CP*\t%sL\n", ireg);
-		len = 2;
-		break;
-	case 0xbe:
-		sprintf(Disass_Str, "CP\t(%s+%02X)\n", ireg, *(*p + 2));
-		break;
-	case 0xcb:
-		b4 = *(*p + 3);
-		switch (b4) {
-		case 0x06:
-			sprintf(Disass_Str, "RLC\t(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x0e:
-			sprintf(Disass_Str, "RRC\t(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x16:
-			sprintf(Disass_Str, "RL\t(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x1e:
-			sprintf(Disass_Str, "RR\t(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x26:
-			sprintf(Disass_Str, "SLA\t(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x2e:
-			sprintf(Disass_Str, "SRA\t(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x36:			/* undocumented */
-			sprintf(Disass_Str, "SLL*\t(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x3e:
-			sprintf(Disass_Str, "SRL\t(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x46:
-			sprintf(Disass_Str, "BIT\t0,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x4e:
-			sprintf(Disass_Str, "BIT\t1,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x56:
-			sprintf(Disass_Str, "BIT\t2,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x5e:
-			sprintf(Disass_Str, "BIT\t3,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x66:
-			sprintf(Disass_Str, "BIT\t4,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x6e:
-			sprintf(Disass_Str, "BIT\t5,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x76:
-			sprintf(Disass_Str, "BIT\t6,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x7e:
-			sprintf(Disass_Str, "BIT\t7,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x86:
-			sprintf(Disass_Str, "RES\t0,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x8e:
-			sprintf(Disass_Str, "RES\t1,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x96:
-			sprintf(Disass_Str, "RES\t2,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0x9e:
-			sprintf(Disass_Str, "RES\t3,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xa6:
-			sprintf(Disass_Str, "RES\t4,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xae:
-			sprintf(Disass_Str, "RES\t5,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xb6:
-			sprintf(Disass_Str, "RES\t6,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xbe:
-			sprintf(Disass_Str, "RES\t7,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xc6:
-			sprintf(Disass_Str, "SET\t0,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xce:
-			sprintf(Disass_Str, "SET\t1,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xd6:
-			sprintf(Disass_Str, "SET\t2,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xde:
-			sprintf(Disass_Str, "SET\t3,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xe6:
-			sprintf(Disass_Str, "SET\t4,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xee:
-			sprintf(Disass_Str, "SET\t5,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xf6:
-			sprintf(Disass_Str, "SET\t6,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		case 0xfe:
-			sprintf(Disass_Str, "SET\t7,(%s+%02X)\n", ireg, *(*p + 2));
-			break;
-		default:			/* undocumented */
-			if (b4 >= 0x00 && b4 <= 0x07) {
-				sprintf(Disass_Str, "RLC*\t(%s+%02X),%s\n",
-					ireg, *(*p + 2), reg[b4 & 7]);
-			} else if (b4 >= 0x08 && b4 <= 0x0f) {
-				sprintf(Disass_Str, "RRC*\t(%s+%02X),%s\n",
-					ireg, *(*p + 2), reg[b4 & 7]);
-			} else if (b4 >= 0x10 && b4 <= 0x17) {
-				sprintf(Disass_Str, "RL*\t(%s+%02X),%s\n",
-					ireg, *(*p + 2), reg[b4 & 7]);
-			} else if (b4 >= 0x18 && b4 <= 0x1f) {
-				sprintf(Disass_Str, "RR*\t(%s+%02X),%s\n",
-					ireg, *(*p + 2), reg[b4 & 7]);
-			} else if (b4 >= 0x20 && b4 <= 0x27) {
-				sprintf(Disass_Str, "SLA*\t(%s+%02X),%s\n",
-					ireg, *(*p + 2), reg[b4 & 7]);
-			} else if (b4 >= 0x28 && b4 <= 0x2f) {
-				sprintf(Disass_Str, "SRA*\t(%s+%02X),%s\n",
-					ireg, *(*p + 2), reg[b4 & 7]);
-			} else if (b4 >= 0x30 && b4 <= 0x37) {
-				sprintf(Disass_Str, "SLL*\t(%s+%02X),%s\n",
-					ireg, *(*p + 2), reg[b4 & 7]);
-			} else if (b4 >= 0x38 && b4 <= 0x3f) {
-				sprintf(Disass_Str, "SRL*\t(%s+%02X),%s\n",
-					ireg, *(*p + 2), reg[b4 & 7]);
-			} else if (b4 >= 0x40 && b4 <= 0x7f) {
-				sprintf(Disass_Str, "BIT*\t%c,(%s+%02X)\n",
-					((b4 >> 3) & 7) + '0', ireg, *(*p + 2));
-			} else if (b4 >= 0x80 && b4 <= 0xbf) {
-				sprintf(Disass_Str, "RES*\t%c,(%s+%02X),%s\n",
-					((b4 >> 3) & 7) + '0', ireg, *(*p + 2),
-					reg[b4 & 7]);
-			} else if (b4 >= 0xc0) {
-				sprintf(Disass_Str, "SET*\t%c,(%s+%02X),%s\n",
-					((b4 >> 3) & 7) + '0', ireg, *(*p + 2),
-					reg[b4 & 7]);
-			}
+	b2 = getmem(a + 1);
+	r1 = (b2 >> 3) & 7;
+	r2 = b2 & 7;
+	if (b2 < 0x40) {
+		switch (b2) {
+		case 0x09:
+			sprintf(Disass_Str, "ADD\t%s,BC", ireg[6]);
+			return(2);
+		case 0x19:
+			sprintf(Disass_Str, "ADD\t%s,DE", ireg[6]);
+			return(2);
+		case 0x21:
+			sprintf(Disass_Str, "LD\t%s,%04X", ireg[6],
+				getmem(a + 2) + (getmem(a + 3) << 8));
+			return(4);
+		case 0x22:
+			sprintf(Disass_Str, "LD\t(%04X),%s",
+				getmem(a + 2) + (getmem(a + 3) << 8), ireg[6]);
+			return(4);
+		case 0x23:
+			sprintf(Disass_Str, "INC\t%s", ireg[6]);
+			return(2);
+		case 0x24:				/* undocumented */
+			sprintf(Disass_Str, "INC*\t%sH", ireg[6]);
+			return(2);
+		case 0x25:				/* undocumented */
+			sprintf(Disass_Str, "DEC*\t%sH", ireg[6]);
+			return(2);
+		case 0x26:				/* undocumented */
+			sprintf(Disass_Str, "LD*\t%sH,%02X", ireg[6],
+				getmem(a + 2));
+			return(3);
+		case 0x29:
+			sprintf(Disass_Str, "ADD\t%s,%s", ireg[6], ireg[6]);
+			return(2);
+		case 0x2a:
+			sprintf(Disass_Str, "LD\t%s,(%04X)", ireg[6],
+				getmem(a + 2) + (getmem(a + 3) << 8));
+			return(4);
+		case 0x2b:
+			sprintf(Disass_Str, "DEC\t%s", ireg[6]);
+			return(2);
+		case 0x2c:				/* undocumented */
+			sprintf(Disass_Str, "INC*\t%sL", ireg[6]);
+			return(2);
+		case 0x2d:				/* undocumented */
+			sprintf(Disass_Str, "DEC*\t%sL", ireg[6]);
+			return(2);
+		case 0x2e:				/* undocumented */
+			sprintf(Disass_Str, "LD*\t%sL,%02X", ireg[6],
+				getmem(a + 2));
+			return(3);
+		case 0x34:
+			sprintf(Disass_Str, "INC\t(%s+%02X)", ireg[6],
+				getmem(a + 2));
+			return(3);
+		case 0x35:
+			sprintf(Disass_Str, "DEC\t(%s+%02X)", ireg[6],
+				getmem(a + 2));
+			return(3);
+		case 0x36:
+			sprintf(Disass_Str, "LD\t(%s+%02X),%02X", ireg[6],
+				getmem(a + 2), getmem(a + 3));
+			return(4);
+		case 0x39:
+			sprintf(Disass_Str, "ADD\t%s,SP", ireg[6]);
+			return(2);
+		default:				/* undocumented */
+			strcpy(Disass_Str, "NOP*");
+			return(1);
 		}
-		len = 4;
-		break;
-	case 0xe1:
-		sprintf(Disass_Str, "POP\t%s\n", ireg);
-		len = 2;
-		break;
-	case 0xe3:
-		sprintf(Disass_Str, "EX\t(SP),%s\n", ireg);
-		len = 2;
-		break;
-	case 0xe5:
-		sprintf(Disass_Str, "PUSH\t%s\n", ireg);
-		len = 2;
-		break;
-	case 0xe9:
-		sprintf(Disass_Str, "JP\t(%s)\n", ireg);
-		len = 2;
-		break;
-	case 0xf9:
-		sprintf(Disass_Str, "LD\tSP,%s\n", ireg);
-		len = 2;
-		break;
-	default:
-		Disass_Str[0] = 0;
-		strcat(Disass_Str, "NOP*\n");
-		len = 1;
+	} else if (b2 < 0x80) {
+		if (((r1 < 4 || r1 > 6) && (r2 < 4 || r2 > 6))
+		    || (r1 == 6 && r2 == 6)) {		/* undocumented */
+			strcpy(Disass_Str, "NOP*");
+			return(1);
+		} else if (r1 == 6) {
+			sprintf(Disass_Str, "LD\t(%s+%02X),%s", ireg[r1],
+				getmem(a + 2), reg[r2]);
+			return(3);
+		} else if (r2 == 6) {
+			sprintf(Disass_Str, "LD\t%s,(%s+%02X)", reg[r1],
+				ireg[r2], getmem(a + 2));
+			return(3);
+		} else {
+			sprintf(Disass_Str, "LD*\t%s,%s", ireg[r1], ireg[r2]);
+			return(2);
+		}
+	} else if (b2 < 0xc0) {
+		if (r2 < 4 || r2 > 6) {			/* undocumented */
+			strcpy(Disass_Str, "NOP*");
+			return(2);
+		} else if (r2 == 6) {
+			sprintf(Disass_Str, "%s(%s+%02X)", aluins[r1],
+				ireg[r2], getmem(a + 2));
+			return(3);
+		} else {				/* undocumented */
+			sprintf(Disass_Str, "%s%s", aluinsu[r1], ireg[r2]);
+			return(2);
+		}
+	} else {
+		switch (b2) {
+		case 0xcb:
+			b4 = getmem(a + 3);
+			if ((b4 & 7) == 6) {
+				if (b4 < 0x40)
+					sprintf(Disass_Str, "%s\t(%s+%02X)",
+						rsins[b4 >> 3], ireg[6],
+						getmem(a + 2));
+				else
+					sprintf(Disass_Str, "%s\t%c,(%s+%02X)",
+						bitins[b4 >> 6],
+						((b4 >> 3) & 7) + '0',
+						ireg[6], getmem(a + 2));
+			} else {
+				if (b4 < 0x40)		/* undocumented */
+					sprintf(Disass_Str, "%s\t(%s+%02X),%s",
+						rsinsu[b4 >> 3], ireg[6],
+						getmem(a + 2), reg[b4 & 7]);
+				else if (b4 < 0x80)	/* undocumented */
+					sprintf(Disass_Str,
+						"%s*\t%c,(%s+%02X)",
+						bitins[b4 >> 6],
+						((b4 >> 3) & 7) + '0',
+						ireg[6], getmem(a + 2));
+				else			/* undocumented */
+					sprintf(Disass_Str,
+						"%s*\t%c,(%s+%02X),%s",
+						bitins[b4 >> 6],
+						((b4 >> 3) & 7) + '0',
+						ireg[6], getmem(a + 2),
+						reg[b4 & 7]);
+			}
+			return(4);
+		case 0xe1:
+			sprintf(Disass_Str, "POP\t%s", ireg[6]);
+			return(2);
+		case 0xe3:
+			sprintf(Disass_Str, "EX\t(SP),%s", ireg[6]);
+			return(2);
+		case 0xe5:
+			sprintf(Disass_Str, "PUSH\t%s", ireg[6]);
+			return(2);
+		case 0xe9:
+			sprintf(Disass_Str, "JP\t(%s)", ireg[6]);
+			return(2);
+		case 0xf9:
+			sprintf(Disass_Str, "LD\tSP,%s", ireg[6]);
+			return(2);
+		default:				/* undocumented */
+			strcpy(Disass_Str, "NOP*");
+			return(1);
+		}
 	}
-	return(len);
 }

--- a/z80sim/srcsim/memory.h
+++ b/z80sim/srcsim/memory.h
@@ -53,11 +53,3 @@ static inline BYTE getmem(WORD addr)
 {
 	return(memory[addr]);
 }
-
-/*
- * return memory base pointer for the simulation frame
- *
- * simctl.c still has a dependency on this
- * 
- */
-#define mem_base() (&memory[0])

--- a/z80sim/srcsim/simctl.c
+++ b/z80sim/srcsim/simctl.c
@@ -77,7 +77,7 @@ extern int load_file(char *, BYTE, WORD);
 static void do_step(void);
 static void do_trace(char *);
 static void do_go(char *);
-static int handel_break(void);
+static int handle_break(void);
 static void do_dump(char *);
 static void do_list(char *);
 static void do_modify(char *);
@@ -117,7 +117,7 @@ void mon(void)
 		do_go("");
 
 	while (eoj) {
-		next:
+	next:
 		printf(">>> ");
 		fflush(stdout);
 		if (fgets(cmd, LENCMD, stdin) == NULL) {
@@ -207,7 +207,7 @@ static void do_step(void)
 		break;
 	}
 	if (cpu_error == OPHALT)
-		handel_break();
+		handle_break();
 	cpu_err_msg();
 	print_head();
 	print_reg();
@@ -245,7 +245,7 @@ static void do_trace(char *s)
 		print_reg();
 		if (cpu_error) {
 			if (cpu_error == OPHALT) {
-				if (!handel_break()) {
+				if (!handle_break()) {
 					break;
 				}
 			} else
@@ -264,7 +264,7 @@ static void do_go(char *s)
 		s++;
 	if (isxdigit((unsigned char) *s))
 		PC = exatoi(s);
-	cont:
+cont:
 	cpu_state = CONTIN_RUN;
 	cpu_error = NONE;
 	switch(cpu) {
@@ -276,7 +276,7 @@ static void do_go(char *s)
 		break;
 	}
 	if (cpu_error == OPHALT)
-		if (handel_break())
+		if (handle_break())
 			if (!cpu_error)
 				goto cont;
 	cpu_err_msg();
@@ -290,7 +290,7 @@ static void do_go(char *s)
  *	Output:	0 breakpoint or other HALT opcode reached (stop)
  *		1 breakpoint reached, passcounter not reached (continue)
  */
-static int handel_break(void)
+static int handle_break(void)
 {
 #ifdef SBSIZE
 	register int i;
@@ -300,7 +300,7 @@ static int handel_break(void)
 		if (soft[i].sb_adr == PC - 1)
 			goto was_softbreak;
 	return(0);
-	was_softbreak:
+was_softbreak:
 #ifdef HISIZE
 	h_next--;			/* correct history */
 	if (h_next < 0)
@@ -352,9 +352,10 @@ static void do_dump(char *s)
 		for (j = 0; j < 16; j++)
 			printf("%02x ", getmem(wrk_addr++));
 		putchar('\t');
-		for (j = -16; j < 0; j++)
-			printf("%c", ((c = getmem(wrk_addr + j)) >= ' ' && c <= 0x7f)
-			       ? c : '.');
+		for (j = -16; j < 0; j++) {
+			c = getmem(wrk_addr + j);
+			printf("%c", isprint((unsigned char) c) ? c : '.');
+		}
 		putchar('\n');
 	}
 }
@@ -647,12 +648,10 @@ static void do_reg(char *s)
 static void print_head(void)
 {
 	if (cpu == Z80)
-
-	printf("\nPC   A  SZHPNC I  IFF BC   DE   HL   A'F' B'C' D'E' H'L' IX   IY   SP\n");
-
+		printf("\nPC   A  SZHPNC I  IFF BC   DE   HL   "
+		       "A'F' B'C' D'E' H'L' IX   IY   SP\n");
 	else
-
-	printf("\nPC   A  SZHPC BC   DE   HL   SP\n");
+		printf("\nPC   A  SZHPC BC   DE   HL   SP\n");
 }
 
 /*
@@ -674,11 +673,13 @@ static void print_reg(void)
 		printf("%c", IFF & 2 ? '1' : '0');
 	}
 	if (cpu == Z80) {
-		printf("  %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %04x %04x %04x\n",
-		 B, C, D, E, H, L, A_, F_, B_, C_, D_, E_, H_, L_, IX, IY, SP);
+		printf("  %02x%02x %02x%02x %02x%02x %02x%02x "
+		       "%02x%02x %02x%02x %02x%02x %04x %04x %04x\n",
+		       B, C, D, E, H, L, A_, F_,
+		       B_, C_, D_, E_, H_, L_, IX, IY, SP);
 	} else {
 		printf(" %02x%02x %02x%02x %02x%02x %04x\n",
-		 B, C, D, E, H, L, SP);
+		       B, C, D, E, H, L, SP);
 	}
 }
 
@@ -780,12 +781,14 @@ static void do_hist(char *s)
 					sa = -1;
 			}
 			if (cpu == Z80) {
-				printf("%04x AF=%04x BC=%04x DE=%04x HL=%04x IX=%04x IY=%04x SP=%04x\n",
+				printf("%04x AF=%04x BC=%04x DE=%04x HL=%04x "
+				       "IX=%04x IY=%04x SP=%04x\n",
 					his[i].h_adr, his[i].h_af, his[i].h_bc,
 					his[i].h_de, his[i].h_hl, his[i].h_ix,
 					his[i].h_iy, his[i].h_sp);
 			} else {
-				printf("%04x AF=%04x BC=%04x DE=%04x HL=%04x SP=%04x\n",
+				printf("%04x AF=%04x BC=%04x DE=%04x HL=%04x "
+				       "SP=%04x\n",
 					his[i].h_adr, his[i].h_af, his[i].h_bc,
 					his[i].h_de, his[i].h_hl, his[i].h_sp);
 			}

--- a/z80sim/srcsim/simctl.c
+++ b/z80sim/srcsim/simctl.c
@@ -68,7 +68,7 @@
 #include "memory.h"
 
 extern void cpu_z80(void), cpu_8080(void);
-extern void disass(int, unsigned char **, int, unsigned char *);
+extern void disass(int, WORD *);
 extern int exatoi(char *);
 extern int getkey(void);
 extern void int_on(void), int_off(void);
@@ -97,7 +97,7 @@ static void do_unix(char *);
 static void do_help(void);
 static void cpu_err_msg(void);
 
-extern BYTE *wrk_ram;
+static WORD wrk_addr;
 struct termios old_term;
 
 /*
@@ -108,6 +108,8 @@ void mon(void)
 {
 	register int eoj = 1;
 	static char cmd[LENCMD];
+
+	wrk_addr = PC;
 
 	tcgetattr(0, &old_term);
 
@@ -192,7 +194,7 @@ void mon(void)
  */
 static void do_step(void)
 {
-	BYTE *p;
+	WORD a;
 
 	cpu_state = SINGLE_STEP;
 	cpu_error = NONE;
@@ -209,8 +211,9 @@ static void do_step(void)
 	cpu_err_msg();
 	print_head();
 	print_reg();
-	p = mem_base() + PC;
-	disass(cpu, &p, PC, mem_base());
+	a = PC;
+	disass(cpu, &a);
+	wrk_addr = PC;
 }
 
 /*
@@ -306,7 +309,7 @@ static int handel_break(void)
 	break_address = PC - 1;		/* store adr of breakpoint */
 	cpu_error = NONE;		/* HALT was a breakpoint */
 	PC--;				/* substitute HALT opcode by */
-	*(mem_base() + PC) = soft[i].sb_oldopc;	/* original opcode */
+	putmem(PC, soft[i].sb_oldopc);	/* original opcode */
 	cpu_state = SINGLE_STEP;	/* and execute it */
 	switch(cpu) {
 	case Z80:
@@ -316,7 +319,7 @@ static int handel_break(void)
 		cpu_8080();
 		break;
 	}
-	*(mem_base() + soft[i].sb_adr) = 0x76; /* restore HALT opcode again */
+	putmem(soft[i].sb_adr, 0x76);	/* restore HALT opcode again */
 	soft[i].sb_passcount++;		/* increment passcounter */
 	if (soft[i].sb_passcount != soft[i].sb_pass)
 		return(1);		/* pass not reached, continue */
@@ -339,22 +342,18 @@ static void do_dump(char *s)
 	while (isspace((unsigned char) *s))
 		s++;
 	if (isxdigit((unsigned char) *s))
-		wrk_ram = mem_base() + exatoi(s) - exatoi(s) % 16;
+		wrk_addr = exatoi(s) - exatoi(s) % 16;
 	printf("Adr    ");
 	for (i = 0; i < 16; i++)
 		printf("%02x ", i);
 	puts(" ASCII");
 	for (i = 0; i < 16; i++) {
-		printf("%04x - ", (unsigned int)(wrk_ram - mem_base()));
-		for (j = 0; j < 16; j++) {
-			printf("%02x ", *wrk_ram);
-			wrk_ram++;
-			if (wrk_ram > mem_base() + 65535)
-				wrk_ram = mem_base();
-		}
+		printf("%04x - ", (unsigned int) wrk_addr);
+		for (j = 0; j < 16; j++)
+			printf("%02x ", getmem(wrk_addr++));
 		putchar('\t');
 		for (j = -16; j < 0; j++)
-			printf("%c", ((c = *(wrk_ram + j)) >= ' ' && c <= 0x7f)
+			printf("%c", ((c = getmem(wrk_addr + j)) >= ' ' && c <= 0x7f)
 			       ? c : '.');
 		putchar('\n');
 	}
@@ -370,10 +369,10 @@ static void do_list(char *s)
 	while (isspace((unsigned char) *s))
 		s++;
 	if (isxdigit((unsigned char) *s))
-		wrk_ram = mem_base() + exatoi(s);
+		wrk_addr = exatoi(s);
 	for (i = 0; i < 10; i++) {
-		printf("%04x - ", (unsigned int)(wrk_ram - mem_base()));
-		disass(cpu, &wrk_ram, wrk_ram - mem_base(), mem_base());
+		printf("%04x - ", (unsigned int) wrk_addr);
+		disass(cpu, &wrk_addr);
 	}
 }
 
@@ -387,22 +386,18 @@ static void do_modify(char *s)
 	while (isspace((unsigned char) *s))
 		s++;
 	if (isxdigit((unsigned char) *s))
-		wrk_ram = mem_base() + exatoi(s);
+		wrk_addr = exatoi(s);
 	for (;;) {
-		printf("%04x = %02x : ", (unsigned int)(wrk_ram - mem_base()),
-		       *wrk_ram);
+		printf("%04x = %02x : ", (unsigned int) wrk_addr,
+		       getmem(wrk_addr));
 		fgets(nv, sizeof(nv), stdin);
 		if (nv[0] == '\n') {
-			wrk_ram++;
-			if (wrk_ram > mem_base() + 65535)
-				wrk_ram = mem_base();
+			wrk_addr++;
 			continue;
 		}
 		if (!isxdigit((unsigned char) nv[0]))
 			break;
-		*wrk_ram++ = exatoi(nv);
-		if (wrk_ram > mem_base() + 65535)
-			wrk_ram = mem_base();
+		putmem(wrk_addr++, exatoi(nv));
 	}
 }
 
@@ -411,13 +406,13 @@ static void do_modify(char *s)
  */
 static void do_fill(char *s)
 {
-	register BYTE *p;
+	register WORD a;
 	register int i;
 	register BYTE val;
 
 	while (isspace((unsigned char) *s))
 		s++;
-	p = mem_base() + exatoi(s);
+	a = exatoi(s);
 	while (*s != ',' && *s != '\0')
 		s++;
 	if (*s) {
@@ -434,11 +429,8 @@ static void do_fill(char *s)
 		puts("value missing");
 		return;
 	}
-	while (i--) {
-		*p++ = val;
-		if (p > mem_base() + 65535)
-			p = mem_base();
-	}
+	while (i--)
+		putmem(a++, val);
 }
 
 /*
@@ -446,17 +438,17 @@ static void do_fill(char *s)
  */
 static void do_move(char *s)
 {
-	register BYTE *p1, *p2;
+	register WORD a1, a2;
 	register int count;
 
 	
 	while (isspace((unsigned char) *s))
 		s++;
-	p1 = mem_base() + exatoi(s);
+	a1 = exatoi(s);
 	while (*s != ',' && *s != '\0')
 		s++;
 	if (*s) {
-		p2 = mem_base() + exatoi(++s);
+		a2 = exatoi(++s);
 	} else {
 		puts("to missing");
 		return;
@@ -469,13 +461,8 @@ static void do_move(char *s)
 		puts("count missing");
 		return;
 	}
-	while (count--) {
-		*p2++ = *p1++;
-		if (p1 > mem_base() + 65535)
-			p1 = mem_base();
-		if (p2 > mem_base() + 65535)
-			p2 = mem_base();
-	}
+	while (count--)
+		putmem(a2++, getmem(a1++));
 }
 
 /*
@@ -730,15 +717,15 @@ static void do_break(char *s)
 	while (isspace((unsigned char) *s))
 		s++;
 	if (*s == 'c') {
-		*(mem_base() + soft[i].sb_adr) = soft[i].sb_oldopc;
+		putmem(soft[i].sb_adr, soft[i].sb_oldopc);
 		memset((char *) &soft[i], 0, sizeof(struct softbreak));
 		return;
 	}
 	if (soft[i].sb_pass)
-		*(mem_base() + soft[i].sb_adr) = soft[i].sb_oldopc;
+		putmem(soft[i].sb_adr, soft[i].sb_oldopc);
 	soft[i].sb_adr = exatoi(s);
-	soft[i].sb_oldopc = *(mem_base() + soft[i].sb_adr);
-	*(mem_base() + soft[i].sb_adr) = 0x76;
+	soft[i].sb_oldopc = getmem(soft[i].sb_adr);
+	putmem(soft[i].sb_adr, 0x76);
 	while (!iscntrl((unsigned char) *s) && !ispunct((unsigned char) *s))
 		s++;
 	if (*s != ',')
@@ -865,12 +852,12 @@ static void do_clock(void)
 	static struct itimerval tim;
 	char *s = NULL;
 
-	save[0] = *(mem_base() + 0x0000); /* save memory locations */
-	save[1] = *(mem_base() + 0x0001); /* 0000H - 0002H */
-	save[2] = *(mem_base() + 0x0002);
-	*(mem_base() + 0x0000) = 0xc3;	/* store opcode JP 0000H at address */
-	*(mem_base() + 0x0001) = 0x00;	/* 0000H */
-	*(mem_base() + 0x0002) = 0x00;
+	save[0] = getmem(0x0000);	/* save memory locations */
+	save[1] = getmem(0x0001);	/* 0000H - 0002H */
+	save[2] = getmem(0x0002);
+	putmem(0x0000, 0xc3);		/* store opcode JP 0000H at address */
+	putmem(0x0001, 0x00);		/* 0000H */
+	putmem(0x0002, 0x00);
 	PC = 0;				/* set PC to this code */
 	R = 0L;				/* clear refresh register */
 	cpu_state = CONTIN_RUN;		/* initialise CPU */
@@ -896,9 +883,9 @@ static void do_clock(void)
 	}
 	newact.sa_handler = SIG_DFL;	/* reset timer interrupt handler */
 	sigaction(SIGALRM, &newact, NULL);
-	*(mem_base() + 0x0000) = save[0]; /* restore memory locations */
-	*(mem_base() + 0x0001) = save[1]; /* 0000H - 0002H */
-	*(mem_base() + 0x0002) = save[2];
+	putmem(0x0000, save[0]);	/* restore memory locations */
+	putmem(0x0001, save[1]);	/* 0000H - 0002H */
+	putmem(0x0002, save[2]);
 	if (cpu_error == NONE) {
 		printf("CPU executed %ld %s instructions in 3 seconds\n", R, s);
 		printf("clock frequency = %5.2f Mhz\n", ((float) R) / 300000.0);
@@ -1016,16 +1003,16 @@ static void cpu_err_msg(void)
 		break;
 	case OPTRAP1:
 		printf("Op-code trap at %04x: %02x\n", PC - 1,
-		       *(mem_base() + PC - 1));
+		       getmem(PC - 1));
 		break;
 	case OPTRAP2:
 		printf("Op-code trap at %04x: %02x %02x\n", PC - 2,
-		       *(mem_base() + PC - 2), *(mem_base() + PC - 1));
+		       getmem(PC - 2), getmem(PC - 1));
 		break;
 	case OPTRAP4:
 		printf("Op-code trap at %04x: %02x %02x %02x %02x\n",
-		       PC - 4, *(mem_base() + PC - 4), *(mem_base() + PC - 3),
-		       *(mem_base() + PC - 2), *(mem_base() + PC - 1));
+		       PC - 4, getmem(PC - 4), getmem(PC - 3),
+		       getmem(PC - 2), getmem(PC - 1));
 		break;
 	case USERINT:
 		puts("User Interrupt");


### PR DESCRIPTION
1. Removed mem_base() and wrk_addr everywhere. simctl.c now uses getmem() and putmem() to access memory. There is a new static variable wrk_addr of type WORD, which should avoid any wraparound problems. It's initialized to PC in mon(). I also set wrk_addr to PC in do_step(), so that one can simply type "l" to see the next instructions that will be executed.
2. Synced mosteksim/srcsim/simctl.c with z80sim/srcsim/simctl.c.
3. The disassembler just looked to "switch"ey...
4. Changed hex loader to set PC to start address in EOF record