### PR TITLE
Add back '\n' in disass and fix bug, remove trailing spaces, UNUSED m…

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -132,3 +132,8 @@ struct softbreak {			/* structure of a breakpoint */
 
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
+
+/*
+ *	macro for declaring unused function parameters
+ */
+#define UNUSED(x)	(void)(x)

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -842,7 +842,7 @@ void init_io(void)
 			strcpy(fn, diskd);
 		} else {
 			/* if not first try ./disks */
-			if ((stat("./disks", &sbuf) == 0) && 
+			if ((stat("./disks", &sbuf) == 0) &&
 			    S_ISDIR(sbuf.st_mode)) {
 				strcpy(fn, "./disks");
 			/* nope, then DISKSDIR as set in Makefile */
@@ -2466,7 +2466,7 @@ static void hwctl_out(BYTE data)
 		hwctl_lock = 0;
 		return;
 	}
-	
+
 	/* process output to unlocked port */
 
 	if (data & 128) {	/* halt system */

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -169,3 +169,8 @@ struct dskdef {
 
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
+
+/*
+ *	macro for declaring unused function parameters
+ */
+#define UNUSED(x)	(void)(x)

--- a/cpmsim/srctools/bin2hex.c
+++ b/cpmsim/srctools/bin2hex.c
@@ -75,14 +75,14 @@ int main(int argc,char *argv[])/*Main routine*/
   }
   ifile = argv[optind];
   ofile = argv[optind+1];
-    
+
   /*Open file check*/
   if((inp = fopen(ifile, "rb")) == NULL){
     printf("ERROR: Cannot open input file.\n");
     return 1;
   }
   fseek (inp, foffset, SEEK_SET);
-  
+
   if (append == 0) {
     if((outp = fopen(ofile, "wt")) == NULL){
       printf("ERROR: Cannot open output file.\n");

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -152,3 +152,8 @@ struct softbreak {			/* structure of a breakpoint */
 
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
+
+/*
+ *	macro for declaring unused function parameters
+ */
+#define UNUSED(x)	(void)(x)

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -146,3 +146,8 @@ struct softbreak {			/* structure of a breakpoint */
 
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
+
+/*
+ *	macro for declaring unused function parameters
+ */
+#define UNUSED(x)	(void)(x)

--- a/iodevices/diskmanager.c
+++ b/iodevices/diskmanager.c
@@ -56,9 +56,6 @@
 #endif
 
 #ifdef HAS_DISKMANAGER
-#ifndef UNUSED
-#define UNUSED(x) (void)(x)
-#endif
 
 static const char *TAG = "diskmanager";
 

--- a/mosteksim/srcsim/iosim.c
+++ b/mosteksim/srcsim/iosim.c
@@ -43,7 +43,7 @@ static void io_no_card_out(BYTE);
  *	input I/O port (0 - 255), to do the required I/O.
  */
 static BYTE (*port_in[256]) (void) = {
-	io_trap_in,			/* port 0 */ 
+	io_trap_in,			/* port 0 */
 	io_trap_in,			/* port 1 */
 	io_trap_in,			/* port 2 */
 	io_trap_in,			/* port 3 */
@@ -57,11 +57,11 @@ static BYTE (*port_in[256]) (void) = {
 	io_trap_in,			/* port 11 */
 	io_trap_in,			/* port 12 */
 	io_trap_in,			/* port 13 */
-	io_trap_in,	 		/* port 14 */ 
+	io_trap_in,	 		/* port 14 */
 	io_trap_in,			/* port 15 */
-	io_trap_in,			/* port 16 */ 
-	io_trap_in,			/* port 17 */ 
-	io_trap_in,			/* port 18 */ 
+	io_trap_in,			/* port 16 */
+	io_trap_in,			/* port 17 */
+	io_trap_in,			/* port 18 */
 	io_trap_in,			/* port 19 */
 	io_trap_in,			/* port 20 */
 	io_trap_in,			/* port 21 */
@@ -313,7 +313,7 @@ static void (*port_out[256]) (BYTE) = {
 	io_trap_out,		/* port 4 */
 	io_trap_out,		/* port 5 */
 	io_trap_out,		/* port 6 */
-	io_trap_out,		/* port 7 */ 
+	io_trap_out,		/* port 7 */
 	io_trap_out,		/* port 8 */
 	io_trap_out,		/* port 9 */
 	io_trap_out,		/* port 10 */
@@ -558,7 +558,7 @@ static void (*port_out[256]) (BYTE) = {
 	io_trap_out,		/* port 249 */
 	io_trap_out,		/* port 250 */
 	io_trap_out,		/* port 251 */
-	io_trap_out,		/* port 252 */ 
+	io_trap_out,		/* port 252 */
 	io_trap_out,		/* port 253 */
 	io_trap_out,		/* port 254 */
 	io_trap_out		/* port 255 */

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -6,8 +6,8 @@
  * This is the configuration I'm using for software testing and debugging
  *
  * History:
- * 15-SEP-19 (Mike Douglas) Created from sim.h from the z80sim source 
- *		directory. Set start-up message for Mostek AID-80F and SYS-80FT 
+ * 15-SEP-19 (Mike Douglas) Created from sim.h from the z80sim source
+ *		directory. Set start-up message for Mostek AID-80F and SYS-80FT
  *		computers.
  * 27_SEP-19 (Udo Munk) modified for integration into 1.37
  */
@@ -119,3 +119,8 @@ struct softbreak {			/* structure of a breakpoint */
 
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
+
+/*
+ *	macro for declaring unused function parameters
+ */
+#define UNUSED(x)	(void)(x)

--- a/mosteksim/srcsim/simctl.c
+++ b/mosteksim/srcsim/simctl.c
@@ -8,7 +8,7 @@
  *
  * History:
  * 15-SEP-19 (Mike Douglas) Created from simctl.c in the z80sim
- *		source directory. Added unix_terminal code to emulate 
+ *		source directory. Added unix_terminal code to emulate
  * 		console I/O for the Mostek AID-80F and SYS-80FT computers
  * 27-SEP-19 (Udo Munk) fix double loading of ROM
  * 30-SEP-19 (Mike Douglas) accept also upper case
@@ -418,7 +418,6 @@ static void do_move(char *s)
 	register WORD a1, a2;
 	register int count;
 
-	
 	while (isspace((unsigned char) *s))
 		s++;
 	a1 = exatoi(s);

--- a/webfrontend/netsrv.h
+++ b/webfrontend/netsrv.h
@@ -15,8 +15,6 @@
 #include <sys/msg.h>
 #include <string.h>
 
-#define UNUSED(x) (void)(x)
-
 enum net_device {
 	DEV_TTY,
 	DEV_TTY2,

--- a/z80core/log.h
+++ b/z80core/log.h
@@ -1,8 +1,8 @@
 /**
  * log.h
- * 
+ *
  * Copyright (C) 2018 by David McNaughton
- * 
+ *
  * NOTICE: This is a deriviative of a work that is can be found at and is itself:
  * https://github.com/espressif/esp-idf/blob/master/components/log/include/esp_log.h
  * Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
@@ -10,10 +10,10 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * History:
  * 12-JUL-18    1.0     Initial Release
- * 
+ *
  */
 #include <stdio.h>
 #include <stdint.h>

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -1469,7 +1469,7 @@ static int op_adhlsp(void)		/* ADD HL,SP */
 
 	BYTE spl = SP & 0xff;
 	BYTE sph = SP >> 8;
-	
+
 	carry = (L + spl > 255) ? 1 : 0;
 	L += spl;
 	((H & 0xf) + (sph & 0xf) + carry > 0xf) ? (F |= H_FLAG)

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -1412,7 +1412,7 @@ static int op_dadsp(void)		/* DAD SP */
 
 	BYTE spl = SP & 0xff;
 	BYTE sph = SP >> 8;
-	
+
 	carry = (L + spl > 255) ? 1 : 0;
 	L += spl;
 	(H + sph + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -628,7 +628,7 @@ static int op_addxb(void)		/* ADD IX,BC */
 	register int carry;
 	BYTE ixl = IX & 0xff;
 	BYTE ixh = IX >> 8;
-	
+
 	carry = (ixl + C > 255) ? 1 : 0;
 	ixl += C;
 	((ixh & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -645,7 +645,7 @@ static int op_addxd(void)		/* ADD IX,DE */
 	register int carry;
 	BYTE ixl = IX & 0xff;
 	BYTE ixh = IX >> 8;
-	
+
 	carry = (ixl + E > 255) ? 1 : 0;
 	ixl += E;
 	((ixh & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -664,7 +664,7 @@ static int op_addxs(void)		/* ADD IX,SP */
 	BYTE ixh = IX >> 8;
 	BYTE spl = SP & 0xff;
 	BYTE sph = SP >> 8;
-	
+
 	carry = (ixl + spl > 255) ? 1 : 0;
 	ixl += spl;
 	((ixh & 0xf) + (sph & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -681,7 +681,7 @@ static int op_addxx(void)		/* ADD IX,IX */
 	register int carry;
 	BYTE ixl = IX & 0xff;
 	BYTE ixh = IX >> 8;
-	
+
 	carry = (ixl << 1 > 255) ? 1 : 0;
 	ixl <<= 1;
 	((ixh & 0xf) + (ixh & 0xf) + carry > 0xf) ? (F |= H_FLAG)

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -628,7 +628,7 @@ static int op_addyb(void)		/* ADD IY,BC */
 	register int carry;
 	BYTE iyl = IY & 0xff;
 	BYTE iyh = IY >> 8;
-	
+
 	carry = (iyl + C > 255) ? 1 : 0;
 	iyl += C;
 	((iyh & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -645,7 +645,7 @@ static int op_addyd(void)		/* ADD IY,DE */
 	register int carry;
 	BYTE iyl = IY & 0xff;
 	BYTE iyh = IY >> 8;
-	
+
 	carry = (iyl + E > 255) ? 1 : 0;
 	iyl += E;
 	((iyh & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -664,7 +664,7 @@ static int op_addys(void)		/* ADD IY,SP */
 	BYTE iyh = IY >> 8;
 	BYTE spl = SP & 0xff;
 	BYTE sph = SP >> 8;
-	
+
 	carry = (iyl + spl > 255) ? 1 : 0;
 	iyl += spl;
 	((iyh & 0xf) + (sph & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -681,7 +681,7 @@ static int op_addyy(void)		/* ADD IY,IY */
 	register int carry;
 	BYTE iyl = IY & 0xff;
 	BYTE iyh = IY >> 8;
-	
+
 	carry = (iyl << 1 > 255) ? 1 : 0;
 	iyl <<= 1;
 	((iyh & 0xf) + (iyh & 0xf) + carry > 0xf) ? (F |= H_FLAG)

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -396,7 +396,7 @@ void start_bus_request(BusDMA_t mode, Tstates_t (*bus_master)(BYTE bus_ack)) {
 	bus_mode = mode;
 	dma_bus_master = bus_master;
 	bus_request = 1;
-} 
+}
 
 /*
  *	End a bus request cycle
@@ -406,4 +406,4 @@ void end_bus_request(void) {
 	bus_mode = BUS_DMA_NONE;
 	dma_bus_master = NULL;
 	bus_request = 0;
-} 
+}

--- a/z80sim/srcsim/disas.c
+++ b/z80sim/srcsim/disas.c
@@ -53,8 +53,6 @@
 #include "sim.h"
 #include "memory.h"
 
-#define UNUSED(x)	(void)(x)
-
 /*
  *	Forward declarations
  */
@@ -471,7 +469,6 @@ char Opcode_Str[64];
 
 static void get_opcodes(WORD addr, int len)
 {
-  
 	switch (len) {
 	case 1:
 		sprintf(Opcode_Str, "%02X         ", getmem(addr));
@@ -554,13 +551,13 @@ void disass(int cpu, WORD *addr)
 			len = (*optp->fun)(optp->text, *addr);
 		}
 	}
+	strcat(Disass_Str, "\n");
 
 	get_opcodes(*addr, len);
 #ifndef WANT_GUI
 	fputs(Opcode_Str, stdout);
 	putchar('\t');
 	fputs(Disass_Str, stdout);
-	putchar('\n');
 #endif
 
 	*addr += len;
@@ -772,14 +769,14 @@ static int ddfd(char *s, WORD a)
 			sprintf(Disass_Str, "LD\t%s,(%s+%02X)", reg[r1],
 				ireg[r2], getmem(a + 2));
 			return(3);
-		} else {
+		} else {				/* undocumented */
 			sprintf(Disass_Str, "LD*\t%s,%s", ireg[r1], ireg[r2]);
 			return(2);
 		}
 	} else if (b2 < 0xc0) {
 		if (r2 < 4 || r2 > 6) {			/* undocumented */
 			strcpy(Disass_Str, "NOP*");
-			return(2);
+			return(1);
 		} else if (r2 == 6) {
 			sprintf(Disass_Str, "%s(%s+%02X)", aluins[r1],
 				ireg[r2], getmem(a + 2));

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -156,3 +156,8 @@ struct softbreak {			/* structure of a breakpoint */
 
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
+
+/*
+ *	macro for declaring unused function parameters
+ */
+#define UNUSED(x)	(void)(x)

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -157,3 +157,8 @@ struct softbreak {			/* structure of a breakpoint */
 
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
+
+/*
+ *	macro for declaring unused function parameters
+ */
+#define UNUSED(x)	(void)(x)

--- a/z80sim/srcsim/simctl.c
+++ b/z80sim/srcsim/simctl.c
@@ -442,7 +442,6 @@ static void do_move(char *s)
 	register WORD a1, a2;
 	register int count;
 
-	
 	while (isspace((unsigned char) *s))
 		s++;
 	a1 = exatoi(s);


### PR DESCRIPTION
…acro

1. Add back the '\n' I removed from DisassStr and fix a instruction length bug
2. Remove some trailing white space
3. Make UNUSED macro globally available in sim.h. Some other files already had they own version. These all include sim.h. Remove the local defines.