### PR TITLE
remove -Wno-self-assign, resolve warnings

### DIFF
--- a/altairsim/srcsim/GNUmakefile
+++ b/altairsim/srcsim/GNUmakefile
@@ -64,7 +64,6 @@ PLAT_LFLAGS = -lXext -lXmu -lXt -lm -lpthread
 endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCL = -I/opt/X11/include
-PLAT_CFLAGS = -Wno-self-assign
 PLAT_LFLAGS = -L/usr/local/lib -L/opt/X11/lib
 .LIBPATTERNS += lib%.dylib
 endif

--- a/altairsim/srcsim/Makefile.bsd
+++ b/altairsim/srcsim/Makefile.bsd
@@ -13,10 +13,10 @@ Z80CORE = ../../z80core
 IODEVICES = ../../iodevices
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
 
 # Production
-CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
+CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
 
 LFLAGS = -L../../frontpanel -L/usr/local/lib \
 	-lfrontpanel -ljpeg -lGL -lGLU -lX11 -lthr

--- a/altairsim/srcsim/Makefile.osx
+++ b/altairsim/srcsim/Makefile.osx
@@ -13,13 +13,13 @@ Z80CORE = ../../z80core
 IODEVICES = ../../iodevices
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
 
 # Production
-CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
+CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
 
 # Debug
-#CFLAGS = -O -g -c -Wno-self-assign -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
+#CFLAGS = -O -g -c -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES)
 
 LFLAGS = -L../../frontpanel -L/usr/local/lib -L/opt/X11/lib \
 	-lfrontpanel -ljpeg -lGL -lGLU -lX11

--- a/cpmsim/srcsim/GNUmakefile
+++ b/cpmsim/srcsim/GNUmakefile
@@ -61,7 +61,6 @@ PLAT_LFLAGS =
 endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCL =
-PLAT_CFLAGS = -Wno-self-assign
 PLAT_LFLAGS =
 .LIBPATTERNS += lib%.dylib
 endif

--- a/cpmsim/srcsim/Makefile.bsd
+++ b/cpmsim/srcsim/Makefile.bsd
@@ -10,10 +10,10 @@ Z80CORE = ../../z80core
 IODEVICES = ../../iodevices
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -I. -I$(Z80CORE) -I$(IODEVICES)
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -I. -I$(Z80CORE) -I$(IODEVICES)
 
 # Production
-CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -I. -I$(Z80CORE) -I$(IODEVICES)
+CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -I. -I$(Z80CORE) -I$(IODEVICES)
 
 LFLAGS =
 

--- a/cpmsim/srcsim/Makefile.osx
+++ b/cpmsim/srcsim/Makefile.osx
@@ -10,10 +10,10 @@ Z80CORE = ../../z80core
 IODEVICES = ../../iodevices
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -I. -I$(Z80CORE) -I$(IODEVICES)
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -I. -I$(Z80CORE) -I$(IODEVICES)
 
 # Production
-CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -I. -I$(Z80CORE) -I$(IODEVICES)
+CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -I. -I$(Z80CORE) -I$(IODEVICES)
 
 LFLAGS =
 

--- a/cromemcosim/srcsim/GNUmakefile
+++ b/cromemcosim/srcsim/GNUmakefile
@@ -66,7 +66,6 @@ PLAT_LFLAGS = -lXext -lXmu -lXt -lm -lpthread
 endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCL = -I/opt/X11/include
-PLAT_CFLAGS = -Wno-self-assign
 PLAT_LFLAGS = -L/usr/local/lib -L/opt/X11/lib
 .LIBPATTERNS += lib%.dylib
 endif

--- a/cromemcosim/srcsim/Makefile.bsd
+++ b/cromemcosim/srcsim/Makefile.bsd
@@ -16,10 +16,10 @@ WEB = ../../webfrontend
 INCL = -I$(WEB)/civetweb/include -I$(WEB)
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 # Production
-CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 LFLAGS = -L../../frontpanel -L/usr/local/lib \
 	-lfrontpanel -ljpeg -lGL -lGLU -lX11 -lpthread \

--- a/cromemcosim/srcsim/Makefile.osx
+++ b/cromemcosim/srcsim/Makefile.osx
@@ -16,13 +16,13 @@ WEB = ../../webfrontend
 INCL = -I$(WEB)/civetweb/include -I$(WEB)
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 # Production
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+#CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 # Debugging
-CFLAGS = -g -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+CFLAGS = -g -c -Wall -Wextra -U_FORTIFY_SOURCE -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 LFLAGS = -L../../frontpanel -L/usr/local/lib -L/opt/X11/lib \
 	-lfrontpanel -ljpeg -lGL -lGLU -lX11 \

--- a/imsaisim/srcsim/GNUmakefile
+++ b/imsaisim/srcsim/GNUmakefile
@@ -66,7 +66,6 @@ PLAT_LFLAGS = -lXext -lXmu -lXt -lm -lpthread
 endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCL = -I/opt/X11/include
-PLAT_CFLAGS = -Wno-self-assign
 PLAT_LFLAGS = -L/usr/local/lib -L/opt/X11/lib
 .LIBPATTERNS += lib%.dylib
 endif

--- a/imsaisim/srcsim/Makefile.bsd
+++ b/imsaisim/srcsim/Makefile.bsd
@@ -16,10 +16,10 @@ WEB = ../../webfrontend
 INCL = -I$(WEB)/civetweb/include -I$(WEB)
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 # Production
-CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -I/usr/local/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 LFLAGS = -L../../frontpanel -L/usr/local/lib \
 	-lfrontpanel -ljpeg -lGL -lGLU -lX11 -lthr \

--- a/imsaisim/srcsim/Makefile.osx
+++ b/imsaisim/srcsim/Makefile.osx
@@ -16,13 +16,13 @@ WEB = ../../webfrontend
 INCL = -I$(WEB)/civetweb/include -I$(WEB)
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 # Production
-CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 # Debug
-#CFLAGS = -O -g -c -Wno-self-assign -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
+#CFLAGS = -O -g -c -I/opt/X11/include -DCONFDIR=\"${CONF}\" -DDISKSDIR=\"${DISKS}\" -DBOOTROM=\"${ROM}\" -I. -I$(Z80CORE) -I$(IODEVICES) ${INCL}
 
 LFLAGS = -L../../frontpanel -L/usr/local/lib -L/opt/X11/lib \
 	 -lfrontpanel -ljpeg -lGL -lGLU -lX11 \

--- a/iodevices/apu/am9511.c
+++ b/iodevices/apu/am9511.c
@@ -16,6 +16,7 @@
 #include "ova.h"
 #include "types.h"
 
+#define UNUSED(x) (void)(x)
 
 /* Define fp_na() -- fp to native and
  *        na_fp() -- native to fp
@@ -784,6 +785,8 @@ void am_reset(void *amp) {
 void *am_create(int status, int data) {
     struct am_context *p;
     void *fpp;
+    UNUSED(status);
+    UNUSED(data);
     fpp = malloc(apu_fp_size());
     if (fpp == NULL)
 	return NULL;

--- a/iodevices/cromemco-88ccc.c
+++ b/iodevices/cromemco-88ccc.c
@@ -13,10 +13,14 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <signal.h>
 #include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
+
+#ifdef HAS_CYCLOPS
+
 #include "config.h"
 #include "../../frontpanel/frontpanel.h"
 #include "memory.h"
@@ -25,8 +29,6 @@
 #endif
 /* #define LOG_LOCAL_LEVEL LOG_DEBUG */
 #include "log.h"
-
-#ifdef HAS_CYCLOPS
 
 static const char *TAG = "88CCC";
 

--- a/iodevices/cromemco-wdi.c
+++ b/iodevices/cromemco-wdi.c
@@ -310,6 +310,7 @@ again:
                 wdi.hd[unit].type = i;
                 if (read(fd, buffer, WDI_BLOCK_SIZE) == WDI_BLOCK_SIZE) {
                     memcpy(wdi.hd[unit].type_s, (char *)&buffer[0x78], 4);
+                    wdi.hd[unit].type_s[5] = '\0';
                 } else {
                     wdi.hd[unit]._fault = 0; /* read fault */
                 }

--- a/iodevices/cromemco-wdi.c
+++ b/iodevices/cromemco-wdi.c
@@ -309,7 +309,7 @@ again:
             if (s.st_size == size) {
                 wdi.hd[unit].type = i;
                 if (read(fd, buffer, WDI_BLOCK_SIZE) == WDI_BLOCK_SIZE) {
-                    strncpy(wdi.hd[unit].type_s, (char *)&buffer[0x78], 4);
+                    memcpy(wdi.hd[unit].type_s, (char *)&buffer[0x78], 4);
                 } else {
                     wdi.hd[unit]._fault = 0; /* read fault */
                 }
@@ -319,7 +319,7 @@ again:
             wdi.hd[unit]._fault = 0;
             wdi.hd[unit].type = 0;
             strcpy(wdi.hd[unit].type_s, disk_param[wdi.hd[unit].type].type);
-            LOGW(TAG, "UNKNOWN DISK IMAGE SIZE [%lld] FOR %s", s.st_size, wdi.hd[unit].fn);
+            LOGW(TAG, "UNKNOWN DISK IMAGE SIZE [%lld] FOR %s", (long long) s.st_size, wdi.hd[unit].fn);
         }
 
         LOG(TAG, "HD%d:[%s]='%s'\n\r", unit, wdi.hd[unit].type_s, wdi.hd[unit].fn);

--- a/iodevices/diskmanager.c
+++ b/iodevices/diskmanager.c
@@ -46,16 +46,17 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/stat.h>
+#include "sim.h"
+
+#ifdef HAS_DISKMANAGER
+
 #define LOCAL_LOG_LEVEL LOG_DEBUG
 #include "log.h"
-#include "sim.h"
 #include "disks.h"
 #ifdef HAS_NETSERVER
 #include "civetweb.h"
 #include "netsrv.h"
 #endif
-
-#ifdef HAS_DISKMANAGER
 
 static const char *TAG = "diskmanager";
 

--- a/webfrontend/netsrv.c
+++ b/webfrontend/netsrv.c
@@ -22,6 +22,9 @@
 #include <sys/utsname.h>
 #include "sim.h"
 #include "simglb.h"
+
+#ifdef HAS_NETSERVER
+
 #include "../../frontpanel/frontpanel.h"
 #include "memory.h"
 #include "log.h"
@@ -36,8 +39,6 @@
 #include "cromemco-hal.h"
 #endif
 #endif 
-
-#ifdef HAS_NETSERVER
 
 #define PORT "8080"
 
@@ -465,7 +466,7 @@ int DirectoryHandler(HttpdConnection_t *conn, void *path) {
 		if (stat(fullpath, &sb) != -1 && S_ISREG(sb.st_mode)) {
 			if (showSize) {
 				httpdPrintf(conn, "%c{ \"%s\":\"%s\",", (i++ > 0)?',':' ', "filename",pDirent->d_name);
-				httpdPrintf(conn, "\"%s\":%lld}", "size", sb.st_size);
+				httpdPrintf(conn, "\"%s\":%lld}", "size", (long long) sb.st_size);
 			} else {
 				httpdPrintf(conn, "%c\"%s\"", (i++ > 0)?',':' ', pDirent->d_name);
 			}
@@ -490,7 +491,8 @@ int UploadHandler(HttpdConnection_t *conn, void *path) {
 
     switch (req->method) {
     case HTTP_PUT:
-		strncpy(output, path, MAX_LFN);
+		strncpy(output, path, MAX_LFN - 1);
+		output[MAX_LFN - 1] = '\0';
 
 		if (output[strlen(output)-1] != '/')
 			strncat(output, "/", MAX_LFN - strlen(output));

--- a/z80sim/srcsim/GNUmakefile
+++ b/z80sim/srcsim/GNUmakefile
@@ -56,7 +56,6 @@ PLAT_LFLAGS =
 endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCL =
-PLAT_CFLAGS = -Wno-self-assign
 PLAT_LFLAGS =
 .LIBPATTERNS += lib%.dylib
 endif

--- a/z80sim/srcsim/Makefile.bsd
+++ b/z80sim/srcsim/Makefile.bsd
@@ -3,10 +3,10 @@ CC = cc
 Z80CORE = ../../z80core
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -I. -I$(Z80CORE)
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -I. -I$(Z80CORE)
 
 # Production
-CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I. -I$(Z80CORE)
+CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -I. -I$(Z80CORE)
 
 LFLAGS =
 

--- a/z80sim/srcsim/Makefile.osx
+++ b/z80sim/srcsim/Makefile.osx
@@ -3,13 +3,13 @@ CC = gcc
 Z80CORE = ../../z80core
 
 # Development
-#CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -fstack-protector-all -D_FORTIFY_SOURCE=2 -I. -I$(Z80CORE)
+#CFLAGS = -O3 -c -Wall -Wextra -fstack-protector-all -D_FORTIFY_SOURCE=2 -I. -I$(Z80CORE)
 
 # Production
-CFLAGS = -O3 -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I. -I$(Z80CORE)
+CFLAGS = -O3 -c -Wall -Wextra -U_FORTIFY_SOURCE -I. -I$(Z80CORE)
 
 # Debugging
-#CFLAGS = -O -g -c -Wall -Wextra -Wno-self-assign -U_FORTIFY_SOURCE -I. -I$(Z80CORE)
+#CFLAGS = -O -g -c -Wall -Wextra -U_FORTIFY_SOURCE -I. -I$(Z80CORE)
 
 LFLAGS =
 


### PR DESCRIPTION
1. Removed -Wno-self-assign from GNUmakefile and Makefile.*
2. Resolve remaining compiler warnings:

   iodevice/apu/am9511.c: Added UNUSED macro, since it doesn't use sim.h

   iodevices/cromemco-88ccc.c: Explicitly include <string.h> since it uses memset (netsrv.h already includes it, but...). Moved "#ifdef HAS_CYCLOPS" before including log.h.

   iodevices/cromemco-wdi.c: Changed strncpy to memcpy. Explicitly cast st_size to long long.

   iodevices/diskmanager.c: Moved "#ifdef HAS_DISKMANAGER" before including log.h.

   webfrontend/netsrv.c: Moved "#ifdef HAS_NETSERVER" before including log.h. Explicitly cast st_size to long long. Fixed strncpy to always '\0' terminate string.