### PR TITLE
clean up, everything now also compiles cleanly & runs using a C++ compiler

### DIFF
--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -211,17 +211,17 @@ struct dskdef disks[16] = {
 	{ "driveb.dsk", &driveb, 77, 26 },
 	{ "drivec.dsk", &drivec, 77, 26 },
 	{ "drived.dsk", &drived, 77, 26 },
-	{ "drivee.dsk", &drivee, -1, -1 },
-	{ "drivef.dsk", &drivef, -1, -1 },
-	{ "driveg.dsk", &driveg, -1, -1 },
-	{ "driveh.dsk", &driveh, -1, -1 },
+	{ "drivee.dsk", &drivee,  0,  0 },
+	{ "drivef.dsk", &drivef,  0,  0 },
+	{ "driveg.dsk", &driveg,  0,  0 },
+	{ "driveh.dsk", &driveh,  0,  0 },
 	{ "drivei.dsk", &drivei, 255, 128 },
 	{ "drivej.dsk", &drivej, 255, 128 },
 	{ "drivek.dsk", &drivek, 255, 128 },
 	{ "drivel.dsk", &drivel, 255, 128 },
-	{ "drivem.dsk", &drivem, -1, -1 },
-	{ "driven.dsk", &driven, -1, -1 },
-	{ "driveo.dsk", &driveo, -1, -1 },
+	{ "drivem.dsk", &drivem,  0,  0 },
+	{ "driven.dsk", &driven,  0,  0 },
+	{ "driveo.dsk", &driveo,  0,  0 },
 	{ "drivep.dsk", &drivep, 256, 16384 }
 };
 
@@ -2308,7 +2308,7 @@ static void mmui_out(BYTE data)
 	}
 
 	for (i = 1; i < data; i++) {
-		if ((memory[i] = malloc(segsize)) == NULL) {
+		if ((memory[i] = (BYTE *) malloc(segsize)) == NULL) {
 			LOGE(TAG, "can't allocate memory for bank %d", i);
 			cpu_error = IOERROR;
 			cpu_state = STOPPED;
@@ -2594,8 +2594,8 @@ static void int_io(int sig)
  */
 void telnet_negotiation(int fd)
 {
-	static char will_echo[3] = {255, 251, 1};
-	static char char_mode[3] = {255, 251, 3};
+	static unsigned char will_echo[3] = {255, 251, 1};
+	static unsigned char char_mode[3] = {255, 251, 3};
 	struct pollfd p[1];
 	BYTE c[3];
 

--- a/cpmsim/srcsim/memory.c
+++ b/cpmsim/srcsim/memory.c
@@ -48,7 +48,7 @@ void init_memory(void)
 	register int i;
 
 	/* allocate the first 64KB bank, so that we have some memory */
-	if ((memory[0] = malloc(65536)) == NULL) {
+	if ((memory[0] = (BYTE *) malloc(65536)) == NULL) {
 		LOGE(TAG, "can't allocate memory for bank 0");
 		cpu_error = IOERROR;
 		cpu_state = STOPPED;

--- a/cromemcosim/srcsim/memory.c
+++ b/cromemcosim/srcsim/memory.c
@@ -68,7 +68,7 @@ void init_memory(void)
 		p_tab[i] = MEM_NONE;
 
 	for (i = 0; i < MAXSEG; i++) {
-		if ((memory[i] = malloc(SEGSIZ)) == NULL) {
+		if ((memory[i] = (BYTE *) malloc(SEGSIZ)) == NULL) {
 			LOGE(TAG, "can't allocate memory for bank %d", i);
 			exit(1);
 		}

--- a/frontpanel/Makefile.bsd
+++ b/frontpanel/Makefile.bsd
@@ -11,10 +11,10 @@ INCLUDE = -I/usr/local/include
 DEFINES =
 
 # Development
-#CFLAGS = -c -O3 -fPIC -Wno-deprecated -fstack-protector-all -D_FORTIFY_SOURCE=2 $(INCLUDE) $(DEFINES)
+#CFLAGS = -c -O3 -fPIC -Wno-deprecated -Wno-register -fstack-protector-all -D_FORTIFY_SOURCE=2 $(INCLUDE) $(DEFINES)
 
 # Production
-CFLAGS = -c -O3 -fPIC -Wno-deprecated -U_FORTIFY_SOURCE $(INCLUDE) $(DEFINES)
+CFLAGS = -c -O3 -fPIC -Wno-deprecated -Wno-register -U_FORTIFY_SOURCE $(INCLUDE) $(DEFINES)
 
 LDFLAGS = -shared
 

--- a/frontpanel/Makefile.cygwin
+++ b/frontpanel/Makefile.cygwin
@@ -11,10 +11,10 @@ INCLUDE =
 DEFINES =
 
 # Development
-#CFLAGS = -c -O3 -fPIC -Wno-deprecated -fstack-protector-all -D_FORTIFY_SOURCE=2 $(INCLUDE) $(DEFINES)
+#CFLAGS = -c -O3 -fPIC -Wno-deprecated -Wno-register -fstack-protector-all -D_FORTIFY_SOURCE=2 $(INCLUDE) $(DEFINES)
 
 # Production
-CFLAGS = -c -O3 -Wno-deprecated -U_FORTIFY_SOURCE $(INCLUDE) $(DEFINES)
+CFLAGS = -c -O3 -Wno-deprecated -Wno-register -U_FORTIFY_SOURCE $(INCLUDE) $(DEFINES)
 
 LDFLAGS = -shared
 

--- a/frontpanel/Makefile.linux
+++ b/frontpanel/Makefile.linux
@@ -11,10 +11,10 @@ INCLUDE =
 DEFINES =
 
 # Development
-#CFLAGS = -c -O3 -fPIC -Wno-deprecated -fstack-protector-all -D_FORTIFY_SOURCE=2 $(INCLUDE) $(DEFINES)
+#CFLAGS = -c -O3 -fPIC -Wno-deprecated -Wno-register -fstack-protector-all -D_FORTIFY_SOURCE=2 $(INCLUDE) $(DEFINES)
 
 # Production
-CFLAGS = -c -O3 -fPIC -Wno-deprecated -U_FORTIFY_SOURCE $(INCLUDE) $(DEFINES)
+CFLAGS = -c -O3 -fPIC -Wno-deprecated -Wno-register -U_FORTIFY_SOURCE $(INCLUDE) $(DEFINES)
 
 LDFLAGS = -shared
 

--- a/frontpanel/Makefile.osx
+++ b/frontpanel/Makefile.osx
@@ -11,10 +11,10 @@ INCLUDE = -I/opt/X11/include -I/usr/local/include
 DEFINES =
 
 # Development
-#CFLAGS = -c -O3 -fPIC -Wno-deprecated -fstack-protector-all -D_FORTIFY_SOURCE=2 $(INCLUDE) $(DEFINES)
+#CFLAGS = -c -O3 -fPIC -Wno-deprecated -Wno-register -fstack-protector-all -D_FORTIFY_SOURCE=2 $(INCLUDE) $(DEFINES)
 
 # Production
-CFLAGS = -c -O3 -fPIC -Wno-deprecated -U_FORTIFY_SOURCE $(INCLUDE) $(DEFINES)
+CFLAGS = -c -O3 -fPIC -Wno-deprecated -Wno-register -U_FORTIFY_SOURCE $(INCLUDE) $(DEFINES)
 
 LDFLAGS = -shared -L/usr/X11/lib -L/usr/local/lib -ljpeg -lGL -lGLU -lX11
 

--- a/iodevices/apu/am9511.c
+++ b/iodevices/apu/am9511.c
@@ -790,7 +790,7 @@ void *am_create(int status, int data) {
     fpp = malloc(apu_fp_size());
     if (fpp == NULL)
 	return NULL;
-    p = malloc(sizeof (struct am_context));
+    p = (struct am_context *)malloc(sizeof (struct am_context));
     if (p == NULL)
 	return NULL;
     p->fptmp = fpp;

--- a/iodevices/cromemco-hal.c
+++ b/iodevices/cromemco-hal.c
@@ -31,32 +31,35 @@
 
 #include "cromemco-hal.h"
 
-#define UNUSED(x) (void)(x)
-
 static const char *TAG = "HAL";
 
 /* -------------------- NULL device HAL -------------------- */
 
 int null_alive(int dev) {
     UNUSED(dev);
+
     return 1; /* NULL is always alive */
 }
 int null_dead(int dev) {
     UNUSED(dev);
+
     return 0; /* NULL is always dead */
 }
 void null_status(int dev, BYTE *stat) {
-    UNUSED(stat);
     UNUSED(dev);
+    UNUSED(stat);
+
     return;
 }
 int null_in(int dev) {
     UNUSED(dev);
+
     return -1;
 }
 void null_out(int dev, BYTE data) {
-    UNUSED(data);
     UNUSED(dev);
+    UNUSED(data);
+
     return;
 }
 
@@ -65,20 +68,20 @@ void null_out(int dev, BYTE data) {
 #ifdef HAS_NETSERVER
 int net_tty_alive(int dev) {
     // LOG(TAG, "WEBTTY %d: %d", dev, net_device_alive(dev));
-    return net_device_alive(dev); /* WEBTTY is only alive if websocket is connected */
+    return net_device_alive((net_device_t) dev); /* WEBTTY is only alive if websocket is connected */
 }
 void net_tty_status(int dev, BYTE *stat) {
     *stat &= (BYTE)(~3);
-    if (net_device_poll(dev)) {
+    if (net_device_poll((net_device_t) dev)) {
         *stat |= 2;
     }
     *stat |= 1;
 }
 int net_tty_in(int dev) {
-    return net_device_get(dev);
+    return net_device_get((net_device_t) dev);
 }
 void net_tty_out(int dev, BYTE data) {
-    net_device_send(dev, (char *)&data, 1);
+    net_device_send((net_device_t) dev, (char *)&data, 1);
 }
 #endif
 
@@ -86,11 +89,13 @@ void net_tty_out(int dev, BYTE data) {
 
 int stdio_alive(int dev) {
     UNUSED(dev);
+
     return 1; /* STDIO is always alive */
 }
 void stdio_status(int dev, BYTE *stat) {
-    UNUSED(dev);
     struct pollfd p[1];
+
+    UNUSED(dev);
 
     p[0].fd = fileno(stdin);
     p[0].events = POLLIN;
@@ -109,9 +114,10 @@ void stdio_status(int dev, BYTE *stat) {
 
 }
 int stdio_in(int dev) {
-    UNUSED(dev);
     int data;
     struct pollfd p[1];
+
+    UNUSED(dev);
 
 again:
     /* if no input waiting return last */
@@ -238,10 +244,12 @@ again:
 
 int modem_alive(int dev) {
     UNUSED(dev);
+
     return modem_device_alive(0);
 }
 void modem_status(int dev, BYTE *stat) {
     UNUSED(dev);
+
     *stat &= (BYTE)(~3);
     if (modem_device_poll(0)) {
         *stat |= 2;
@@ -250,10 +258,12 @@ void modem_status(int dev, BYTE *stat) {
 }
 int modem_in(int dev) {
     UNUSED(dev);
+
     return modem_device_get(0);
 }
 void modem_out(int dev, BYTE data){
     UNUSED(dev);
+
     modem_device_send(0, (char) data);
 }
 #endif /*HAS_MODEM*/
@@ -289,7 +299,7 @@ hal_device_t tuart[MAX_TUART_PORT][MAX_HAL_DEV];
 
 /* -------------------- HAL utility functions -------------------- */
 
-static void hal_report() {
+static void hal_report(void) {
 
     int i, j;
 
@@ -322,7 +332,7 @@ static int hal_find_device(char *dev) {
     return -1;
 }
 
-static void hal_init() {
+static void hal_init(void) {
 
     int i, j, d;
     char *setting;
@@ -388,7 +398,7 @@ static void hal_init() {
     }
 }
 
-void hal_reset() {
+void hal_reset(void) {
     hal_init();
     hal_report();
 }

--- a/iodevices/cromemco-hal.h
+++ b/iodevices/cromemco-hal.h
@@ -44,7 +44,7 @@ struct hal_device {
 
 typedef struct hal_device hal_device_t;
 
-extern void hal_reset();
+extern void hal_reset(void);
 
 extern void hal_status_in(tuart_port_t dev, BYTE *stat);
 extern int hal_data_in(tuart_port_t dev);

--- a/iodevices/cromemco-tu-art.c
+++ b/iodevices/cromemco-tu-art.c
@@ -228,7 +228,6 @@ void cromemco_tuart_0a_timer5_out(BYTE data)
 /*	Device 1A	*/
 /************************/
 
-int uart1a_int_mask;
 int uart1a_int_mask, uart1a_int, uart1a_int_pending;
 int uart1a_sense, uart1a_lpt_busy;
 int uart1a_tbe, uart1a_rda;

--- a/iodevices/cromemco-wdi.c
+++ b/iodevices/cromemco-wdi.c
@@ -1026,7 +1026,7 @@ void cromemco_wdi_dma0_out(BYTE data)
 
                     if ((data & 0x07) == 4) { /* WR1 */
                         wdi.dma.wr1.base = data;
-                        wdi.dma.wr1.a_device = (data & 0x08) >> 3;
+                        wdi.dma.wr1.a_device = (dma_dev_t) ((data & 0x08) >> 3);
                         wdi.dma.wr1.a_fixed = (data & 0x30) >> 4;
                         if (wdi.dma.wr1.base & 0x40) {
                             wdi.dma.wr_state = WR1;
@@ -1034,7 +1034,7 @@ void cromemco_wdi_dma0_out(BYTE data)
                         LOGD(TAG, "DMA WR1: Port A: inc. mode %d, dev %c", wdi.dma.wr1.a_device, wdi.dma.wr1.a_device?'I':'M');
                     } else if ((data & 0x07) == 0) { /* WR2 */
                         wdi.dma.wr2.base = data;
-                        wdi.dma.wr2.b_device = (data & 0x08) >> 3;
+                        wdi.dma.wr2.b_device = (dma_dev_t) ((data & 0x08) >> 3);
                         wdi.dma.wr2.b_fixed = (data & 0x30) >> 4;
                         if (wdi.dma.wr2.base & 0x40) {
                             wdi.dma.wr_state = WR2;

--- a/iodevices/generic-at-modem.c
+++ b/iodevices/generic-at-modem.c
@@ -96,7 +96,7 @@ static const char* TAG = "at-modem";
 #define OPT_ECHO    0x1
 #define OPT_QUIET   0x2
 
-void modem_device_init();
+void modem_device_init(void);
 
 static bool daemon_f = false;
 
@@ -1097,7 +1097,7 @@ int modem_device_alive(int i) {
     return 0;
 }
 
-static int _read() {
+static int _read(void) {
 
     unsigned char data;
 
@@ -1341,7 +1341,7 @@ int modem_device_carrier(int i) {
     return carrier_detect;
 }
 
-void modem_device_init() {
+void modem_device_init(void) {
     if (*active_sfd) {
         close_socket();
     }

--- a/iodevices/generic-at-modem.h
+++ b/iodevices/generic-at-modem.h
@@ -20,6 +20,6 @@ extern int modem_device_poll(int);
 extern int modem_device_get(int);
 extern void modem_device_send(int, char);
 extern int modem_device_carrier(int);
-extern void modem_device_init();
+extern void modem_device_init(void);
 
 #define DEV_SIO2B 0

--- a/iodevices/imsai-hal.c
+++ b/iodevices/imsai-hal.c
@@ -31,30 +31,30 @@
 
 #include "imsai-hal.h"
 
-#define UNUSED(x) (void)(x)
-
 static const char *TAG = "HAL";
 
 /* -------------------- NULL device HAL -------------------- */
 
-int null_alive() {
+int null_alive(void) {
     return 1; /* NULL is always alive */
 }
-int null_dead() {
+int null_dead(void) {
     return 0; /* NULL is always dead */
 }
 void null_status(BYTE *stat) {
     UNUSED(stat);
+
     return;
 }
-int null_in() {
+int null_in(void) {
     return -1;
 }
 void null_out(BYTE data) {
     UNUSED(data);
+
     return;
 }
-int null_cd() {
+int null_cd(void) {
     return 0;
 }
 
@@ -95,7 +95,7 @@ void vio_kbd_out(BYTE data) {
 /* -------------------- WEBTTY HAL -------------------- */
 
 #ifdef HAS_NETSERVER
-int net_tty_alive() {
+int net_tty_alive(void) {
     return net_device_alive(DEV_TTY); /* WEBTTY is only alive if websocket is connected */
 }
 void net_tty_status(BYTE *stat) {
@@ -105,7 +105,7 @@ void net_tty_status(BYTE *stat) {
     }
     *stat |= 1;
 }
-int net_tty_in() {
+int net_tty_in(void) {
     return net_device_get(DEV_TTY);
 }
 void net_tty_out(BYTE data) {
@@ -116,7 +116,7 @@ void net_tty_out(BYTE data) {
 /* -------------------- WEBPTR HAL -------------------- */
 
 #ifdef HAS_NETSERVER
-int net_ptr_alive() {
+int net_ptr_alive(void) {
     return net_device_alive(DEV_PTR); /* WEBPTR is only alive if websocket is connected */
 }
 void net_ptr_status(BYTE *stat) {
@@ -126,7 +126,7 @@ void net_ptr_status(BYTE *stat) {
     }
     *stat |= 1;
 }
-int net_ptr_in() {
+int net_ptr_in(void) {
     return net_device_get(DEV_PTR);
 }
 void net_ptr_out(BYTE data) {
@@ -136,7 +136,7 @@ void net_ptr_out(BYTE data) {
 
 /* -------------------- STDIO HAL -------------------- */
 
-int stdio_alive() {
+int stdio_alive(void) {
     return 1; /* STDIO is always alive */
 }
 void stdio_status(BYTE *stat) {
@@ -157,7 +157,7 @@ void stdio_status(BYTE *stat) {
     *stat |= 1;
 
 }
-int stdio_in() {
+int stdio_in(void) {
     int data;
 	struct pollfd p[1];
 
@@ -195,7 +195,7 @@ again:
 
 /* -------------------- SOCKET SERVER HAL -------------------- */
 
-int scktsrv_alive() {
+int scktsrv_alive(void) {
 
     struct pollfd p[1];
 
@@ -236,7 +236,7 @@ void scktsrv_status(BYTE *stat) {
 		*stat = 0;
 	}
 }
-int scktsrv_in() {
+int scktsrv_in(void) {
     BYTE data;
 	struct pollfd p[1];
 
@@ -296,7 +296,7 @@ again:
 #ifdef HAS_MODEM
 #include "generic-at-modem.h"
 
-int modem_alive() {
+int modem_alive(void) {
     return modem_device_alive(0);
 }
 void modem_status(BYTE *stat) {
@@ -306,13 +306,13 @@ void modem_status(BYTE *stat) {
     }
     *stat |= 1;
 }
-int modem_in() {
+int modem_in(void) {
     return modem_device_get(0);
 }
 void modem_out(BYTE data){
     modem_device_send(0, (char) data);
 }
-int modem_cd() {
+int modem_cd(void) {
     return modem_device_carrier(0);
 }
 #endif /*HAS_MODEM*/
@@ -344,7 +344,7 @@ hal_device_t sio[MAX_SIO_PORT][MAX_HAL_DEV];
 
 /* -------------------- HAL utility functions -------------------- */
 
-static void hal_report() {
+static void hal_report(void) {
 
     int i, j;
 
@@ -377,7 +377,7 @@ static int hal_find_device(char *dev) {
     return -1;
 }
 
-static void hal_init() {
+static void hal_init(void) {
 
     int i, j, d;
     char *setting;
@@ -446,7 +446,7 @@ static void hal_init() {
     }
 }
 
-void hal_reset() {
+void hal_reset(void) {
     hal_init();
     hal_report();
 }

--- a/iodevices/imsai-hal.h
+++ b/iodevices/imsai-hal.h
@@ -34,16 +34,16 @@ enum hal_dev {
 struct hal_device {
     char *name;
     int fallthrough;
-	int	(*alive)();
+	int	(*alive)(void);
 	void (*status)(BYTE *stat);
-	int (*in)();
+	int (*in)(void);
 	void (*out)(BYTE);
-    int (*cd)();
+    int (*cd)(void);
 };
 
 typedef struct hal_device hal_device_t;
 
-extern void hal_reset();
+extern void hal_reset(void);
 
 extern void hal_status_in(sio_port_t sio, BYTE *stat);
 extern int hal_data_in(sio_port_t sio);

--- a/iodevices/unix_network.c
+++ b/iodevices/unix_network.c
@@ -188,8 +188,8 @@ void sigio_tcp_server_socket(int sig)
  */
 void telnet_negotiation(int fd)
 {
-	static char will_echo[3] = {255, 251, 1};
-	static char char_mode[3] = {255, 251, 3};
+	static unsigned char will_echo[3] = {255, 251, 1};
+	static unsigned char char_mode[3] = {255, 251, 3};
 	struct pollfd p[1];
 	BYTE c[3];
 

--- a/webfrontend/netsrv.h
+++ b/webfrontend/netsrv.h
@@ -31,12 +31,12 @@ enum net_device {
 
 typedef enum net_device net_device_t;
 
-struct msgbuf {
+struct msgbuf_s {
 	long			mtype;
 	unsigned char	mtext[128];
 };
 
-typedef struct msgbuf msgbuf_t;
+typedef struct msgbuf_s msgbuf_t;
 
 struct ws_client {
 	struct mg_connection *conn;

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -222,7 +222,7 @@ void options(int argc, char *argv[])
 			}
 	i = 0;
 	while (argc-- && i < MAXFN) {
-		if ((infiles[i] = malloc(LENFN + 1)) == NULL)
+		if ((infiles[i] = (char *) malloc(LENFN + 1)) == NULL)
 			fatal(F_OUTMEM, "filenames");
 		get_fn(infiles[i], *argv++, SRCEXT);
 		i++;

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -31,7 +31,9 @@
 #include "z80a.h"
 #include "z80aglb.h"
 
+struct sym *get_sym(char *);
 int hash(char *);
+char *strsave(char *);
 int numcmp(int, int);
 
 /* z80amain.c */
@@ -137,11 +139,8 @@ struct sym *get_sym(char *sym_name)
  */
 int put_sym(char *sym_name, int sym_val)
 {
-	struct sym *get_sym();
 	register int hashval;
 	register struct sym *np;
-
-	char *strsave(char *);
 
 	if ((np = get_sym(sym_name)) == NULL) {
 		np = (struct sym *) malloc(sizeof (struct sym));
@@ -163,8 +162,6 @@ int put_sym(char *sym_name, int sym_val)
  */
 void put_label(void)
 {
-	struct sym *get_sym(char *);
-
 	if (get_sym(label) == NULL) {
 		if (put_sym(label, pc))
 			fatal(F_OUTMEM, "symbols");
@@ -199,7 +196,7 @@ char *strsave(char *s)
 {
 	register char *p;
 
-	if ((p = malloc((unsigned) strlen(s) + 1)) != NULL)
+	if ((p = (char *) malloc((unsigned) strlen(s) + 1)) != NULL)
 		strcpy(p, s);
 	return(p);
 }

--- a/z80core/log.h
+++ b/z80core/log.h
@@ -43,7 +43,7 @@ static void _log_write(log_level_t level, const char* tag, const char* format, .
     (void)(level);
     (void)(tag);
 
-    va_list(args);
+    va_list args;
     va_start(args, format);
     vprintf(format, args);
 }
@@ -83,7 +83,7 @@ static inline uint32_t _log_timestamp(void) {
 #define LOG_LOCAL_LEVEL  ((log_level_t) LOG_DEFAULT_LEVEL)
 #endif
 
-#define LOG( tag, format, ... )  _log_write(0, NULL, format, ##__VA_ARGS__);
+#define LOG( tag, format, ... )  _log_write(LOG_NONE, NULL, format, ##__VA_ARGS__);
 #define LOGE( tag, format, ... )  if (LOG_LOCAL_LEVEL >= LOG_ERROR)   { _log_write(LOG_ERROR,   tag, _LOG_FORMAT(E, format), _log_timestamp(), tag, ##__VA_ARGS__); }
 #define LOGW( tag, format, ... )  if (LOG_LOCAL_LEVEL >= LOG_WARN)    { _log_write(LOG_WARN,    tag, _LOG_FORMAT(W, format), _log_timestamp(), tag, ##__VA_ARGS__); }
 #define LOGI( tag, format, ... )  if (LOG_LOCAL_LEVEL >= LOG_INFO)    { _log_write(LOG_INFO,    tag, _LOG_FORMAT(I, format), _log_timestamp(), tag, ##__VA_ARGS__); }

--- a/z80core/sim6.c
+++ b/z80core/sim6.c
@@ -149,7 +149,7 @@ static int op_undoc_srlixdl(int);
 
 int op_ddcb_handel(void)
 {
-	static int (*op_ddcb[256]) () = {
+	static int (*op_ddcb[256]) (int) = {
 		UNDOC(op_undoc_rlcixdb),	/* 0x00 */
 		UNDOC(op_undoc_rlcixdc),	/* 0x01 */
 		UNDOC(op_undoc_rlcixdd),	/* 0x02 */

--- a/z80core/sim7.c
+++ b/z80core/sim7.c
@@ -149,7 +149,7 @@ static int op_undoc_srliydl(int);
 
 int op_fdcb_handel(void)
 {
-	static int (*op_fdcb[256]) () = {
+	static int (*op_fdcb[256]) (int) = {
 		UNDOC(op_undoc_rlciydb),	/* 0x00 */
 		UNDOC(op_undoc_rlciydc),	/* 0x01 */
 		UNDOC(op_undoc_rlciydd),	/* 0x02 */


### PR DESCRIPTION
... except one line in webfrontend/civetweb/src/md5.inl.

General: Added void to functions without parameters. Casts of malloc() result. Casts of int to enum (C++ doesn't do that automatically, since int and enums are separate types there).

cpmsim/srcsim/iosim.c: disks[] was initialized with negative tracks and sectors values, but these are defined as unsigned. telnet_negotiation() used unsigned char range values with a char array.

frontpanel/Makefile.*: Added -Wno-register to CFLAGS

iodevices/{cromemco-hal.c, imsai-hal.c}: They actually do include sim.h. Removed UNUSED macro.

iodevices/cromemco-tu-art.c: Doubly defined variable.

iodevices/unix_network.c: telnet_negotiation() used unsigned char range values with a char array.

webfrontend/netsrv.c: Enclosed a range of statements inside a switch statement that declares variables in a {} block. C++ doesn't like new variables not in blocks between case: labels, since their scope would be the whole switch statement.

webfrontend/netsrv.h: Renamed a struct since it clashes with a struct with the same name in a system include file (at least on Linux). C++ doesn't allow redefining a struct.

z80core:/sim[56].c: Were missing the parameter type in the opcode lists.