### PR TITLE
GNUmakefiles, Makefile.*s clean up, added some frontpanel instructions

### DIFF
--- a/altairsim/srcsim/GNUmakefile
+++ b/altairsim/srcsim/GNUmakefile
@@ -1,5 +1,5 @@
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = altair
@@ -33,7 +33,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 ###
@@ -57,21 +57,21 @@ endif
 ###
 
 SIM = ../$(MACHINE)sim
-EXEC = $(SIM)
 
 CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 FP_DIR = ../../frontpanel
 
 VPATH = $(CORE_DIR) $(IO_DIR) $(FP_DIR)
-CC = gcc
-CXX = g++
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 include $(CORE_DIR)/Makefile.in-os
 
+CC = gcc
+CXX = g++
+EXEC = $(SIM)
 ifeq ($(TARGET_OS),BSD)
 CC = cc
 CXX = c++
@@ -82,7 +82,6 @@ endif
 ifeq ($(TARGET_OS),WIN32)
 EXEC := $(EXEC:=.exe)
 PLAT_LDFLAGS = -lm -lpthread
-.LIBPATTERNS += lib%.dll.a
 endif
 ifeq ($(TARGET_OS),LINUX)
 PLAT_LIBS = -lm -lpthread
@@ -90,14 +89,13 @@ endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCS = -I/opt/X11/include
 PLAT_LDFLAGS = -L/usr/local/lib -L/opt/X11/lib
-.LIBPATTERNS += lib%.dylib
 endif
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/altairsim/srcsim/Makefile.bsd
+++ b/altairsim/srcsim/Makefile.bsd
@@ -1,7 +1,7 @@
 # Makefile pre-configured for BSD
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = altair
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -53,7 +53,7 @@ IO_DIR = ../../iodevices
 FP_DIR = ../../frontpanel
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = cc
 CXX = c++
@@ -62,11 +62,11 @@ PLAT_INCS = -I/usr/local/include
 PLAT_LDFLAGS = -L/usr/local/lib
 PLAT_LIBS = -lm -lthr
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/altairsim/srcsim/Makefile.cygwin
+++ b/altairsim/srcsim/Makefile.cygwin
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Windows/Cygwin
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = altair
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -53,20 +53,18 @@ IO_DIR = ../../iodevices
 FP_DIR = ../../frontpanel
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 CXX = g++
 EXEC = $(SIM).exe
-PLAT_INCS =
-PLAT_LDFLAGS =
 PLAT_LIBS = -lm -lpthread
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/altairsim/srcsim/Makefile.linux
+++ b/altairsim/srcsim/Makefile.linux
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Linux
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = altair
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -53,20 +53,18 @@ IO_DIR = ../../iodevices
 FP_DIR = ../../frontpanel
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 CXX = g++
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
 PLAT_LIBS = -lm -lpthread
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/altairsim/srcsim/Makefile.osx
+++ b/altairsim/srcsim/Makefile.osx
@@ -1,7 +1,7 @@
 # Makefile pre-configured for macOS
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = altair
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -53,20 +53,19 @@ IO_DIR = ../../iodevices
 FP_DIR = ../../frontpanel
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 CXX = g++
 EXEC = $(SIM)
 PLAT_INCS = -I/opt/X11/include
 PLAT_LDFLAGS = -L/usr/local/lib -L/opt/X11/lib
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/cpmsim/srcsim/GNUmakefile
+++ b/cpmsim/srcsim/GNUmakefile
@@ -1,5 +1,5 @@
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cpm
@@ -29,48 +29,39 @@ CONF_DIR = $(ROOT_DIR)/conf
 # system wide location for disk images
 DISKS_DIR = $(ROOT_DIR)/disks
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
-EXEC = $(SIM)
 
 CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 VPATH = $(CORE_DIR) $(IO_DIR)
-CC = gcc
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 include $(CORE_DIR)/Makefile.in-os
 
+CC = gcc
+EXEC = $(SIM)
 ifeq ($(TARGET_OS),BSD)
 CC = cc
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 endif
 ifeq ($(TARGET_OS),WIN32)
 EXEC := $(EXEC:=.exe)
-PLAT_LDFLAGS =
-.LIBPATTERNS += lib%.dll.a
 endif
 ifeq ($(TARGET_OS),LINUX)
-PLAT_LIBS =
 endif
 ifeq ($(TARGET_OS),OSX)
-PLAT_INCS =
-PLAT_LDFLAGS =
-.LIBPATTERNS += lib%.dylib
 endif
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\"
+INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/cpmsim/srcsim/Makefile.bsd
+++ b/cpmsim/srcsim/Makefile.bsd
@@ -1,7 +1,7 @@
 # Makefile pre-configured for BSD
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cpm
@@ -31,7 +31,7 @@ CONF_DIR = $(ROOT_DIR)/conf
 # system wide location for disk images
 DISKS_DIR = $(ROOT_DIR)/disks
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -40,19 +40,16 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = cc
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\"
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/cpmsim/srcsim/Makefile.cygwin
+++ b/cpmsim/srcsim/Makefile.cygwin
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Windows/Cygwin
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cpm
@@ -31,7 +31,7 @@ CONF_DIR = $(ROOT_DIR)/conf
 # system wide location for disk images
 DISKS_DIR = $(ROOT_DIR)/disks
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -40,19 +40,16 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 EXEC = $(SIM).exe
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\"
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/cpmsim/srcsim/Makefile.linux
+++ b/cpmsim/srcsim/Makefile.linux
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Linux
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cpm
@@ -31,7 +31,7 @@ CONF_DIR = $(ROOT_DIR)/conf
 # system wide location for disk images
 DISKS_DIR = $(ROOT_DIR)/disks
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -40,19 +40,16 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\"
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/cpmsim/srcsim/Makefile.osx
+++ b/cpmsim/srcsim/Makefile.osx
@@ -1,7 +1,7 @@
 # Makefile pre-configured for macOS
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cpm
@@ -31,7 +31,7 @@ CONF_DIR = $(ROOT_DIR)/conf
 # system wide location for disk images
 DISKS_DIR = $(ROOT_DIR)/disks
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -40,19 +40,16 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\"
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/cromemcosim/srcsim/GNUmakefile
+++ b/cromemcosim/srcsim/GNUmakefile
@@ -1,5 +1,5 @@
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cromemco
@@ -33,7 +33,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 ###
@@ -57,7 +57,6 @@ endif
 ###
 
 SIM = ../$(MACHINE)sim
-EXEC = $(SIM)
 
 CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
@@ -66,14 +65,15 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR:=/civetweb)
 
 VPATH = $(CORE_DIR) $(IO_DIR) $(FP_DIR) $(NET_DIR) $(CIV_DIR)
-CC = gcc
-CXX = g++
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 include $(CORE_DIR)/Makefile.in-os
 
+CC = gcc
+CXX = g++
+EXEC = $(SIM)
 ifeq ($(TARGET_OS),BSD)
 CC = cc
 CXX = c++
@@ -84,7 +84,6 @@ endif
 ifeq ($(TARGET_OS),WIN32)
 EXEC := $(EXEC:=.exe)
 PLAT_LDFLAGS = -lm -lpthread
-.LIBPATTERNS += lib%.dll.a
 endif
 ifeq ($(TARGET_OS),LINUX)
 PLAT_LIBS = -lm -lpthread
@@ -92,14 +91,13 @@ endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCS = -I/opt/X11/include
 PLAT_LDFLAGS = -L/usr/local/lib -L/opt/X11/lib
-.LIBPATTERNS += lib%.dylib
 endif
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR:=/include) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR:=/include) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/cromemcosim/srcsim/Makefile.bsd
+++ b/cromemcosim/srcsim/Makefile.bsd
@@ -1,7 +1,7 @@
 # Makefile pre-configured for BSD
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cromemco
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -55,7 +55,7 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR)/civetweb
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = cc
 CXX = c++
@@ -64,11 +64,11 @@ PLAT_INCS = -I/usr/local/include
 PLAT_LDFLAGS = -L/usr/local/lib
 PLAT_LIBS = -lm -lthr
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/cromemcosim/srcsim/Makefile.cygwin
+++ b/cromemcosim/srcsim/Makefile.cygwin
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Windows/Cygwin
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cromemco
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -55,20 +55,18 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR)/civetweb
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 CXX = g++
 EXEC = $(SIM).exe
-PLAT_INCS =
-PLAT_LDFLAGS =
 PLAT_LIBS = -lm -lpthread
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/cromemcosim/srcsim/Makefile.linux
+++ b/cromemcosim/srcsim/Makefile.linux
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Linux
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cromemco
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -55,20 +55,18 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR)/civetweb
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 CXX = g++
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
 PLAT_LIBS = -lm -lpthread
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/cromemcosim/srcsim/Makefile.osx
+++ b/cromemcosim/srcsim/Makefile.osx
@@ -1,7 +1,7 @@
 # Makefile pre-configured for macOS
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = cromemco
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -55,20 +55,19 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR)/civetweb
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 CXX = g++
 EXEC = $(SIM)
 PLAT_INCS = -I/opt/X11/include
 PLAT_LDFLAGS = -L/usr/local/lib -L/opt/X11/lib
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/doc/README-frontpanel.txt
+++ b/doc/README-frontpanel.txt
@@ -9,12 +9,30 @@ the released version at sourceforge, due to somewhat different directory
 structure of the packages.
 
 To build the Altair 8800, IMSAI 8080 and Cromemco Z-1 emulations including
-the frontpanel first change to directory ~/z80pack-x.y/frontpanel. There
-you'll find several files Makefile.operating-system, to build the library
-for your OS type:
+the frontpanel and you use GNU make (usually the case on Linux, macOS, and
+Windows/Cygwin) build the simulated machines as follows:
+
+cd ~/z80pack-x.y/altairsim/srcsim
+make
+make clean
+
+cd ~/z80pack-x.y/imsaisim/srcsim
+make
+make clean
+
+cd ~/z80pack-x.y/cromemco/srcsim
+make
+make clean
+
+If you don't want to include the frontpanel replace the first "make"
+command with "make FRONTPANEL=NO".
+
+Without GNU make first change to the directory ~/z80pack-x.y/frontpanel.
+There you'll find several files Makefile.operating-system, to build the
+library for your OS type:
 
 make -f Makefile.linux		for a Linux system
-make -f Makefile.osx		for an Apple OS X system
+make -f Makefile.osx		for an Apple macOS system
 ...
 
 This will build the library libfrontpanel.a.
@@ -32,6 +50,11 @@ make -f Makefile.operating-system clean
 cd ~/z80pack-x.y/cromemco/srcsim
 make -f Makefile.operating-system
 make -f Makefile.operating-system clean
+
+To build without the frontpanel you must first edit the file
+"Makefile.operating-system" and comment out the four lines after
+"# emulate a machine's frontpanel" and uncomment the four lines
+after "# no frontpanel emulation" and then run the "make" commands.
 
 To run the systems change into directory ~/z80pack-x.y/imsaisim
 and run the program imsasim. To load memory with the included

--- a/frontpanel/GNUmakefile
+++ b/frontpanel/GNUmakefile
@@ -5,29 +5,25 @@ SRCS = jpeg.cpp lpanel.cpp lp_gfx.cpp lp_main.cpp lp_utils.cpp lp_window.cpp \
 
 CORE_DIR = ../z80core
 
-CXX = g++
-
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 include $(CORE_DIR)/Makefile.in-os
 
+CXX = g++
 ifeq ($(TARGET_OS),BSD)
 CXX = c++
 PLAT_INCS = -I/usr/local/include
 endif
 ifeq ($(TARGET_OS),WIN32)
-EXEC := $(EXEC:=.exe)
-.LIBPATTERNS += lib%.dll.a
 endif
 ifeq ($(TARGET_OS),LINUX)
 endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCS = -I/opt/X11/include
-.LIBPATTERNS += lib%.dylib
 endif
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
 CXXWARNS = -Wall -Wextra
@@ -53,7 +49,7 @@ all: $(LIB)
 	@echo
 
 $(LIB): $(OBJS)
-	rm -f $@
+	@rm -f $@
 	ar cq $@ $(OBJS)
 
 %.d: %.cpp

--- a/frontpanel/Makefile.bsd
+++ b/frontpanel/Makefile.bsd
@@ -5,27 +5,46 @@ LIB = libfrontpanel.a
 SRCS = jpeg.cpp lpanel.cpp lp_gfx.cpp lp_main.cpp lp_utils.cpp lp_window.cpp \
 	lp_switch.cpp lp_font.cpp lp_materials.cpp
 
-OBJS = $(SRCS:.cpp=.o)
-
-CXX = g++
-
-# compiler switches
-
-INCS = -I/usr/local/include
-DEFS =
+###
+### START O/S PLATFORM DEPENDENT VARIABLES
+###
+CXX = c++
+PLAT_INCS = -I/usr/local/include
+###
+### END O/S DEPENDENT VARIABLES
+###
 
 CXXWARNS = -Wall -Wextra
-COMMON = $(INCS) $(DEFS)
 
 # Development
-#CXXFLAGS = -O3 $(CXXWARNS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(COMMON)
+#CXXFLAGS = -O3 $(CXXWARNS) $(PLAT_CXXFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(PLAT_INCS)
 
 # Production
-CXXFLAGS = -O3 $(CXXWARNS) -U_FORTIFY_SOURCE $(COMMON)
+CXXFLAGS = -O3 $(CXXWARNS) $(PLAT_CXXFLAGS) -U_FORTIFY_SOURCE $(PLAT_INCS)
+
+# Debug
+#CXXFLAGS = -O -g $(PLAT_CXXFLAGS) $(PLAT_INCS)
+
+OBJS = $(SRCS:.cpp=.o)
+
+all: $(LIB)
+	@echo
+	@echo "Done."
+	@echo
 
 $(LIB): $(OBJS)
-	rm -f $@
+	@rm -f $@
 	ar cq $@ $(OBJS)
+
+build: _rm_obj all
+
+clean: _rm_obj
+
+_rm_obj:
+	rm -f *.o
+
+allclean: clean
+	rm -f $(LIB)
 
 jpeg.o: jpeg.cpp cdjpeg.h
 	$(CXX) $(CXXFLAGS) -c jpeg.cpp -o jpeg.o
@@ -53,11 +72,3 @@ lp_window.o: lp_window.cpp lpanel.h
 
 lp_materials.o: lp_materials.cpp lp_materials.h
 	$(CXX) $(CXXFLAGS) -c lp_materials.cpp -o lp_materials.o
-
-clean:
-	rm -f *.o
-
-allclean: clean
-	rm -f $(LIB)
-
-all: clean $(LIB)

--- a/frontpanel/Makefile.cygwin
+++ b/frontpanel/Makefile.cygwin
@@ -5,27 +5,45 @@ LIB = libfrontpanel.a
 SRCS = jpeg.cpp lpanel.cpp lp_gfx.cpp lp_main.cpp lp_utils.cpp lp_window.cpp \
 	lp_switch.cpp lp_font.cpp lp_materials.cpp
 
-OBJS = $(SRCS:.cpp=.o)
-
+###
+### START O/S PLATFORM DEPENDENT VARIABLES
+###
 CXX = g++
-
-# compiler switches
-
-INCS =
-DEFS =
+###
+### END O/S DEPENDENT VARIABLES
+###
 
 CXXWARNS = -Wall -Wextra
-COMMON = $(INCS) $(DEFS)
 
 # Development
-#CXXFLAGS = -O3 $(CXXWARNS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(COMMON)
+#CXXFLAGS = -O3 $(CXXWARNS) $(PLAT_CXXFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(PLAT_INCS)
 
 # Production
-CXXFLAGS = -O3 $(CXXWARNS) -U_FORTIFY_SOURCE $(COMMON)
+CXXFLAGS = -O3 $(CXXWARNS) $(PLAT_CXXFLAGS) -U_FORTIFY_SOURCE $(PLAT_INCS)
+
+# Debug
+#CXXFLAGS = -O -g $(PLAT_CXXFLAGS) $(PLAT_INCS)
+
+OBJS = $(SRCS:.cpp=.o)
+
+all: $(LIB)
+	@echo
+	@echo "Done."
+	@echo
 
 $(LIB): $(OBJS)
-	rm -f $@
+	@rm -f $@
 	ar cq $@ $(OBJS)
+
+build: _rm_obj all
+
+clean: _rm_obj
+
+_rm_obj:
+	rm -f *.o
+
+allclean: clean
+	rm -f $(LIB)
 
 jpeg.o: jpeg.cpp cdjpeg.h
 	$(CXX) $(CXXFLAGS) -c jpeg.cpp -o jpeg.o
@@ -53,11 +71,3 @@ lp_window.o: lp_window.cpp lpanel.h
 
 lp_materials.o: lp_materials.cpp lp_materials.h
 	$(CXX) $(CXXFLAGS) -c lp_materials.cpp -o lp_materials.o
-
-clean:
-	rm -f *.o
-
-allclean: clean
-	rm -f $(LIB)
-
-all: clean $(LIB)

--- a/frontpanel/Makefile.linux
+++ b/frontpanel/Makefile.linux
@@ -5,27 +5,45 @@ LIB = libfrontpanel.a
 SRCS = jpeg.cpp lpanel.cpp lp_gfx.cpp lp_main.cpp lp_utils.cpp lp_window.cpp \
 	lp_switch.cpp lp_font.cpp lp_materials.cpp
 
-OBJS = $(SRCS:.cpp=.o)
-
+###
+### START O/S PLATFORM DEPENDENT VARIABLES
+###
 CXX = g++
-
-# compiler switches
-
-INCS =
-DEFS =
+###
+### END O/S DEPENDENT VARIABLES
+###
 
 CXXWARNS = -Wall -Wextra
-COMMON = $(INCS) $(DEFS)
 
 # Development
-#CXXFLAGS = -O3 $(CXXWARNS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(COMMON)
+#CXXFLAGS = -O3 $(CXXWARNS) $(PLAT_CXXFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(PLAT_INCS)
 
 # Production
-CXXFLAGS = -O3 $(CXXWARNS) -U_FORTIFY_SOURCE $(COMMON)
+CXXFLAGS = -O3 $(CXXWARNS) $(PLAT_CXXFLAGS) -U_FORTIFY_SOURCE $(PLAT_INCS)
+
+# Debug
+#CXXFLAGS = -O -g $(PLAT_CXXFLAGS) $(PLAT_INCS)
+
+OBJS = $(SRCS:.cpp=.o)
+
+all: $(LIB)
+	@echo
+	@echo "Done."
+	@echo
 
 $(LIB): $(OBJS)
-	rm -f $@
+	@rm -f $@
 	ar cq $@ $(OBJS)
+
+build: _rm_obj all
+
+clean: _rm_obj
+
+_rm_obj:
+	rm -f *.o
+
+allclean: clean
+	rm -f $(LIB)
 
 jpeg.o: jpeg.cpp cdjpeg.h
 	$(CXX) $(CXXFLAGS) -c jpeg.cpp -o jpeg.o
@@ -53,11 +71,3 @@ lp_window.o: lp_window.cpp lpanel.h
 
 lp_materials.o: lp_materials.cpp lp_materials.h
 	$(CXX) $(CXXFLAGS) -c lp_materials.cpp -o lp_materials.o
-
-clean:
-	rm -f *.o
-
-allclean: clean
-	rm -f $(LIB)
-
-all: clean $(LIB)

--- a/frontpanel/Makefile.osx
+++ b/frontpanel/Makefile.osx
@@ -5,27 +5,46 @@ LIB = libfrontpanel.a
 SRCS = jpeg.cpp lpanel.cpp lp_gfx.cpp lp_main.cpp lp_utils.cpp lp_window.cpp \
 	lp_switch.cpp lp_font.cpp lp_materials.cpp
 
-OBJS = $(SRCS:.cpp=.o)
-
+###
+### START O/S PLATFORM DEPENDENT VARIABLES
+###
 CXX = g++
-
-# compiler switches
-
-INCS = -I/opt/X11/include -I/usr/local/include
-DEFS =
+PLAT_INCS = -I/opt/X11/include -I/usr/local/include
+###
+### END O/S DEPENDENT VARIABLES
+###
 
 CXXWARNS = -Wall -Wextra
-COMMON = $(INCS) $(DEFS)
 
 # Development
-#CXXFLAGS = -O3 $(CXXWARNS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(COMMON)
+#CXXFLAGS = -O3 $(CXXWARNS) $(PLAT_CXXFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(PLAT_INCS)
 
 # Production
-CXXFLAGS = -O3 $(CXXWARNS) -U_FORTIFY_SOURCE $(COMMON)
+CXXFLAGS = -O3 $(CXXWARNS) $(PLAT_CXXFLAGS) -U_FORTIFY_SOURCE $(PLAT_INCS)
+
+# Debug
+#CXXFLAGS = -O -g $(PLAT_CXXFLAGS) $(PLAT_INCS)
+
+OBJS = $(SRCS:.cpp=.o)
+
+all: $(LIB)
+	@echo
+	@echo "Done."
+	@echo
 
 $(LIB): $(OBJS)
-	rm -f $@
+	@rm -f $@
 	ar cq $@ $(OBJS)
+
+build: _rm_obj all
+
+clean: _rm_obj
+
+_rm_obj:
+	rm -f *.o
+
+allclean: clean
+	rm -f $(LIB)
 
 jpeg.o: jpeg.cpp cdjpeg.h
 	$(CXX) $(CXXFLAGS) -c jpeg.cpp -o jpeg.o
@@ -53,11 +72,3 @@ lp_window.o: lp_window.cpp lpanel.h
 
 lp_materials.o: lp_materials.cpp lp_materials.h
 	$(CXX) $(CXXFLAGS) -c lp_materials.cpp -o lp_materials.o
-
-clean:
-	rm -f *.o
-
-allclean: clean
-	rm -f $(LIB)
-
-all: clean $(LIB)

--- a/imsaisim/srcsim/GNUmakefile
+++ b/imsaisim/srcsim/GNUmakefile
@@ -1,5 +1,5 @@
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = imsai
@@ -33,7 +33,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 ###
@@ -57,7 +57,6 @@ endif
 ###
 
 SIM = ../$(MACHINE)sim
-EXEC = $(SIM)
 
 CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
@@ -66,14 +65,15 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR:=/civetweb)
 
 VPATH = $(CORE_DIR) $(IO_DIR) $(IO_DIR:=/apu) $(FP_DIR) $(NET_DIR) $(CIV_DIR)
-CC = gcc
-CXX = g++
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 include $(CORE_DIR)/Makefile.in-os
 
+CC = gcc
+CXX = g++
+EXEC = $(SIM)
 ifeq ($(TARGET_OS),BSD)
 CC = cc
 CXX = c++
@@ -84,7 +84,6 @@ endif
 ifeq ($(TARGET_OS),WIN32)
 EXEC := $(EXEC:=.exe)
 PLAT_LDFLAGS = -lm -lpthread
-.LIBPATTERNS += lib%.dll.a
 endif
 ifeq ($(TARGET_OS),LINUX)
 PLAT_LIBS = -lm -lpthread
@@ -92,14 +91,13 @@ endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCS = -I/opt/X11/include
 PLAT_LDFLAGS = -L/usr/local/lib -L/opt/X11/lib
-.LIBPATTERNS += lib%.dylib
 endif
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR:=/include) $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR:=/include) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/imsaisim/srcsim/Makefile.bsd
+++ b/imsaisim/srcsim/Makefile.bsd
@@ -1,7 +1,7 @@
 # Makefile pre-configured for BSD
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = imsai
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -55,7 +55,7 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR)/civetweb
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = cc
 CXX = c++
@@ -64,11 +64,11 @@ PLAT_INCS = -I/usr/local/include
 PLAT_LDFLAGS = -L/usr/local/lib
 PLAT_LIBS = -lm -lthr
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/imsaisim/srcsim/Makefile.cygwin
+++ b/imsaisim/srcsim/Makefile.cygwin
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Windows/Cygwin
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = imsai
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -55,20 +55,18 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR)/civetweb
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 CXX = g++
 EXEC = $(SIM).exe
-PLAT_INCS =
-PLAT_LDFLAGS =
 PLAT_LIBS = -lm -lpthread
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/imsaisim/srcsim/Makefile.linux
+++ b/imsaisim/srcsim/Makefile.linux
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Linux
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = imsai
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -55,20 +55,18 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR)/civetweb
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 CXX = g++
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
 PLAT_LIBS = -lm -lpthread
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/imsaisim/srcsim/Makefile.osx
+++ b/imsaisim/srcsim/Makefile.osx
@@ -1,7 +1,7 @@
 # Makefile pre-configured for macOS
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = imsai
@@ -43,7 +43,7 @@ DISKS_DIR = $(ROOT_DIR)/disks
 # default boot ROM path
 ROMS_DIR = $(ROOT_DIR)/roms
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -55,20 +55,19 @@ NET_DIR = ../../webfrontend
 CIV_DIR = $(NET_DIR)/civetweb
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 CXX = g++
 EXEC = $(SIM)
 PLAT_INCS = -I/opt/X11/include
 PLAT_LDFLAGS = -L/usr/local/lib -L/opt/X11/lib
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR)/include $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 CXXWARNS = -Wall -Wextra

--- a/mosteksim/srcsim/GNUmakefile
+++ b/mosteksim/srcsim/GNUmakefile
@@ -1,5 +1,5 @@
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = mostek
@@ -25,48 +25,39 @@ LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
 
 #ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
-EXEC = $(SIM)
 
 CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 VPATH = $(CORE_DIR) $(IO_DIR)
-CC = gcc
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 include $(CORE_DIR)/Makefile.in-os
 
+CC = gcc
+EXEC = $(SIM)
 ifeq ($(TARGET_OS),BSD)
 CC = cc
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 endif
 ifeq ($(TARGET_OS),WIN32)
 EXEC := $(EXEC:=.exe)
-PLAT_LDFLAGS =
-.LIBPATTERNS += lib%.dll.a
 endif
 ifeq ($(TARGET_OS),LINUX)
-PLAT_LIBS =
 endif
 ifeq ($(TARGET_OS),OSX)
-PLAT_INCS =
-PLAT_LDFLAGS =
-.LIBPATTERNS += lib%.dylib
 endif
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/mosteksim/srcsim/Makefile.bsd
+++ b/mosteksim/srcsim/Makefile.bsd
@@ -1,7 +1,7 @@
 # Makefile pre-configured for BSD
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = mostek
@@ -31,7 +31,7 @@ CONF_DIR = $(ROOT_DIR)/conf
 # system wide location for disk images
 DISKS_DIR = $(ROOT_DIR)/disks
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -40,19 +40,16 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = cc
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/mosteksim/srcsim/Makefile.cygwin
+++ b/mosteksim/srcsim/Makefile.cygwin
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Windows/Cygwin
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = mostek
@@ -31,7 +31,7 @@ CONF_DIR = $(ROOT_DIR)/conf
 # system wide location for disk images
 DISKS_DIR = $(ROOT_DIR)/disks
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -40,19 +40,16 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 EXEC = $(SIM).exe
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/mosteksim/srcsim/Makefile.linux
+++ b/mosteksim/srcsim/Makefile.linux
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Linux
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = mostek
@@ -31,7 +31,7 @@ CONF_DIR = $(ROOT_DIR)/conf
 # system wide location for disk images
 DISKS_DIR = $(ROOT_DIR)/disks
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -40,19 +40,16 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/mosteksim/srcsim/Makefile.osx
+++ b/mosteksim/srcsim/Makefile.osx
@@ -1,7 +1,7 @@
 # Makefile pre-configured for macOS
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = mostek
@@ -31,7 +31,7 @@ CONF_DIR = $(ROOT_DIR)/conf
 # system wide location for disk images
 DISKS_DIR = $(ROOT_DIR)/disks
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -40,19 +40,16 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/z80asm/Makefile
+++ b/z80asm/Makefile
@@ -10,8 +10,6 @@ CWARNS = -Wall -Wextra -Wwrite-strings
 CFLAGS = -O3 $(CWARNS) -D_POSIX_C_SOURCE=200809L
 #CFLAGS = -O $(CWARNS)
 
-LDFLAGS =
-
 #
 # installation directory
 #

--- a/z80sim/srcsim/GNUmakefile
+++ b/z80sim/srcsim/GNUmakefile
@@ -1,5 +1,5 @@
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = z80
@@ -25,47 +25,38 @@ LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
 
 # ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
-EXEC = $(SIM)
 
 CORE_DIR = ../../z80core
 
 VPATH = $(CORE_DIR) $(IO_DIR)
-CC = gcc
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 include $(CORE_DIR)/Makefile.in-os
 
+CC = gcc
+EXEC = $(SIM)
 ifeq ($(TARGET_OS),BSD)
 CC = cc
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 endif
 ifeq ($(TARGET_OS),WIN32)
 EXEC := $(EXEC:=.exe)
-PLAT_LDFLAGS =
-.LIBPATTERNS += lib%.dll.a
 endif
 ifeq ($(TARGET_OS),LINUX)
-PLAT_LIBS =
 endif
 ifeq ($(TARGET_OS),OSX)
-PLAT_INCS =
-PLAT_LDFLAGS =
-.LIBPATTERNS += lib%.dylib
 endif
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -iquote . -I$(CORE_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -iquote . -I$(CORE_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/z80sim/srcsim/Makefile.bsd
+++ b/z80sim/srcsim/Makefile.bsd
@@ -1,7 +1,7 @@
 # Makefile pre-configured for BSD
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = z80
@@ -27,7 +27,7 @@ LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
 
 # ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -35,19 +35,16 @@ SIM = ../$(MACHINE)sim
 CORE_DIR = ../../z80core
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = cc
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -I. -I$(CORE_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/z80sim/srcsim/Makefile.cygwin
+++ b/z80sim/srcsim/Makefile.cygwin
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Windows/Cygwin
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = z80
@@ -27,7 +27,7 @@ LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
 
 # ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -35,19 +35,16 @@ SIM = ../$(MACHINE)sim
 CORE_DIR = ../../z80core
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 EXEC = $(SIM).exe
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -I. -I$(CORE_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/z80sim/srcsim/Makefile.linux
+++ b/z80sim/srcsim/Makefile.linux
@@ -1,7 +1,7 @@
 # Makefile pre-configured for Linux
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = z80
@@ -27,7 +27,7 @@ LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
 
 # ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -35,19 +35,16 @@ SIM = ../$(MACHINE)sim
 CORE_DIR = ../../z80core
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -I. -I$(CORE_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 

--- a/z80sim/srcsim/Makefile.osx
+++ b/z80sim/srcsim/Makefile.osx
@@ -1,7 +1,7 @@
 # Makefile pre-configured for macOS
 
 ###
-### START MACHINE DEPENDANT VARIABLES
+### START MACHINE DEPENDENT VARIABLES
 ###
 # (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
 MACHINE = z80
@@ -27,7 +27,7 @@ LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
 
 # ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
-### END MACHINE DEPENDANT VARIABLES
+### END MACHINE DEPENDENT VARIABLES
 ###
 
 SIM = ../$(MACHINE)sim
@@ -35,19 +35,16 @@ SIM = ../$(MACHINE)sim
 CORE_DIR = ../../z80core
 
 ###
-### START O/S PLATFORM DEPENDANT VARIABLES
+### START O/S PLATFORM DEPENDENT VARIABLES
 ###
 CC = gcc
 EXEC = $(SIM)
-PLAT_INCS =
-PLAT_LDFLAGS =
-PLAT_LIBS =
 ###
-### END O/S DEPENDANT VARIABLES
+### END O/S DEPENDENT VARIABLES
 ###
 
-INCS = -I. -I$(CORE_DIR) $(PLAT_INCS)
 DEFS =
+INCS = -I. -I$(CORE_DIR) $(PLAT_INCS)
 
 CWARNS = -Wall -Wextra -Wwrite-strings
 


### PR DESCRIPTION
1. Move CC, CXX, EXEC inside the platform dependent block in the GNUmakefiles, to correspond with the Makefile.*s.
2. Remove empty "PLAT_*" lines and ".LIBPATTERNS".
3. Now that frontpanel has a GNUmakefile, model Makefile.*s after it.
4. Fix typos.
5. Switch "INCS & DEFS" to correspond with usage sequence... to keep up with my usual totally unneeded changes :-)
6. Add some instructions to build with GNU make and with/without frontpanels to README-frontpanel.txt.