### PR TITLE
use magic to autogenerate Makefile.* rules, only remove drives a-d

### DIFF
--- a/altairsim/srcsim/GNUmakefile
+++ b/altairsim/srcsim/GNUmakefile
@@ -9,7 +9,7 @@ FRONTPANEL = YES
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
 IO_SRCS = cromemco-dazzler.c proctec-vdm.c tarbell_fdc.c altair-88-dcdd.c altair-88-sio.c altair-88-2sio.c unix_terminal.c unix_network.c simbdos.c
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -161,10 +161,31 @@ _rm_deps:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
-	rm -f ../disks/mits_*.dsk
+	rm -f ../disks/drive[abcd].dsk
+	rm -f ../disks/mits_[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
+makerules:
+	@echo "# AUTOMATICALLY GENERATED DO NOT EDIT" >tmp.rules
+	@echo >>tmp.rules;
+	@for i in *.d; do \
+		sed -e 's;$(CORE_DIR);$$(CORE_DIR);g' -e 's;$(IO_DIR);$$(IO_DIR);g' \
+			-e 's;$(FP_DIR);$$(FP_DIR);g' <$$i >tmp.deps; \
+		cat tmp.deps >>tmp.rules; \
+		f=`sed 's/.*: \([^ ]*\).*/\1/;2,$$d' tmp.deps`; \
+		if grep -q '\.cpp' tmp.deps; then \
+			echo '	$$(CXX) $$(CXXFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		else \
+			echo '	$$(CC) $$(CFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		fi ; \
+		echo >>tmp.rules; \
+	done
+	@echo '# DO NOT PUT ANYTHING AFTER THIS LINE' >>tmp.rules;
+	@for i in Makefile.*; do \
+		sed '/^# AUTOMATICALLY GENERATED DO NOT EDIT/,$$d' <$$i >tmp.make; \
+		cat tmp.rules >>tmp.make; \
+		mv -f tmp.make $$i; \
+	done
+	@rm -f tmp.rules tmp.deps tmp.make
 
-.PHONY: all build install clean allclean
+.PHONY: all build install clean allclean makerules

--- a/altairsim/srcsim/Makefile.bsd
+++ b/altairsim/srcsim/Makefile.bsd
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-dazzler.o proctec-vdm.o tarbell_fdc.o altair-88-dcdd.o altair-88-sio.o altair-88-2sio.o unix_terminal.o unix_network.o simbdos.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -112,93 +112,125 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
-	rm -f ../disks/mits_*.dsk
+	rm -f ../disks/drive[abcd].dsk
+	rm -f ../disks/mits_[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
+
+altair-88-2sio.o: $(IO_DIR)/altair-88-2sio.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-2sio.c
+
+altair-88-dcdd.o: $(IO_DIR)/altair-88-dcdd.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-dcdd.c
+
+altair-88-sio.o: $(IO_DIR)/altair-88-sio.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-sio.c
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(FP_DIR)/frontpanel.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
 
 fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/unix_network.h \
+ $(IO_DIR)/altair-88-sio.h $(IO_DIR)/altair-88-2sio.h \
+ $(IO_DIR)/tarbell_fdc.h $(IO_DIR)/altair-88-dcdd.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/proctec-vdm.h \
+ $(FP_DIR)/frontpanel.h memory.h config.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
+proctec-vdm.o: $(IO_DIR)/proctec-vdm.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/proctec-vdm-charset.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/proctec-vdm.c
 
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
 
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
 
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
 
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
 
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
 
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
 
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
 
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
 
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
 
 simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
 
 simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
+tarbell_fdc.o: $(IO_DIR)/tarbell_fdc.c sim.h $(CORE_DIR)/simglb.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/tarbell_fdc.c
 
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-altair-88-sio.o: $(IO_DIR)/altair-88-sio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-sio.c
-
-altair-88-2sio.o: $(IO_DIR)/altair-88-2sio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-2sio.c
-
-tarbell_fdc.o: $(IO_DIR)/tarbell_fdc.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/tarbell_fdc.c
-
-altair-88-dcdd.o: $(IO_DIR)/altair-88-dcdd.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-dcdd.c
-
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
-
-proctec-vdm.o: $(IO_DIR)/proctec-vdm.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/proctec-vdm.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/altairsim/srcsim/Makefile.cygwin
+++ b/altairsim/srcsim/Makefile.cygwin
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-dazzler.o proctec-vdm.o tarbell_fdc.o altair-88-dcdd.o altair-88-sio.o altair-88-2sio.o unix_terminal.o unix_network.o simbdos.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -110,93 +110,125 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
-	rm -f ../disks/mits_*.dsk
+	rm -f ../disks/drive[abcd].dsk
+	rm -f ../disks/mits_[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
+
+altair-88-2sio.o: $(IO_DIR)/altair-88-2sio.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-2sio.c
+
+altair-88-dcdd.o: $(IO_DIR)/altair-88-dcdd.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-dcdd.c
+
+altair-88-sio.o: $(IO_DIR)/altair-88-sio.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-sio.c
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(FP_DIR)/frontpanel.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
 
 fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/unix_network.h \
+ $(IO_DIR)/altair-88-sio.h $(IO_DIR)/altair-88-2sio.h \
+ $(IO_DIR)/tarbell_fdc.h $(IO_DIR)/altair-88-dcdd.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/proctec-vdm.h \
+ $(FP_DIR)/frontpanel.h memory.h config.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
+proctec-vdm.o: $(IO_DIR)/proctec-vdm.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/proctec-vdm-charset.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/proctec-vdm.c
 
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
 
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
 
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
 
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
 
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
 
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
 
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
 
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
 
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
 
 simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
 
 simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
+tarbell_fdc.o: $(IO_DIR)/tarbell_fdc.c sim.h $(CORE_DIR)/simglb.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/tarbell_fdc.c
 
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-altair-88-sio.o: $(IO_DIR)/altair-88-sio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-sio.c
-
-altair-88-2sio.o: $(IO_DIR)/altair-88-2sio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-2sio.c
-
-tarbell_fdc.o: $(IO_DIR)/tarbell_fdc.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/tarbell_fdc.c
-
-altair-88-dcdd.o: $(IO_DIR)/altair-88-dcdd.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-dcdd.c
-
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
-
-proctec-vdm.o: $(IO_DIR)/proctec-vdm.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/proctec-vdm.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/altairsim/srcsim/Makefile.linux
+++ b/altairsim/srcsim/Makefile.linux
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-dazzler.o proctec-vdm.o tarbell_fdc.o altair-88-dcdd.o altair-88-sio.o altair-88-2sio.o unix_terminal.o unix_network.o simbdos.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -110,93 +110,125 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
-	rm -f ../disks/mits_*.dsk
+	rm -f ../disks/drive[abcd].dsk
+	rm -f ../disks/mits_[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
+
+altair-88-2sio.o: $(IO_DIR)/altair-88-2sio.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-2sio.c
+
+altair-88-dcdd.o: $(IO_DIR)/altair-88-dcdd.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-dcdd.c
+
+altair-88-sio.o: $(IO_DIR)/altair-88-sio.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-sio.c
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(FP_DIR)/frontpanel.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
 
 fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/unix_network.h \
+ $(IO_DIR)/altair-88-sio.h $(IO_DIR)/altair-88-2sio.h \
+ $(IO_DIR)/tarbell_fdc.h $(IO_DIR)/altair-88-dcdd.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/proctec-vdm.h \
+ $(FP_DIR)/frontpanel.h memory.h config.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
+proctec-vdm.o: $(IO_DIR)/proctec-vdm.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/proctec-vdm-charset.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/proctec-vdm.c
 
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
 
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
 
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
 
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
 
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
 
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
 
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
 
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
 
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
 
 simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
 
 simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
+tarbell_fdc.o: $(IO_DIR)/tarbell_fdc.c sim.h $(CORE_DIR)/simglb.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/tarbell_fdc.c
 
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-altair-88-sio.o: $(IO_DIR)/altair-88-sio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-sio.c
-
-altair-88-2sio.o: $(IO_DIR)/altair-88-2sio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-2sio.c
-
-tarbell_fdc.o: $(IO_DIR)/tarbell_fdc.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/tarbell_fdc.c
-
-altair-88-dcdd.o: $(IO_DIR)/altair-88-dcdd.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-dcdd.c
-
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
-
-proctec-vdm.o: $(IO_DIR)/proctec-vdm.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/proctec-vdm.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/altairsim/srcsim/Makefile.osx
+++ b/altairsim/srcsim/Makefile.osx
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-dazzler.o proctec-vdm.o tarbell_fdc.o altair-88-dcdd.o altair-88-sio.o altair-88-2sio.o unix_terminal.o unix_network.o simbdos.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -111,93 +111,125 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
-	rm -f ../disks/mits_*.dsk
+	rm -f ../disks/drive[abcd].dsk
+	rm -f ../disks/mits_[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
+
+altair-88-2sio.o: $(IO_DIR)/altair-88-2sio.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-2sio.c
+
+altair-88-dcdd.o: $(IO_DIR)/altair-88-dcdd.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-dcdd.c
+
+altair-88-sio.o: $(IO_DIR)/altair-88-sio.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/altair-88-sio.c
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(FP_DIR)/frontpanel.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
 
 fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/unix_network.h \
+ $(IO_DIR)/altair-88-sio.h $(IO_DIR)/altair-88-2sio.h \
+ $(IO_DIR)/tarbell_fdc.h $(IO_DIR)/altair-88-dcdd.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/proctec-vdm.h \
+ $(FP_DIR)/frontpanel.h memory.h config.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
+proctec-vdm.o: $(IO_DIR)/proctec-vdm.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/proctec-vdm-charset.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/proctec-vdm.c
 
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
 
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
 
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
 
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
 
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
 
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
 
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
 
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
 
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
 
 simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
 
 simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
+tarbell_fdc.o: $(IO_DIR)/tarbell_fdc.c sim.h $(CORE_DIR)/simglb.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/tarbell_fdc.c
 
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-altair-88-sio.o: $(IO_DIR)/altair-88-sio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-sio.c
-
-altair-88-2sio.o: $(IO_DIR)/altair-88-2sio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-2sio.c
-
-tarbell_fdc.o: $(IO_DIR)/tarbell_fdc.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/tarbell_fdc.c
-
-altair-88-dcdd.o: $(IO_DIR)/altair-88-dcdd.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/altair-88-dcdd.c
-
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
-
-proctec-vdm.o: $(IO_DIR)/proctec-vdm.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/proctec-vdm.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/cpmsim/srcsim/GNUmakefile
+++ b/cpmsim/srcsim/GNUmakefile
@@ -7,7 +7,7 @@ MACHINE = cpm
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
 IO_SRCS = unix_terminal.c rtc.c simbdos.c
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -126,9 +126,30 @@ _rm_deps:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../auxiliaryin.txt ../auxiliaryout.txt ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
+makerules:
+	@echo "# AUTOMATICALLY GENERATED DO NOT EDIT" >tmp.rules
+	@echo >>tmp.rules;
+	@for i in *.d; do \
+		sed -e 's;$(CORE_DIR);$$(CORE_DIR);g' \
+			-e 's;$(IO_DIR);$$(IO_DIR);g' <$$i >tmp.deps; \
+		cat tmp.deps >>tmp.rules; \
+		f=`sed 's/.*: \([^ ]*\).*/\1/;2,$$d' tmp.deps`; \
+		if grep -q '\.cpp' tmp.deps; then \
+			echo '	$$(CXX) $$(CXXFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		else \
+			echo '	$$(CC) $$(CFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		fi ; \
+		echo >>tmp.rules; \
+	done
+	@echo '# DO NOT PUT ANYTHING AFTER THIS LINE' >>tmp.rules;
+	@for i in Makefile.*; do \
+		sed '/^# AUTOMATICALLY GENERATED DO NOT EDIT/,$$d' <$$i >tmp.make; \
+		cat tmp.rules >>tmp.make; \
+		mv -f tmp.make $$i; \
+	done
+	@rm -f tmp.rules tmp.deps tmp.make
 
-.PHONY: all build install clean allclean
+.PHONY: all build install clean allclean makerules

--- a/cpmsim/srcsim/Makefile.bsd
+++ b/cpmsim/srcsim/Makefile.bsd
@@ -9,7 +9,7 @@ MACHINE = cpm
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = unix_terminal.o rtc.o simbdos.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -101,72 +101,86 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../auxiliaryin.txt ../auxiliaryout.txt ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/rtc.h
-	$(CC) $(CFLAGS) -c iosim.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ memory.h $(CORE_DIR)/log.h $(IO_DIR)/rtc.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h \
-	  $(IO_DIR)/unix_terminal.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
-
-unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
 rtc.o: $(IO_DIR)/rtc.c sim.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/rtc.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/rtc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(IO_DIR)/unix_terminal.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+unix_terminal.o: $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/cpmsim/srcsim/Makefile.cygwin
+++ b/cpmsim/srcsim/Makefile.cygwin
@@ -9,7 +9,7 @@ MACHINE = cpm
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = unix_terminal.o rtc.o simbdos.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -101,72 +101,86 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../auxiliaryin.txt ../auxiliaryout.txt ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/rtc.h
-	$(CC) $(CFLAGS) -c iosim.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ memory.h $(CORE_DIR)/log.h $(IO_DIR)/rtc.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h \
-	  $(IO_DIR)/unix_terminal.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
-
-unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
 rtc.o: $(IO_DIR)/rtc.c sim.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/rtc.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/rtc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(IO_DIR)/unix_terminal.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+unix_terminal.o: $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/cpmsim/srcsim/Makefile.linux
+++ b/cpmsim/srcsim/Makefile.linux
@@ -9,7 +9,7 @@ MACHINE = cpm
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = unix_terminal.o rtc.o simbdos.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -101,72 +101,86 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../auxiliaryin.txt ../auxiliaryout.txt ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/rtc.h
-	$(CC) $(CFLAGS) -c iosim.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ memory.h $(CORE_DIR)/log.h $(IO_DIR)/rtc.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h \
-	  $(IO_DIR)/unix_terminal.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
-
-unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
 rtc.o: $(IO_DIR)/rtc.c sim.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/rtc.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/rtc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(IO_DIR)/unix_terminal.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+unix_terminal.o: $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/cpmsim/srcsim/Makefile.osx
+++ b/cpmsim/srcsim/Makefile.osx
@@ -9,7 +9,7 @@ MACHINE = cpm
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = unix_terminal.o rtc.o simbdos.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -101,72 +101,86 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../auxiliaryin.txt ../auxiliaryout.txt ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/rtc.h
-	$(CC) $(CFLAGS) -c iosim.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ memory.h $(CORE_DIR)/log.h $(IO_DIR)/rtc.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h \
-	  $(IO_DIR)/unix_terminal.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
-
-unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
 rtc.o: $(IO_DIR)/rtc.c sim.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/rtc.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/rtc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(IO_DIR)/unix_terminal.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+unix_terminal.o: $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/cromemcosim/srcsim/GNUmakefile
+++ b/cromemcosim/srcsim/GNUmakefile
@@ -9,7 +9,7 @@ FRONTPANEL = YES
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
 IO_SRCS = cromemco-wdi.c cromemco-d+7a.c cromemco-dazzler.c cromemco-fdc.c cromemco-tu-art.c cromemco-hal.c unix_terminal.c unix_network.c simbdos.c netsrv.c generic-at-modem.c libtelnet.c diskmanager.c
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -166,9 +166,31 @@ _rm_deps:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../lpt[12].txt
 
-#test: ; @echo $(ROOT_DIR)
+makerules:
+	@echo "# AUTOMATICALLY GENERATED DO NOT EDIT" >tmp.rules
+	@echo >>tmp.rules;
+	@for i in *.d; do \
+		sed -e 's;$(CORE_DIR);$$(CORE_DIR);g' -e 's;$(IO_DIR);$$(IO_DIR);g' \
+			-e 's;$(FP_DIR);$$(FP_DIR);g' -e 's;$(NET_DIR);$$(NET_DIR);g' \
+			-e 's;$(CIV_DIR);$$(CIV_DIR);g' <$$i >tmp.deps; \
+		cat tmp.deps >>tmp.rules; \
+		f=`sed 's/.*: \([^ ]*\).*/\1/;2,$$d' tmp.deps`; \
+		if grep -q '\.cpp' tmp.deps; then \
+			echo '	$$(CXX) $$(CXXFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		else \
+			echo '	$$(CC) $$(CFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		fi ; \
+		echo >>tmp.rules; \
+	done
+	@echo '# DO NOT PUT ANYTHING AFTER THIS LINE' >>tmp.rules;
+	@for i in Makefile.*; do \
+		sed '/^# AUTOMATICALLY GENERATED DO NOT EDIT/,$$d' <$$i >tmp.make; \
+		cat tmp.rules >>tmp.make; \
+		mv -f tmp.make $$i; \
+	done
+	@rm -f tmp.rules tmp.deps tmp.make
 
-.PHONY: all build install clean allclean
+.PHONY: all build install clean allclean makerules

--- a/cromemcosim/srcsim/Makefile.bsd
+++ b/cromemcosim/srcsim/Makefile.bsd
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-wdi.o cromemco-d+7a.o cromemco-dazzler.o cromemco-fdc.o cromemco-tu-art.o cromemco-hal.o unix_terminal.o unix_network.o simbdos.o netsrv.o generic-at-modem.o libtelnet.o diskmanager.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -114,111 +114,142 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../lpt[12].txt
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(FP_DIR)/frontpanel.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-d+7a.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
+
+cromemco-fdc.o: $(IO_DIR)/cromemco-fdc.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h config.h \
+ $(IO_DIR)/cromemco-fdc.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-fdc.c
+
+cromemco-hal.o: $(IO_DIR)/cromemco-hal.c sim.h \
+ $(CORE_DIR)/simglb.h $(IO_DIR)/unix_terminal.h \
+ $(IO_DIR)/unix_network.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/cromemco-hal.h $(IO_DIR)/generic-at-modem.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-hal.c
+
+cromemco-tu-art.o: $(IO_DIR)/cromemco-tu-art.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h \
+ $(IO_DIR)/cromemco-hal.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-tu-art.c
+
+cromemco-wdi.o: $(IO_DIR)/cromemco-wdi.c sim.h \
+ $(CORE_DIR)/simglb.h memory.h $(FP_DIR)/frontpanel.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-wdi.c
+
+diskmanager.o: $(IO_DIR)/diskmanager.c sim.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/diskmanager.c
 
 fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+generic-at-modem.o: $(IO_DIR)/generic-at-modem.c \
+ $(IO_DIR)/libtelnet.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/generic-at-modem.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/unix_network.h $(IO_DIR)/cromemco-tu-art.h \
+ $(IO_DIR)/generic-at-modem.h $(IO_DIR)/cromemco-fdc.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/cromemco-d+7a.h \
+ $(FP_DIR)/frontpanel.h memory.h config.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/cromemco-hal.h $(IO_DIR)/cromemco-wdi.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
+libtelnet.o: $(IO_DIR)/libtelnet.c $(IO_DIR)/libtelnet.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/libtelnet.c
 
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
+netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(NET_DIR)/netsrv.c
 
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
 
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
 
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
 
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
 
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
 
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
 
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
 
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
 
 simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-diskmanager.o: $(IO_DIR)/diskmanager.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/diskmanager.c
-
-cromemco-tu-art.o: $(IO_DIR)/cromemco-tu-art.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-tu-art.c
-
-cromemco-fdc.o: $(IO_DIR)/cromemco-fdc.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-fdc.c
-
-cromemco-wdi.o: $(IO_DIR)/cromemco-wdi.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-wdi.c
-
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
-
-cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h $(CORE_DIR)/simglb.h \
-		  config.h memory.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-88ccc.c
-
-cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-d+7a.c
-
-cromemco-hal.o: $(IO_DIR)/cromemco-hal.c sim.h $(CORE_DIR)/simglb.h \
-		$(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-hal.c
-
-netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h memory.h $(NET_DIR)/netsrv.h \
-	  $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(NET_DIR)/netsrv.c
-
-generic-at-modem.o: $(IO_DIR)/generic-at-modem.c $(IO_DIR)/libtelnet.h \
-		    $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/generic-at-modem.c
-
-libtelnet.o: $(IO_DIR)/libtelnet.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/libtelnet.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/cromemcosim/srcsim/Makefile.cygwin
+++ b/cromemcosim/srcsim/Makefile.cygwin
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-wdi.o cromemco-d+7a.o cromemco-dazzler.o cromemco-fdc.o cromemco-tu-art.o cromemco-hal.o unix_terminal.o unix_network.o simbdos.o netsrv.o generic-at-modem.o libtelnet.o diskmanager.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -112,111 +112,142 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../lpt[12].txt
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(FP_DIR)/frontpanel.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-d+7a.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
+
+cromemco-fdc.o: $(IO_DIR)/cromemco-fdc.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h config.h \
+ $(IO_DIR)/cromemco-fdc.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-fdc.c
+
+cromemco-hal.o: $(IO_DIR)/cromemco-hal.c sim.h \
+ $(CORE_DIR)/simglb.h $(IO_DIR)/unix_terminal.h \
+ $(IO_DIR)/unix_network.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/cromemco-hal.h $(IO_DIR)/generic-at-modem.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-hal.c
+
+cromemco-tu-art.o: $(IO_DIR)/cromemco-tu-art.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h \
+ $(IO_DIR)/cromemco-hal.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-tu-art.c
+
+cromemco-wdi.o: $(IO_DIR)/cromemco-wdi.c sim.h \
+ $(CORE_DIR)/simglb.h memory.h $(FP_DIR)/frontpanel.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-wdi.c
+
+diskmanager.o: $(IO_DIR)/diskmanager.c sim.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/diskmanager.c
 
 fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+generic-at-modem.o: $(IO_DIR)/generic-at-modem.c \
+ $(IO_DIR)/libtelnet.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/generic-at-modem.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/unix_network.h $(IO_DIR)/cromemco-tu-art.h \
+ $(IO_DIR)/generic-at-modem.h $(IO_DIR)/cromemco-fdc.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/cromemco-d+7a.h \
+ $(FP_DIR)/frontpanel.h memory.h config.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/cromemco-hal.h $(IO_DIR)/cromemco-wdi.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
+libtelnet.o: $(IO_DIR)/libtelnet.c $(IO_DIR)/libtelnet.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/libtelnet.c
 
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
+netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(NET_DIR)/netsrv.c
 
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
 
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
 
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
 
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
 
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
 
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
 
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
 
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
 
 simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-diskmanager.o: $(IO_DIR)/diskmanager.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/diskmanager.c
-
-cromemco-tu-art.o: $(IO_DIR)/cromemco-tu-art.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-tu-art.c
-
-cromemco-fdc.o: $(IO_DIR)/cromemco-fdc.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-fdc.c
-
-cromemco-wdi.o: $(IO_DIR)/cromemco-wdi.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-wdi.c
-
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
-
-cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h $(CORE_DIR)/simglb.h \
-		  config.h memory.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-88ccc.c
-
-cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-d+7a.c
-
-cromemco-hal.o: $(IO_DIR)/cromemco-hal.c sim.h $(CORE_DIR)/simglb.h \
-		$(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-hal.c
-
-netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h memory.h $(NET_DIR)/netsrv.h \
-	  $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(NET_DIR)/netsrv.c
-
-generic-at-modem.o: $(IO_DIR)/generic-at-modem.c $(IO_DIR)/libtelnet.h \
-		    $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/generic-at-modem.c
-
-libtelnet.o: $(IO_DIR)/libtelnet.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/libtelnet.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/cromemcosim/srcsim/Makefile.linux
+++ b/cromemcosim/srcsim/Makefile.linux
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-wdi.o cromemco-d+7a.o cromemco-dazzler.o cromemco-fdc.o cromemco-tu-art.o cromemco-hal.o unix_terminal.o unix_network.o simbdos.o netsrv.o generic-at-modem.o libtelnet.o diskmanager.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -112,111 +112,142 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../lpt[12].txt
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(FP_DIR)/frontpanel.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-d+7a.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
+
+cromemco-fdc.o: $(IO_DIR)/cromemco-fdc.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h config.h \
+ $(IO_DIR)/cromemco-fdc.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-fdc.c
+
+cromemco-hal.o: $(IO_DIR)/cromemco-hal.c sim.h \
+ $(CORE_DIR)/simglb.h $(IO_DIR)/unix_terminal.h \
+ $(IO_DIR)/unix_network.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/cromemco-hal.h $(IO_DIR)/generic-at-modem.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-hal.c
+
+cromemco-tu-art.o: $(IO_DIR)/cromemco-tu-art.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h \
+ $(IO_DIR)/cromemco-hal.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-tu-art.c
+
+cromemco-wdi.o: $(IO_DIR)/cromemco-wdi.c sim.h \
+ $(CORE_DIR)/simglb.h memory.h $(FP_DIR)/frontpanel.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-wdi.c
+
+diskmanager.o: $(IO_DIR)/diskmanager.c sim.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/diskmanager.c
 
 fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+generic-at-modem.o: $(IO_DIR)/generic-at-modem.c \
+ $(IO_DIR)/libtelnet.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/generic-at-modem.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/unix_network.h $(IO_DIR)/cromemco-tu-art.h \
+ $(IO_DIR)/generic-at-modem.h $(IO_DIR)/cromemco-fdc.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/cromemco-d+7a.h \
+ $(FP_DIR)/frontpanel.h memory.h config.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/cromemco-hal.h $(IO_DIR)/cromemco-wdi.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
+libtelnet.o: $(IO_DIR)/libtelnet.c $(IO_DIR)/libtelnet.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/libtelnet.c
 
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
+netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(NET_DIR)/netsrv.c
 
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
 
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
 
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
 
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
 
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
 
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
 
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
 
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
 
 simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-diskmanager.o: $(IO_DIR)/diskmanager.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/diskmanager.c
-
-cromemco-tu-art.o: $(IO_DIR)/cromemco-tu-art.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-tu-art.c
-
-cromemco-fdc.o: $(IO_DIR)/cromemco-fdc.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-fdc.c
-
-cromemco-wdi.o: $(IO_DIR)/cromemco-wdi.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-wdi.c
-
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
-
-cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h $(CORE_DIR)/simglb.h \
-		  config.h memory.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-88ccc.c
-
-cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-d+7a.c
-
-cromemco-hal.o: $(IO_DIR)/cromemco-hal.c sim.h $(CORE_DIR)/simglb.h \
-		$(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-hal.c
-
-netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h memory.h $(NET_DIR)/netsrv.h \
-	  $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(NET_DIR)/netsrv.c
-
-generic-at-modem.o: $(IO_DIR)/generic-at-modem.c $(IO_DIR)/libtelnet.h \
-		    $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/generic-at-modem.c
-
-libtelnet.o: $(IO_DIR)/libtelnet.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/libtelnet.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/cromemcosim/srcsim/Makefile.osx
+++ b/cromemcosim/srcsim/Makefile.osx
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-wdi.o cromemco-d+7a.o cromemco-dazzler.o cromemco-fdc.o cromemco-tu-art.o cromemco-hal.o unix_terminal.o unix_network.o simbdos.o netsrv.o generic-at-modem.o libtelnet.o diskmanager.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -113,111 +113,142 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../lpt[12].txt
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(FP_DIR)/frontpanel.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-d+7a.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
+
+cromemco-fdc.o: $(IO_DIR)/cromemco-fdc.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h config.h \
+ $(IO_DIR)/cromemco-fdc.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-fdc.c
+
+cromemco-hal.o: $(IO_DIR)/cromemco-hal.c sim.h \
+ $(CORE_DIR)/simglb.h $(IO_DIR)/unix_terminal.h \
+ $(IO_DIR)/unix_network.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/cromemco-hal.h $(IO_DIR)/generic-at-modem.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-hal.c
+
+cromemco-tu-art.o: $(IO_DIR)/cromemco-tu-art.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h \
+ $(IO_DIR)/cromemco-hal.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-tu-art.c
+
+cromemco-wdi.o: $(IO_DIR)/cromemco-wdi.c sim.h \
+ $(CORE_DIR)/simglb.h memory.h $(FP_DIR)/frontpanel.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-wdi.c
+
+diskmanager.o: $(IO_DIR)/diskmanager.c sim.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/diskmanager.c
 
 fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+generic-at-modem.o: $(IO_DIR)/generic-at-modem.c \
+ $(IO_DIR)/libtelnet.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/generic-at-modem.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/unix_network.h $(IO_DIR)/cromemco-tu-art.h \
+ $(IO_DIR)/generic-at-modem.h $(IO_DIR)/cromemco-fdc.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/cromemco-d+7a.h \
+ $(FP_DIR)/frontpanel.h memory.h config.h $(CORE_DIR)/log.h \
+ $(IO_DIR)/cromemco-hal.h $(IO_DIR)/cromemco-wdi.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
+libtelnet.o: $(IO_DIR)/libtelnet.c $(IO_DIR)/libtelnet.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/libtelnet.c
 
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
+netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(NET_DIR)/netsrv.c
 
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
 
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
 
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
 
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
 
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
 
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
 
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
 
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
 
 simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-diskmanager.o: $(IO_DIR)/diskmanager.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/diskmanager.c
-
-cromemco-tu-art.o: $(IO_DIR)/cromemco-tu-art.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-tu-art.c
-
-cromemco-fdc.o: $(IO_DIR)/cromemco-fdc.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-fdc.c
-
-cromemco-wdi.o: $(IO_DIR)/cromemco-wdi.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-wdi.c
-
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
-
-cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h $(CORE_DIR)/simglb.h \
-		  config.h memory.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-88ccc.c
-
-cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-d+7a.c
-
-cromemco-hal.o: $(IO_DIR)/cromemco-hal.c sim.h $(CORE_DIR)/simglb.h \
-		$(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-hal.c
-
-netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h memory.h $(NET_DIR)/netsrv.h \
-	  $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(NET_DIR)/netsrv.c
-
-generic-at-modem.o: $(IO_DIR)/generic-at-modem.c $(IO_DIR)/libtelnet.h \
-		    $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/generic-at-modem.c
-
-libtelnet.o: $(IO_DIR)/libtelnet.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/libtelnet.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/frontpanel/GNUmakefile
+++ b/frontpanel/GNUmakefile
@@ -70,4 +70,25 @@ _rm_deps:
 allclean: clean
 	rm -f $(LIB)
 
-.PHONY: all build clean allclean
+makerules:
+	@echo "# AUTOMATICALLY GENERATED DO NOT EDIT" >tmp.rules
+	@echo >>tmp.rules;
+	@for i in *.d; do \
+		cat $$i >>tmp.rules; \
+		f=`sed 's/.*: \([^ ]*\).*/\1/;2,$$d' $$i`; \
+		if grep -q '\.cpp' $$i; then \
+			echo '	$$(CXX) $$(CXXFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		else \
+			echo '	$$(CC) $$(CFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		fi ; \
+		echo >>tmp.rules; \
+	done
+	@echo '# DO NOT PUT ANYTHING AFTER THIS LINE' >>tmp.rules;
+	@for i in Makefile.*; do \
+		sed '/^# AUTOMATICALLY GENERATED DO NOT EDIT/,$$d' <$$i >tmp.make; \
+		cat tmp.rules >>tmp.make; \
+		mv -f tmp.make $$i; \
+	done
+	@rm -f tmp.rules tmp.make
+
+.PHONY: all build clean allclean makerules

--- a/frontpanel/Makefile.bsd
+++ b/frontpanel/Makefile.bsd
@@ -46,29 +46,37 @@ _rm_obj:
 allclean: clean
 	rm -f $(LIB)
 
-jpeg.o: jpeg.cpp cdjpeg.h
-	$(CXX) $(CXXFLAGS) -c jpeg.cpp -o jpeg.o
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
-lpanel.o: lpanel.cpp lpanel.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lpanel.cpp -o lpanel.o
+jpeg.o: jpeg.cpp cdjpeg.h jinclude.h cderror.h
+	$(CXX) $(CXXFLAGS) -c -o $@ jpeg.cpp
 
 lp_font.o: lp_font.cpp lp_font.h
-	$(CXX) $(CXXFLAGS) -c lp_font.cpp -o lp_font.o
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_font.cpp
 
-lp_gfx.o: lp_gfx.cpp lpanel.h lp_utils.h jpeg.h
-	$(CXX) $(CXXFLAGS) -c lp_gfx.cpp -o lp_gfx.o
+lp_gfx.o: lp_gfx.cpp lpanel.h lp_gfx.h lp_switch.h lp_utils.h \
+ lp_materials.h jpeg.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_gfx.cpp
 
-lp_main.o: lp_main.cpp lp_main.h lpanel.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_main.cpp -o lp_main.o
-
-lp_switch.o: lp_switch.cpp lpanel.h lp_switch.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_switch.cpp -o lp_switch.o
-
-lp_utils.o: lp_utils.cpp lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_utils.cpp -o lp_utils.o
-
-lp_window.o: lp_window.cpp lpanel.h
-	$(CXX) $(CXXFLAGS) -c lp_window.cpp -o lp_window.o
+lp_main.o: lp_main.cpp lpanel.h lp_gfx.h lp_switch.h lp_main.h \
+ frontpanel.h lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_main.cpp
 
 lp_materials.o: lp_materials.cpp lp_materials.h
-	$(CXX) $(CXXFLAGS) -c lp_materials.cpp -o lp_materials.o
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_materials.cpp
+
+lp_switch.o: lp_switch.cpp lpanel.h lp_gfx.h lp_switch.h lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_switch.cpp
+
+lp_utils.o: lp_utils.cpp lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_utils.cpp
+
+lp_window.o: lp_window.cpp lpanel.h lp_gfx.h lp_switch.h lp_materials.h \
+ lp_font.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_window.cpp
+
+lpanel.o: lpanel.cpp lp_utils.h lp_materials.h lpanel.h lp_gfx.h \
+ lp_switch.h lpanel_data.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lpanel.cpp
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/frontpanel/Makefile.cygwin
+++ b/frontpanel/Makefile.cygwin
@@ -45,29 +45,37 @@ _rm_obj:
 allclean: clean
 	rm -f $(LIB)
 
-jpeg.o: jpeg.cpp cdjpeg.h
-	$(CXX) $(CXXFLAGS) -c jpeg.cpp -o jpeg.o
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
-lpanel.o: lpanel.cpp lpanel.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lpanel.cpp -o lpanel.o
+jpeg.o: jpeg.cpp cdjpeg.h jinclude.h cderror.h
+	$(CXX) $(CXXFLAGS) -c -o $@ jpeg.cpp
 
 lp_font.o: lp_font.cpp lp_font.h
-	$(CXX) $(CXXFLAGS) -c lp_font.cpp -o lp_font.o
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_font.cpp
 
-lp_gfx.o: lp_gfx.cpp lpanel.h lp_utils.h jpeg.h
-	$(CXX) $(CXXFLAGS) -c lp_gfx.cpp -o lp_gfx.o
+lp_gfx.o: lp_gfx.cpp lpanel.h lp_gfx.h lp_switch.h lp_utils.h \
+ lp_materials.h jpeg.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_gfx.cpp
 
-lp_main.o: lp_main.cpp lp_main.h lpanel.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_main.cpp -o lp_main.o
-
-lp_switch.o: lp_switch.cpp lpanel.h lp_switch.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_switch.cpp -o lp_switch.o
-
-lp_utils.o: lp_utils.cpp lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_utils.cpp -o lp_utils.o
-
-lp_window.o: lp_window.cpp lpanel.h
-	$(CXX) $(CXXFLAGS) -c lp_window.cpp -o lp_window.o
+lp_main.o: lp_main.cpp lpanel.h lp_gfx.h lp_switch.h lp_main.h \
+ frontpanel.h lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_main.cpp
 
 lp_materials.o: lp_materials.cpp lp_materials.h
-	$(CXX) $(CXXFLAGS) -c lp_materials.cpp -o lp_materials.o
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_materials.cpp
+
+lp_switch.o: lp_switch.cpp lpanel.h lp_gfx.h lp_switch.h lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_switch.cpp
+
+lp_utils.o: lp_utils.cpp lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_utils.cpp
+
+lp_window.o: lp_window.cpp lpanel.h lp_gfx.h lp_switch.h lp_materials.h \
+ lp_font.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_window.cpp
+
+lpanel.o: lpanel.cpp lp_utils.h lp_materials.h lpanel.h lp_gfx.h \
+ lp_switch.h lpanel_data.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lpanel.cpp
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/frontpanel/Makefile.linux
+++ b/frontpanel/Makefile.linux
@@ -45,29 +45,37 @@ _rm_obj:
 allclean: clean
 	rm -f $(LIB)
 
-jpeg.o: jpeg.cpp cdjpeg.h
-	$(CXX) $(CXXFLAGS) -c jpeg.cpp -o jpeg.o
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
-lpanel.o: lpanel.cpp lpanel.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lpanel.cpp -o lpanel.o
+jpeg.o: jpeg.cpp cdjpeg.h jinclude.h cderror.h
+	$(CXX) $(CXXFLAGS) -c -o $@ jpeg.cpp
 
 lp_font.o: lp_font.cpp lp_font.h
-	$(CXX) $(CXXFLAGS) -c lp_font.cpp -o lp_font.o
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_font.cpp
 
-lp_gfx.o: lp_gfx.cpp lpanel.h lp_utils.h jpeg.h
-	$(CXX) $(CXXFLAGS) -c lp_gfx.cpp -o lp_gfx.o
+lp_gfx.o: lp_gfx.cpp lpanel.h lp_gfx.h lp_switch.h lp_utils.h \
+ lp_materials.h jpeg.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_gfx.cpp
 
-lp_main.o: lp_main.cpp lp_main.h lpanel.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_main.cpp -o lp_main.o
-
-lp_switch.o: lp_switch.cpp lpanel.h lp_switch.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_switch.cpp -o lp_switch.o
-
-lp_utils.o: lp_utils.cpp lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_utils.cpp -o lp_utils.o
-
-lp_window.o: lp_window.cpp lpanel.h
-	$(CXX) $(CXXFLAGS) -c lp_window.cpp -o lp_window.o
+lp_main.o: lp_main.cpp lpanel.h lp_gfx.h lp_switch.h lp_main.h \
+ frontpanel.h lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_main.cpp
 
 lp_materials.o: lp_materials.cpp lp_materials.h
-	$(CXX) $(CXXFLAGS) -c lp_materials.cpp -o lp_materials.o
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_materials.cpp
+
+lp_switch.o: lp_switch.cpp lpanel.h lp_gfx.h lp_switch.h lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_switch.cpp
+
+lp_utils.o: lp_utils.cpp lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_utils.cpp
+
+lp_window.o: lp_window.cpp lpanel.h lp_gfx.h lp_switch.h lp_materials.h \
+ lp_font.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_window.cpp
+
+lpanel.o: lpanel.cpp lp_utils.h lp_materials.h lpanel.h lp_gfx.h \
+ lp_switch.h lpanel_data.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lpanel.cpp
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/frontpanel/Makefile.osx
+++ b/frontpanel/Makefile.osx
@@ -46,29 +46,37 @@ _rm_obj:
 allclean: clean
 	rm -f $(LIB)
 
-jpeg.o: jpeg.cpp cdjpeg.h
-	$(CXX) $(CXXFLAGS) -c jpeg.cpp -o jpeg.o
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
-lpanel.o: lpanel.cpp lpanel.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lpanel.cpp -o lpanel.o
+jpeg.o: jpeg.cpp cdjpeg.h jinclude.h cderror.h
+	$(CXX) $(CXXFLAGS) -c -o $@ jpeg.cpp
 
 lp_font.o: lp_font.cpp lp_font.h
-	$(CXX) $(CXXFLAGS) -c lp_font.cpp -o lp_font.o
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_font.cpp
 
-lp_gfx.o: lp_gfx.cpp lpanel.h lp_utils.h jpeg.h
-	$(CXX) $(CXXFLAGS) -c lp_gfx.cpp -o lp_gfx.o
+lp_gfx.o: lp_gfx.cpp lpanel.h lp_gfx.h lp_switch.h lp_utils.h \
+ lp_materials.h jpeg.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_gfx.cpp
 
-lp_main.o: lp_main.cpp lp_main.h lpanel.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_main.cpp -o lp_main.o
-
-lp_switch.o: lp_switch.cpp lpanel.h lp_switch.h lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_switch.cpp -o lp_switch.o
-
-lp_utils.o: lp_utils.cpp lp_utils.h
-	$(CXX) $(CXXFLAGS) -c lp_utils.cpp -o lp_utils.o
-
-lp_window.o: lp_window.cpp lpanel.h
-	$(CXX) $(CXXFLAGS) -c lp_window.cpp -o lp_window.o
+lp_main.o: lp_main.cpp lpanel.h lp_gfx.h lp_switch.h lp_main.h \
+ frontpanel.h lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_main.cpp
 
 lp_materials.o: lp_materials.cpp lp_materials.h
-	$(CXX) $(CXXFLAGS) -c lp_materials.cpp -o lp_materials.o
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_materials.cpp
+
+lp_switch.o: lp_switch.cpp lpanel.h lp_gfx.h lp_switch.h lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_switch.cpp
+
+lp_utils.o: lp_utils.cpp lp_utils.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_utils.cpp
+
+lp_window.o: lp_window.cpp lpanel.h lp_gfx.h lp_switch.h lp_materials.h \
+ lp_font.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lp_window.cpp
+
+lpanel.o: lpanel.cpp lp_utils.h lp_materials.h lpanel.h lp_gfx.h \
+ lp_switch.h lpanel_data.h
+	$(CXX) $(CXXFLAGS) -c -o $@ lpanel.cpp
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/imsaisim/srcsim/GNUmakefile
+++ b/imsaisim/srcsim/GNUmakefile
@@ -9,7 +9,7 @@ FRONTPANEL = YES
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
 IO_SRCS = cromemco-dazzler.c cromemco-88ccc.c cromemco-d+7a.c diskmanager.c imsai-fif.c imsai-sio2.c imsai-hal.c imsai-vio.c unix_terminal.c unix_network.c netsrv.c generic-at-modem.c libtelnet.c rtc.c simbdos.c am9511.c floatcnv.c ova.c
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -166,9 +166,31 @@ _rm_deps:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
+makerules:
+	@echo "# AUTOMATICALLY GENERATED DO NOT EDIT" >tmp.rules
+	@echo >>tmp.rules;
+	@for i in *.d; do \
+		sed -e 's;$(CORE_DIR);$$(CORE_DIR);g' -e 's;$(IO_DIR);$$(IO_DIR);g' \
+			-e 's;$(FP_DIR);$$(FP_DIR);g' -e 's;$(NET_DIR);$$(NET_DIR);g' \
+			-e 's;$(CIV_DIR);$$(CIV_DIR);g' <$$i >tmp.deps; \
+		cat tmp.deps >>tmp.rules; \
+		f=`sed 's/.*: \([^ ]*\).*/\1/;2,$$d' tmp.deps`; \
+		if grep -q '\.cpp' tmp.deps; then \
+			echo '	$$(CXX) $$(CXXFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		else \
+			echo '	$$(CC) $$(CFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		fi ; \
+		echo >>tmp.rules; \
+	done
+	@echo '# DO NOT PUT ANYTHING AFTER THIS LINE' >>tmp.rules;
+	@for i in Makefile.*; do \
+		sed '/^# AUTOMATICALLY GENERATED DO NOT EDIT/,$$d' <$$i >tmp.make; \
+		cat tmp.rules >>tmp.make; \
+		mv -f tmp.make $$i; \
+	done
+	@rm -f tmp.rules tmp.deps tmp.make
 
-.PHONY: all build install clean allclean
+.PHONY: all build install clean allclean makerules

--- a/imsaisim/srcsim/Makefile.bsd
+++ b/imsaisim/srcsim/Makefile.bsd
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-dazzler.o cromemco-88ccc.o cromemco-d+7a.o diskmanager.o imsai-fif.o imsai-sio2.o imsai-hal.o imsai-vio.o unix_terminal.o unix_network.o netsrv.o generic-at-modem.o libtelnet.o rtc.o simbdos.o am9511.o floatcnv.o ova.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -114,126 +114,161 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
-
-fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
-
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/rtc.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 am9511.o: $(IO_DIR)/apu/am9511.c $(IO_DIR)/apu/am9511.h \
-	  $(IO_DIR)/apu/floatcnv.h $(IO_DIR)/apu/ova.h \
-	  $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/am9511.c
+ $(IO_DIR)/apu/floatcnv.h $(IO_DIR)/apu/ova.h \
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/am9511.c
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h \
+ $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-88ccc.c
+
+cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-d+7a.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
+
+diskmanager.o: $(IO_DIR)/diskmanager.c sim.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/diskmanager.c
 
 floatcnv.o: $(IO_DIR)/apu/floatcnv.c $(IO_DIR)/apu/floatcnv.h \
-	    $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/floatcnv.c
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/floatcnv.c
 
-ova.o: $(IO_DIR)/apu/ova.c $(IO_DIR)/apu/ova.h $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/ova.c
+fpmain.o: $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+generic-at-modem.o: $(IO_DIR)/generic-at-modem.c \
+ $(IO_DIR)/libtelnet.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/generic-at-modem.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-imsai-sio2.o: $(IO_DIR)/imsai-sio2.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-sio2.c
+imsai-fif.o: $(IO_DIR)/imsai-fif.c sim.h $(CORE_DIR)/simglb.h \
+ config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-fif.c
 
 imsai-hal.o: $(IO_DIR)/imsai-hal.c sim.h $(CORE_DIR)/simglb.h \
-	     $(CORE_DIR)/log.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-hal.c
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/imsai-hal.h \
+ $(IO_DIR)/generic-at-modem.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-hal.c
 
-imsai-fif.o: $(IO_DIR)/imsai-fif.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-fif.c
+imsai-sio2.o: $(IO_DIR)/imsai-sio2.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/imsai-hal.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-sio2.c
 
-diskmanager.o: $(IO_DIR)/diskmanager.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/diskmanager.c
+imsai-vio.o: $(IO_DIR)/imsai-vio.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/imsai-vio-charset.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-vio.c
 
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/unix_network.h $(IO_DIR)/imsai-sio2.h \
+ $(IO_DIR)/imsai-fif.h $(IO_DIR)/generic-at-modem.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/cromemco-d+7a.h \
+ $(IO_DIR)/imsai-vio.h $(FP_DIR)/frontpanel.h memory.h \
+ config.h $(CORE_DIR)/log.h $(IO_DIR)/rtc.h \
+ $(IO_DIR)/imsai-hal.h $(IO_DIR)/apu/am9511.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h $(CORE_DIR)/simglb.h \
-		  config.h memory.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-88ccc.c
+libtelnet.o: $(IO_DIR)/libtelnet.c $(IO_DIR)/libtelnet.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/libtelnet.c
 
-cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-d+7a.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-imsai-vio.o: $(IO_DIR)/imsai-vio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-vio.c
+netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(NET_DIR)/netsrv.c
 
-netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h memory.h $(NET_DIR)/netsrv.h \
-	  $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c ../../webfrontend/netsrv.c
-
-generic-at-modem.o: $(IO_DIR)/generic-at-modem.c $(IO_DIR)/libtelnet.h \
-		    $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/generic-at-modem.c
-
-libtelnet.o: $(IO_DIR)/libtelnet.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/libtelnet.c
+ova.o: $(IO_DIR)/apu/ova.c $(IO_DIR)/apu/ova.h \
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/ova.c
 
 rtc.o: $(IO_DIR)/rtc.c sim.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/rtc.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/rtc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
+
+unix_terminal.o: $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/imsaisim/srcsim/Makefile.cygwin
+++ b/imsaisim/srcsim/Makefile.cygwin
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-dazzler.o cromemco-88ccc.o cromemco-d+7a.o diskmanager.o imsai-fif.o imsai-sio2.o imsai-hal.o imsai-vio.o unix_terminal.o unix_network.o netsrv.o generic-at-modem.o libtelnet.o rtc.o simbdos.o am9511.o floatcnv.o ova.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -112,126 +112,161 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
-
-fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
-
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/rtc.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 am9511.o: $(IO_DIR)/apu/am9511.c $(IO_DIR)/apu/am9511.h \
-	  $(IO_DIR)/apu/floatcnv.h $(IO_DIR)/apu/ova.h \
-	  $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/am9511.c
+ $(IO_DIR)/apu/floatcnv.h $(IO_DIR)/apu/ova.h \
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/am9511.c
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h \
+ $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-88ccc.c
+
+cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-d+7a.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
+
+diskmanager.o: $(IO_DIR)/diskmanager.c sim.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/diskmanager.c
 
 floatcnv.o: $(IO_DIR)/apu/floatcnv.c $(IO_DIR)/apu/floatcnv.h \
-	    $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/floatcnv.c
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/floatcnv.c
 
-ova.o: $(IO_DIR)/apu/ova.c $(IO_DIR)/apu/ova.h $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/ova.c
+fpmain.o: $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+generic-at-modem.o: $(IO_DIR)/generic-at-modem.c \
+ $(IO_DIR)/libtelnet.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/generic-at-modem.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-imsai-sio2.o: $(IO_DIR)/imsai-sio2.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-sio2.c
+imsai-fif.o: $(IO_DIR)/imsai-fif.c sim.h $(CORE_DIR)/simglb.h \
+ config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-fif.c
 
 imsai-hal.o: $(IO_DIR)/imsai-hal.c sim.h $(CORE_DIR)/simglb.h \
-	     $(CORE_DIR)/log.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-hal.c
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/imsai-hal.h \
+ $(IO_DIR)/generic-at-modem.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-hal.c
 
-imsai-fif.o: $(IO_DIR)/imsai-fif.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-fif.c
+imsai-sio2.o: $(IO_DIR)/imsai-sio2.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/imsai-hal.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-sio2.c
 
-diskmanager.o: $(IO_DIR)/diskmanager.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/diskmanager.c
+imsai-vio.o: $(IO_DIR)/imsai-vio.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/imsai-vio-charset.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-vio.c
 
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/unix_network.h $(IO_DIR)/imsai-sio2.h \
+ $(IO_DIR)/imsai-fif.h $(IO_DIR)/generic-at-modem.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/cromemco-d+7a.h \
+ $(IO_DIR)/imsai-vio.h $(FP_DIR)/frontpanel.h memory.h \
+ config.h $(CORE_DIR)/log.h $(IO_DIR)/rtc.h \
+ $(IO_DIR)/imsai-hal.h $(IO_DIR)/apu/am9511.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h $(CORE_DIR)/simglb.h \
-		  config.h memory.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-88ccc.c
+libtelnet.o: $(IO_DIR)/libtelnet.c $(IO_DIR)/libtelnet.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/libtelnet.c
 
-cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-d+7a.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-imsai-vio.o: $(IO_DIR)/imsai-vio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-vio.c
+netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(NET_DIR)/netsrv.c
 
-netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h memory.h $(NET_DIR)/netsrv.h \
-	  $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c ../../webfrontend/netsrv.c
-
-generic-at-modem.o: $(IO_DIR)/generic-at-modem.c $(IO_DIR)/libtelnet.h \
-		    $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/generic-at-modem.c
-
-libtelnet.o: $(IO_DIR)/libtelnet.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/libtelnet.c
+ova.o: $(IO_DIR)/apu/ova.c $(IO_DIR)/apu/ova.h \
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/ova.c
 
 rtc.o: $(IO_DIR)/rtc.c sim.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/rtc.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/rtc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
+
+unix_terminal.o: $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/imsaisim/srcsim/Makefile.linux
+++ b/imsaisim/srcsim/Makefile.linux
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-dazzler.o cromemco-88ccc.o cromemco-d+7a.o diskmanager.o imsai-fif.o imsai-sio2.o imsai-hal.o imsai-vio.o unix_terminal.o unix_network.o netsrv.o generic-at-modem.o libtelnet.o rtc.o simbdos.o am9511.o floatcnv.o ova.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -112,126 +112,161 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
-
-fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
-
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/rtc.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 am9511.o: $(IO_DIR)/apu/am9511.c $(IO_DIR)/apu/am9511.h \
-	  $(IO_DIR)/apu/floatcnv.h $(IO_DIR)/apu/ova.h \
-	  $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/am9511.c
+ $(IO_DIR)/apu/floatcnv.h $(IO_DIR)/apu/ova.h \
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/am9511.c
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h \
+ $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-88ccc.c
+
+cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-d+7a.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
+
+diskmanager.o: $(IO_DIR)/diskmanager.c sim.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/diskmanager.c
 
 floatcnv.o: $(IO_DIR)/apu/floatcnv.c $(IO_DIR)/apu/floatcnv.h \
-	    $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/floatcnv.c
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/floatcnv.c
 
-ova.o: $(IO_DIR)/apu/ova.c $(IO_DIR)/apu/ova.h $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/ova.c
+fpmain.o: $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+generic-at-modem.o: $(IO_DIR)/generic-at-modem.c \
+ $(IO_DIR)/libtelnet.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/generic-at-modem.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-imsai-sio2.o: $(IO_DIR)/imsai-sio2.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-sio2.c
+imsai-fif.o: $(IO_DIR)/imsai-fif.c sim.h $(CORE_DIR)/simglb.h \
+ config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-fif.c
 
 imsai-hal.o: $(IO_DIR)/imsai-hal.c sim.h $(CORE_DIR)/simglb.h \
-	     $(CORE_DIR)/log.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-hal.c
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/imsai-hal.h \
+ $(IO_DIR)/generic-at-modem.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-hal.c
 
-imsai-fif.o: $(IO_DIR)/imsai-fif.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-fif.c
+imsai-sio2.o: $(IO_DIR)/imsai-sio2.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/imsai-hal.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-sio2.c
 
-diskmanager.o: $(IO_DIR)/diskmanager.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/diskmanager.c
+imsai-vio.o: $(IO_DIR)/imsai-vio.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/imsai-vio-charset.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-vio.c
 
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/unix_network.h $(IO_DIR)/imsai-sio2.h \
+ $(IO_DIR)/imsai-fif.h $(IO_DIR)/generic-at-modem.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/cromemco-d+7a.h \
+ $(IO_DIR)/imsai-vio.h $(FP_DIR)/frontpanel.h memory.h \
+ config.h $(CORE_DIR)/log.h $(IO_DIR)/rtc.h \
+ $(IO_DIR)/imsai-hal.h $(IO_DIR)/apu/am9511.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h $(CORE_DIR)/simglb.h \
-		  config.h memory.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-88ccc.c
+libtelnet.o: $(IO_DIR)/libtelnet.c $(IO_DIR)/libtelnet.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/libtelnet.c
 
-cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-d+7a.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-imsai-vio.o: $(IO_DIR)/imsai-vio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-vio.c
+netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(NET_DIR)/netsrv.c
 
-netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h memory.h $(NET_DIR)/netsrv.h \
-	  $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c ../../webfrontend/netsrv.c
-
-generic-at-modem.o: $(IO_DIR)/generic-at-modem.c $(IO_DIR)/libtelnet.h \
-		    $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/generic-at-modem.c
-
-libtelnet.o: $(IO_DIR)/libtelnet.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/libtelnet.c
+ova.o: $(IO_DIR)/apu/ova.c $(IO_DIR)/apu/ova.h \
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/ova.c
 
 rtc.o: $(IO_DIR)/rtc.c sim.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/rtc.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/rtc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
+
+unix_terminal.o: $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/imsaisim/srcsim/Makefile.osx
+++ b/imsaisim/srcsim/Makefile.osx
@@ -19,7 +19,7 @@ CCLD = $(CXX)
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = cromemco-dazzler.o cromemco-88ccc.o cromemco-d+7a.o diskmanager.o imsai-fif.o imsai-sio2.o imsai-hal.o imsai-vio.o unix_terminal.o unix_network.o netsrv.o generic-at-modem.o libtelnet.o rtc.o simbdos.o am9511.o floatcnv.o ova.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS = -lcivetweb
 
 # Installation directories by convention
@@ -113,126 +113,161 @@ _rm_obj:
 
 allclean: clean
 	rm -f $(EXEC)
-	rm -f ../disks/drive*.dsk
+	rm -f ../disks/drive[abcd].dsk
 	rm -f ../printer.txt
 
-#test: ; @echo $(ROOT_DIR)
-
-fpmain.o: $(CORE_DIR)/fpmain.cpp
-	$(CXX) $(CXXFLAGS) -c $(CORE_DIR)/fpmain.cpp
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
-
-config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h memory.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/rtc.h
-	$(CC) $(CFLAGS) -c iosim.c
-
-memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c memory.c
-
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h memory.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c simctl.c
-
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 am9511.o: $(IO_DIR)/apu/am9511.c $(IO_DIR)/apu/am9511.h \
-	  $(IO_DIR)/apu/floatcnv.h $(IO_DIR)/apu/ova.h \
-	  $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/am9511.c
+ $(IO_DIR)/apu/floatcnv.h $(IO_DIR)/apu/ova.h \
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/am9511.c
+
+config.o: config.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
+
+cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h \
+ $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-88ccc.c
+
+cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h \
+ $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-d+7a.c
+
+cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c sim.h \
+ $(CORE_DIR)/simglb.h config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/cromemco-dazzler.c
+
+diskmanager.o: $(IO_DIR)/diskmanager.c sim.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/diskmanager.c
 
 floatcnv.o: $(IO_DIR)/apu/floatcnv.c $(IO_DIR)/apu/floatcnv.h \
-	    $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/floatcnv.c
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/floatcnv.c
 
-ova.o: $(IO_DIR)/apu/ova.c $(IO_DIR)/apu/ova.h $(IO_DIR)/apu/types.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/apu/ova.c
+fpmain.o: $(CORE_DIR)/fpmain.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $(CORE_DIR)/fpmain.cpp
 
-unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+generic-at-modem.o: $(IO_DIR)/generic-at-modem.c \
+ $(IO_DIR)/libtelnet.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/generic-at-modem.c
 
-unix_network.o: $(IO_DIR)/unix_network.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_network.c
-
-imsai-sio2.o: $(IO_DIR)/imsai-sio2.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-sio2.c
+imsai-fif.o: $(IO_DIR)/imsai-fif.c sim.h $(CORE_DIR)/simglb.h \
+ config.h $(FP_DIR)/frontpanel.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-fif.c
 
 imsai-hal.o: $(IO_DIR)/imsai-hal.c sim.h $(CORE_DIR)/simglb.h \
-	     $(CORE_DIR)/log.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-hal.c
+ $(IO_DIR)/unix_terminal.h $(IO_DIR)/unix_network.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/imsai-hal.h \
+ $(IO_DIR)/generic-at-modem.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-hal.c
 
-imsai-fif.o: $(IO_DIR)/imsai-fif.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-fif.c
+imsai-sio2.o: $(IO_DIR)/imsai-sio2.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/imsai-hal.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-sio2.c
 
-diskmanager.o: $(IO_DIR)/diskmanager.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/diskmanager.c
+imsai-vio.o: $(IO_DIR)/imsai-vio.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h \
+ $(CORE_DIR)/log.h $(IO_DIR)/imsai-vio-charset.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/imsai-vio.c
 
-cromemco-dazzler.o: $(IO_DIR)/cromemco-dazzler.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-dazzler.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/unix_network.h $(IO_DIR)/imsai-sio2.h \
+ $(IO_DIR)/imsai-fif.h $(IO_DIR)/generic-at-modem.h \
+ $(IO_DIR)/cromemco-dazzler.h $(IO_DIR)/cromemco-d+7a.h \
+ $(IO_DIR)/imsai-vio.h $(FP_DIR)/frontpanel.h memory.h \
+ config.h $(CORE_DIR)/log.h $(IO_DIR)/rtc.h \
+ $(IO_DIR)/imsai-hal.h $(IO_DIR)/apu/am9511.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-cromemco-88ccc.o: $(IO_DIR)/cromemco-88ccc.c sim.h $(CORE_DIR)/simglb.h \
-		  config.h memory.h $(NET_DIR)/netsrv.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-88ccc.c
+libtelnet.o: $(IO_DIR)/libtelnet.c $(IO_DIR)/libtelnet.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/libtelnet.c
 
-cromemco-d+7a.o: $(IO_DIR)/cromemco-d+7a.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/cromemco-d+7a.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h config.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-imsai-vio.o: $(IO_DIR)/imsai-vio.c $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/imsai-vio.c
+netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(NET_DIR)/netsrv.c
 
-netsrv.o: $(NET_DIR)/netsrv.c sim.h $(CORE_DIR)/simglb.h memory.h $(NET_DIR)/netsrv.h \
-	  $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c ../../webfrontend/netsrv.c
-
-generic-at-modem.o: $(IO_DIR)/generic-at-modem.c $(IO_DIR)/libtelnet.h \
-		    $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/generic-at-modem.c
-
-libtelnet.o: $(IO_DIR)/libtelnet.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/libtelnet.c
+ova.o: $(IO_DIR)/apu/ova.c $(IO_DIR)/apu/ova.h \
+ $(IO_DIR)/apu/types.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/apu/ova.c
 
 rtc.o: $(IO_DIR)/rtc.c sim.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/rtc.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/rtc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ $(FP_DIR)/frontpanel.h memory.h $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h config.h \
+ $(FP_DIR)/frontpanel.h memory.h $(IO_DIR)/unix_terminal.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(FP_DIR)/frontpanel.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+unix_network.o: $(IO_DIR)/unix_network.c \
+ $(IO_DIR)/unix_network.h sim.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_network.c
+
+unix_terminal.o: $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/mosteksim/srcsim/GNUmakefile
+++ b/mosteksim/srcsim/GNUmakefile
@@ -7,7 +7,7 @@ MACHINE = mostek
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
 IO_SRCS = simbdos.c unix_terminal.c mostek-cpu.c mostek-fdc.c
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -22,8 +22,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-#ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -113,6 +111,27 @@ _rm_deps:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
+makerules:
+	@echo "# AUTOMATICALLY GENERATED DO NOT EDIT" >tmp.rules
+	@echo >>tmp.rules;
+	@for i in *.d; do \
+		sed -e 's;$(CORE_DIR);$$(CORE_DIR);g' \
+			-e 's;$(IO_DIR);$$(IO_DIR);g' <$$i >tmp.deps; \
+		cat tmp.deps >>tmp.rules; \
+		f=`sed 's/.*: \([^ ]*\).*/\1/;2,$$d' tmp.deps`; \
+		if grep -q '\.cpp' tmp.deps; then \
+			echo '	$$(CXX) $$(CXXFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		else \
+			echo '	$$(CC) $$(CFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		fi ; \
+		echo >>tmp.rules; \
+	done
+	@echo '# DO NOT PUT ANYTHING AFTER THIS LINE' >>tmp.rules;
+	@for i in Makefile.*; do \
+		sed '/^# AUTOMATICALLY GENERATED DO NOT EDIT/,$$d' <$$i >tmp.make; \
+		cat tmp.rules >>tmp.make; \
+		mv -f tmp.make $$i; \
+	done
+	@rm -f tmp.rules tmp.deps tmp.make
 
-.PHONY: all build install clean allclean
+.PHONY: all build install clean allclean makerules

--- a/mosteksim/srcsim/Makefile.bsd
+++ b/mosteksim/srcsim/Makefile.bsd
@@ -9,7 +9,7 @@ MACHINE = mostek
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = simbdos.o unix_terminal.o mostek-cpu.o mostek-fdc.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -24,12 +24,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
-# system wide location for machines configuration files
-CONF_DIR = $(ROOT_DIR)/conf
-# system wide location for disk images
-DISKS_DIR = $(ROOT_DIR)/disks
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -92,74 +86,88 @@ _rm_obj:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
-
-config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/mostek-cpu.h \
-	 $(IO_DIR)/mostek-fdc.h
-	$(CC) $(CFLAGS) -c iosim.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/mostek-cpu.h $(IO_DIR)/mostek-fdc.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
 memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c memory.c
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/unix_terminal.h \
-	  $(IO_DIR)/mostek-fdc.h
-	$(CC) $(CFLAGS) -c simctl.c
+mostek-cpu.o: $(IO_DIR)/mostek-cpu.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/unix_terminal.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/mostek-cpu.c
 
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+mostek-fdc.o: $(IO_DIR)/mostek-fdc.c sim.h $(CORE_DIR)/simglb.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/mostek-fdc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/mostek-fdc.h $(IO_DIR)/unix_terminal.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-mostek-cpu.o: $(IO_DIR)/mostek-cpu.c $(IO_DIR)/unix_terminal.h sim.h \
-	      $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/mostek-cpu.c
-
-mostek-fdc.o: $(IO_DIR)/mostek-fdc.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/mostek-fdc.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/mosteksim/srcsim/Makefile.cygwin
+++ b/mosteksim/srcsim/Makefile.cygwin
@@ -9,7 +9,7 @@ MACHINE = mostek
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = simbdos.o unix_terminal.o mostek-cpu.o mostek-fdc.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -24,12 +24,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
-# system wide location for machines configuration files
-CONF_DIR = $(ROOT_DIR)/conf
-# system wide location for disk images
-DISKS_DIR = $(ROOT_DIR)/disks
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -92,74 +86,88 @@ _rm_obj:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
-
-config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/mostek-cpu.h \
-	 $(IO_DIR)/mostek-fdc.h
-	$(CC) $(CFLAGS) -c iosim.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/mostek-cpu.h $(IO_DIR)/mostek-fdc.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
 memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c memory.c
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/unix_terminal.h \
-	  $(IO_DIR)/mostek-fdc.h
-	$(CC) $(CFLAGS) -c simctl.c
+mostek-cpu.o: $(IO_DIR)/mostek-cpu.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/unix_terminal.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/mostek-cpu.c
 
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+mostek-fdc.o: $(IO_DIR)/mostek-fdc.c sim.h $(CORE_DIR)/simglb.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/mostek-fdc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/mostek-fdc.h $(IO_DIR)/unix_terminal.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-mostek-cpu.o: $(IO_DIR)/mostek-cpu.c $(IO_DIR)/unix_terminal.h sim.h \
-	      $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/mostek-cpu.c
-
-mostek-fdc.o: $(IO_DIR)/mostek-fdc.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/mostek-fdc.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/mosteksim/srcsim/Makefile.linux
+++ b/mosteksim/srcsim/Makefile.linux
@@ -9,7 +9,7 @@ MACHINE = mostek
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = simbdos.o unix_terminal.o mostek-cpu.o mostek-fdc.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -24,12 +24,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
-# system wide location for machines configuration files
-CONF_DIR = $(ROOT_DIR)/conf
-# system wide location for disk images
-DISKS_DIR = $(ROOT_DIR)/disks
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -92,74 +86,88 @@ _rm_obj:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
-
-config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/mostek-cpu.h \
-	 $(IO_DIR)/mostek-fdc.h
-	$(CC) $(CFLAGS) -c iosim.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/mostek-cpu.h $(IO_DIR)/mostek-fdc.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
 memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c memory.c
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/unix_terminal.h \
-	  $(IO_DIR)/mostek-fdc.h
-	$(CC) $(CFLAGS) -c simctl.c
+mostek-cpu.o: $(IO_DIR)/mostek-cpu.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/unix_terminal.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/mostek-cpu.c
 
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+mostek-fdc.o: $(IO_DIR)/mostek-fdc.c sim.h $(CORE_DIR)/simglb.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/mostek-fdc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/mostek-fdc.h $(IO_DIR)/unix_terminal.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-mostek-cpu.o: $(IO_DIR)/mostek-cpu.c $(IO_DIR)/unix_terminal.h sim.h \
-	      $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/mostek-cpu.c
-
-mostek-fdc.o: $(IO_DIR)/mostek-fdc.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/mostek-fdc.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/mosteksim/srcsim/Makefile.osx
+++ b/mosteksim/srcsim/Makefile.osx
@@ -9,7 +9,7 @@ MACHINE = mostek
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS = simbdos.o unix_terminal.o mostek-cpu.o mostek-fdc.o
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -24,12 +24,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
-# system wide location for machines configuration files
-CONF_DIR = $(ROOT_DIR)/conf
-# system wide location for disk images
-DISKS_DIR = $(ROOT_DIR)/disks
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -92,74 +86,88 @@ _rm_obj:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
+config.o: config.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
-
-config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
-
-iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(CORE_DIR)/log.h \
-	 $(IO_DIR)/simbdos.h $(IO_DIR)/mostek-cpu.h \
-	 $(IO_DIR)/mostek-fdc.h
-	$(CC) $(CFLAGS) -c iosim.c
+iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/simbdos.h \
+ $(IO_DIR)/mostek-cpu.h $(IO_DIR)/mostek-fdc.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
 memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c memory.c
+	$(CC) $(CFLAGS) -c -o $@ memory.c
 
-simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h $(IO_DIR)/unix_terminal.h \
-	  $(IO_DIR)/mostek-fdc.h
-	$(CC) $(CFLAGS) -c simctl.c
+mostek-cpu.o: $(IO_DIR)/mostek-cpu.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/unix_terminal.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/mostek-cpu.c
 
-simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/simbdos.c
+mostek-fdc.o: $(IO_DIR)/mostek-fdc.c sim.h $(CORE_DIR)/simglb.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/mostek-fdc.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
+
+simbdos.o: $(IO_DIR)/simbdos.c sim.h $(CORE_DIR)/simglb.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/simbdos.c
+
+simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h \
+ $(IO_DIR)/mostek-fdc.h $(IO_DIR)/unix_terminal.h
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
 
 unix_terminal.o: $(IO_DIR)/unix_terminal.c
-	$(CC) $(CFLAGS) -c $(IO_DIR)/unix_terminal.c
+	$(CC) $(CFLAGS) -c -o $@ $(IO_DIR)/unix_terminal.c
 
-mostek-cpu.o: $(IO_DIR)/mostek-cpu.c $(IO_DIR)/unix_terminal.h sim.h \
-	      $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/mostek-cpu.c
-
-mostek-fdc.o: $(IO_DIR)/mostek-fdc.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(IO_DIR)/mostek-fdc.c
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/z80sim/srcsim/GNUmakefile
+++ b/z80sim/srcsim/GNUmakefile
@@ -7,7 +7,7 @@ MACHINE = z80
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
 IO_SRCS =
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -22,8 +22,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-# ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -32,7 +30,7 @@ SIM = ../$(MACHINE)sim
 
 CORE_DIR = ../../z80core
 
-VPATH = $(CORE_DIR) $(IO_DIR)
+VPATH = $(CORE_DIR)
 
 ###
 ### START O/S PLATFORM DEPENDENT VARIABLES
@@ -112,6 +110,26 @@ _rm_deps:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
+makerules:
+	@echo "# AUTOMATICALLY GENERATED DO NOT EDIT" >tmp.rules
+	@echo >>tmp.rules;
+	@for i in *.d; do \
+		sed -e 's;$(CORE_DIR);$$(CORE_DIR);g' <$$i >tmp.deps; \
+		cat tmp.deps >>tmp.rules; \
+		f=`sed 's/.*: \([^ ]*\).*/\1/;2,$$d' tmp.deps`; \
+		if grep -q '\.cpp' tmp.deps; then \
+			echo '	$$(CXX) $$(CXXFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		else \
+			echo '	$$(CC) $$(CFLAGS) -c -o $$@' $$f >>tmp.rules; \
+		fi ; \
+		echo >>tmp.rules; \
+	done
+	@echo '# DO NOT PUT ANYTHING AFTER THIS LINE' >>tmp.rules;
+	@for i in Makefile.*; do \
+		sed '/^# AUTOMATICALLY GENERATED DO NOT EDIT/,$$d' <$$i >tmp.make; \
+		cat tmp.rules >>tmp.make; \
+		mv -f tmp.make $$i; \
+	done
+	@rm -f tmp.rules tmp.deps tmp.make
 
-.PHONY: all build install clean allclean
+.PHONY: all build install clean allclean makerules

--- a/z80sim/srcsim/Makefile.bsd
+++ b/z80sim/srcsim/Makefile.bsd
@@ -9,7 +9,7 @@ MACHINE = z80
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS =
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -24,8 +24,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-# ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -87,58 +85,70 @@ _rm_obj:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
 iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c iosim.c
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-memory.o: memory.c sim.h
-	$(CC) $(CFLAGS) -c memory.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
 
 simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c simctl.c
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/z80sim/srcsim/Makefile.cygwin
+++ b/z80sim/srcsim/Makefile.cygwin
@@ -9,7 +9,7 @@ MACHINE = z80
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS =
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -24,8 +24,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-# ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -87,58 +85,70 @@ _rm_obj:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
 iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c iosim.c
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-memory.o: memory.c sim.h
-	$(CC) $(CFLAGS) -c memory.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
 
 simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c simctl.c
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/z80sim/srcsim/Makefile.linux
+++ b/z80sim/srcsim/Makefile.linux
@@ -9,7 +9,7 @@ MACHINE = z80
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS =
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -24,8 +24,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-# ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -87,58 +85,70 @@ _rm_obj:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
 iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c iosim.c
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-memory.o: memory.c sim.h
-	$(CC) $(CFLAGS) -c memory.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
 
 simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c simctl.c
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE

--- a/z80sim/srcsim/Makefile.osx
+++ b/z80sim/srcsim/Makefile.osx
@@ -9,7 +9,7 @@ MACHINE = z80
 MACHINE_OBJS = config.o iosim.o memory.o simctl.o
 # machine specific I/O object files
 IO_OBJS =
-#machine specifc libraries
+# machine specifc libraries
 MACHINE_LIBS =
 
 # Installation directories by convention
@@ -24,8 +24,6 @@ SYSCONFDIR = $(PREFIX)/etc
 HTMLDIR = $(DOCDIR)
 INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
 LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
-
-# ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -87,58 +85,70 @@ _rm_obj:
 allclean: clean
 	rm -f $(EXEC)
 
-#test: ; @echo $(ROOT_DIR)
-
-sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim0.c
-
-sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1.c
-
-sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim1a.c
-
-sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim2.c
-
-sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim3.c
-
-sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim4.c
-
-sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim5.c
-
-sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim6.c
-
-sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/sim7.c
-
-simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h config.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simdis.c
-
-simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/log.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simfun.c
-
-simglb.o: $(CORE_DIR)/simglb.c sim.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simglb.c
-
-simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simice.c
-
-simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c $(CORE_DIR)/simint.c
+# AUTOMATICALLY GENERATED DO NOT EDIT
 
 config.o: config.c
-	$(CC) $(CFLAGS) -c config.c
+	$(CC) $(CFLAGS) -c -o $@ config.c
 
 iosim.o: iosim.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c iosim.c
+	$(CC) $(CFLAGS) -c -o $@ iosim.c
 
-memory.o: memory.c sim.h
-	$(CC) $(CFLAGS) -c memory.c
+memory.o: memory.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ memory.c
+
+sim0.o: $(CORE_DIR)/sim0.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim0.c
+
+sim1.o: $(CORE_DIR)/sim1.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1.c
+
+sim1a.o: $(CORE_DIR)/sim1a.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim1a.c
+
+sim2.o: $(CORE_DIR)/sim2.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim2.c
+
+sim3.o: $(CORE_DIR)/sim3.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim3.c
+
+sim4.o: $(CORE_DIR)/sim4.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim4.c
+
+sim5.o: $(CORE_DIR)/sim5.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim5.c
+
+sim6.o: $(CORE_DIR)/sim6.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim6.c
+
+sim7.o: $(CORE_DIR)/sim7.c sim.h $(CORE_DIR)/simglb.h config.h \
+ memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/sim7.c
 
 simctl.o: simctl.c sim.h $(CORE_DIR)/simglb.h
-	$(CC) $(CFLAGS) -c simctl.c
+	$(CC) $(CFLAGS) -c -o $@ simctl.c
+
+simdis.o: $(CORE_DIR)/simdis.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simdis.c
+
+simfun.o: $(CORE_DIR)/simfun.c sim.h $(CORE_DIR)/simglb.h memory.h \
+ $(CORE_DIR)/log.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simfun.c
+
+simglb.o: $(CORE_DIR)/simglb.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simglb.c
+
+simice.o: $(CORE_DIR)/simice.c sim.h $(CORE_DIR)/simglb.h memory.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simice.c
+
+simint.o: $(CORE_DIR)/simint.c sim.h $(CORE_DIR)/simglb.h
+	$(CC) $(CFLAGS) -c -o $@ $(CORE_DIR)/simint.c
+
+# DO NOT PUT ANYTHING AFTER THIS LINE


### PR DESCRIPTION
1. Use magic to autogenerate Makefile.* rules. Should make maintenance of the old style Makefiles even easier.
2. Only remove drives a-d with allclean. Got already bitten by this as it removed my drivej.dsk work disk.
3. Some clean up of GNUmakefiles and Makefile.*s.