### PR TITLE
z80asm: bug fixes, Intel-like macros, misc stuff

### DIFF
--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -26,11 +26,11 @@ together with option -l.
 
 Option e:
 Set the significant number of characters in symbols to <num>.
-The default is 8.
+The default is 8 and the allowed range is 6 to 32.
 
 Option h:
 Set the maximum number of bytes per hex record to <num>.
-The default is 32.
+The default is 32 and the allowed range is 1 to 32.
 
 Option x:
 Don't fill binary files up to the last used logical address. This means,
@@ -142,7 +142,7 @@ PRINT   <'string'>      - print string to stdout
 ASEG                    - does nothing (like its alias ABS)
 
 
-Precedeuce for expression operators:
+Precedence for expression operators:
 
 ()
 unary + - ~ NOT HIGH LOW NUL TYPE

--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -111,16 +111,25 @@ IF1                     - assemble if in pass 1
 IF2                     - assemble if in pass 2
                           the '<' and '>' in the following pseudo ops
                           are required
-IFB     <seq>           - assemble if char sequence inside <> is empty
-IFNB    <seq>           - assemble if char sequence inside <> is not empty
-IFIDN   <seq1>,<seq2>   - assemble if char sequences inside <> are equal
-IFDIF   <seq1>,<seq2>   - assemble if char sequences inside <> are not equal
-
 ELSE                    - else for all conditionals
 ENDIF                   - end of conditional assembly
 
 The aliases COND and IFT for IF, and IFE for IFF, and ENDC for ENDIF are
 also accepted.
+
+
+Intel-like macros:
+<sym> MACRO <dummy>,... - define named macro
+IRP     <id>,<<cl,...>> - inline macro, iterate over character lists
+IRPC    <id>,<clist>    - inline macro, iterate over character list
+REPT    <count>         - inline macro, repeat <count> times
+ENDM                    - end macro
+EXITM                   - exit macro expansion
+MACLIB  <filename>      - include macro library
+IFB     <seq>           - assemble if char sequence inside <> is empty
+IFNB    <seq>           - assemble if char sequence inside <> is not empty
+IFIDN   <seq1>,<seq2>   - assemble if char sequences inside <> are equal
+IFDIF   <seq1>,<seq2>   - assemble if char sequences inside <> are not equal
 
 
 Manipulation of list file:

--- a/z80asm/Makefile
+++ b/z80asm/Makefile
@@ -20,6 +20,7 @@ OBJ =   z80amain.o \
 	z80atab.o \
 	z80anum.o \
 	z80aout.o \
+	z80amfun.o \
 	z80arfun.o \
 	z80apfun.o \
 	z80aopc.o \
@@ -39,6 +40,9 @@ z80anum.o : z80anum.c z80a.h z80aglb.h
 
 z80aout.o : z80aout.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80aout.c
+
+z80amfun.o : z80amfun.c z80a.h z80aglb.h
+	$(CC) $(CFLAGS) -c z80amfun.c
 
 z80arfun.o : z80arfun.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80arfun.c

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -1,5 +1,5 @@
 /*
- *	Z80 - Assembler
+ *	Z80 - Macro - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
  *
@@ -55,11 +55,14 @@ int  list_flag,			/* flag for option -l */
      phs_flag,			/* flag for being inside a .PHASE block */
      pass,			/* processed pass */
      iflevel,			/* IF nesting level */
+     condnest[IFNEST],		/* IF nesting stack */
      gencode,			/* flag for conditional code (>0 yes, <0 no) */
+     mac_def_nest,		/* macro definition nesting level */
+     mac_exp_nest,		/* macro expansion nesting level */
      errors,			/* error counter */
      errnum,			/* error number in pass 2 */
-     a_mode,			/* address output mode for pseudo ops */
-     a_addr,			/* output address for A_ADDR mode */
+     a_mode,			/* location output mode for pseudo ops */
+     a_addr,			/* output value for A_ADDR/A_VALUE mode */
      load_addr,			/* load address of program */
      load_flag,			/* flag for load_addr valid */
      start_addr,		/* start address of program */
@@ -75,7 +78,6 @@ FILE *srcfp,			/* file pointer for current source */
 
 unsigned
      c_line,			/* current line no. in current source */
-     s_line,			/* line no. counter for listing */
      p_line,			/* no. printed lines on page */
      ppl = PLENGTH,		/* page length */
      page;			/* no. of pages for listing */

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -1,5 +1,5 @@
 /*
- *	Z80 - Assembler
+ *	Z80 - Macro - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
  *
@@ -50,7 +50,10 @@ extern int	list_flag,
 		phs_flag,
 		pass,
 		iflevel,
+		condnest[],
 		gencode,
+		mac_def_nest,
+		mac_exp_nest,
 		errors,
 		errnum,
 		a_mode,
@@ -69,7 +72,6 @@ extern FILE	*srcfp,
 		*errfp;
 
 extern unsigned	c_line,
-		s_line,
 		p_line,
 		ppl,
 		page;

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -1,5 +1,5 @@
 /*
- *	Z80 - Assembler
+ *	Z80 - Macro - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
  *
@@ -37,8 +37,8 @@
 
 void init(void), options(int, char *[]);
 void usage(void), fatal(int, const char *);
-void do_pass(void), pass_file(char *);
-int pass_line(char *);
+void do_pass(int), process_file(char *);
+int process_line(char *);
 void open_o_files(char *), get_fn(char *, char *, const char *);
 char *get_label(char *, char *);
 char *get_opcode(char *, char *);
@@ -46,12 +46,20 @@ char *get_arg(char *, char *, int);
 
 /* z80aout.c */
 extern void asmerr(int);
-extern void lst_line(int, int);
+extern void lst_line(char *, int, int, int);
 extern void lst_sym(void);
 extern void lst_sort_sym(int);
 extern void obj_header(void);
 extern void obj_end(void);
 extern void obj_writeb(int);
+
+/* z80mfun.c */
+extern void mac_start_pass(void);
+extern void mac_end_pass(void);
+extern char *mac_expand(void);
+extern void mac_add_line(struct opc *, char *);
+extern int mac_lookup(char *);
+extern int mac_call(void);
 
 /* z80anum.c */
 int is_sym_char(char);
@@ -66,12 +74,13 @@ extern void a_sort_sym(int);
 
 static const char *errmsg[] = {		/* error messages for fatal() */
 	"out of memory: %s",		/* 0 */
-	"usage: z80asm -f{b|m|h} -s[n|a] -e<num> -h<num> -x -8 -u -v\n"
-	"              -o<file> -l[<file>] -d<symbol> ... <file> ...", /* 1 */
+	("usage: z80asm -f{b|m|h} -s[n|a] -e<num> -h<num> -x -8 -u -v\n"
+	 "              -o<file> -l[<file>] -d<symbol> ... <file> ..."),/* 1 */
 	"Assembly halted",		/* 2 */
 	"can't open file %s",		/* 3 */
 	"internal error: %s",		/* 4 */
-	"invalid hex record length: %s"	/* 5 */
+	"invalid symbol length: %s",	/* 5 */
+	"invalid hex record length: %s"	/* 6 */
 };
 
 int main(int argc, char *argv[])
@@ -80,11 +89,9 @@ int main(int argc, char *argv[])
 
 	init();
 	options(argc, argv);
-	printf("Z80 - Assembler Release %s, %s\n", REL, COPYR);
-	pass = 1;
-	do_pass();
-	pass = 2;
-	do_pass();
+	printf("Z80 - Macro - Assembler Release %s\n%s\n", REL, COPYR);
+	do_pass(1);
+	do_pass(2);
 	if (list_flag) {
 		switch (sym_flag) {
 		case 0:		/* no symbol table */
@@ -204,6 +211,8 @@ void options(int argc, char *argv[])
 					usage();
 				}
 				symlen = atoi(s);
+				if (symlen < 6 || symlen > 32)
+					fatal(F_SYMLEN, s);
 				s += (strlen(s) - 1);
 				break;
 			case 'h':
@@ -254,14 +263,15 @@ void fatal(int i, const char *arg)
 /*
  *	process all source files
  */
-void do_pass(void)
+void do_pass(int p)
 {
 	register int fi;
 
+	pass = p;
 	radix = 10;
 	rpc = pc = 0;
 	gencode = pass;
-	a_mode = A_STD;
+	mac_start_pass();
 	fi = 0;
 	if (ver_flag)
 		printf("Pass %d\n", pass);
@@ -272,9 +282,10 @@ void do_pass(void)
 	while (infiles[fi] != NULL) {
 		if (ver_flag)
 			printf("   Read    %s\n", infiles[fi]);
-		pass_file(infiles[fi]);
+		process_file(infiles[fi]);
 		fi++;
 	}
+	mac_end_pass();
 	if (pass == 1) {			/* PASS 1 */
 		if (errors) {
 			fclose(objfp);
@@ -287,7 +298,6 @@ void do_pass(void)
 		fclose(objfp);
 		printf("%d error(s)\n", errors);
 	}
-
 }
 
 /*
@@ -295,17 +305,24 @@ void do_pass(void)
  *
  *	Input: name of source file
  */
-void pass_file(char *fn)
+void process_file(char *fn)
 {
+	register char *l;
+
 	c_line = 0;
 	srcfn = fn;
 	if ((srcfp = fopen(fn, READA)) == NULL)
 		fatal(F_FOPEN, fn);
 	do {
-		if (fgets(line, MAXLINE, srcfp) == NULL)
+		l = NULL;
+		while (mac_exp_nest > 0 && (l = mac_expand()) == NULL)
+			;
+		if (l == NULL && (l = fgets(line, MAXLINE, srcfp)) == NULL)
 			break;
-	} while (pass_line(line));
+	} while (process_line(l));
 	fclose(srcfp);
+	if (mac_def_nest > 0)
+		asmerr(E_MISEMA);
 	if (phs_flag)
 		asmerr(E_MISDPH);
 	if (iflevel)
@@ -318,55 +335,87 @@ void pass_file(char *fn)
  *	Output: 1 line processed
  *		0 END
  */
-int pass_line(char *l)
+int process_line(char *l)
 {
 	register char *p;
-	register int op_count, lbl_flag;
+	register int op_count, lbl_flag, expn_flag;
 	register struct opc *op;
 
-	c_line++;
-	if (pass == 2)
-		s_line++;
+	/*
+	 *	need expn_flag and lbl_flag, since the conditions
+	 *	can change during opcode execution or macro definition
+	 */
+	expn_flag = (mac_exp_nest > 0);
+	if (!expn_flag)
+		c_line++;
+	a_mode = A_STD;
 	op = NULL;
 	op_count = 0;
 	p = get_label(label, l);
 	p = get_opcode(opcode, p);
 	lbl_flag = (gencode > 0 && *label != '\0');
-	if (*opcode != '\0') {
-		if ((op = search_op(opcode)) != NULL) {
-			if (lbl_flag) {
-				if (op->op_flags & OP_NOLBL)
-					asmerr(E_ILLLBL);
-				else if (!(op->op_flags & OP_SET))
-					if (gencode == 1)
-						put_label();
-			}
-			p = get_arg(operand, p, op->op_flags & OP_NOPRE);
-			if ((op->op_flags & OP_NOOPR) && *operand != '\0'
-						      && *operand != COMMENT)
-				asmerr(E_ILLOPE);
-			else if (gencode > 0 || (op->op_flags & OP_COND)) {
-				op_count = (*op->op_fun)(op->op_c1, op->op_c2);
-				if (lbl_flag && a_mode == A_NONE)
-					a_mode = A_STD;
-			} else
-				a_mode = A_NONE;
-		} else {
-			asmerr(E_ILLOPC);
+	if (mac_def_nest > 0) {
+		if (*opcode != '\0')
+			op = search_op(opcode);
+		mac_add_line(op, l);
+	} else if (*opcode == '\0') {
+		if (lbl_flag) {
+			if (gencode == 1)
+				put_label();
+		} else
 			a_mode = A_NONE;
-		}
-	} else if (lbl_flag) {
-		if (gencode == 1)
+	} else if (mac_lookup(opcode)) {
+		p = get_arg(operand, p, 1);
+		if (lbl_flag && gencode == 1)
 			put_label();
-	} else
+		if (gencode > 0) {
+			mac_call();
+			if (lbl_flag)
+				a_mode = A_STD;
+		} else
+			a_mode = A_NONE;
+	} else if ((op = search_op(opcode)) != NULL) {
+		p = get_arg(operand, p, op->op_flags & OP_NOPRE);
+		if (lbl_flag) {
+			if (op->op_flags & OP_NOLBL)
+				asmerr(E_ILLLBL);
+			else if (!(op->op_flags & OP_SET))
+				if (gencode == 1)
+					put_label();
+		}
+		if (*operand != '\0' && *operand != COMMENT
+				     && (op->op_flags & OP_NOOPR))
+			asmerr(E_ILLOPE);
+		else if (gencode > 0 || (op->op_flags & OP_COND)) {
+			if (pass == 2 && (op->op_flags & OP_INCL)) {
+				/* list INCLUDE before include file */
+				a_mode = A_NONE;
+				lst_line(l, 0, 0, expn_flag);
+			}
+			op_count = (*op->op_fun)(op->op_c1, op->op_c2);
+			if (lbl_flag && !(op->op_flags & OP_SET)
+				     && a_mode == A_NONE)
+				a_mode = A_STD;
+		} else
+			a_mode = A_NONE;
+	} else {
+		asmerr(E_ILLOPC);
 		a_mode = A_NONE;
-	if (pass == 2) {
-		obj_writeb(op_count);
-		lst_line(pc, op_count);
 	}
-	pc += op_count;
-	rpc += op_count;
-	return(op == NULL || !(op->op_flags & OP_END));
+	if (pass == 2) {
+		if (gencode > 0 && (op == NULL || !(op->op_flags & OP_DS)))
+			obj_writeb(op_count);
+		/* already listed INCLUDE */
+		if ((op == NULL || !(op->op_flags & OP_INCL))
+		    && !(expn_flag && (a_mode == A_NONE || op_count == 0)))
+			lst_line(l, pc, op_count, expn_flag);
+	}
+	if (gencode > 0) {
+		pc += op_count;
+		rpc += op_count;
+		return(op == NULL || !(op->op_flags & OP_END));
+	} else
+		return(1);
 }
 
 /*
@@ -474,7 +523,7 @@ char *get_opcode(char *s, char *l)
 		goto comment;
 	while (isspace((unsigned char) *l))
 		l++;
-	while (!isspace((unsigned char) *l) && *l != COMMENT)
+	while (!isspace((unsigned char) *l) && *l != COMMENT && *l != '\0')
 		*s++ = toupper((unsigned char) *l++);
 comment:
 	*s = '\0';
@@ -550,7 +599,7 @@ char *next_arg(char *p, int *str_flag)
 	register char c;
 	register int sf;
 
-	sf = 1;					/* pretend it is a string */
+	sf = 1;					/* assume it is a string */
 	while (*p != '\0' && *p != ',') {
 		c = *p++;
 		if (c == STRDEL || c == STRDEL2) {

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -1,0 +1,1140 @@
+/*
+ *	Z80 - Macro - Assembler - Intel-like macro implementation
+ *	Copyright (C) 2022 by Thomas Eberhardt
+ *
+ *	History:
+ *	??-OCT-2022 Intel-like macros
+ */
+
+/*
+ *	processing of all macro PSEUDO ops
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include "z80a.h"
+#include "z80aglb.h"
+
+/* z80amain.c */
+extern void fatal(int, const char *);
+extern void process_line(char *);
+extern char *next_arg(char *, int *);
+
+/* z80anum.c */
+extern int is_first_sym_char(char);
+extern int is_sym_char(char);
+extern int eval(char *);
+
+/* z80aout.c */
+extern void asmerr(int);
+
+/* z80atab.c */
+extern char *strsave(char *);
+
+#define MACNEST	16				/* max. expansion nesting */
+
+struct dum {					/* macro dummy */
+	char *dum_name;				/* dummy name */
+	struct dum *dum_next;
+};
+
+struct line {					/* macro source line */
+	char *line_text;			/* source line */
+	struct line *line_next;
+};
+
+struct expn;
+
+struct mac {					/* macro */
+	void (*mac_start)(struct expn *);	/* start expansion function */
+	int (*mac_rept)(struct expn *);		/* repeat expansion function */
+	char *mac_name;				/* macro name */
+	int mac_level;				/* definition nesting level */
+	int mac_count;				/* REPT count */
+	char *mac_irp;				/* IRP, IRPC character list */
+	struct dum *mac_dums, *mac_dums_last;	/* macro dummies */
+	struct line *mac_lines, *mac_lines_last; /* macro body */
+	struct mac *mac_next;
+};
+
+struct parm {					/* expansion parameter */
+	char *parm_name;			/* dummy name */
+	char *parm_val;				/* parameter value */
+	struct parm *parm_next;
+};
+
+struct loc {					/* expansion local label */
+	char *loc_name;				/* local label name */
+	char loc_val[8];			/* local label value ??xxxx */
+	struct loc *loc_next;
+};
+
+struct expn {					/* macro expansion */
+	struct mac *expn_mac;			/* macro being expanded */
+	struct parm *expn_parms, *expn_parms_last; /* macro parameters */
+	struct loc *expn_locs;			/* expansion local labels */
+	struct line *expn_line;			/* current expansion line */
+	int expn_iflevel;			/* iflevel before expansion */
+	int expn_iter;				/* curr. expansion iteration */
+	char *expn_irp;				/* IRP, IRPC character list */
+};
+
+static struct mac *mac_table;			/* MACRO table */
+static struct mac *mac_def;			/* macro being defined */
+static struct mac *mac_found;			/* found macro */
+static struct expn mac_expn[MACNEST];		/* macro expansion stack */
+static int mac_loc_cnt;				/* counter for LOCAL labels */
+static char tmp[MAXLINE + 1];			/* temporary buffer */
+
+void mac_print_table(void)
+{
+	register struct mac *m;
+	register struct dum *d;
+	register struct line *l;
+
+	for (m = mac_table; m != NULL; m = m->mac_next) {
+		printf("MACRO: %s\n", m->mac_name);
+		for (d = m->mac_dums; d != NULL; d = d->dum_next)
+			printf("DUMMY: %s\n", d->dum_name);
+		for (l = m->mac_lines; l != NULL; l = l->line_next)
+			printf("LINE: %s", l->line_text);
+		putchar('\n');
+	}
+}
+
+/*
+ *	verify that p is a legal symbol
+ *	return 1 if legal, otherwise 0
+ */
+int is_symbol(char *p)
+{
+	if (!is_sym_char(*p) || isdigit((unsigned char) *p))
+		return(0);
+	p++;
+	while (is_sym_char(*p))
+		p++;
+	return(*p == '\0');
+}
+
+/*
+ *	allocate a new macro with optional name and
+ *	start/repeat expansion function
+ */
+struct mac *mac_new(char *name, void (*start)(struct expn *),
+		    int (*rept)(struct expn *))
+{
+	struct mac *m;
+
+	if ((m = (struct mac *) malloc(sizeof(struct mac))) == NULL)
+		fatal(F_OUTMEM, "macro");
+	if (name != NULL) {
+		if ((m->mac_name = strsave(name)) == NULL)
+			fatal(F_OUTMEM, "macro name");
+	} else
+		m->mac_name = NULL;
+	m->mac_level = mac_exp_nest;
+	m->mac_start = start;
+	m->mac_rept = rept;
+	m->mac_count = 0;
+	m->mac_irp = NULL;
+	m->mac_dums_last = m->mac_dums = NULL;
+	m->mac_lines_last = m->mac_lines = NULL;
+	m->mac_next = NULL;
+	return(m);
+}
+
+/*
+ *	delete a macro
+ */
+void mac_delete(struct mac *m)
+{
+	struct dum *d, *d1;
+	struct line *ln, *ln1;
+
+	for (d = m->mac_dums; d != NULL; d = d1) {
+		d1 = d->dum_next;
+		free(d->dum_name);
+		free(d);
+	}
+	for (ln = m->mac_lines; ln != NULL; ln = ln1) {
+		ln1 = ln->line_next;
+		free(ln->line_text);
+		free(ln);
+	}
+	if (m->mac_irp != NULL)
+		free(m->mac_irp);
+	if (m->mac_name != NULL)
+		free(m->mac_name);
+	free(m);
+}
+
+/*
+ *	initialize variables at start of pass
+ */
+void mac_start_pass(void)
+{
+	mac_loc_cnt = 0;
+}
+
+/*
+ *	clean up at end of pass
+ */
+void mac_end_pass(void)
+{
+	register struct mac *m;
+
+	while (mac_table != NULL) {
+		m = mac_table->mac_next;
+		mac_delete(mac_table);
+		mac_table = m;
+	}
+}
+
+/*
+ * 	add a dummy to a macro
+ */
+void mac_add_dum(struct mac *m, char *name)
+{
+	register struct dum *d;
+
+	for (d = m->mac_dums; d; d = d->dum_next)
+		if (strcmp(d->dum_name, name) == 0) {
+			asmerr(E_MULSYM);
+			return;
+		}
+	d = (struct dum *) malloc(sizeof(struct dum));
+	if (d == NULL || (d->dum_name = strsave(name)) == NULL)
+		fatal(F_OUTMEM, "macro dummy");
+	d->dum_next = NULL;
+	if (m->mac_dums == NULL)
+		m->mac_dums = d;
+	else
+		m->mac_dums_last->dum_next = d;
+	m->mac_dums_last = d;
+}
+
+/*
+ * 	add a local to a macro expansion
+ */
+void expn_add_loc(struct expn *e, char *name)
+{
+	register struct loc *l;
+	register struct dum *d;
+
+	for (l = e->expn_locs; l; l = l->loc_next)
+		if (strcmp(l->loc_name, name) == 0) {
+			asmerr(E_MULSYM);
+			return;
+		}
+	for (d = e->expn_mac->mac_dums; d; d = d->dum_next)
+		if (strcmp(d->dum_name, name) == 0) {
+			asmerr(E_MULSYM);
+			return;
+		}
+	l = (struct loc *) malloc(sizeof(struct loc));
+	if (l == NULL || (l->loc_name = strsave(name)) == NULL)
+		fatal(F_OUTMEM, "macro local label");
+	l->loc_next = e->expn_locs;
+	e->expn_locs = l;
+}
+
+/*
+ *	start macro expansion
+ *	assign values to parameters, save iflevel
+ */
+void mac_start_expn(struct mac *m)
+{
+	register struct expn *e;
+	register struct dum *d;
+	register struct parm *p;
+
+	if (mac_exp_nest == MACNEST) {
+		/* abort macro expansion */
+		mac_exp_nest = 0;
+		if ((iflevel = mac_expn[0].expn_iflevel) > 0)
+			gencode = condnest[iflevel - 1];
+		else
+			gencode = pass;
+		asmerr(E_MACNEST);
+		return;
+	}
+	if (m->mac_lines != NULL) {
+		e = &mac_expn[mac_exp_nest];
+		e->expn_mac = m;
+		e->expn_parms_last = e->expn_parms = NULL;
+		for (d = m->mac_dums; d; d = d->dum_next) {
+			p = (struct parm *) malloc(sizeof(struct parm));
+			if (p == NULL)
+				fatal(F_OUTMEM, "macro parameter");
+			p->parm_name = d->dum_name;
+			p->parm_val = NULL;
+			p->parm_next = NULL;
+			if (e->expn_parms == NULL)
+				e->expn_parms = p;
+			else
+				e->expn_parms_last->parm_next = p;
+			e->expn_parms_last = p;
+		}
+		e->expn_locs = NULL;
+		e->expn_line = m->mac_lines;
+		e->expn_iflevel = iflevel;
+		e->expn_iter = 0;
+		e->expn_irp = m->mac_irp;
+		(*m->mac_start)(e);
+		mac_exp_nest++;
+	}
+}
+
+/*
+ *	end macro expansion
+ *	delete parameters and local labels, restore iflevel
+ */
+void mac_end_expn(void)
+{
+	register struct expn *e;
+	register struct parm *p, *p1;
+	register struct loc *l, *l1;
+	register struct mac *m;
+
+	e = &mac_expn[mac_exp_nest - 1];
+	for (p = e->expn_parms; p; p = p1) {
+		p1 = p->parm_next;
+		if (p->parm_val != NULL)
+			free(p->parm_val);
+		free(p);
+	}
+	for (l = e->expn_locs; l; l = l1) {
+		l1 = l->loc_next;
+		free(l);
+	}
+	if ((iflevel = e->expn_iflevel) > 0)
+		gencode = condnest[iflevel - 1];
+	else
+		gencode = pass;
+	m = e->expn_mac;
+	mac_exp_nest--;
+	/* delete unnamed macros (IRP, IRPC, REPT) */
+	if (m->mac_name == NULL)
+		mac_delete(m);
+}
+
+/*
+ *	repeat macro for IRP, IRPC, REPT when end reached
+ *	end expansion for MACRO
+ */
+int mac_rept_expn(void)
+{
+	register struct expn *e;
+	register struct mac *m;
+	register struct loc *l, *l1;
+
+	e = &mac_expn[mac_exp_nest - 1];
+	e->expn_iter++;
+	m = e->expn_mac;
+	if (*m->mac_rept != NULL && (*m->mac_rept)(e)) {
+		for (l = e->expn_locs; l; l = l1) {
+			l1 = l->loc_next;
+			free(l);
+		}
+		if ((iflevel = e->expn_iflevel) > 0)
+			gencode = condnest[iflevel - 1];
+		else
+			gencode = pass;
+		e->expn_locs = NULL;
+		e->expn_line = m->mac_lines;
+		return(1);
+	} else {
+		mac_end_expn();
+		return(0);
+	}
+}
+
+/*
+ *	add source line l to current macro definition
+ */
+void mac_add_line(struct opc *op, char *line)
+{
+	register struct line *l;
+	register struct mac *m;
+
+	a_mode = A_NONE;
+	l = (struct line *) malloc(sizeof(struct line));
+	if (l == NULL || (l->line_text = strsave(line)) == NULL)
+		fatal(F_OUTMEM, "macro body line");
+	l->line_next = NULL;
+	m = mac_def;
+	if (m->mac_lines == NULL)
+		m->mac_lines = l;
+	else
+		m->mac_lines_last->line_next = l;
+	m->mac_lines_last = l;
+	if (op != NULL) {
+		if (op->op_flags & OP_MDEF)
+			mac_def_nest++;
+		else if (op->op_flags & OP_MEND) {
+			if (--mac_def_nest == 0) {
+				m = mac_def;
+				mac_def = NULL;
+				/* start expansion for IRP, IRPC, REPT */
+				if (m->mac_name == NULL)
+					mac_start_expn(m);
+			}
+		}
+	}
+}
+
+/*
+ *	return value of dummy or local s, NULL if not found
+ */
+const char *mac_get_dumloc(struct expn *e, char *s)
+{
+	register struct parm *p;
+	register struct loc *l;
+
+	for (p = e->expn_parms; p; p = p->parm_next)
+		if (strcmp(p->parm_name, s) == 0)
+			return(p->parm_val == NULL ? "" : p->parm_val);
+	for (l = e->expn_locs; l; l = l->loc_next)
+		if (strcmp(l->loc_name, s) == 0)
+			return(l->loc_val);
+	return(NULL);
+}
+
+/*
+ *	substitute dummies and locals with actual values
+ *	in current expansion source line and return the
+ *	result
+ */
+char *mac_subst_dumloc(struct expn *e)
+{
+	register char *p, *q, *q1;
+	register const char *v;
+	register char c;
+	register int n, amp_flag;
+
+	p = e->expn_line->line_text;
+	if (*p == LINCOM)
+		return(p);
+	q = tmp;
+	*q++ = ' ';
+	n = 0;
+	while (*p != '\n' && *p != '\0') {
+		if (is_first_sym_char(*p)) {
+			q1 = q;
+			*q++ = toupper((unsigned char) *p++);
+			while (is_sym_char(*p))
+				*q++ = toupper((unsigned char) *p++);
+			if (*(q1 - 1) != '^') {
+				*q = '\0';
+				v = mac_get_dumloc(e, q1);
+				if (v != NULL) {
+					if (*(q1 - 1) == '&')
+						q1--;
+					q = q1;
+					while (*v != '\0')
+						*q++ = *v++;
+					if (*p == '&')
+						p++;
+				}
+			}
+		} else if (*p == STRDEL || *p == STRDEL2) {
+			*q++ = c = *p++;
+			amp_flag = 0;
+			while (1) {
+				if (*p == '\n' || *p == '\0') {
+					asmerr(E_MISDEL);
+					goto done;
+				} else if (*p == c) {
+					amp_flag = 0;
+					*q++ = *p++;
+					if (*p != c)
+						break;
+					else {
+						*q++ = *p++;
+						continue;
+					}
+				} else if (is_first_sym_char(*p)) {
+					q1 = q;
+					*q++ = *p++;
+					while (is_sym_char(*p))
+						*q++ = *p++;
+					*q = '\0';
+					if (*(q1 - 1) == '&' || *p == '&'
+							     || amp_flag) {
+						amp_flag = 0;
+						v = mac_get_dumloc(e, q1);
+						if (v != NULL) {
+							if (*(q1 - 1) == '&')
+								q1--;
+							q = q1;
+							while (*v != '\0')
+								*q++ = *v++;
+							if (*p == '&') {
+								amp_flag = 1;
+								p++;
+							}
+						}
+					}
+				} else {
+					amp_flag = 0;
+					*q++ = *p++;
+				}
+			}
+		} else if (*p == '^') {
+			*q++ = *p++;
+			if (*p != '\n' && *p != '\0')
+				*q++ = toupper((unsigned char) *p++);
+			else {
+				asmerr(E_ILLOPE);
+				goto done;
+			}
+		} else if (*p == '<') {
+			n++;
+			*q++ = *p++;
+		} else if (*p == '>') {
+			n--;
+			*q++ = *p++;
+		} else if (n == 0 && *p == COMMENT) {
+			if (*(p + 1) != COMMENT)
+				while (*p != '\n' && *p != '\0')
+					*q++ = *p++;
+			goto done;
+		} else
+			*q++ = toupper((unsigned char) *p++);
+	}
+	if (n > 0)
+		asmerr(E_MISDEL);
+done:
+	*q++ = '\n';
+	*q = '\0';
+	return(tmp + 1);
+}
+
+/*
+ *	get next macro expansion line
+ */
+char *mac_expand(void)
+{
+	register struct expn *e;
+	register char *p;
+
+	e = &mac_expn[mac_exp_nest - 1];
+	if (e->expn_line == NULL && !mac_rept_expn())
+		return(NULL);
+	p = mac_subst_dumloc(e);
+	e->expn_line = e->expn_line->line_next;
+	return(p);
+}
+
+/*
+ *	macro lookup
+ */
+int mac_lookup(char *opcode)
+{
+	register struct mac *m;
+
+	mac_found = NULL;
+	for (m = mac_table; m; m = m->mac_next)
+		if (strcmp(m->mac_name, opcode) == 0) {
+			mac_found = m;
+			return(1);
+		}
+	return(0);
+}
+
+/*
+ *	MACRO invocation, to be called after successful mac_lookup()
+ */
+void mac_call(void)
+{
+	if (mac_found != NULL)
+		mac_start_expn(mac_found);
+	else
+		fatal(F_INTERN, "mac_call with no macro");
+}
+
+/*
+ *	get next MACRO or IRP parameter
+ */
+char *mac_next_parm(char *s)
+{
+	register char *t, c;
+	register int n;
+
+	t = tmp;
+	while (isspace((unsigned char) *s))
+		s++;
+	if (*s == STRDEL || *s == STRDEL2) {
+		*t++ = c = *s++;
+		while (1) {
+			if (*s == '\n' || *s == '\0') {
+				asmerr(E_MISDEL);
+				return(NULL);
+			} else if (*s == c) {
+				if (*(s + 1) != c)
+					break;
+				else
+					s++;
+			}
+			*t++ = *s++;
+		}
+		*t++ = *s++;
+	} else if (*s == '<') {
+		s++;
+		n = 0;
+		while (1) {
+			if (*s == '\n' || *s == '\0'
+				       || *s == COMMENT) {
+				asmerr(E_MISDEL);
+				return(NULL);
+			} else if (*s == '<')
+				n++;
+			else if (*s == '>') {
+				if (n == 0)
+					break;
+				else
+					n--;
+			} else if (*s == '^') {
+				s++;
+				if (*s == '\n' || *s == '\0') {
+					asmerr(E_ILLOPE);
+					return(NULL);
+				}
+			} else if (*s == STRDEL || *s == STRDEL2) {
+				*t++ = c = *s++;
+				while (1) {
+					if (*s == '\n' || *s == '\0') {
+						asmerr(E_MISDEL);
+						return(NULL);
+					} else if (*s == c) {
+						if (*(s + 1) != c)
+							break;
+						else
+							s++;
+					}
+					*t++ = *s++;
+				}
+			}
+			*t++ = toupper((unsigned char) *s++);
+		}
+		s++;
+#if 0
+	} else if (*s == '^') {
+		s++;
+		if (*s == '\n' || *s == '\0') {
+			asmerr(E_ILLOPE);
+			return(NULL);
+		}
+		*t++ = toupper((unsigned char) *s++);
+#endif
+	} else if (*s == '%') {
+		s++;
+		while (*s != '\n' && *s != '\0'
+				  && *s != ',' && *s != COMMENT) {
+			*t++ = c = toupper((unsigned char) *s++);
+			if (c == STRDEL || c == STRDEL2) {
+				while (1) {
+					if (*s == '\n' || *s == '\0') {
+						asmerr(E_MISDEL);
+						return(NULL);
+					} else if (*s == c) {
+						*t++ = *s++;
+						if (*s != c)
+							break;
+					}
+					*t++ = *s++;
+				}
+			}
+		}
+		*t = '\0';
+		sprintf(tmp, "%d", eval(tmp));
+		t = tmp + strlen(tmp);
+	} else
+		while (!isspace((unsigned char) *s) && *s != '\n'
+						    && *s != '\0'
+						    && *s != ','
+						    && *s != COMMENT)
+			*t++ = toupper((unsigned char) *s++);
+	while (isspace((unsigned char) *s))
+		s++;
+	*t = '\0';
+	return s;
+}
+
+/*
+ *	start IRP macro expansion
+ */
+void mac_start_irp(struct expn *e)
+{
+	register char *s;
+
+	if (*e->expn_irp != '\0') {
+		if ((s = mac_next_parm(e->expn_irp)) != NULL) {
+			e->expn_irp = s;
+			if ((s = strsave(tmp)) == NULL)
+				fatal(F_OUTMEM, "IRP character list");
+			e->expn_parms->parm_val = s;
+		}
+	}
+}
+
+/*
+ *	repeat IRP macro expansion
+ */
+int mac_rept_irp(struct expn *e)
+{
+	register char *s;
+
+	s = e->expn_irp;
+	if (*s == '\0')
+		return(0);
+	else if (*s != ',') {
+		asmerr(E_ILLOPE);
+		return(0);
+	} else {
+		if ((s = mac_next_parm(s + 1)) == NULL)
+			return(0);
+		e->expn_irp = s;
+		if ((s = strsave(tmp)) == NULL)
+			fatal(F_OUTMEM, "IRP character list");
+		if (e->expn_parms->parm_val != NULL)
+			free(e->expn_parms->parm_val);
+		e->expn_parms->parm_val = s;
+		return(1);
+	}
+}
+
+/*
+ *	start IRPC macro expansion
+ */
+void mac_start_irpc(struct expn *e)
+{
+	register char *s;
+
+	if (*e->expn_irp != '\0') {
+		if ((s = (char *) malloc(sizeof(char) * 2)) == NULL)
+			fatal(F_OUTMEM, "IRPC character");
+		*s = *e->expn_irp++;
+		*(s + 1) = '\0';
+		e->expn_parms->parm_val = s;
+	}
+}
+
+/*
+ *	repeat IRPC macro expansion
+ */
+int mac_rept_irpc(struct expn *e)
+{
+	if (*e->expn_irp != '\0') {
+		e->expn_parms->parm_val[0] = *e->expn_irp++;
+		return(1);
+	} else
+		return(0);
+}
+
+/*
+ *	start MACRO macro expansion
+ */
+void mac_start_macro(struct expn *e)
+{
+	register char *s;
+	register struct parm *p;
+
+	s = operand;
+	p = e->expn_parms;
+	while (p != NULL && *s != '\n' && *s != '\0' && *s != COMMENT) {
+		if ((s = mac_next_parm(s)) == NULL)
+			return;
+		if (*s == ',') {
+			s++;
+			while (isspace((unsigned char) *s))
+				s++;
+		} else if (*s != '\0' && *s != COMMENT) {
+			asmerr(E_ILLOPE);
+			return;
+		}
+		if ((p->parm_val = strsave(tmp)) == NULL)
+			fatal(F_OUTMEM, "parameter assignment");
+		p = p->parm_next;
+	}
+}
+
+/*
+ *	start REPT macro expansion
+ */
+void mac_start_rept(struct expn *e)
+{
+	if (e->expn_mac->mac_count <= 0)
+		e->expn_line = NULL;
+}
+
+/*
+ *	repeat REPT macro expansion
+ */
+int mac_rept_rept(struct expn *e)
+{
+	return(e->expn_iter < e->expn_mac->mac_count);
+}
+
+/*
+ *	ENDM
+ */
+int op_endm(int dummy1, int dummy2)
+{
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
+	a_mode = A_NONE;
+	if (mac_exp_nest == 0)
+		asmerr(E_NIMEXP);
+	else
+		(void) mac_rept_expn();
+	return(0);
+}
+
+/*
+ *	EXITM
+ */
+int op_exitm(int dummy1, int dummy2)
+{
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
+	a_mode = A_NONE;
+	if (mac_exp_nest == 0)
+		asmerr(E_NIMEXP);
+	else
+		mac_end_expn();
+	return(0);
+}
+
+/*
+ *	IFB, IFNB, IFIDN, IFDIF
+ */
+int op_mcond(int op_code, int dummy)
+{
+	register char *p, *p1, *p2;
+
+	UNUSED(dummy);
+
+	a_mode = A_NONE;
+	if (iflevel >= IFNEST) {
+		asmerr(E_IFNEST);
+		return(0);
+	}
+	condnest[iflevel++] = gencode;
+	if (gencode < 0)
+		return(0);
+	switch(op_code) {
+	case 1:				/* IFB */
+	case 2:				/* IFNB */
+	case 3:				/* IFIDN */
+	case 4:				/* IFDIF */
+		p = operand;
+		if (*p == '\0' || *p == COMMENT) {
+			asmerr(E_MISOPE);
+			return(0);
+		}
+		if (*p++ != '<') {
+			asmerr(E_ILLOPE);
+			return(0);
+		}
+		while (*p != '>' && *p != '\0' && *p != COMMENT)
+			p++;
+		if (*p++ != '>') {
+			asmerr(E_MISPAR);
+			return(0);
+		}
+		p1 = p;
+		while (isspace((unsigned char) *p1))
+			p1++;
+		if (op_code == 1 || op_code == 2) { /* IFB and IFNB */
+			if (*p1 != '\0' && *p1 != COMMENT) {
+				asmerr(E_ILLOPE);
+				return(0);
+			}
+			gencode = ((p - operand) == 2) ? pass : -pass;
+		} else {		/* IFIDN and IFDIF */
+			if (*p1 != ',') {
+				asmerr(E_MISOPE);
+				return(0);
+			}
+			*p = '\0';
+			while (isspace((unsigned char) *p1))
+				p1++;
+			p = p1;
+			if (*p1++ != '<') {
+				asmerr(E_ILLOPE);
+				return(0);
+			}
+			while (*p1 != '>' && *p1 != '\0' && *p1 != COMMENT)
+				p1++;
+			if (*p1++ != '>') {
+				asmerr(E_MISPAR);
+				return(0);
+			}
+			p2 = p1;
+			while (isspace((unsigned char) *p2))
+				p2++;
+			if (*p2 != '\0' && *p2 != COMMENT) {
+				asmerr(E_ILLOPE);
+				return(0);
+			}
+			*p1 = '\0';
+			gencode = (strcmp(operand, p) == 0) ? pass : -pass;
+		}
+		break;
+	default:
+		fatal(F_INTERN, "invalid opcode for function op_mcond");
+		break;
+	}
+	if ((op_code & 1) == 0)		/* negate for inverse IF */
+		gencode = -gencode;
+	return(0);
+}
+
+/*
+ *	IRP
+ */
+int op_irp(int dummy1, int dummy2)
+{
+	register char *s, *t, c;
+	register struct mac *m;
+	register int n;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
+	a_mode = A_NONE;
+	m = mac_new(NULL, mac_start_irp, mac_rept_irp);
+	s = operand;
+	t = tmp;
+	if (!is_first_sym_char(*s)) {
+		asmerr(E_ILLOPE);
+		return(0);
+	}
+	*t++ = toupper((unsigned char) *s++);
+	while (is_sym_char(*s))
+		*t++ = toupper((unsigned char) *s++);
+	*t = '\0';
+	mac_add_dum(m, tmp);
+	while (isspace((unsigned char) *s))
+		s++;
+	if (*s++ != ',') {
+		asmerr(E_ILLOPE);
+		return(0);
+	}
+	while (isspace((unsigned char) *s))
+		s++;
+	t = tmp;
+	n = 0;
+	if (*s++ != '<') {
+		asmerr(E_ILLOPE);
+		return(0);
+	}
+	while (1) {
+		if (*s  == '\n' || *s == '\0' || *s == COMMENT) {
+			asmerr(E_MISDEL);
+			return(0);
+		} else if (*s == STRDEL || *s == STRDEL2) {
+			*t++ = c = *s++;
+			while (1) {
+				if (*s == '\n' || *s == '\0') {
+					asmerr(E_MISDEL);
+					return(0);
+				} else if (*s == c) {
+					*t++ = *s++;
+					if (*s != c)
+						break;
+					else {
+						*t++ = *s++;
+						continue;
+					}
+				} else
+					*t++ = *s++;
+			}
+		} else if (*s == '^') {
+			*t++ = *s++;
+			if (*s != '\n' || *s != '\0')
+				*t++ = toupper((unsigned char) *s++);
+			else {
+				asmerr(E_ILLOPE);
+				return(0);
+			}
+		} else if (*s == '<') {
+			n++;
+			*t++ = *s++;
+		} else if (*s == '>') {
+			if (n == 0)
+				break;
+			else {
+				n--;
+				*t++ = *s++;
+			}
+		} else
+			*t++ = toupper((unsigned char) *s++);
+	}
+	*t = '\0';
+	if ((m->mac_irp = strsave(tmp)) == NULL)
+		fatal(F_OUTMEM, "IRP character lists");
+	mac_def = m;
+	mac_def_nest++;
+	return(0);
+}
+
+/*
+ *	IPRC
+ */
+int op_irpc(int dummy1, int dummy2)
+{
+	register char *s, *t;
+	register struct mac *m;
+	register int n;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
+	a_mode = A_NONE;
+	m = mac_new(NULL, mac_start_irpc, mac_rept_irpc);
+	s = operand;
+	t = tmp;
+	if (!is_first_sym_char(*s)) {
+		asmerr(E_ILLOPE);
+		return(0);
+	}
+	*t++ = toupper((unsigned char) *s++);
+	while (is_sym_char(*s))
+		*t++ = toupper((unsigned char) *s++);
+	*t = '\0';
+	mac_add_dum(m, tmp);
+	while (isspace((unsigned char) *s))
+		s++;
+	if (*s++ != ',') {
+		asmerr(E_ILLOPE);
+		return(0);
+	}
+	while (isspace((unsigned char) *s))
+		s++;
+	t = tmp;
+	n = 0;
+	if (*s == '<') {
+		s++;
+		n++;
+	}
+	while (!isspace((unsigned char) *s) && *s != '\n' && *s != '\0'
+					    && *s != COMMENT) {
+		if (*s == '>' && n > 0) {
+			s++;
+			break;
+		} else if (*s == '^') {
+			s++;
+			if (*s == '\n' || *s == '\0') {
+				asmerr(E_ILLOPE);
+				return(0);
+			}
+		}
+		*t++ = toupper((unsigned char) *s++);
+	}
+	while (isspace((unsigned char) *s))
+		s++;
+	if (*s != '\0' && *s != COMMENT) {
+		asmerr(E_ILLOPE);
+		return(0);
+	}
+	*t = '\0';
+	if ((m->mac_irp = strsave(tmp)) == NULL)
+		fatal(F_OUTMEM, "IRPC character list");
+	mac_def = m;
+	mac_def_nest++;
+	return(0);
+}
+
+/*
+ *	LOCAL
+ */
+int op_local(int dummy1, int dummy2)
+{
+	register char *p, *p1;
+	register struct expn *e;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
+	a_mode = A_NONE;
+	if (mac_exp_nest == 0) {
+		asmerr(E_NIMEXP);
+		return(0);
+	}
+	e = &mac_expn[mac_exp_nest - 1];
+	p = operand;
+	/* XXX loop does (n-1)*n/2+n*m strcmp's for n locals and m dummies */
+	while (p != NULL) {
+		p1 = next_arg(p, NULL);
+		if (*p != '\0') {
+			if (is_symbol(p)) {
+				expn_add_loc(e, p);
+				if (mac_loc_cnt == 10000)
+					asmerr(E_OUTLCL);
+				else
+					mac_loc_cnt++;
+				sprintf(e->expn_locs->loc_val,
+					"??%04d", mac_loc_cnt);
+			} else
+				asmerr(E_ILLOPE);
+		}
+		p = p1;
+	}
+	return(0);
+}
+
+/*
+ *	MACRO
+ */
+int op_macro(int dummy1, int dummy2)
+{
+	register char *p, *p1;
+	register struct mac *m;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
+	a_mode = A_NONE;
+	m = mac_new(label, mac_start_macro, NULL);
+	m->mac_next = mac_table;
+	mac_table = m;
+	p = operand;
+	/* XXX loop does (n-1)*n/2 strcmp's for n dummies */
+	while (p != NULL) {
+		p1 = next_arg(p, NULL);
+		if (*p != '\0') {
+			if (is_symbol(p))
+				mac_add_dum(m, p);
+			else
+				asmerr(E_ILLOPE);
+		}
+		p = p1;
+	}
+	mac_def = m;
+	mac_def_nest++;
+	return(0);
+}
+
+/*
+ *	REPT
+ */
+int op_rept(int dummy1, int dummy2)
+{
+	register struct mac *m;
+
+	UNUSED(dummy1);
+	UNUSED(dummy2);
+
+	a_mode = A_NONE;
+	m = mac_new(NULL, mac_start_rept, mac_rept_rept);
+	m->mac_count = eval(operand);
+	mac_def = m;
+	mac_def_nest++;
+	return(0);
+}

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -3,7 +3,7 @@
  *	Copyright (C) 2022 by Thomas Eberhardt
  *
  *	History:
- *	??-OCT-2022 Intel-like macros
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -87,22 +87,6 @@ static struct expn mac_expn[MACNEST];		/* macro expansion stack */
 static int mac_loc_cnt;				/* counter for LOCAL labels */
 static char tmp[MAXLINE + 1];			/* temporary buffer */
 
-void mac_print_table(void)
-{
-	register struct mac *m;
-	register struct dum *d;
-	register struct line *l;
-
-	for (m = mac_table; m != NULL; m = m->mac_next) {
-		printf("MACRO: %s\n", m->mac_name);
-		for (d = m->mac_dums; d != NULL; d = d->dum_next)
-			printf("DUMMY: %s\n", d->dum_name);
-		for (l = m->mac_lines; l != NULL; l = l->line_next)
-			printf("LINE: %s", l->line_text);
-		putchar('\n');
-	}
-}
-
 /*
  *	verify that p is a legal symbol
  *	return 1 if legal, otherwise 0

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -51,7 +51,6 @@ struct mac {					/* macro */
 	void (*mac_start)(struct expn *);	/* start expansion function */
 	int (*mac_rept)(struct expn *);		/* repeat expansion function */
 	char *mac_name;				/* macro name */
-	int mac_level;				/* definition nesting level */
 	int mac_count;				/* REPT count */
 	char *mac_irp;				/* IRP, IRPC character list */
 	struct dum *mac_dums, *mac_dums_last;	/* macro dummies */
@@ -134,7 +133,6 @@ struct mac *mac_new(char *name, void (*start)(struct expn *),
 			fatal(F_OUTMEM, "macro name");
 	} else
 		m->mac_name = NULL;
-	m->mac_level = mac_exp_nest;
 	m->mac_start = start;
 	m->mac_rept = rept;
 	m->mac_count = 0;

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 #include <stdlib.h>

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -1,5 +1,5 @@
 /*
- *	Z80 - Assembler
+ *	Z80 - Macro - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
  *
@@ -40,8 +40,8 @@ extern struct sym *get_sym(char *);
  *	definition of token types
  */
 #define T_EMPTY		0	/* nothing */
-#define T_VAL		1	/* number, string, or $ */
-#define T_SYM		2	/* symbol */
+#define T_VAL		1	/* number, string, $, or symbol */
+#define T_UNDSYM	2	/* undefined symbol */
 #define T_SUB		3	/* - */
 #define T_ADD		4	/* + */
 #define T_NOT		5	/* NOT or ~ */
@@ -102,13 +102,19 @@ int no_operators = sizeof(oprtab) / sizeof(struct opr);
 
 static int tok_type;	/* token type and flags */
 static int tok_val;	/* token value for T_VAL type */
-static char tok_sym[MAXLINE]; /* last symbol scanned (T_VAL, T_SYM) */
+static char tok_sym[MAXLINE]; /* last symbol scanned (T_VAL) */
 static char *scan_pos;	/* current scanning position */
+
+int is_first_sym_char(char c)
+{
+	return(isalpha((unsigned char) c) || c == '$' || c == '.' || c == '?'
+					  || c == '@' || c == '_');
+}
 
 int is_sym_char(char c)
 {
-	return(isalnum((unsigned char) c) || c == '$' || c == '%' || c == '.'
-					  || c == '?' || c == '@' || c == '_');
+	return(isalnum((unsigned char) c) || c == '$' || c == '.' || c == '?'
+					  || c == '@' || c == '_');
 }
 
 /*
@@ -116,7 +122,7 @@ int is_sym_char(char c)
  *
  *	Input: pointer to string with operator
  *
- *	Output: symbol for operator, T_SYM if operator not found
+ *	Output: symbol for operator, T_UNDSYM if operator not found
  */
 int search_opr(char *s)
 {
@@ -134,7 +140,7 @@ int search_opr(char *s)
 		else
 			return(mid->opr_type);
 	}
-	return(T_SYM);
+	return(T_UNDSYM);
 }
 
 /*
@@ -147,6 +153,7 @@ int get_token(void)
 {
 	register char *p1, *p2, *s;
 	register int n, m, base;
+	register struct sym *sp;
 
 	s = scan_pos;
 	tok_sym[0] = '\0';
@@ -218,10 +225,14 @@ int get_token(void)
 		if (*p1 == '$' && *(p1 + 1) == '\0') {	/* location counter */
 			tok_type = T_VAL;
 			tok_val = pc;
-		} else {				/* look for word opr */
-			tok_type = search_opr(p1);
+		} else {				/* symbol / word opr */
 			if (p2 - p1 > symlen)		/* trim for lookup */
 				*(p1 + symlen) = '\0';
+			if ((sp = get_sym(tok_sym)) != NULL) {	/* a symbol */
+				tok_type = T_VAL;
+				tok_val = sp->sym_val;
+			} else				/* look for word opr */
+				tok_type = search_opr(p1);
 		}
 		goto finish;
 	}
@@ -321,15 +332,10 @@ finish:
 
 int factor(int *resultp)
 {
-	int opr_type, value, err, erru;
-	struct sym *sp;
+	register int opr_type, err, erru;
+	register char *s;
+	int value;
 
-	/*
-	 *	if the token is not a T_VAL, but a word operator or
-	 *	T_SYM, look it up now since tok_sym gets overwritten
-	 *	by the next get_token().
-	 */
-	sp = (tok_type != T_VAL && *tok_sym) ? get_sym(tok_sym) : NULL;
 	switch (tok_type) {
 	case T_VAL:
 		value = tok_val;
@@ -337,14 +343,57 @@ int factor(int *resultp)
 			return(err);
 		*resultp = value;
 		return(E_NOERR);
-	case T_SYM:
+	case T_UNDSYM:
 		if ((err = get_token()))
 			return(err);
-		if (sp) {
-			*resultp = sp->sym_val;
-			return(E_NOERR);
-		} else
-			return(E_UNDSYM);
+		return(E_UNDSYM);
+	case T_NUL:
+		s = scan_pos;
+		while (isspace((unsigned char) *s))
+			s++;
+		if (strcmp(s, "''") == 0 || strcmp(s, "\"\"") == 0)
+			*resultp = -1;
+		else
+			*resultp = (*s == '\0') ? -1 : 0;
+		/* short circuit to end of expression */
+		while (*s != '\0')
+			s++;
+		scan_pos = s;
+		tok_type = T_EMPTY;
+		return(E_NOERR);
+	case T_TYPE:
+		if ((erru = get_token()) && erru != E_UNDSYM)
+			return(erru);
+		*resultp = ((erru || factor(&value)) ? 0x00 : 0x20);
+		return(E_NOERR);
+	case T_ADD:
+	case T_SUB:
+	case T_NOT:
+	case T_HIGH:
+	case T_LOW:
+		opr_type = tok_type;
+		if ((err = get_token()) || (err = factor(&value)))
+			return(err);
+		switch (opr_type) {
+		case T_ADD:
+			*resultp = value;
+			break;
+		case T_SUB:
+			*resultp = -value;
+			break;
+		case T_NOT:
+			*resultp = ~value;
+			break;
+		case T_HIGH:
+			*resultp = (value >> 8) & 0xff;
+			break;
+		case T_LOW:
+			*resultp = value & 0xff;
+			break;
+		default:
+			break;
+		}
+		return(E_NOERR);
 	case T_LPAREN:
 		if ((err = get_token()))
 			return(err);
@@ -358,81 +407,18 @@ int factor(int *resultp)
 			else {
 				*resultp = value;
 				return(E_NOERR);
-			}
+ 			}
 		} else
 			return(E_MISPAR);
-	case T_ADD:
-	case T_SUB:
-	case T_NOT:
-	case T_HIGH:
-	case T_LOW:
-	case T_NUL:
-	case T_TYPE:
-		opr_type = tok_type;
-		if ((err = get_token()))
-			return(err);
-		/*
-		 *	if an unary word operator, that was found in the
-		 *	symbol table, is not followed by a <factor> excl.
-		 *	unary + and - (which are also binary), return the
-		 *	symbol value.
-		 */
-		if (sp != NULL && tok_type != T_VAL && tok_type != T_SYM
-			       && tok_type != T_LPAREN && tok_type != T_NOT
-			       && tok_type != T_HIGH && tok_type != T_LOW
-			       && tok_type != T_NUL && tok_type != T_TYPE)
-			*resultp = sp->sym_val;
-		else if (opr_type == T_NUL) {
-			*resultp = (tok_type == T_EMPTY) ? -1 : 0;
-			/* short circuit to end of expression */
-			while (*scan_pos != '\0')
-				scan_pos++;
-			tok_type = T_EMPTY;
-		} else if (opr_type == T_TYPE)
-			*resultp = (factor(&value) ? 0x00 : 0x20);
-		else {
-			if ((err = factor(&value)))
-				return(err);
-			switch (opr_type) {
-			case T_ADD:
-				*resultp = value;
-				break;
-			case T_SUB:
-				*resultp = -value;
-				break;
-			case T_NOT:
-				*resultp = ~value;
-				break;
-			case T_HIGH:
-				*resultp = (value >> 8) & 0xff;
-				break;
-			case T_LOW:
-				*resultp = value & 0xff;
-				break;
-			default:
-				break;
-			}
-		}
-		return(E_NOERR);
 	default:
-		/*
-		 *	if the token is an unexpected word operator
-		 *	that was found in the symbol table, return
-		 *	the symbol value.
-		 */
-		if (sp) {
-			if ((err = get_token()))
-				return(err);
-			*resultp = sp->sym_val;
-			return(E_NOERR);
-		} else
-			return(E_INVEXP);
+		return(E_INVEXP);
 	}
 }
 
 int mul_term(int *resultp)
 {
-	int opr_type, value, err, erru;
+	register int opr_type, err, erru;
+	int value;
 
 	if ((erru = factor(resultp)) && erru != E_UNDSYM)
 		return(erru);
@@ -476,7 +462,8 @@ int mul_term(int *resultp)
 
 int add_term(int *resultp)
 {
-	int opr_type, value, err, erru;
+	register int opr_type, err, erru;
+	int value;
 
 	if ((erru = mul_term(resultp)) && erru != E_UNDSYM)
 		return(erru);
@@ -506,7 +493,8 @@ int add_term(int *resultp)
 
 int cmp_term(int *resultp)
 {
-	int opr_type, value, err, erru;
+	register int opr_type, err, erru;
+	int value;
 
 	if ((erru = add_term(resultp)) && erru != E_UNDSYM)
 		return(erru);
@@ -550,7 +538,8 @@ int cmp_term(int *resultp)
 
 int expr(int *resultp)
 {
-	int opr_type, value, err, erru;
+	register int opr_type, err, erru;
+	int value;
 
 	if ((erru = cmp_term(resultp)) && erru != E_UNDSYM)
 		return(erru);
@@ -583,7 +572,8 @@ int expr(int *resultp)
 
 int eval(char *s)
 {
-	int result, err;
+	register int err;
+	int result;
 
 	if (s == NULL || *s == '\0') {
 		asmerr(E_MISOPE);

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -1,5 +1,5 @@
 /*
- *	Z80 - Assembler
+ *	Z80 - Macro - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
  *
@@ -63,7 +63,12 @@ static const char *errmsg[] = {		/* error messages for asmerr() */
 	"invalid expression",		/* 18 */
 	"object code before ORG",	/* 19 */
 	"illegal label",		/* 20 */
-	"missing .DEPHASE"		/* 21 */
+	"missing .DEPHASE",		/* 21 */
+	"not in macro definition",	/* 22 */
+	"missing ENDM",			/* 23 */
+	"not in macro expansion",	/* 24 */
+	"macro expansion nested too deep", /* 25 */
+	"too many local labels"		/* 26 */
 };
 
 /*
@@ -102,7 +107,7 @@ void lst_header(void)
 {
 	time_t tloc = time(&tloc);
 
-	fprintf(lstfp, "\fZ80-Assembler\tRelease %s\t%.24s\tPage %d\n", REL,
+	fprintf(lstfp, "\fZ80-Macro-Assembler  Release %s\t%.24s\tPage %d\n", REL,
 		ctime(&tloc), ++page);
 	fprintf(lstfp, "Source file: %s\n", srcfn);
 	fprintf(lstfp, "Title:       %s\n", title);
@@ -121,22 +126,35 @@ void lst_attl(void)
 /*
  *	print one line into listfile, if -l option set
  */
-void lst_line(int addr, int op_cnt)
+void lst_line(char *l, int addr, int op_cnt, int expn_flag)
 {
 	register int i, j;
+	register const char *a_mark;
+	static int s_line;
 
-	if (!list_flag || a_mode == A_SUPPR)
-		goto done;
+	s_line++;
+	if (!list_flag)
+		return;
 	if (p_line >= ppl || c_line == 1) {
 		lst_header();
 		lst_attl();
 	}
+	a_mark = "   ";
 	switch (a_mode) {
 	case A_STD:
 		fprintf(lstfp, "%04x  ", addr & 0xffff);
 		break;
-	case A_ADDR:
+	case A_EQU:
 		fprintf(lstfp, "%04x  ", a_addr & 0xffff);
+		a_mark = "=  ";
+		break;
+	case A_SET:
+		fprintf(lstfp, "%04x  ", a_addr & 0xffff);
+		a_mark = "#  ";
+		break;
+	case A_DS:
+		fprintf(lstfp, "%04x  ", a_addr & 0xffff);
+		op_cnt = 0;
 		break;
 	case A_NONE:
 		fputs("      ", lstfp);
@@ -149,9 +167,12 @@ void lst_line(int addr, int op_cnt)
 	for (j = 0; j < 4; j++)
 		if (op_cnt-- > 0)
 			fprintf(lstfp, "%02x ", ops[i++]);
+		else if (j == 0)
+			fputs(a_mark, lstfp);
 		else
 			fputs("   ", lstfp);
-	fprintf(lstfp, "%6d %6d %s", c_line, s_line, line);
+	fprintf(lstfp, "%c%5d %6d %s", expn_flag ? '+' : ' ',
+		c_line, s_line, l);
 	p_line++;
 	if (errnum) {
 		fprintf(errfp, "=> %s\n", errmsg[errnum]);
@@ -171,11 +192,10 @@ void lst_line(int addr, int op_cnt)
 				fprintf(lstfp, "%02x ", ops[i++]);
 			else
 				fputs("   ", lstfp);
-		fprintf(lstfp, "%6d %6d\n", c_line, s_line);
+		fprintf(lstfp, "%c%5d %6d\n", expn_flag ? '+' : ' ',
+			c_line, s_line);
 		p_line++;
 	}
-done:
-	a_mode = A_STD;
 }
 
 /*

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -1,5 +1,5 @@
 /*
- *	Z80 - Assembler
+ *	Z80 - Macro - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
  *
@@ -22,7 +22,7 @@
  */
 
 /*
- *	processing of all PSEUDO ops
+ *	processing of all PSEUDO ops except macro related
  */
 
 #include <stdio.h>
@@ -33,7 +33,7 @@
 
 /* z80amain.c */
 extern void fatal(int, const char *);
-extern void pass_file(char *);
+extern void process_file(char *);
 extern char *next_arg(char *, int *);
 
 /* z80anum.c */
@@ -44,7 +44,6 @@ extern int chk_byte(int);
 extern void asmerr(int);
 extern void lst_header(void);
 extern void lst_attl(void);
-extern void lst_line(int, int);
 extern void obj_org(int);
 extern void obj_fill(int);
 extern void obj_fill_value(int, int);
@@ -157,7 +156,7 @@ int op_equ(int dummy1, int dummy2)
 		} else
 			asmerr(E_MULSYM);
 	} else {			/* PASS 2 */
-		a_mode = A_ADDR;
+		a_mode = A_EQU;
 		a_addr = eval(operand);
 	}
 	return(0);
@@ -171,7 +170,7 @@ int op_dl(int dummy1, int dummy2)
 	UNUSED(dummy1);
 	UNUSED(dummy2);
 
-	a_mode = A_ADDR;
+	a_mode = A_SET;
 	a_addr = eval(operand);
 	if (put_sym(label, a_addr))
 		fatal(F_OUTMEM, "symbols");
@@ -189,7 +188,7 @@ int op_ds(int dummy1, int dummy2)
 	UNUSED(dummy1);
 	UNUSED(dummy2);
 
-	a_mode = A_ADDR;
+	a_mode = A_DS;
 	a_addr = pc;
 	p = next_arg(operand, NULL);
 	count = eval(operand);
@@ -200,9 +199,7 @@ int op_ds(int dummy1, int dummy2)
 		} else
 			obj_fill(count);
 	}
-	pc += count;
-	rpc += count;
-	return(0);
+	return(count);
 }
 
 /*
@@ -290,7 +287,7 @@ int op_dw(int dummy1, int dummy2)
 }
 
 /*
- *	EJECT, LIST, NOLIST, PAGE, PRINT, TITLE, INCLUDE
+ *	EJECT, LIST, NOLIST, PAGE, PRINT, INCLUDE, MACLIB, TITLE
  */
 int op_misc(int op_code, int dummy)
 {
@@ -338,7 +335,7 @@ int op_misc(int op_code, int dummy)
 			fputs(operand, stdout);
 		putchar('\n');
 		break;
-	case 6:				/* INCLUDE */
+	case 6:				/* INCLUDE and MACLIB */
 		if (incnest >= INCNEST) {
 			asmerr(E_INCNEST);
 			break;
@@ -353,11 +350,9 @@ int op_misc(int op_code, int dummy)
 						    && *p != '\0')
 			*d++ = *p++;
 		*d = '\0';
-		if (pass == 2)
-			lst_line(0, 0);
 		if (ver_flag)
 			printf("   Include %s\n", fn);
-		pass_file(fn);
+		process_file(fn);
 		incnest--;
 		c_line = incl[incnest].inc_line;
 		srcfn = incl[incnest].inc_fn;
@@ -368,7 +363,6 @@ int op_misc(int op_code, int dummy)
 			lst_header();
 			lst_attl();
 		}
-		a_mode = A_SUPPR;
 		break;
 	case 7:				/* TITLE */
 		if (pass == 2) {
@@ -401,13 +395,11 @@ int op_misc(int op_code, int dummy)
 }
 
 /*
- *	IFDEF, IFNDEF, IFEQ, IFNEQ, COND, IF, IFT, IFE, IFF,
- *	IF1, IF2, IFB, IFNB, IFIDN, IFDIF
+ *	IFDEF, IFNDEF, IFEQ, IFNEQ, COND, IF, IFT, IFE, IFF, IF1, IF2
  */
 int op_cond(int op_code, int dummy)
 {
-	register char *p, *p1, *p2;
-	static int condnest[IFNEST];
+	register char *p;
 
 	UNUSED(dummy);
 
@@ -444,66 +436,6 @@ int op_cond(int op_code, int dummy)
 		case 8:				/* IF2 */
 			gencode = (pass == 2) ? -1 : 1;
 			break;
-		case 9:				/* IFB */
-		case 10:			/* IFNB */
-		case 11:			/* IFIDN */
-		case 12:			/* IFDIF */
-			p = operand;
-			if (*p == '\0' || *p == COMMENT) {
-				asmerr(E_MISOPE);
-				return(0);
-			}
-			if (*p++ != '<') {
-				asmerr(E_ILLOPE);
-				return(0);
-			}
-			while (*p != '>' && *p != '\0' && *p != COMMENT)
-				p++;
-			if (*p++ != '>') {
-				asmerr(E_MISPAR);
-				return(0);
-			}
-			p1 = p;
-			while (isspace((unsigned char) *p1))
-				p1++;
-			if (op_code == 9 || op_code == 10) { /* IFB and IFNB */
-				if (*p1 != '\0' && *p1 != COMMENT) {
-					asmerr(E_ILLOPE);
-					return(0);
-				}
-				gencode = ((p - operand) == 2) ? pass : -pass;
-			} else {		/* IFIDN and IFDIF */
-				if (*p1 != ',') {
-					asmerr(E_MISOPE);
-					return(0);
-				}
-				*p = '\0';
-				while (isspace((unsigned char) *p1))
-					p1++;
-				p = p1;
-				if (*p1++ != '<') {
-					asmerr(E_ILLOPE);
-					return(0);
-				}
-				while (*p1 != '>' && *p1 != '\0'
-						  && *p1 != COMMENT)
-					p1++;
-				if (*p1++ != '>') {
-					asmerr(E_MISPAR);
-					return(0);
-				}
-				p2 = p1;
-				while (isspace((unsigned char) *p2))
-					p2++;
-				if (*p2 != '\0' && *p2 != COMMENT) {
-					asmerr(E_ILLOPE);
-					return(0);
-				}
-				*p1 = '\0';
-				gencode = (strcmp(operand, p) == 0) ? pass
-								    : -pass;
-			}
-			break;
 		default:
 			fatal(F_INTERN, "invalid opcode for function op_cond");
 			break;
@@ -517,7 +449,7 @@ int op_cond(int op_code, int dummy)
 		}
 		switch(op_code) {
 		case 98:			/* ELSE */
-			if (condnest[iflevel - 1] == 1)
+			if (condnest[iflevel - 1] > 0)
 				gencode = -gencode;
 			break;
 		case 99:			/* ENDIF and ENDC */

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -1,5 +1,5 @@
 /*
- *	Z80 - Assembler
+ *	Z80 - Macro - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
  *

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -19,6 +19,7 @@
  *	28-JAN-2022 added syntax check for OUT (n),A
  *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
  *	04-OCT-2022 new expression parser (TE)
+ *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -1,5 +1,5 @@
 /*
- *	Z80 - Assembler
+ *	Z80 - Macro - Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
  *


### PR DESCRIPTION
1. Fixed a bug I introduced in get_opcode() by using isspace(). This caused the '\n' to be skipped, and since there was no check for '\0'... spectactular crash on empty lines...
2. Fixed ELSE. I broke it...
3. Added range check for -e option.
4. Added myself to COPYR.
5. Intel-like macros.
6. Increased IFNEST for macros.
7. Changed A_* to explicit pseudo-ops.
8. Moved condnest to globals for macros (EXITM, ENDM).
9. Since condnest is now global, moved macro specific IF* to macro module.
10. Moved s_line to lst_line as static variable.
11. Word operators are no longer usable when defined as symbols, just like other opcodes when redefined as macros.
12. This allowed NUL to be implemented correctly. Hopefully...
13. Moved INCLUDE list processing to main line loop.
14. Let DEFS return an op_count, for macro expansion listing.
15. Add '=' and '#' indicators for EQU and DEFL in listing.
16. Add '+' indicator for macro expansion in listing.
17. Removed '%' as allowed symbol character.

This is not perfect, but I commit this, so that others can comment and perhaps give hints for
making it better.

Documentation is not updated yet.

It assembles ex.mac (when changing "error" and ".printx" to print) correctly
It assembles and Hex compares altairsim/roms/tinybasic-1.0 and tinybasic-2.0.
