### PR TITLE
z80asm: fix sorted macro list, add "page 0" and "page" support

### DIFF
--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -1,7 +1,7 @@
 Usage:
 
-z80asm -f{b|m|h} -s[n|a] -e<num> -h<num> -x -8 -u -v -m
-       -o<file> -l[<file>] -d<symbol> ... <file> ...
+z80asm -f{b|m|h} -s[n|a] -p<num> -e<num> -h<num> -x -8 -u
+       -v -m -o<file> -l[<file>] -d<symbol> ... <file> ...
 
 A maximum of 512 source files is allowed. If the file name of a source
 doesn't have an extension the default extension ".asm" will be appended.
@@ -23,6 +23,10 @@ Option s:
 This option prints the symbol table unsorted (-s), sorted by name (-sn)
 or sorted by address (-sa) into the list file. This option only works
 together with option -l.
+
+Option p:
+Set the page length for the list file.
+The default is 65 and the allowed range is 6 to 144 or 0.
 
 Option e:
 Set the significant number of characters in symbols to <num>.

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -236,8 +236,9 @@ struct inc {
 #define F_HALT		2	/* assembly halted */
 #define F_FOPEN		3	/* can't open file */
 #define F_INTERN	4	/* internal error */
-#define F_SYMLEN	5	/* symbol length out of range */
-#define F_HEXLEN	6	/* hex record length out of range */
+#define F_PAGLEN	5	/* page length out of range */
+#define F_SYMLEN	6	/* symbol length out of range */
+#define F_HEXLEN	7	/* hex record length out of range */
 
 /*
  *	macro for declaring unused function parameters

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -73,7 +73,9 @@ int  list_flag,			/* flag for option -l */
      symlen = SYMLEN,		/* significant characters in symbols */
      symmax,			/* max. symbol name length encountered */
      symsize,			/* size of symarray */
-     hexlen = MAXHEX;		/* hex record length */
+     hexlen = MAXHEX,		/* hex record length */
+     p_line,			/* no. printed lines on page */
+     ppl = PLENGTH;		/* page length */
 
 FILE *srcfp,			/* file pointer for current source */
      *objfp,			/* file pointer for object code */
@@ -82,8 +84,6 @@ FILE *srcfp,			/* file pointer for current source */
 
 unsigned
      c_line,			/* current line no. in current source */
-     p_line,			/* no. printed lines on page */
-     ppl = PLENGTH,		/* page length */
      page;			/* no. of pages for listing */
 
 struct sym

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -68,7 +68,9 @@ extern int	list_flag,
 		symlen,
 		symmax,
 		symsize,
-		hexlen;
+		hexlen,
+		p_line,
+		ppl;
 
 extern FILE	*srcfp,
 		*objfp,
@@ -76,8 +78,6 @@ extern FILE	*srcfp,
 		*errfp;
 
 extern unsigned	c_line,
-		p_line,
-		ppl,
 		page;
 
 extern struct sym *symtab[],

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -76,13 +76,14 @@ extern void a_sort_sym(int);
 
 static const char *errmsg[] = {		/* error messages for fatal() */
 	"out of memory: %s",		/* 0 */
-	("usage: z80asm -f{b|m|h} -s[n|a] -e<num> -h<num> -x -8 -u -v -m\n"
-	 "              -o<file> -l[<file>] -d<symbol> ... <file> ..."),/* 1 */
+	("usage: z80asm -f{b|m|h} -s[n|a] -p<num> -e<num> -h<num> -x -8 -u\n"
+	 "              -v -m -o<file> -l[<file>] -d<symbol> ... <file> ..."),
 	"Assembly halted",		/* 2 */
 	"can't open file %s",		/* 3 */
 	"internal error: %s",		/* 4 */
-	"invalid symbol length: %s",	/* 5 */
-	"invalid hex record length: %s"	/* 6 */
+	"invalid page length: %s",	/* 5 */
+	"invalid symbol length: %s",	/* 6 */
+	"invalid hex record length: %s"	/* 7 */
 };
 
 int main(int argc, char *argv[])
@@ -214,6 +215,16 @@ void options(int argc, char *argv[])
 				if (mac_list_flag < 2)
 					mac_list_flag++;
 				break;
+			case 'p':
+				if (*++s == '\0') {
+					puts("length missing in option -p");
+					usage();
+				}
+				ppl = atoi(s);
+				if (ppl != 0 && (ppl < 6 || ppl > 144))
+					fatal(F_PAGLEN, s);
+				s += (strlen(s) - 1);
+				break;
 			case 'e':
 				if (*++s == '\0') {
 					puts("length missing in option -e");
@@ -234,7 +245,7 @@ void options(int argc, char *argv[])
 					fatal(F_HEXLEN, s);
 				s += (strlen(s) - 1);
 				break;
-			default :
+			default:
 				printf("unknown option %c\n", *s);
 				usage();
 			}

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -163,6 +163,7 @@ char *mac_lst_first(int sorted, int *ip)
 		}
 		mac_aused = i;
 		qsort(mac_array, mac_aused, sizeof(struct mac *), mac_compare);
+		*ip = mac_array[mac_aindex]->mac_refcnt;
 		return(mac_array[mac_aindex++]->mac_name);
 	} else {
 		for (m = mac_table; m->mac_next != NULL; m = m->mac_next)
@@ -179,9 +180,10 @@ char *mac_lst_first(int sorted, int *ip)
 char *mac_lst_next(int sorted, int *ip)
 {
 	if (sorted) {
-		if (mac_aindex < mac_aused)
+		if (mac_aindex < mac_aused) {
+			*ip = mac_array[mac_aindex]->mac_refcnt;
 			return(mac_array[mac_aindex++]->mac_name);
-		else
+		} else
 			return(NULL);
 	} else {
 		mac_curr = mac_curr->mac_prev;

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -293,9 +293,11 @@ int op_dw(int dummy1, int dummy2)
 int op_misc(int op_code, int dummy)
 {
 	register char *p, *d, c;
+	register int n;
 	static char fn[LENFN];
 	static int incnest;
 	static struct inc incl[INCNEST];
+	static int page_done;
 
 	UNUSED(dummy);
 
@@ -303,7 +305,7 @@ int op_misc(int op_code, int dummy)
 	switch(op_code) {
 	case 1:				/* EJECT */
 		if (pass == 2)
-			p_line = ppl;
+			p_line = ppl - 1;
 		break;
 	case 2:				/* LIST */
 		if (pass == 2)
@@ -314,8 +316,17 @@ int op_misc(int op_code, int dummy)
 			list_flag = 0;
 		break;
 	case 4:				/* PAGE */
-		if (pass == 2)
-			ppl = eval(operand);
+		if (*operand != '\0') {
+			if ((pass == 1 && !page_done) || pass == 2) {
+				n = eval(operand);
+				if (n != 0 && (n < 6 || n > 144))
+					asmerr(E_VALOUT);
+				else
+					ppl = n;
+				page_done = 1;
+			}
+		} else if (pass == 2)
+			p_line = ppl - 1;
 		break;
 	case 5:				/* PRINT */
 		p = operand;


### PR DESCRIPTION
1. The sorted macro list had the reference mark wrong.
2. Allow PAGE without operand as EJECT alias for MAC compatibility.
3. EJECT and PAGE without operand are printed on the current page.
3. Support "PAGE 0" nearly like MAC. Instead of producing no headers, add one header at the top of the list file.
4. Execute the first "PAGE" with operand in pass 1, to allow "PAGE 0" to work.
5. Add "-p" option to set page length between 6 - 144 or 0.
6. There is no more form feed at the start of the list file.

You now need to check that your line printer is at the start of a page...
Perhaps "-p0" is best for the list files included in the repository?