### PR TITLE
z80asm: don't do unnessesary hex flushes on ORG and DEFS

### DIFF
--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -243,11 +243,11 @@ void lst_mac(int sorted)
 	strcpy(title,"Macro table");
 	while (p != NULL) {
 		if (p_line == 0) {
-			if (ppl == 0) {
-				fputc('\n', lstfp);
-				fputs(title, lstfp);
-			}
 			lst_header();
+			if (ppl == 0) {
+				fputs(title, lstfp);
+				fputc('\n', lstfp);
+			}
 			fputc('\n', lstfp);
 			p_line++;
 		}
@@ -283,11 +283,11 @@ void lst_sym(void)
 		if (symtab[i] != NULL) {
 			for (np = symtab[i]; np != NULL; np = np->sym_next) {
 				if (p_line == 0) {
-					if (ppl == 0) {
-						fputc('\n', lstfp);
-						fputs(title, lstfp);
-					}
 					lst_header();
+					if (ppl == 0) {
+						fputs(title, lstfp);
+						fputc('\n', lstfp);
+					}
 					fputc('\n', lstfp);
 					p_line++;
 				}
@@ -320,11 +320,11 @@ void lst_sort_sym(int len)
 	strcpy(title, "Symbol table");
 	while (i < len) {
 		if (p_line == 0) {
-			if (ppl == 0) {
-				fputc('\n', lstfp);
-				fputs(title, lstfp);
-			}
 			lst_header();
+			if (ppl == 0) {
+				fputs(title, lstfp);
+				fputc('\n', lstfp);
+			}
 			fputc('\n', lstfp);
 			p_line++;
 		}


### PR DESCRIPTION
Don't panic :-), the first commit doesn't change the listing output. I'm done with listing changes.

I compared all the hex files in the repository with the ones generated with this changes.
They all match, except imsaisim/roms/basic4k.hex. The original hex file contains a few unnecessary
hex flushes and the beginning (all the ORGs for the RST vectors), this causes massive diffs.
I did a load and core save with z80sim -m0 -s and compared the core files. The memory content matches.

All the *.asm files on the xybasic disk now assemble and the hex files match the ones on the disk.