### PR TITLE
z80asm: remove unnecessary code & coding consistency, macro fix

### DIFF
--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -519,9 +519,9 @@ void mac_subst(char *t, char *s, struct expn *e,
 				while (s < s1)
 					*t++ = *s++;
 			} else {
-				if (amp_flag == 1)
-					t1--;
 				t = t1;
+				if (amp_flag == 1)
+					t--;
 				while (*v != '\0')
 					*t++ = *v++;
 				if (*s == '&') {
@@ -558,9 +558,9 @@ void mac_subst(char *t, char *s, struct expn *e,
 						if (v == NULL)
 							amp_flag = 0;
 						else {
-							if (amp_flag == 1)
-								t1--;
 							t = t1;
+							if (amp_flag == 1)
+								t--;
 							while (*v != '\0')
 								*t++ = *v++;
 							if (*s == '&') {

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -458,16 +458,19 @@ void mac_add_line(struct opc *op, char *line)
 /*
  *	return value of dummy s, NULL if not found
  */
-const char *mac_get_dummy(struct expn *e, char *s)
+const char *mac_get_dummy(struct expn *e, char *s, int uc_flag)
 {
 	register struct parm *p;
 	register char *t;
 
-	for (t = expr; *s != '\0'; s++)
-		*t++ = toupper((unsigned char) *s);
-	*t = '\0';
+	if (uc_flag) {
+		for (t = expr; *s != '\0'; s++)
+			*t++ = toupper((unsigned char) *s);
+		*t = '\0';
+		s = expr;
+	}
 	for (p = e->expn_parms; p; p = p->parm_next)
-		if (strncmp(p->parm_name, expr, symlen) == 0)
+		if (strncmp(p->parm_name, s, symlen) == 0)
 			return(p->parm_val == NULL ? "" : p->parm_val);
 	return(NULL);
 }
@@ -475,16 +478,19 @@ const char *mac_get_dummy(struct expn *e, char *s)
 /*
  *	return value of local label s, NULL if not found
  */
-const char *mac_get_local(struct expn *e, char *s)
+const char *mac_get_local(struct expn *e, char *s, int uc_flag)
 {
 	register struct loc *l;
 	register char *t;
 
-	for (t = expr; *s != '\0'; s++)
-		*t++ = toupper((unsigned char) *s);
-	*t = '\0';
+	if (uc_flag) {
+		for (t = expr; *s != '\0'; s++)
+			*t++ = toupper((unsigned char) *s);
+		*t = '\0';
+		s = expr;
+	}
 	for (l = e->expn_locs; l; l = l->loc_next)
-		if (strncmp(l->loc_name, expr, symlen) == 0)
+		if (strncmp(l->loc_name, s, symlen) == 0)
 			return(l->loc_val);
 	return(NULL);
 }
@@ -494,7 +500,7 @@ const char *mac_get_local(struct expn *e, char *s)
  *	in source line s and return the result in t
  */
 void mac_subst(char *t, char *s, struct expn *e,
-	       const char *(getf)(struct expn *, char *))
+	       const char *(getf)(struct expn *, char *, int))
 {
 	register char *t1;
 	register const char *v;
@@ -514,7 +520,7 @@ void mac_subst(char *t, char *s, struct expn *e,
 			while (is_sym_char(*s))
 				*t++ = *s++;
 			*t = '\0';
-			v = (*getf)(e, t1);
+			v = (*getf)(e, t1, 1);
 			if (v == NULL)
 				amp_flag = 0;
 			else if (esc_flag) {
@@ -559,7 +565,7 @@ void mac_subst(char *t, char *s, struct expn *e,
 						*t++ = *s++;
 					*t = '\0';
 					if (amp_flag > 0 || *s == '&') {
-						v = (*getf)(e, t1);
+						v = (*getf)(e, t1, 0);
 						if (v == NULL)
 							amp_flag = 0;
 						else {

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -1526,8 +1526,6 @@ int op8080_reg16(int base_op, int dummy)
 	case REGD:			/* INX/DAD/DCX D */
 	case REGH:			/* INX/DAD/DCX H */
 	case REGSP:			/* INX/DAD/DCX SP */
-		if (op == REGSP)
-			op = REGM;
 		ops[0] = base_op + ((op & OPMASK) << 3);
 		break;
 	case NOOPERA:			/* missing operand */
@@ -1613,8 +1611,6 @@ int op8080_pupo(int base_op, int dummy)
 	case REGD:			/* PUSH/POP D */
 	case REGH:			/* PUSH/POP H */
 	case REGPSW:			/* PUSH/POP PSW */
-		if (op == REGPSW)
-			op = REGM;
 		ops[0] = base_op + ((op & OPMASK) << 3);
 		break;
 	case NOOPERA:			/* missing operand */
@@ -1705,8 +1701,6 @@ int op8080_lxi(int base_op, int dummy)
 	case REGSP:			/* LXI SP,nn */
 		len = 3;
 		if (pass == 2) {
-			if (op == REGSP)
-				op = REGM;
 			i = eval(sec);
 			ops[0] = base_op + ((op & OPMASK) << 3);
 			ops[1] = i & 0xff;

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -481,12 +481,10 @@ int op_ld(int base_op, int dummy)
 		asmerr(E_MISOPE);
 		break;
 	default:
-		if (strncmp(operand, "(IX+", 4) == 0)	/* LD (IX+d),? */
-			len = ldiixy(0xdd, base_op + ((REGIHL & OPMASK) << 3),
-				     sec);
-		else if (strncmp(operand, "(IY+", 4) == 0) /* LD (IY+d),? */
-			len = ldiixy(0xfd, base_op + ((REGIHL & OPMASK) << 3),
-				     sec);
+		if (strncmp(operand, "(IX+", 4) == 0	/* LD (I[XY]+d),? */
+		    || strncmp(operand, "(IY+", 4) == 0)
+			len = ldiixy(operand[2] == 'Y' ? 0xfd : 0xdd,
+				     base_op + ((REGIHL & OPMASK) << 3), sec);
 		else if (*operand == '(')		/* LD (nn),? */
 			len = ldinn(sec);
 		else {			/* invalid operand */
@@ -1313,10 +1311,10 @@ int op_cbgrp(int base_op, int dummy)
 	case NOREG:			/* CBOP {n,}(I[XY]+d){,reg} */
 		len = 4;
 		if (pass == 2) {
-			if (strncmp(sec, "(IX+", 4) == 0)
-				cbgrp_iixy(0xdd, base_op, i, sec);
-			else if (strncmp(sec, "(IY+", 4) == 0)
-				cbgrp_iixy(0xfd, base_op, i, sec);
+			if (strncmp(sec, "(IX+", 4) == 0
+			    || strncmp(sec, "(IY+", 4) == 0)
+				cbgrp_iixy(*(sec + 2) == 'Y' ? 0xfd : 0xdd,
+					   base_op, i, sec);
 			else {		/* invalid operand */
 				ops[0] = 0;
 				ops[1] = 0;


### PR DESCRIPTION
Remove some code from before I had the register values fully assigned.

Use the same coding style everywhere

Don't convert symbols inside strings to upper case for macro parameter substitution.
