### PR TITLE
z80asm: some clean up, changes for Coherent 3.2

### DIFF
--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -88,7 +88,7 @@ static int mac_asize;				/* size of mac_array */
 static int mac_aused;				/* used entries of mac_array */
 static int mac_aindex;				/* index into mac_array */
 static struct expn mac_expn[MACNEST];		/* macro expansion stack */
-static int mac_loc_cnt;				/* counter for LOCAL labels */
+static unsigned mac_loc_cnt;			/* counter for LOCAL labels */
 static char tmp[MAXLINE];			/* temporary buffer */
 static char expr[MAXLINE];			/* expr buffer (for '%') */
 
@@ -486,7 +486,7 @@ const char *mac_get_local(struct expn *e, char *s)
  *	in source line s and return the result in t
  */
 void mac_subst(char *t, char *s, struct expn *e,
-	       const char *(getf)(struct expn *, char *))
+	       const char *(*getf)(struct expn *, char *))
 {
 	register char *s1, *t1;
 	register const char *v;
@@ -1029,11 +1029,9 @@ int op_local(int dummy1, int dummy2)
 		if (*s != '\0') {
 			if (is_symbol(s)) {
 				l = expn_add_loc(e, s);
-				if (mac_loc_cnt == 65536)
+				if (mac_loc_cnt == 65535U)
 					asmerr(E_OUTLCL);
-				else
-					mac_loc_cnt++;
-				sprintf(l->loc_val, "??%04X", mac_loc_cnt);
+				sprintf(l->loc_val, "??%04x", mac_loc_cnt++);
 			} else
 				asmerr(E_ILLOPE);
 		}

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -33,7 +33,7 @@
 #include "z80aglb.h"
 
 void fill_bin(void);
-void eof_hex(void);
+void eof_hex(int);
 void flush_hex(void);
 void hex_record(int);
 int chksum(int);
@@ -377,8 +377,7 @@ void obj_end(void)
 		break;
 	case OUTHEX:
 		flush_hex();
-		hex_addr = start_addr;
-		eof_hex();
+		eof_hex(start_addr);
 		break;
 	}
 }
@@ -513,9 +512,10 @@ void fill_bin(void)
 /*
  *	create a hex end-of-file record in ASCII and write into object file
  */
-void eof_hex(void)
+void eof_hex(int addr)
 {
 	hex_cnt = 0;
+	hex_addr = addr;
 	hex_record(HEX_EOF);
 }
 


### PR DESCRIPTION
I tried compiling and running the latest z80asm on Coherent 3.2.
Needed to make some changes and now it runs and assembles ex.mac.

1. Forgot a '*' in the function pointer parameter in mac_subst().
   Strange that this didn't generate some kind of warning with gcc
   or clang.
2. Changed mac_loc_cnt to unsigned to make it work up to 65535 for
   16bit machines. Local labels now count up to 65534, so we lose one...
3. After some malloc related crashes which baffled me, I finally
   found out that Coherent's sprintf isn't C89 conform.
   '%x' behaves like '%X' in C89 and '%X' expects a long int, so
   the sprintf in op_local was happily overwriting the char[8] array...
   Just changed the code to use '%x', so local labels are now
   lower case in the listing when not using Coherent.