### PR TITLE
z80asm: use BYTE & WORD, don't use sprintf, do own %x, REG* again

### DIFF
--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -62,14 +62,20 @@
 #define MAXHEX		32	/* max. no bytes/hex record */
 
 /*
+ *	types for working with op-codes, addresses and expressions
+ */
+typedef unsigned char BYTE;
+typedef unsigned short WORD;
+
+/*
  *	structure opcode table
  */
 struct opc {
 	const char *op_name;	/* opcode name */
-	int (*op_fun) (int, int); /* function pointer code generation */
-	unsigned char op_c1;	/* first base opcode */
-	unsigned char op_c2;	/* second base opcode */
-	unsigned short op_flags; /* opcode flags */
+	int (*op_fun) (BYTE, BYTE); /* function pointer code gen. */
+	BYTE op_c1;		/* first base opcode */
+	BYTE op_c2;		/* second base opcode */
+	WORD op_flags;		/* opcode flags */
 };
 
 /*
@@ -77,8 +83,8 @@ struct opc {
  */
 struct ope {
 	const char *ope_name;	/* operand name */
-	unsigned char ope_sym;	/* operand symbol value */
-	unsigned char ope_flags; /* operand flags */
+	BYTE ope_sym;		/* operand symbol value */
+	BYTE ope_flags;		/* operand flags */
 };
 
 /*
@@ -96,7 +102,7 @@ struct opset {
  */
 struct sym {
 	char *sym_name;		/* symbol name */
-	int  sym_val;		/* symbol value */
+	WORD sym_val;		/* symbol value */
 	int  sym_refcnt;	/* symbol reference counter */
 	struct sym *sym_next;	/* next entry */
 };
@@ -130,47 +136,51 @@ struct inc {
  *	these are defined as the bits used in opcodes and
  *	may not be changed!
  */
-#define REGB		000	/* register B */
-#define REGC		001	/* register C */
-#define REGD		002	/* register D */
-#define REGE		003	/* register E */
-#define REGH		004	/* register H */
-#define REGL		005	/* register L */
-#define REGIHL		006	/* register indirect HL */
-#define REGM		006	/* register indirect HL (8080) */
-#define REGA		007	/* register A */
-#define REGBC		010	/* register pair BC */
-#define REGDE		012	/* register pair DE */
-#define REGHL		014	/* register pair HL */
-#define REGAF		016	/* register pair AF */
-#define REGPSW		016	/* register pair AF (8080) */
-#define REGIXH		024	/* register IXH */
-#define REGIXL		025	/* register IXL */
-#define REGIX		034	/* register IX */
-#define REGIIX		036	/* register indirect IX */
-#define REGIYH		044	/* register IYH */
-#define REGIYL		045	/* register IYL */
-#define REGIY		054	/* register IY */
-#define REGIIY		056	/* register indirect IY */
-#define REGSP		066	/* register SP */
-#define REGIBC		070	/* register indirect BC */
-#define REGIDE		072	/* register indirect DE */
-#define REGISP		076	/* register indirect SP */
-#define REGI		0100	/* register I */
-#define REGR		0101	/* register R */
-#define FLGNZ		0110	/* flag not zero */
-#define FLGZ		0111	/* flag zero */
-#define FLGNC		0112	/* flag no carry */
-#define FLGC		0113	/* flag carry */
-#define FLGPO		0114	/* flag parity odd */
-#define FLGPE		0115	/* flag parity even */
-#define FLGP		0116	/* flag plus */
-#define FLGM		0117	/* flag minus */
-#define NOOPERA		0176	/* no operand */
-#define NOREG		0177	/* operand isn't register */
+				/* usable with OPMASK0 and OPMASK3 */
+#define REGB		0000	/* register B */
+#define REGC		0011	/* register C */
+#define REGD		0022	/* register D */
+#define REGE		0033	/* register E */
+#define REGH		0044	/* register H */
+#define REGL		0055	/* register L */
+#define REGIHL		0066	/* register indirect HL */
+#define REGM		0066	/* register indirect HL (8080) */
+#define REGA		0077	/* register A */
+#define REGIXH		0244	/* register IXH */
+#define REGIXL		0255	/* register IXL */
+#define REGIYH		0344	/* register IYH */
+#define REGIYL		0355	/* register IYL */
+				/* usable with OPMASK3 */
+#define REGBC		0001	/* register pair BC */
+#define REGDE		0021	/* register pair DE */
+#define REGHL		0041	/* register pair HL */
+#define REGAF		0061	/* register pair AF */
+#define REGPSW		0061	/* register pair AF (8080) */
+#define REGSP		0062	/* register SP */
+#define REGIBC		0003	/* register indirect BC */
+#define REGIDE		0023	/* register indirect DE */
+#define REGISP		0063	/* register indirect SP */
+#define REGIX		0240	/* register IX */
+#define REGIIX		0260	/* register indirect IX */
+#define REGIY		0340	/* register IY */
+#define REGIIY		0360	/* register indirect IY */
+#define REGI		0004	/* register I */
+#define REGR		0014	/* register R */
+#define FLGNZ		0100	/* flag not zero */
+#define FLGZ		0110	/* flag zero */
+#define FLGNC		0120	/* flag no carry */
+#define FLGC		0130	/* flag carry */
+#define FLGPO		0140	/* flag parity odd */
+#define FLGPE		0150	/* flag parity even */
+#define FLGP		0160	/* flag plus */
+#define FLGM		0170	/* flag minus */
 
-#define OPMASK		007	/* bit mask for the registers/flags */
-#define XYMASK		040	/* bit mask for IX/IY */
+#define NOOPERA		0376	/* no operand */
+#define NOREG		0377	/* operand isn't register */
+
+#define OPMASK0		0007	/* << 0 bit mask for the registers */
+#define OPMASK3		0070	/* << 3 bit mask for the registers/flags */
+#define XYMASK		0100	/* bit mask for IX/IY */
 
 /*
  *	definition of operand flags

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -40,8 +40,15 @@ char *infiles[MAXFN],		/* source filenames */
      operand[MAXLINE],		/* buffer for working with operand */
      title[MAXLINE];		/* buffer for title of source */
 
-unsigned char
-     ops[OPCARRAY];		/* buffer for generated object code */
+BYTE ops[OPCARRAY];		/* buffer for generated object code */
+
+WORD rpc,			/* real program counter */
+     pc,			/* logical program counter, normally equal */
+				/* to rpc, except when inside a .PHASE block */
+     a_addr,			/* output value for A_ADDR/A_VALUE mode */
+     load_addr,			/* load address of program */
+     start_addr,		/* start address of program */
+     hexlen = MAXHEX;		/* hex record length */
 
 int  list_flag,			/* flag for option -l */
      sym_flag,			/* flag for option -s */
@@ -52,9 +59,6 @@ int  list_flag,			/* flag for option -l */
      mac_list_flag,		/* flag for option -m */
      radix,			/* current radix, set to 10 at start of pass */
      opset = OPSET_Z80,		/* current operations set (default Z80) */
-     rpc,			/* real program counter */
-     pc,			/* logical program counter, normally equal */
-				/* to rpc, except when inside a .PHASE block */
      phs_flag,			/* flag for being inside a .PHASE block */
      pass,			/* processed pass */
      iflevel,			/* IF nesting level */
@@ -67,15 +71,11 @@ int  list_flag,			/* flag for option -l */
      errors,			/* error counter */
      errnum,			/* error number in pass 2 */
      a_mode,			/* location output mode for pseudo ops */
-     a_addr,			/* output value for A_ADDR/A_VALUE mode */
-     load_addr,			/* load address of program */
      load_flag,			/* flag for load_addr valid */
-     start_addr,		/* start address of program */
      out_form = OUTDEF,		/* format of object file */
      symlen = SYMLEN,		/* significant characters in symbols */
      symmax,			/* max. symbol name length encountered */
      symsize,			/* size of symarray */
-     hexlen = MAXHEX,		/* hex record length */
      p_line,			/* no. printed lines on page */
      ppl = PLENGTH;		/* page length */
 
@@ -85,8 +85,10 @@ FILE *srcfp,			/* file pointer for current source */
      *errfp;			/* file pointer for error output */
 
 unsigned
-     c_line,			/* current line no. in current source */
      page;			/* no. of pages for listing */
+
+unsigned long
+     c_line;			/* current line no. in current source */
 
 struct sym
      *symtab[HASHSIZE],		/* symbol table */

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -36,8 +36,14 @@ extern char	*infiles[],
 		operand[],
 		title[];
 
-extern unsigned char
-		ops[];
+extern BYTE	ops[];
+
+extern WORD	rpc,
+		pc,
+		a_addr,
+		load_addr,
+		start_addr,
+		hexlen;
 
 extern int	list_flag,
 		sym_flag,
@@ -48,8 +54,6 @@ extern int	list_flag,
 		mac_list_flag,
 		radix,
 		opset,
-		rpc,
-		pc,
 		phs_flag,
 		pass,
 		iflevel,
@@ -62,15 +66,11 @@ extern int	list_flag,
 		errors,
 		errnum,
 		a_mode,
-		a_addr,
-		load_addr,
 		load_flag,
-		start_addr,
 		out_form,
 		symlen,
 		symmax,
 		symsize,
-		hexlen,
 		p_line,
 		ppl;
 
@@ -79,8 +79,9 @@ extern FILE	*srcfp,
 		*lstfp,
 		*errfp;
 
-extern unsigned	c_line,
-		page;
+extern unsigned	page;
+
+extern unsigned long c_line;
 
 extern struct sym *symtab[],
 		  **symarray;

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -47,7 +47,7 @@ char *get_arg(char *, char *, int);
 
 /* z80aout.c */
 extern void asmerr(int);
-extern void lst_line(char *, int, int, int);
+extern void lst_line(char *, WORD, int, int);
 extern void lst_mac(int);
 extern void lst_sym(void);
 extern void lst_sort_sym(int);

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -29,7 +29,7 @@
 #include "z80a.h"
 #include "z80aglb.h"
 
-int expr(int *);
+int expr(WORD *);
 
 /* z80aout.c */
 extern void asmerr(int);
@@ -102,7 +102,7 @@ struct opr oprtab[] = {
 int no_operators = sizeof(oprtab) / sizeof(struct opr);
 
 static int tok_type;	/* token type and flags */
-static int tok_val;	/* token value for T_VAL type */
+static WORD tok_val;	/* token value for T_VAL type */
 static char tok_sym[MAXLINE]; /* last symbol scanned (T_VAL) */
 static char *scan_pos;	/* current scanning position */
 
@@ -153,7 +153,7 @@ int search_opr(char *s)
 int get_token(void)
 {
 	register char *p1, *p2, *s;
-	register int n, m, base;
+	register WORD n, m, base;
 	register struct sym *sp;
 
 	s = scan_pos;
@@ -331,11 +331,11 @@ finish:
  *	inspired by the previous expression parser by Didier Derny.
  */
 
-int factor(int *resultp)
+int factor(WORD *resultp)
 {
 	register int opr_type, err, erru;
 	register char *s;
-	int value;
+	WORD value;
 
 	switch (tok_type) {
 	case T_VAL:
@@ -386,7 +386,7 @@ int factor(int *resultp)
 			*resultp = ~value;
 			break;
 		case T_HIGH:
-			*resultp = (value >> 8) & 0xff;
+			*resultp = value >> 8;
 			break;
 		case T_LOW:
 			*resultp = value & 0xff;
@@ -416,10 +416,10 @@ int factor(int *resultp)
 	}
 }
 
-int mul_term(int *resultp)
+int mul_term(WORD *resultp)
 {
 	register int opr_type, err, erru;
-	int value;
+	WORD value;
 
 	if ((erru = factor(resultp)) && erru != E_UNDSYM)
 		return(erru);
@@ -449,7 +449,7 @@ int mul_term(int *resultp)
 			*resultp %= value;
 			break;
 		case T_SHR:
-			*resultp = ((unsigned) *resultp) >> value;
+			*resultp >>= value;
 			break;
 		case T_SHL:
 			*resultp <<= value;
@@ -461,10 +461,10 @@ int mul_term(int *resultp)
 	return(erru ? E_UNDSYM : E_NOERR);
 }
 
-int add_term(int *resultp)
+int add_term(WORD *resultp)
 {
 	register int opr_type, err, erru;
-	int value;
+	WORD value;
 
 	if ((erru = mul_term(resultp)) && erru != E_UNDSYM)
 		return(erru);
@@ -492,10 +492,10 @@ int add_term(int *resultp)
 	return(erru ? E_UNDSYM : E_NOERR);
 }
 
-int cmp_term(int *resultp)
+int cmp_term(WORD *resultp)
 {
 	register int opr_type, err, erru;
-	int value;
+	WORD value;
 
 	if ((erru = add_term(resultp)) && erru != E_UNDSYM)
 		return(erru);
@@ -537,10 +537,10 @@ int cmp_term(int *resultp)
 	return(erru ? E_UNDSYM : E_NOERR);
 }
 
-int expr(int *resultp)
+int expr(WORD *resultp)
 {
 	register int opr_type, err, erru;
-	int value;
+	WORD value;
 
 	if ((erru = cmp_term(resultp)) && erru != E_UNDSYM)
 		return(erru);
@@ -571,10 +571,10 @@ int expr(int *resultp)
 	return(erru ? E_UNDSYM : E_NOERR);
 }
 
-int eval(char *s)
+WORD eval(char *s)
 {
 	register int err;
-	int result;
+	WORD result;
 
 	if (s == NULL || *s == '\0') {
 		asmerr(E_MISOPE);
@@ -596,10 +596,10 @@ int eval(char *s)
  *	check value for range -257 < value < 256
  *	Output: value if in range, otherwise 0 and error message
  */
-int chk_byte(int i)
+BYTE chk_byte(WORD n)
 {
-	if (i >= -256 && i <= 255)
-		return(i);
+	if (n >= (WORD) -256 || n <= 255)
+		return(n);
 	else {
 		asmerr(E_VALOUT);
 		return(0);
@@ -610,10 +610,10 @@ int chk_byte(int i)
  *	check value for range -129 < value < 128
  *	Output: value if in range, otherwise 0 and error message
  */
-int chk_sbyte(int i)
+BYTE chk_sbyte(WORD n)
 {
-	if (i >= -128 && i <= 127)
-		return(i);
+	if (n >= (WORD) -128 || n <= 127)
+		return(n);
 	else {
 		asmerr(E_VALOUT);
 		return(0);

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -30,27 +30,29 @@
 #include "z80a.h"
 
 /* z80amfun.c */
-extern int op_endm(int, int), op_exitm(int, int), op_irp(int, int);
-extern int op_local(int, int), op_macro(int, int), op_mcond(int, int);
-extern int op_rept(int, int);
+extern int op_endm(BYTE, BYTE), op_exitm(BYTE, BYTE), op_irp(BYTE, BYTE);
+extern int op_local(BYTE, BYTE), op_macro(BYTE, BYTE), op_mcond(BYTE, BYTE);
+extern int op_rept(BYTE, BYTE);
 
 /* z80apfun.c */
-extern int op_opset(int, int), op_org(int, int), op_radix(int, int);
-extern int op_equ(int, int), op_dl(int, int), op_ds(int, int), op_db(int, int);
-extern int op_dw(int, int), op_misc(int, int), op_cond(int, int);
-extern int op_glob(int, int), op_end(int, int);
+extern int op_opset(BYTE, BYTE), op_org(BYTE, BYTE), op_radix(BYTE, BYTE);
+extern int op_equ(BYTE, BYTE), op_dl(BYTE, BYTE), op_ds(BYTE, BYTE);
+extern int op_db(BYTE, BYTE), op_dw(BYTE, BYTE), op_misc(BYTE, BYTE);
+extern int op_cond(BYTE, BYTE), op_glob(BYTE, BYTE), op_end(BYTE, BYTE);
 
 /* z80arfun.c */
-extern int op_1b(int, int), op_2b(int, int), op_im(int, int);
-extern int op_pupo(int, int), op_ex(int, int), op_rst(int, int);
-extern int op_ret(int, int), op_jpcall(int, int), op_jr(int, int);
-extern int op_djnz(int, int), op_ld(int, int), op_add(int, int);
-extern int op_sbadc(int, int), op_decinc(int, int), op_alu(int, int);
-extern int op_out(int, int), op_in(int, int), op_cbgrp(int, int);
-extern int op8080_mov(int, int), op8080_alu(int, int), op8080_dcrinr(int, int);
-extern int op8080_reg16(int, int), op8080_regbd(int, int);
-extern int op8080_imm(int, int), op8080_rst(int, int), op8080_pupo(int, int);
-extern int op8080_addr(int, int), op8080_mvi(int, int), op8080_lxi(int, int);
+extern int op_1b(BYTE, BYTE), op_2b(BYTE, BYTE), op_im(BYTE, BYTE);
+extern int op_pupo(BYTE, BYTE), op_ex(BYTE, BYTE), op_rst(BYTE, BYTE);
+extern int op_ret(BYTE, BYTE), op_jpcall(BYTE, BYTE), op_jr(BYTE, BYTE);
+extern int op_djnz(BYTE, BYTE), op_ld(BYTE, BYTE), op_add(BYTE, BYTE);
+extern int op_sbadc(BYTE, BYTE), op_decinc(BYTE, BYTE), op_alu(BYTE, BYTE);
+extern int op_out(BYTE, BYTE), op_in(BYTE, BYTE), op_cbgrp(BYTE, BYTE);
+extern int op8080_mov(BYTE, BYTE), op8080_alu(BYTE, BYTE);
+extern int op8080_dcrinr(BYTE, BYTE), op8080_reg16(BYTE, BYTE);
+extern int op8080_regbd(BYTE, BYTE), op8080_imm(BYTE, BYTE);
+extern int op8080_rst(BYTE, BYTE), op8080_pupo(BYTE, BYTE);
+extern int op8080_addr(BYTE, BYTE), op8080_mvi(BYTE, BYTE);
+extern int op8080_lxi(BYTE, BYTE);
 
 /*
  *	pseudo op table:
@@ -158,7 +160,7 @@ struct opc opctab_z80[] = {
 	{ "EX",		op_ex,		0xe3,	0xeb,	0	 },
 	{ "EXX",	op_1b,		0xd9,	0,	OP_NOOPR },
 	{ "HALT",	op_1b,		0x76,	0,	OP_NOOPR },
-	{ "IM",		op_im,		0x46,	0,	0	 },
+	{ "IM",		op_im,		0xed,	0x46,	0	 },
 	{ "IN",		op_in,		0xdb,	0x40,	0	 },
 	{ "INC",	op_decinc,	0x04,	0x03,	0	 },
 	{ "IND",	op_2b,		0xed,	0xaa,	OP_NOOPR },

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -35,7 +35,7 @@
 struct sym *get_sym(char *);
 int hash(char *);
 char *strsave(char *);
-int numcmp(int, int);
+int numcmp(WORD, WORD);
 
 /* z80amain.c */
 extern void fatal(int, const char *);
@@ -84,7 +84,7 @@ struct opc *search_op(char *op_name)
  *	Output: symbol for operand, NOOPERA if empty operand,
  *		NOREG if operand not found
  */
-int get_reg(char *s)
+BYTE get_reg(char *s)
 {
 	register int cond;
 	register struct ope *low, *high, *mid;
@@ -281,11 +281,11 @@ void a_sort_sym(int len)
 /*
  *	compares two 16bit values, result like strcmp()
  */
-int numcmp(int n1, int n2)
+int numcmp(WORD n1, WORD n2)
 {
-	if ((unsigned) (n1 & 0xffff) < (unsigned) (n2 & 0xffff))
+	if (n1 < n2)
 		return(-1);
-	else if ((unsigned) (n1 & 0xffff) > (unsigned) (n2 & 0xffff))
+	else if (n1 > n2)
 		return(1);
 	else
 		return(0);


### PR DESCRIPTION
This is a rather large commit, since my playing around with Coherent 3.2 unearthed some problems with the code.

1. Expression evaluation needs to be done with 16-bit unsigned arithmetic, otherwise one gets problems like "(1 EQ 1) SHR 1" resulting in 0xffff and not 0x7fff.
2. Just bitten the bullet and introduced BYTE and WORD like in z80core and used them where applicable.
3. Listing line counting needs to be done with long's, since, for example, the full macro expansion listing of ex.mac has 157226 source lines.
4. Don't use sprintf, since Coherent's is not usable. It doesn't return the number of characters printed.
5. Do '%x' formatting by hand, since Coherent's is upper case.
6. Couldn't stop and have redone the register/flags number assignments so that "<< 3" shifting is no longer needed.

Now the fully macro expanded listing of ex.mac is identical on Coherent 3.2 and Linux. The stripped binary of z80asm on Coherent is only 2.5K larger than the old version in /usr/local/bin. Probably due to my relentless fiddling with z80arfun.c.