### PR TITLE
cpmsim: rename send & receive tools, names are to generic

### DIFF
--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -876,15 +876,15 @@ void init_io(void)
 		exit(1);
 	case 0:
 		/* . might not be in path, so check that first */
-		if (access("./receive", X_OK) == 0)
-			execlp("./receive", "receive", "auxiliaryout.txt",
+		if (access("./cpmrecv", X_OK) == 0)
+			execlp("./cpmrecv", "cpmrecv", "auxiliaryout.txt",
 				(char *) NULL);
 		/* should be in path somewhere */
 		else
-			execlp("receive", "receive", "auxiliaryout.txt",
+			execlp("cpmrecv", "cpmrecv", "auxiliaryout.txt",
 				(char *) NULL);
 		/* if not cry and die */
-		LOGE(TAG, "can't exec receive process, compile/install the tools dude");
+		LOGE(TAG, "can't exec cpmrecv process, compile/install the tools dude");
 		kill(0, SIGQUIT);
 		exit(1);
 	}

--- a/cpmsim/srctools/Makefile
+++ b/cpmsim/srctools/Makefile
@@ -10,7 +10,7 @@ CC = gcc
 CWARNS= -Wall -Wextra -Wwrite-strings
 CFLAGS= -O3 $(CWARNS)
 
-all: test mkdskimg bin2hex send receive ptp2bin
+all: test mkdskimg bin2hex cpmsend cpmrecv ptp2bin
 	@echo
 	@echo "Done."
 	@echo "Now run make install"
@@ -25,11 +25,11 @@ mkdskimg: mkdskimg.c
 bin2hex: bin2hex.c
 	$(CC) $(CFLAGS) -o bin2hex bin2hex.c
 
-send: send.c
-	$(CC) $(CFLAGS) -o send send.c
+cpmsend: cpmsend.c
+	$(CC) $(CFLAGS) -o cpmsend cpmsend.c
 
-receive: receive.c
-	$(CC) $(CFLAGS) -o receive receive.c
+cpmrecv: cpmrecv.c
+	$(CC) $(CFLAGS) -o cpmrecv cpmrecv.c
 
 ptp2bin: ptp2bin.c
 	$(CC) $(CFLAGS) -o ptp2bin ptp2bin.c
@@ -37,8 +37,8 @@ ptp2bin: ptp2bin.c
 install:
 	cp mkdskimg ${INSTALLDIR}
 	cp bin2hex ${INSTALLDIR}
-	cp send ${INSTALLDIR}
-	cp receive ${INSTALLDIR}
+	cp cpmsend ${INSTALLDIR}
+	cp cpmrecv ${INSTALLDIR}
 	cp ptp2bin ${INSTALLDIR}
 	@echo
 	@echo "Tools installed in ${INSTALLDIR}, make sure it is"
@@ -46,5 +46,5 @@ install:
 	@echo
 
 clean:
-	rm -f mkdskimg mkdskimg.exe bin2hex bin2hex.exe receive receive.exe \
-	send send.exe ptp2bin ptp2bin.exe
+	rm -f mkdskimg mkdskimg.exe bin2hex bin2hex.exe cpmrecv cpmrecv.exe \
+	cpmsend cpmsend.exe ptp2bin ptp2bin.exe

--- a/cpmsim/srctools/cpmrecv.c
+++ b/cpmsim/srctools/cpmrecv.c
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
 	fdout = 0;
 
 	if (argc != 2) {
-		puts("usage: receive filname &");
+		puts("usage: cpmrecv filename &");
 		exit(1);
 	}
 	if ((fdin = open("/tmp/.z80pack/cpmsim.auxout", O_RDONLY)) == -1) {

--- a/cpmsim/srctools/cpmsend.c
+++ b/cpmsim/srctools/cpmsend.c
@@ -27,7 +27,7 @@ int main(int argc,char *argv[])
 	register int readn;
 
 	if (argc != 2) {
-		puts("usage: send filname &");
+		puts("usage: cpmsend filname &");
 		exit(1);
 	}
 	if ((fdin = open(argv[1], O_RDONLY)) == -1) {

--- a/cpmsim/srctools/cpmsend.c
+++ b/cpmsim/srctools/cpmsend.c
@@ -27,7 +27,7 @@ int main(int argc,char *argv[])
 	register int readn;
 
 	if (argc != 2) {
-		puts("usage: cpmsend filname &");
+		puts("usage: cpmsend filename &");
 		exit(1);
 	}
 	if ((fdin = open(argv[1], O_RDONLY)) == -1) {

--- a/doc/README-cpm.txt
+++ b/doc/README-cpm.txt
@@ -37,7 +37,7 @@ mkdskimg:
 bin2hex:
 	converts binary files to Intel hex.
 
-receive:
+cpmrecv:
 	This is a process spawned by cpmsim. It reads input from
 	the named pipe auxout and writes all input from the pipe to the
 	file, which is given as first argument. cpmsim spawns this process
@@ -47,9 +47,9 @@ receive:
 	to device PUN: goes into the file auxiliaryout.txt on the
 	host system.
 
-send:
+cpmsend:
 	This program is used to send a file from the host to the
-	simulator. Type send <filename> &, and then run cpmsim.
+	simulator. Type cpmsend <filename> &, and then run cpmsim.
 	The process writes all data from file into the named pipe
 	auxin, which is also connected to I/O-port 5, which is
 	assigned to the CP/M 2 device RDR:. One may use this to


### PR DESCRIPTION
The names of the cpmsim tools send and receive are a bit too generic. Make them more specific to z80pack.