### PR TITLE
z80asm: '$' labels fix, some clean-up

### DIFF
--- a/z80asm/Makefile
+++ b/z80asm/Makefile
@@ -16,7 +16,7 @@ CFLAGS = -O3 $(CWARNS) -D_POSIX_C_SOURCE=200809L
 DESTDIR = "${HOME}/bin"
 #DESTDIR = /usr/local/bin
 
-OBJ =   z80amain.o \
+OBJS =	z80amain.o \
 	z80atab.o \
 	z80anum.o \
 	z80aout.o \
@@ -26,34 +26,34 @@ OBJ =   z80amain.o \
 	z80aopc.o \
 	z80aglb.o
 
-z80asm : $(OBJ)
-	$(CC) $(OBJ) $(LDFLAGS) -o z80asm
+z80asm: $(OBJS)
+	$(CC) $(OBJS) $(LDFLAGS) -o z80asm
 
-z80amain.o : z80amain.c z80a.h z80aglb.h
+z80amain.o: z80amain.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80amain.c
 
-z80atab.o : z80atab.c z80a.h z80aglb.h
+z80atab.o: z80atab.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80atab.c
 
-z80anum.o : z80anum.c z80a.h z80aglb.h
+z80anum.o: z80anum.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80anum.c
 
-z80aout.o : z80aout.c z80a.h z80aglb.h
+z80aout.o: z80aout.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80aout.c
 
-z80amfun.o : z80amfun.c z80a.h z80aglb.h
+z80amfun.o: z80amfun.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80amfun.c
 
-z80arfun.o : z80arfun.c z80a.h z80aglb.h
+z80arfun.o: z80arfun.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80arfun.c
 
-z80apfun.o : z80apfun.c z80a.h z80aglb.h
+z80apfun.o: z80apfun.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80apfun.c
 
-z80aopc.o : z80aopc.c z80a.h
+z80aopc.o: z80aopc.c z80a.h
 	$(CC) $(CFLAGS) -c z80aopc.c
 
-z80aglb.o : z80aglb.c z80a.h
+z80aglb.o: z80aglb.c z80a.h
 	$(CC) $(CFLAGS) -c z80aglb.c
 
 clean:

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -380,7 +380,7 @@ int process_line(char *l)
 	op = NULL;
 	op_count = 0;
 	old_genc = gencode;
-	if (*l == LINCOM || *l == LINOPT)
+	if (*l == LINCOM || (*l == LINOPT && !is_sym_char(*(l + 1))))
 		a_mode = A_NONE;
 	else {
 		p = get_symbol(label, l, 1);

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -501,7 +501,7 @@ void mac_subst(char *t, char *s, struct expn *e,
 	int amp_flag;	/* 0 = no &, 1 = & before, 2 = & after */
 	int esc_flag;	/* 0 = no ^, 1 = ^ before */
 
-	if (*s == LINCOM || *s == LINOPT) {
+	if (*s == LINCOM || (*s == LINOPT && !is_sym_char(*(s + 1)))) {
 		while (*s != '\n' && *s != '\0')
 			*t++ = *s++;
 		goto done;


### PR DESCRIPTION
1. '$' in the first column is only treated as an option line if not followed by a valid symbol character (MAC uses '$*', '$+', and '$-' for options). This caused errors with z80dis.asm.
2. Some code clean-up...