### PR TITLE
z80asm: macro memory leak fix, optimizations, clean up

### DIFF
--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -54,11 +54,11 @@
 #define INCNEST		5	/* max. INCLUDE nesting depth */
 #define HASHSIZE	500	/* max. entries in symbol hash array */
 #define OPCARRAY	256	/* size of object buffer */
-#define SYMINC		100	/* start size of sorted symbol array */
 #define MAXHEX		32	/* max. no bytes/hex record */
 
 /*
- *	types for working with op-codes, addresses and expressions
+ *	types for working with op-codes, addresses, expressions,
+ *	and bit flags and masks
  */
 typedef unsigned char BYTE;
 typedef unsigned short WORD;
@@ -68,7 +68,7 @@ typedef unsigned short WORD;
  */
 struct opc {
 	const char *op_name;	/* opcode name */
-	int (*op_fun) (BYTE, BYTE); /* function pointer code gen. */
+	unsigned (*op_fun) (BYTE, BYTE); /* function pointer code gen. */
 	BYTE op_c1;		/* first base opcode */
 	BYTE op_c2;		/* second base opcode */
 	WORD op_flags;		/* opcode flags */
@@ -84,22 +84,12 @@ struct ope {
 };
 
 /*
- *	structure operations set
- */
-struct opset {
-	int no_opcodes;		/* number of opcode entries */
-	struct opc *opctab;	/* opcode table */
-	int no_operands;	/* number of operand entries */
-	struct ope *opetab;	/* operand table */
-};
-
-/*
  *	structure symbol table entries
  */
 struct sym {
 	char *sym_name;		/* symbol name */
 	WORD sym_val;		/* symbol value */
-	int  sym_refcnt;	/* symbol reference counter */
+	unsigned sym_refcnt;	/* symbol reference counter */
 	struct sym *sym_next;	/* next entry */
 };
 
@@ -201,7 +191,7 @@ struct inc {
 /*
  *	definition of operation sets
  */
-#define OPSET_PSD	0	/* pseudo ops */
+#define OPSET_NONE	0	/* not set */
 #define OPSET_Z80	1	/* Z80 opcodes */
 #define OPSET_8080	2	/* 8080 opcodes */
 
@@ -220,6 +210,16 @@ struct inc {
 #define	M_OPS		0	/* only list macro expansions producing ops */
 #define M_ALL		1	/* list all macro expansions */
 #define M_NONE		2	/* list no macro expansions */
+
+/*
+ *	definition of character types
+ */
+#define C_FSYM		0x01	/* first symbol character */
+#define C_SYM		0x02	/* symbol character */
+#define C_LOW		0x04	/* lower case letter */
+#define C_DIG		0x08	/* decimal digit */
+#define C_XDIG		0x10	/* hexadecimal digit */
+#define C_SPC		0x20	/* white space */
 
 /*
  *	definition of error numbers for error messages in listfile
@@ -251,7 +251,7 @@ struct inc {
 #define E_NIMEXP	24	/* not in macro expansion */
 #define E_MACNEST	25	/* macro expansion nested too deep */
 #define E_OUTLCL	26	/* too many local labels */
-#define E_LBLDIF	27	/* label value differs between passes */
+#define E_LBLDIF	27	/* label address differs between passes */
 
 /*
  *	definition of fatal errors
@@ -269,3 +269,14 @@ struct inc {
  *	macro for declaring unused function parameters
  */
 #define UNUSED(x)	(void)(x)
+
+/*
+ *	macros for character classification and conversion
+ */
+#define IS_FSYM(c)	(ctype[(BYTE) (c)] & C_FSYM)
+#define IS_SYM(c)	(ctype[(BYTE) (c)] & C_SYM)
+#define IS_DIG(c)	(ctype[(BYTE) (c)] & C_DIG)
+#define IS_XDIG(c)	(ctype[(BYTE) (c)] & C_XDIG)
+#define IS_SPC(c)	(ctype[(BYTE) (c)] & C_SPC)
+/* don't use parameters with side-effects with this! */
+#define TO_UPP(c)	((ctype[(BYTE) (c)] & C_LOW) ? ((c) - 32) : (c))

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -40,7 +40,8 @@ char *infiles[MAXFN],		/* source filenames */
      operand[MAXLINE],		/* buffer for working with operand */
      title[MAXLINE];		/* buffer for title of source */
 
-BYTE ops[OPCARRAY];		/* buffer for generated object code */
+BYTE ops[OPCARRAY],		/* buffer for generated object code */
+     ctype[256];		/* table for character classification */
 
 WORD rpc,			/* real program counter */
      pc,			/* logical program counter, normally equal */
@@ -58,26 +59,16 @@ int  list_flag,			/* flag for option -l */
      upcase_flag,		/* flag for option -U */
      mac_list_flag,		/* flag for option -m */
      radix,			/* current radix, set to 10 at start of pass */
-     opset = OPSET_Z80,		/* current operations set (default Z80) */
+     opset,			/* current operations set */
      phs_flag,			/* flag for being inside a .PHASE block */
      pass,			/* processed pass */
-     iflevel,			/* IF nesting level */
-     act_iflevel,		/* active IF nesting level */
-     act_elselevel,		/* active ELSE nesting level */
      gencode,			/* flag for conditional code */
      nofalselist,		/* flag for false conditional listing */
-     mac_def_nest,		/* macro definition nesting level */
-     mac_exp_nest,		/* macro expansion nesting level */
-     mac_symmax,		/* max. macro symbol length encountered */
-     errors,			/* error counter */
      errnum,			/* error number in pass 2 */
      a_mode,			/* location output mode for pseudo ops */
      load_flag,			/* flag for load_addr valid */
      obj_fmt = OBJ_HEX,		/* format of object file (default Intel hex) */
-     symlen = SYMLEN,		/* significant characters in symbols */
-     symmax,			/* max. symbol name length encountered */
-     symsize,			/* size of symarray */
-     p_line,			/* no. printed lines on page */
+     p_line,			/* no. printed lines on page (can be < 0) */
      ppl = PLENGTH;		/* page length */
 
 FILE *srcfp,			/* file pointer for current source */
@@ -86,6 +77,16 @@ FILE *srcfp,			/* file pointer for current source */
      *errfp;			/* file pointer for error output */
 
 unsigned
+     iflevel,			/* IF nesting level */
+     act_iflevel,		/* active IF nesting level */
+     act_elselevel,		/* active ELSE nesting level */
+     mac_def_nest,		/* macro definition nesting level */
+     mac_exp_nest,		/* macro expansion nesting level */
+     mac_symmax,		/* max. macro symbol length encountered */
+     errors,			/* error counter */
+     symlen = SYMLEN,		/* significant characters in symbols */
+     symmax,			/* max. symbol name length encountered */
+     symcnt,			/* number of symbols defined */
      page;			/* no. of pages for listing */
 
 unsigned long

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -36,7 +36,8 @@ extern char	*infiles[],
 		operand[],
 		title[];
 
-extern BYTE	ops[];
+extern BYTE	ops[],
+		ctype[];
 
 extern WORD	rpc,
 		pc,
@@ -56,22 +57,12 @@ extern int	list_flag,
 		opset,
 		phs_flag,
 		pass,
-		iflevel,
-		act_iflevel,
-		act_elselevel,
 		gencode,
 		nofalselist,
-		mac_def_nest,
-		mac_exp_nest,
-		mac_symmax,
-		errors,
 		errnum,
 		a_mode,
 		load_flag,
 		obj_fmt,
-		symlen,
-		symmax,
-		symsize,
 		p_line,
 		ppl;
 
@@ -80,11 +71,25 @@ extern FILE	*srcfp,
 		*lstfp,
 		*errfp;
 
-extern unsigned	page;
+extern unsigned	iflevel,
+		act_iflevel,
+		act_elselevel,
+		mac_def_nest,
+		mac_exp_nest,
+		mac_symmax,
+		errors,
+		symlen,
+		symmax,
+		symcnt,
+		page,
+		no_opcodes,
+		no_operands;
 
 extern unsigned long c_line;
 
 extern struct sym *symtab[],
 		  **symarray;
 
-extern struct opset opsettab[];
+extern struct opc **opctab;
+
+extern struct ope *opetab;

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -31,9 +31,10 @@
 #include "z80a.h"
 #include "z80aglb.h"
 
-int ldreg(BYTE, char *), ldixhl(BYTE, char *), ldiyhl(BYTE, char *);
-int ldsp(char *), ldihl(BYTE, char *), ldiixy(BYTE, BYTE, char *);
-int ldinn(char *), aluop(BYTE, char *), cbgrp_iixy(BYTE, BYTE, BYTE, char *);
+unsigned ldreg(BYTE, char *), ldixhl(BYTE, char *), ldiyhl(BYTE, char *);
+unsigned ldsp(char *), ldihl(BYTE, char *), ldiixy(BYTE, BYTE, char *);
+unsigned ldinn(char *), aluop(BYTE, char *);
+unsigned cbgrp_iixy(BYTE, BYTE, BYTE, char *);
 
 /* z80amain.c */
 extern void asmerr(int);
@@ -50,7 +51,7 @@ extern BYTE get_reg(char *);
 /*
  *	process 1byte opcodes without arguments
  */
-int op_1b(BYTE b1, BYTE dummy)
+unsigned op_1b(BYTE b1, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -61,7 +62,7 @@ int op_1b(BYTE b1, BYTE dummy)
 /*
  *	process 2byte opcodes without arguments
  */
-int op_2b(BYTE b1, BYTE b2)
+unsigned op_2b(BYTE b1, BYTE b2)
 {
 	ops[0] = b1;
 	ops[1] = b2;
@@ -71,7 +72,7 @@ int op_2b(BYTE b1, BYTE b2)
 /*
  *	IM
  */
-int op_im(BYTE base_op1, BYTE base_op2)
+unsigned op_im(BYTE base_op1, BYTE base_op2)
 {
 	register WORD n;
 
@@ -98,10 +99,10 @@ int op_im(BYTE base_op1, BYTE base_op2)
 /*
  *	PUSH and POP
  */
-int op_pupo(BYTE base_op, BYTE dummy)
+unsigned op_pupo(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	UNUSED(dummy);
 
@@ -135,9 +136,9 @@ int op_pupo(BYTE base_op, BYTE dummy)
 /*
  *	EX
  */
-int op_ex(BYTE base_ops, BYTE base_opd)
+unsigned op_ex(BYTE base_ops, BYTE base_opd)
 {
-	register int len;
+	register unsigned len;
 
 	if (strcmp(operand, "DE,HL") == 0) {
 		len = 1;
@@ -167,7 +168,7 @@ int op_ex(BYTE base_ops, BYTE base_opd)
 /*
  *	RST
  */
-int op_rst(BYTE base_op, BYTE dummy)
+unsigned op_rst(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -187,7 +188,7 @@ int op_rst(BYTE base_op, BYTE dummy)
 /*
  *	RET
  */
-int op_ret(BYTE base_op, BYTE base_opc)
+unsigned op_ret(BYTE base_op, BYTE base_opc)
 {
 	register BYTE op;
 
@@ -217,12 +218,12 @@ int op_ret(BYTE base_op, BYTE base_opc)
 /*
  *	JP and CALL
  */
-int op_jpcall(BYTE base_op, BYTE base_opc)
+unsigned op_jpcall(BYTE base_op, BYTE base_opc)
 {
 	register char *sec;
 	register BYTE op;
 	register WORD n;
-	register int len;
+	register unsigned len;
 
 	len = 0;			/* silence compiler */
 	sec = next_arg(operand, NULL);
@@ -298,7 +299,7 @@ int op_jpcall(BYTE base_op, BYTE base_opc)
 /*
  *	JR
  */
-int op_jr(BYTE base_op, BYTE base_opc)
+unsigned op_jr(BYTE base_op, BYTE base_opc)
 {
 	register char *sec;
 	register BYTE op;
@@ -342,7 +343,7 @@ int op_jr(BYTE base_op, BYTE base_opc)
 /*
  *	DJNZ
  */
-int op_djnz(BYTE base_op, BYTE dummy)
+unsigned op_djnz(BYTE base_op, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -356,12 +357,12 @@ int op_djnz(BYTE base_op, BYTE dummy)
 /*
  *	LD
  */
-int op_ld(BYTE base_op, BYTE dummy)
+unsigned op_ld(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op;
 	register WORD n;
-	register int len;
+	register unsigned len;
 
 	UNUSED(dummy);
 
@@ -502,11 +503,11 @@ int op_ld(BYTE base_op, BYTE dummy)
 /*
  *	LD [A,B,C,D,E,H,L],?
  */
-int ldreg(BYTE base_op, char *sec)
+unsigned ldreg(BYTE base_op, char *sec)
 {
 	register BYTE op;
 	register WORD n;
-	register int len;
+	register unsigned len;
 
 	len = 0;			/* silence compiler */
 	switch (op = get_reg(sec)) {
@@ -602,10 +603,10 @@ int ldreg(BYTE base_op, char *sec)
 /*
  *	LD IX[HL],? (undoc)
  */
-int ldixhl(BYTE base_op, char *sec)
+unsigned ldixhl(BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD IX[HL],A (undoc) */
@@ -643,10 +644,10 @@ int ldixhl(BYTE base_op, char *sec)
 /*
  *	LD IY[HL],? (undoc)
  */
-int ldiyhl(BYTE base_op, char *sec)
+unsigned ldiyhl(BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD IY[HL],A (undoc) */
@@ -684,11 +685,11 @@ int ldiyhl(BYTE base_op, char *sec)
 /*
  *	LD SP,?
  */
-int ldsp(char *sec)
+unsigned ldsp(char *sec)
 {
 	register BYTE op;
 	register WORD n;
-	register int len;
+	register unsigned len;
 
 	switch (op = get_reg(sec)) {
 	case REGHL:			/* LD SP,HL */
@@ -737,10 +738,10 @@ int ldsp(char *sec)
 /*
  *	LD (HL),?
  */
-int ldihl(BYTE base_op, char *sec)
+unsigned ldihl(BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD (HL),A */
@@ -776,10 +777,10 @@ int ldihl(BYTE base_op, char *sec)
 /*
  *	LD (I[XY]+d),?
  */
-int ldiixy(BYTE prefix, BYTE base_op, char *sec)
+unsigned ldiixy(BYTE prefix, BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD (I[XY]+d),A */
@@ -823,11 +824,11 @@ int ldiixy(BYTE prefix, BYTE base_op, char *sec)
 /*
  *	LD (nn),?
  */
-int ldinn(char *sec)
+unsigned ldinn(char *sec)
 {
 	register BYTE op;
 	register WORD n;
-	register int len;
+	register unsigned len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD (nn),A */
@@ -887,11 +888,11 @@ int ldinn(char *sec)
 /*
  *	ADD ?,?
  */
-int op_add(BYTE base_op, BYTE base_op16)
+unsigned op_add(BYTE base_op, BYTE base_op16)
 {
 	register char *sec;
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	sec = next_arg(operand, NULL);
 	switch (get_reg(operand)) {
@@ -974,11 +975,11 @@ int op_add(BYTE base_op, BYTE base_op16)
 /*
  *	SBC ?,? and ADC ?,?
  */
-int op_sbadc(BYTE base_op, BYTE base_op16)
+unsigned op_sbadc(BYTE base_op, BYTE base_op16)
 {
 	register char *sec;
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	sec = next_arg(operand, NULL);
 	switch (get_reg(operand)) {
@@ -1022,10 +1023,10 @@ int op_sbadc(BYTE base_op, BYTE base_op16)
 /*
  *	DEC and INC
  */
-int op_decinc(BYTE base_op, BYTE base_op16)
+unsigned op_decinc(BYTE base_op, BYTE base_op16)
 {
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	switch (op = get_reg(operand)) {
 	case REGA:			/* INC/DEC A */
@@ -1092,7 +1093,7 @@ int op_decinc(BYTE base_op, BYTE base_op16)
 /*
  *	SUB, AND, XOR, OR, CP
  */
-int op_alu(BYTE base_op, BYTE dummy)
+unsigned op_alu(BYTE base_op, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -1102,10 +1103,10 @@ int op_alu(BYTE base_op, BYTE dummy)
 /*
  *	ADD A, ADC A, SUB, SBC A, AND, XOR, OR, CP
  */
-int aluop(BYTE base_op, char *sec)
+unsigned aluop(BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* ALUOP {A,}A */
@@ -1161,7 +1162,7 @@ int aluop(BYTE base_op, char *sec)
 /*
  *	OUT
  */
-int op_out(BYTE op_base, BYTE op_basec)
+unsigned op_out(BYTE op_base, BYTE op_basec)
 {
 	register char *sec;
 	register BYTE op;
@@ -1227,7 +1228,7 @@ int op_out(BYTE op_base, BYTE op_basec)
 /*
  *	IN
  */
-int op_in(BYTE op_base, BYTE op_basec)
+unsigned op_in(BYTE op_base, BYTE op_basec)
 {
 	register char *sec;
 	register BYTE op;
@@ -1294,11 +1295,11 @@ int op_in(BYTE op_base, BYTE op_basec)
 /*
  *	RLC, RRC, RL, RR, SLA, SRA, SLL, SRL, BIT, RES, SET
  */
-int op_cbgrp(BYTE base_op, BYTE dummy)
+unsigned op_cbgrp(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op, bit;
-	register int len;
+	register unsigned len;
 
 	UNUSED(dummy);
 
@@ -1353,7 +1354,7 @@ int op_cbgrp(BYTE base_op, BYTE dummy)
 /*
  *	CBOP {n,}(I[XY]+d){,reg}
  */
-int cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
+unsigned cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 {
 	register char *tert;
 	register BYTE op;
@@ -1412,7 +1413,7 @@ int cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 /*
  *	8080 MOV
  */
-int op8080_mov(BYTE base_op, BYTE dummy)
+unsigned op8080_mov(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op1, op2;
@@ -1468,7 +1469,7 @@ int op8080_mov(BYTE base_op, BYTE dummy)
 /*
  *	8080 ADC, ADD, ANA, CMP, ORA, SBB, SUB, XRA
  */
-int op8080_alu(BYTE base_op, BYTE dummy)
+unsigned op8080_alu(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1499,7 +1500,7 @@ int op8080_alu(BYTE base_op, BYTE dummy)
 /*
  *	8080 DCR and INR
  */
-int op8080_dcrinr(BYTE base_op, BYTE dummy)
+unsigned op8080_dcrinr(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1530,7 +1531,7 @@ int op8080_dcrinr(BYTE base_op, BYTE dummy)
 /*
  *	8080 INX, DAD, DCX
  */
-int op8080_reg16(BYTE base_op, BYTE dummy)
+unsigned op8080_reg16(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1557,7 +1558,7 @@ int op8080_reg16(BYTE base_op, BYTE dummy)
 /*
  *	8080 STAX and LDAX
  */
-int op8080_regbd(BYTE base_op, BYTE dummy)
+unsigned op8080_regbd(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1582,7 +1583,7 @@ int op8080_regbd(BYTE base_op, BYTE dummy)
 /*
  *	8080 ACI, ADI, ANI, CPI, ORI, SBI, SUI, XRI, OUT, IN
  */
-int op8080_imm(BYTE base_op, BYTE dummy)
+unsigned op8080_imm(BYTE base_op, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -1596,7 +1597,7 @@ int op8080_imm(BYTE base_op, BYTE dummy)
 /*
  *	8080 RST
  */
-int op8080_rst(BYTE base_op, BYTE dummy)
+unsigned op8080_rst(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1615,7 +1616,7 @@ int op8080_rst(BYTE base_op, BYTE dummy)
 /*
  *	8080 PUSH and POP
  */
-int op8080_pupo(BYTE base_op, BYTE dummy)
+unsigned op8080_pupo(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1644,7 +1645,7 @@ int op8080_pupo(BYTE base_op, BYTE dummy)
  *	     JMP, JNZ, JZ, JNC, JC, JPO, JPE, JP, JM
  *	     CALL, CNZ, CZ, CNC, CC, CPO, CPE, CP, CM
  */
-int op8080_addr(BYTE base_op, BYTE dummy)
+unsigned op8080_addr(BYTE base_op, BYTE dummy)
 {
 	register WORD n;
 
@@ -1662,11 +1663,11 @@ int op8080_addr(BYTE base_op, BYTE dummy)
 /*
  *	8080 MVI
  */
-int op8080_mvi(BYTE base_op, BYTE dummy)
+unsigned op8080_mvi(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op;
-	register int len;
+	register unsigned len;
 
 	UNUSED(dummy);
 
@@ -1702,12 +1703,12 @@ int op8080_mvi(BYTE base_op, BYTE dummy)
 /*
  *	8080 LXI
  */
-int op8080_lxi(BYTE base_op, BYTE dummy)
+unsigned op8080_lxi(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op;
 	register WORD n;
-	register int len;
+	register unsigned len;
 
 	UNUSED(dummy);
 


### PR DESCRIPTION
1. Moved line upcasing into the fgets block, since during macro expansion the lines are already upcased.
2. Fixed a memory leak in the macro code discovered by valgrind.
3. is_sym_char and is_first_sym_char were in the top 4 when running valgrind's callgrind. Removed is_sym_char and is_first_sym_char and made them into macros with a ctype-like array to check for symbol characters. Since I now had this array just used it for all character classifications.
4. Now strcmp and search_op were in the top 4 of the callgrind list. Built a single sorted list of struct opc * with all opcodes when switching the instruction set. Reduced instructions count for strcmp by half, and search_op by 60% when assembling ex.mac!
5. Just keep counters of the number of symbols and macros defined, and remove the realloc code from the table sorting functions.
6. Removed the call to strsave and used malloc directly, since the length of a new symbol/macro name is needed for recording the maximum length. Halved the strlen calls for new symbols and macros. Moved strsave to the macro code, since it is the only user now.
7. Use unsigned for all counters and indices.
8. If you define a label twice in pass 1 with different addresses you now get E_MULSYM again... I only tested IF1 and IF2 before.
9. Added DEFS to M_OPS listing. The ex.mac listing now has the same number of code lines as M80's.
10. The usual clean up...