### PR TITLE
z80asm: code reorg, iterator style symbol table list, clean up

### DIFF
--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -189,11 +189,11 @@ struct inc {
 #define SYM_SORTA	3	/* symbol table sorted by address */
 
 /*
- *	definition of operation sets
+ *	definition of instruction sets
  */
-#define OPSET_NONE	0	/* not set */
-#define OPSET_Z80	1	/* Z80 opcodes */
-#define OPSET_8080	2	/* 8080 opcodes */
+#define INSTR_NONE	0	/* not yet initialized */
+#define INSTR_Z80 	1	/* Z80 instructions set */
+#define INSTR_8080	2	/* 8080 instructions set */
 
 /*
  *	definition of address output modes for pseudo ops

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -58,8 +58,8 @@ int  list_flag,			/* flag for option -l */
      nofill_flag,		/* flag for option -x */
      upcase_flag,		/* flag for option -U */
      mac_list_flag,		/* flag for option -m */
+     i8080_flag,		/* flag for option -8 */
      radix,			/* current radix, set to 10 at start of pass */
-     opset,			/* current operations set */
      phs_flag,			/* flag for being inside a .PHASE block */
      pass,			/* processed pass */
      gencode,			/* flag for conditional code */
@@ -91,7 +91,3 @@ unsigned
 
 unsigned long
      c_line;			/* current line no. in current source */
-
-struct sym
-     *symtab[HASHSIZE],		/* symbol table */
-     **symarray;		/* sorted symbol table */

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -86,7 +86,6 @@ unsigned
      errors,			/* error counter */
      symlen = SYMLEN,		/* significant characters in symbols */
      symmax,			/* max. symbol name length encountered */
-     symcnt,			/* number of symbols defined */
      page;			/* no. of pages for listing */
 
 unsigned long

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -80,7 +80,6 @@ extern unsigned	iflevel,
 		errors,
 		symlen,
 		symmax,
-		symcnt,
 		page;
 
 extern unsigned long c_line;

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -53,8 +53,8 @@ extern int	list_flag,
 		nofill_flag,
 		upcase_flag,
 		mac_list_flag,
+		i8080_flag,
 		radix,
-		opset,
 		phs_flag,
 		pass,
 		gencode,
@@ -81,15 +81,6 @@ extern unsigned	iflevel,
 		symlen,
 		symmax,
 		symcnt,
-		page,
-		no_opcodes,
-		no_operands;
+		page;
 
 extern unsigned long c_line;
-
-extern struct sym *symtab[],
-		  **symarray;
-
-extern struct opc **opctab;
-
-extern struct ope *opetab;

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -78,7 +78,7 @@ struct opr {
  *	table with operators
  *	must be sorted in ascending order!
  */
-struct opr oprtab[] = {
+static struct opr oprtab[] = {
 	{ "AND",	T_AND		},
 	{ "EQ",		T_EQ		},
 	{ "GE",		T_GE		},
@@ -97,7 +97,7 @@ struct opr oprtab[] = {
 	{ "TYPE",	T_TYPE		},
 	{ "XOR",	T_XOR		}
 };
-unsigned no_operators = sizeof(oprtab) / sizeof(struct opr);
+static unsigned no_operators = sizeof(oprtab) / sizeof(struct opr);
 
 static BYTE tok_type;	/* token type and flags */
 static WORD tok_val;	/* token value for T_VAL type */

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -42,7 +42,7 @@ extern WORD eval(char *);
 extern BYTE chk_byte(WORD);
 
 /* z80aopc.c */
-extern void set_opset(int);
+extern void instrset(int);
 
 /* z80aout.c */
 extern void asmerr(int);
@@ -61,20 +61,20 @@ extern void put_sym(char *, WORD);
 /*
  *	.Z80 and .8080
  */
-unsigned op_opset(BYTE op_code, BYTE dummy)
+unsigned op_instrset(BYTE op_code, BYTE dummy)
 {
 	UNUSED(dummy);
 
 	a_mode = A_NONE;
 	switch (op_code) {
 	case 1:				/* .Z80 */
-		set_opset(OPSET_Z80);
+		instrset(INSTR_Z80);
 		break;
 	case 2:				/* .8080 */
-		set_opset(OPSET_8080);
+		instrset(INSTR_8080);
 		break;
 	default:
-		fatal(F_INTERN, "invalid opcode for function op_opset");
+		fatal(F_INTERN, "invalid opcode for function op_instrset");
 	}
 	return(0);
 }

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -46,6 +46,7 @@ extern void fatal(int, const char *);
 extern void asmerr(int);
 
 static struct sym *symtab[HASHSIZE];	/* symbol table */
+static unsigned symcnt;			/* number of symbols defined */
 static struct sym **symarray;		/* sorted symbol table */
 static int symsort;			/* sort mode for iterator */
 static unsigned symidx;			/* hash table index for iterator */


### PR DESCRIPTION
1. Move the rest of the opc code into z80aopc.c. It now contains the only code handling the opc and ope tables. Make the arrays and variables static like the macro code.
2. Convert symbol list to iterator style like the macro list. Now there is only one function to list the symbol table. main() is really short now.
3. z80atab.c now contains only symbol table code and is the only code that handles the internals of the symbol table. Make symbol table and variables static.
4. Clean up... should I even mentions this :-)

And it still compiles and runs on Coherent 3.2.