### PR TITLE
z80asm: inc_line is long, op_count is WORD, revert some unsigned's, misc

### DIFF
--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -173,7 +173,7 @@ The alias ABS for ASEG is also accepted.
 
 Precedence for expression operators:
 
-()
+( )
 unary + - ~ NOT HIGH LOW NUL TYPE
 * / MOD % SHR >> SHL <<
 + -
@@ -181,5 +181,5 @@ EQ = == NE <> != LT < LE <= GT > GE >=
 AND & XOR ^ OR |
 
 Usage of the %, ^, >>, <<, <>, <, <=, >, and >= operators in macros
-and macro parameters is not recommended, since they clash with the
+and macro parameters is not possible, since they clash with the
 escape character ^, the pass by value % and <> bracket lists.

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -69,7 +69,7 @@ typedef unsigned short WORD;
  */
 struct opc {
 	const char *op_name;	/* opcode name */
-	unsigned (*op_fun) (BYTE, BYTE); /* function pointer code gen. */
+	WORD (*op_fun) (BYTE, BYTE); /* function pointer code gen. */
 	BYTE op_c1;		/* first base opcode */
 	BYTE op_c2;		/* second base opcode */
 	WORD op_flags;		/* opcode flags */
@@ -90,7 +90,7 @@ struct ope {
 struct sym {
 	char *sym_name;		/* symbol name */
 	WORD sym_val;		/* symbol value */
-	unsigned sym_refcnt;	/* symbol reference counter */
+	int sym_refflg;		/* symbol reference flag */
 	struct sym *sym_next;	/* next entry */
 };
 
@@ -98,7 +98,7 @@ struct sym {
  *	structure nested INCLUDE's
  */
 struct inc {
-	unsigned inc_line;	/* line counter for listing */
+	unsigned long inc_line;	/* line counter for listing */
 	char *inc_fn;		/* filename */
 	FILE *inc_fp;		/* file pointer */
 };

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -31,14 +31,15 @@
 #include "z80a.h"
 
 char *infiles[MAXFN],		/* source filenames */
+     *srcfn,			/* filename of current processed source file */
      objfn[LENFN + 1],		/* object filename */
      lstfn[LENFN + 1],		/* listing filename */
-     *srcfn,			/* filename of current processed source file */
-     line[MAXLINE],		/* buffer for one line of source */
-     label[MAXLINE],		/* buffer for label */
-     opcode[MAXLINE],		/* buffer for opcode */
-     operand[MAXLINE],		/* buffer for working with operand */
-     title[MAXLINE];		/* buffer for title of source */
+     line[MAXLINE + 2],		/* buffer for one line of source */
+     tmp[MAXLINE + 2],		/* temporary buffer */
+     label[MAXLINE + 1],	/* buffer for label */
+     opcode[MAXLINE + 1],	/* buffer for opcode */
+     operand[MAXLINE + 1],	/* buffer for working with operand */
+     title[MAXLINE + 1];	/* buffer for title of source */
 
 BYTE ops[OPCARRAY],		/* buffer for generated object code */
      ctype[256];		/* table for character classification */
@@ -62,31 +63,28 @@ int  list_flag,			/* flag for option -l */
      radix,			/* current radix, set to 10 at start of pass */
      phs_flag,			/* flag for being inside a .PHASE block */
      pass,			/* processed pass */
-     gencode,			/* flag for conditional code */
+     iflevel,			/* IF nesting level */
+     act_iflevel,		/* active IF nesting level */
+     act_elselevel,		/* active ELSE nesting level */
+     gencode = 1,		/* flag for conditional code */
      nofalselist,		/* flag for false conditional listing */
+     mac_def_nest,		/* macro definition nesting level */
+     mac_exp_nest,		/* macro expansion nesting level */
+     mac_symmax,		/* max. macro symbol length encountered */
+     errors,			/* error counter */
      errnum,			/* error number in pass 2 */
-     a_mode,			/* location output mode for pseudo ops */
+     a_mode,			/* address output mode for pseudo ops */
      load_flag,			/* flag for load_addr valid */
      obj_fmt = OBJ_HEX,		/* format of object file (default Intel hex) */
+     symlen = SYMLEN,		/* significant characters in symbols */
+     symmax,			/* max. symbol name length encountered */
      p_line,			/* no. printed lines on page (can be < 0) */
-     ppl = PLENGTH;		/* page length */
+     ppl = PLENGTH,		/* page length */
+     page;			/* no. of pages for listing */
+
+unsigned long c_line;		/* current line no. in current source */
 
 FILE *srcfp,			/* file pointer for current source */
      *objfp,			/* file pointer for object code */
      *lstfp,			/* file pointer for listing */
      *errfp;			/* file pointer for error output */
-
-unsigned
-     iflevel,			/* IF nesting level */
-     act_iflevel,		/* active IF nesting level */
-     act_elselevel,		/* active ELSE nesting level */
-     mac_def_nest,		/* macro definition nesting level */
-     mac_exp_nest,		/* macro expansion nesting level */
-     mac_symmax,		/* max. macro symbol length encountered */
-     errors,			/* error counter */
-     symlen = SYMLEN,		/* significant characters in symbols */
-     symmax,			/* max. symbol name length encountered */
-     page;			/* no. of pages for listing */
-
-unsigned long
-     c_line;			/* current line no. in current source */

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -82,7 +82,8 @@ int  list_flag,			/* flag for option -l */
      ppl = PLENGTH,		/* page length */
      page;			/* no. of pages for listing */
 
-unsigned long c_line;		/* current line no. in current source */
+unsigned long
+     c_line;			/* current line no. in current source */
 
 FILE *srcfp,			/* file pointer for current source */
      *objfp,			/* file pointer for object code */

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -27,10 +27,11 @@
  */
 
 extern char	*infiles[],
+		*srcfn,
 		objfn[],
 		lstfn[],
-		*srcfn,
 		line[],
+		tmp[],
 		label[],
 		opcode[],
 		operand[],
@@ -57,29 +58,29 @@ extern int	list_flag,
 		radix,
 		phs_flag,
 		pass,
+		iflevel,
+		act_iflevel,
+		act_elselevel,
 		gencode,
 		nofalselist,
+		mac_def_nest,
+		mac_exp_nest,
+		mac_symmax,
+		errors,
 		errnum,
 		a_mode,
 		load_flag,
 		obj_fmt,
+		symlen,
+		symmax,
 		p_line,
-		ppl;
+		ppl,
+		page;
+
+extern unsigned long
+		c_line;
 
 extern FILE	*srcfp,
 		*objfp,
 		*lstfp,
 		*errfp;
-
-extern unsigned	iflevel,
-		act_iflevel,
-		act_elselevel,
-		mac_def_nest,
-		mac_exp_nest,
-		mac_symmax,
-		errors,
-		symlen,
-		symmax,
-		page;
-
-extern unsigned long c_line;

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -45,12 +45,12 @@ char *get_operand(char *, char *, int);
 
 /* z80aout.c */
 extern void asmerr(int);
-extern void lst_line(char *, WORD, unsigned, int);
+extern void lst_line(char *, WORD, WORD, int);
 extern void lst_mac(int);
 extern void lst_sym(int);
 extern void obj_header(void);
 extern void obj_end(void);
-extern void obj_writeb(unsigned);
+extern void obj_writeb(WORD);
 
 /* z80mfun.c */
 extern void mac_start_pass(void);
@@ -117,7 +117,7 @@ void init(void)
 void options(int argc, char *argv[])
 {
 	register char *s, *t;
-	register unsigned i;
+	register int i;
 
 	while (--argc > 0 && (*++argv)[0] == '-')
 		for (s = argv[0] + 1; *s != '\0'; s++)
@@ -271,14 +271,13 @@ void fatal(int i, const char *arg)
  */
 void do_pass(int p)
 {
-	register unsigned fi;
+	register int fi;
 
 	pass = p;
 	radix = 10;
 	rpc = pc = 0;
-	gencode = 1;
-	mac_start_pass();
 	fi = 0;
+	mac_start_pass();
 	if (ver_flag)
 		printf("Pass %d\n", pass);
 	if (pass == 1)				/* PASS 1 */
@@ -322,7 +321,7 @@ void process_file(char *fn)
 		while (mac_exp_nest > 0 && (l = mac_expand()) == NULL)
 			;
 		if (l == NULL) {
-			if ((l = fgets(line, MAXLINE, srcfp)) == NULL)
+			if ((l = fgets(line, MAXLINE + 2, srcfp)) == NULL)
 				break;
 			if (upcase_flag)
 				for (s = l; *s; s++)
@@ -346,7 +345,7 @@ int process_line(char *l)
 {
 	register char *p;
 	register int old_genc, lbl_flag, expn_flag, lflag;
-	register unsigned op_count;
+	register WORD op_count;
 	register struct opc *op;
 
 	/*
@@ -500,7 +499,7 @@ void open_o_files(char *source)
  */
 void get_fn(char *dest, char *src, const char *ext)
 {
-	register unsigned i;
+	register int i;
 	register char *sp, *dp;
 
 	i = 0;
@@ -513,7 +512,7 @@ void get_fn(char *dest, char *src, const char *ext)
 		dp++;
 	else
 		dp = dest;
-	if (strrchr(dp, '.') == NULL && (strlen(dest) + strlen(ext) < LENFN))
+	if (strrchr(dp, '.') == NULL && (strlen(dest) + strlen(ext) <= LENFN))
 		strcat(dest, ext);
 }
 
@@ -525,7 +524,7 @@ void get_fn(char *dest, char *src, const char *ext)
  */
 char *get_symbol(char *s, char *l, int lbl_flag)
 {
-	register unsigned i;
+	register int i;
 
 	if (!lbl_flag)
 		while (IS_SPC(*l))

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -97,11 +97,10 @@ static struct opr oprtab[] = {
 	{ "TYPE",	T_TYPE		},
 	{ "XOR",	T_XOR		}
 };
-static unsigned no_operators = sizeof(oprtab) / sizeof(struct opr);
+static int no_operators = sizeof(oprtab) / sizeof(struct opr);
 
 static BYTE tok_type;	/* token type and flags */
 static WORD tok_val;	/* token value for T_VAL type */
-static char tok_sym[MAXLINE]; /* last symbol scanned (T_VAL) */
 static char *scan_pos;	/* current scanning position */
 
 void init_ctype(void)
@@ -156,7 +155,7 @@ BYTE search_opr(char *s)
 
 /*
  *	get next token
- *	updates tok_type, tok_val, tok_sym and scan_pos
+ *	updates tok_type, tok_val and scan_pos
  *	returns E_NOERR on success
  */
 int get_token(void)
@@ -166,7 +165,6 @@ int get_token(void)
 	register struct sym *sp;
 
 	s = scan_pos;
-	tok_sym[0] = '\0';
 	tok_val = 0;
 	while (IS_SPC(*s))				/* skip white space */
 		s++;
@@ -191,7 +189,7 @@ int get_token(void)
 			goto done;
 		}
 	}
-	p1 = p2 = tok_sym;				/* gather symbol */
+	p1 = p2 = tmp;					/* gather symbol */
 	while (IS_SYM(*s))
 		*p2++ = *s++;
 	*p2 = '\0';
@@ -235,9 +233,9 @@ int get_token(void)
 			tok_type = T_VAL;
 			tok_val = pc;
 		} else {				/* symbol / word opr */
-			if ((unsigned) (p2 - p1) > symlen) /* trim to symlen */
+			if ((p2 - p1) > symlen)		/* trim for lookup */
 				*(p1 + symlen) = '\0';
-			if ((sp = get_sym(tok_sym)) != NULL) {	/* a symbol */
+			if ((sp = get_sym(tmp)) != NULL) { /* a symbol */
 				tok_type = T_VAL;
 				tok_val = sp->sym_val;
 			} else				/* look for word opr */
@@ -614,13 +612,13 @@ WORD eval(char *s)
 }
 
 /*
- *	check value for range -256 <= value <= 255
- *	returns value if in range, otherwise 0 and error message
+ *	check w for range -256 <= value <= 255
+ *	returns w as BYTE if in range, otherwise 0 and error message
  */
-BYTE chk_byte(WORD n)
+BYTE chk_byte(WORD w)
 {
-	if (n >= (WORD) -256 || n <= 255)
-		return(n);
+	if (w >= (WORD) -256 || w <= 255)
+		return(w);
 	else {
 		asmerr(E_VALOUT);
 		return(0);
@@ -628,13 +626,13 @@ BYTE chk_byte(WORD n)
 }
 
 /*
- *	check value for range -128 <= value <= 127
- *	returns value if in range, otherwise 0 and error message
+ *	check w for range -128 <= value <= 127
+ *	returns w as BYTE if in range, otherwise 0 and error message
  */
-BYTE chk_sbyte(WORD n)
+BYTE chk_sbyte(WORD w)
 {
-	if (n >= (WORD) -128 || n <= 127)
-		return(n);
+	if (w >= (WORD) -128 || w <= 127)
+		return(w);
 	else {
 		asmerr(E_VALOUT);
 		return(0);

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -38,30 +38,29 @@ int opccmp(const void *, const void *);
 extern void fatal(int, const char *);
 
 /* z80amfun.c */
-extern unsigned op_endm(BYTE, BYTE), op_exitm(BYTE, BYTE), op_irp(BYTE, BYTE);
-extern unsigned op_local(BYTE, BYTE), op_macro(BYTE, BYTE);
-extern unsigned op_mcond(BYTE, BYTE), op_rept(BYTE, BYTE);
+extern WORD op_endm(BYTE, BYTE), op_exitm(BYTE, BYTE), op_irp(BYTE, BYTE);
+extern WORD op_local(BYTE, BYTE), op_macro(BYTE, BYTE), op_mcond(BYTE, BYTE);
+extern WORD op_rept(BYTE, BYTE);
 
 /* z80apfun.c */
-extern unsigned op_instrset(BYTE, BYTE), op_org(BYTE, BYTE);
-extern unsigned op_radix(BYTE, BYTE), op_equ(BYTE, BYTE), op_dl(BYTE, BYTE);
-extern unsigned op_ds(BYTE, BYTE), op_db(BYTE, BYTE), op_dw(BYTE, BYTE);
-extern unsigned op_misc(BYTE, BYTE), op_cond(BYTE, BYTE), op_glob(BYTE, BYTE);
-extern unsigned op_end(BYTE, BYTE);
+extern WORD op_instrset(BYTE, BYTE), op_org(BYTE, BYTE), op_radix(BYTE, BYTE);
+extern WORD op_equ(BYTE, BYTE), op_dl(BYTE, BYTE), op_ds(BYTE, BYTE);
+extern WORD op_db(BYTE, BYTE), op_dw(BYTE, BYTE), op_misc(BYTE, BYTE);
+extern WORD op_cond(BYTE, BYTE), op_glob(BYTE, BYTE), op_end(BYTE, BYTE);
 
 /* z80arfun.c */
-extern unsigned op_1b(BYTE, BYTE), op_2b(BYTE, BYTE), op_im(BYTE, BYTE);
-extern unsigned op_pupo(BYTE, BYTE), op_ex(BYTE, BYTE), op_rst(BYTE, BYTE);
-extern unsigned op_ret(BYTE, BYTE), op_jpcall(BYTE, BYTE), op_jr(BYTE, BYTE);
-extern unsigned op_djnz(BYTE, BYTE), op_ld(BYTE, BYTE), op_add(BYTE, BYTE);
-extern unsigned op_sbadc(BYTE, BYTE), op_decinc(BYTE, BYTE);
-extern unsigned op_alu(BYTE, BYTE), op_out(BYTE, BYTE), op_in(BYTE, BYTE);
-extern unsigned op_cbgrp(BYTE, BYTE), op8080_mov(BYTE, BYTE);
-extern unsigned op8080_alu(BYTE, BYTE), op8080_dcrinr(BYTE, BYTE);
-extern unsigned op8080_reg16(BYTE, BYTE), op8080_regbd(BYTE, BYTE);
-extern unsigned op8080_imm(BYTE, BYTE), op8080_rst(BYTE, BYTE);
-extern unsigned op8080_pupo(BYTE, BYTE), op8080_addr(BYTE, BYTE);
-extern unsigned op8080_mvi(BYTE, BYTE), op8080_lxi(BYTE, BYTE);
+extern WORD op_1b(BYTE, BYTE), op_2b(BYTE, BYTE), op_im(BYTE, BYTE);
+extern WORD op_pupo(BYTE, BYTE), op_ex(BYTE, BYTE), op_rst(BYTE, BYTE);
+extern WORD op_ret(BYTE, BYTE), op_jpcall(BYTE, BYTE), op_jr(BYTE, BYTE);
+extern WORD op_djnz(BYTE, BYTE), op_ld(BYTE, BYTE), op_add(BYTE, BYTE);
+extern WORD op_sbadc(BYTE, BYTE), op_decinc(BYTE, BYTE), op_alu(BYTE, BYTE);
+extern WORD op_out(BYTE, BYTE), op_in(BYTE, BYTE), op_cbgrp(BYTE, BYTE);
+extern WORD op8080_mov(BYTE, BYTE), op8080_alu(BYTE, BYTE);
+extern WORD op8080_dcrinr(BYTE, BYTE), op8080_reg16(BYTE, BYTE);
+extern WORD op8080_regbd(BYTE, BYTE), op8080_imm(BYTE, BYTE);
+extern WORD op8080_rst(BYTE, BYTE), op8080_pupo(BYTE, BYTE);
+extern WORD op8080_addr(BYTE, BYTE), op8080_mvi(BYTE, BYTE);
+extern WORD op8080_lxi(BYTE, BYTE);
 
 /*
  *	pseudo op table
@@ -141,7 +140,7 @@ static struct opc opctab_psd[] = {
 	{ "REPT",	op_rept,	3,	0,	OP_MDEF	 },
 	{ "TITLE",	op_misc,	7,	0,	OP_NOLBL | OP_NOPRE }
 };
-static unsigned no_opc_psd = sizeof(opctab_psd) / sizeof(struct opc);
+static int no_opc_psd = sizeof(opctab_psd) / sizeof(struct opc);
 
 /*
  *	Z80 opcode table
@@ -218,7 +217,7 @@ static struct opc opctab_z80[] = {
 	{ "SUB",	op_alu,		0x90,	0,	0	 },
 	{ "XOR",	op_alu,		0xa8,	0,	0	 }
 };
-static unsigned no_opc_z80 = sizeof(opctab_z80) / sizeof(struct opc);
+static int no_opc_z80 = sizeof(opctab_z80) / sizeof(struct opc);
 
 /*
  *	table with reserved Z80 register and flag operand words
@@ -259,7 +258,7 @@ static struct ope opetab_z80[] = {
 	{ "SP",		REGSP,	0	  },
 	{ "Z",		FLGZ,	0	  }
 };
-static unsigned no_ope_z80 = sizeof(opetab_z80) / sizeof(struct ope);
+static int no_ope_z80 = sizeof(opetab_z80) / sizeof(struct ope);
 
 /*
  *	8080 opcode table
@@ -347,7 +346,7 @@ static struct opc opctab_8080[] = {
 	{ "XRI",	op8080_imm,	0xee,	0,	0	 },
 	{ "XTHL",	op_1b,		0xe3,	0,	OP_NOOPR }
 };
-static unsigned no_opc_8080 = sizeof(opctab_8080) / sizeof(struct opc);
+static int no_opc_8080 = sizeof(opctab_8080) / sizeof(struct opc);
 
 /*
  *	table with reserved 8080 register and flag operand words
@@ -365,13 +364,13 @@ static struct ope opetab_8080[] = {
 	{ "PSW",	REGPSW,	0 },
 	{ "SP",		REGSP,	0 }
 };
-static unsigned no_ope_8080 = sizeof(opetab_8080) / sizeof(struct ope);
+static int no_ope_8080 = sizeof(opetab_8080) / sizeof(struct ope);
 
 static int curr_instrset;	/* current instructions set */
 static struct opc **opctab;	/* current sorted operations table */
-static unsigned no_opcodes;	/* current of operations */
+static int no_opcodes;		/* current of operations */
 static struct ope *opetab;	/* current sorted register/flags table */
-static unsigned no_operands;	/* current number of register/flags */
+static int no_operands;		/* current number of register/flags */
 
 /*
  *	build sorted table opctab for instruction set is
@@ -379,7 +378,7 @@ static unsigned no_operands;	/* current number of register/flags */
 void instrset(int is)
 {
 	register struct opc *opc, *p, **q;
-	register unsigned i, nopc;
+	register int i, nopc;
 
 	nopc = 0;		/* silence compiler */
 	if (is == curr_instrset)

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -61,7 +61,7 @@ extern void put_sym(char *, WORD);
 /*
  *	.Z80 and .8080
  */
-unsigned op_instrset(BYTE op_code, BYTE dummy)
+WORD op_instrset(BYTE op_code, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -82,7 +82,7 @@ unsigned op_instrset(BYTE op_code, BYTE dummy)
 /*
  *	ORG, .PHASE, .DEPHASE
  */
-unsigned op_org(BYTE op_code, BYTE dummy)
+WORD op_org(BYTE op_code, BYTE dummy)
 {
 	register WORD n;
 
@@ -130,7 +130,7 @@ unsigned op_org(BYTE op_code, BYTE dummy)
 /*
  *	.RADIX
  */
-unsigned op_radix(BYTE dummy1, BYTE dummy2)
+WORD op_radix(BYTE dummy1, BYTE dummy2)
 {
 	BYTE r;
 
@@ -149,7 +149,7 @@ unsigned op_radix(BYTE dummy1, BYTE dummy2)
 /*
  *	EQU
  */
-unsigned op_equ(BYTE dummy1, BYTE dummy2)
+WORD op_equ(BYTE dummy1, BYTE dummy2)
 {
 	register struct sym *sp;
 
@@ -168,7 +168,7 @@ unsigned op_equ(BYTE dummy1, BYTE dummy2)
 /*
  *	DEFL, ASET, and SET (in 8080 mode)
  */
-unsigned op_dl(BYTE dummy1, BYTE dummy2)
+WORD op_dl(BYTE dummy1, BYTE dummy2)
 {
 	UNUSED(dummy1);
 	UNUSED(dummy2);
@@ -182,7 +182,7 @@ unsigned op_dl(BYTE dummy1, BYTE dummy2)
 /*
  *	DEFS and DS
  */
-unsigned op_ds(BYTE dummy1, BYTE dummy2)
+WORD op_ds(BYTE dummy1, BYTE dummy2)
 {
 	register char *p;
 	register WORD count, value;
@@ -207,10 +207,10 @@ unsigned op_ds(BYTE dummy1, BYTE dummy2)
 /*
  *	DEFB, DB, DEFM, DEFC, DC, DEFZ
  */
-unsigned op_db(BYTE op_code, BYTE dummy)
+WORD op_db(BYTE op_code, BYTE dummy)
 {
 	register char *p, *p1, c;
-	register unsigned i;
+	register int i;
 	int sf;
 
 	UNUSED(dummy);
@@ -262,10 +262,10 @@ unsigned op_db(BYTE op_code, BYTE dummy)
 /*
  *	DEFW and DW
  */
-unsigned op_dw(BYTE dummy1, BYTE dummy2)
+WORD op_dw(BYTE dummy1, BYTE dummy2)
 {
 	register char *p, *p1;
-	register unsigned i;
+	register int i;
 	register WORD n;
 
 	UNUSED(dummy1);
@@ -294,12 +294,12 @@ unsigned op_dw(BYTE dummy1, BYTE dummy2)
  *	EJECT, PAGE, LIST, .LIST, NOLIST, .XLIST, .PRINTX, PRINT, INCLUDE,
  *	MACLIB, TITLE, .XALL, .LALL, .SALL, .SFCOND, .LFCOND
  */
-unsigned op_misc(BYTE op_code, BYTE dummy)
+WORD op_misc(BYTE op_code, BYTE dummy)
 {
 	register char *p, *d, c;
 	register BYTE n;
 	static char fn[LENFN];
-	static unsigned incnest;
+	static int incnest;
 	static struct inc incl[INCNEST];
 	static int page_done;
 
@@ -439,7 +439,7 @@ unsigned op_misc(BYTE op_code, BYTE dummy)
 /*
  *	IFDEF, IFNDEF, IFEQ, IFNEQ, COND, IF, IFT, IFE, IFF, IF1, IF2
  */
-unsigned op_cond(BYTE op_code, BYTE dummy)
+WORD op_cond(BYTE op_code, BYTE dummy)
 {
 	register char *p;
 
@@ -447,7 +447,7 @@ unsigned op_cond(BYTE op_code, BYTE dummy)
 
 	a_mode = A_NONE;
 	if (op_code < 90) {
-		if (iflevel == UINT_MAX) {
+		if (iflevel == INT_MAX) {
 			asmerr(E_IFNEST);
 			return(0);
 		}
@@ -521,7 +521,7 @@ unsigned op_cond(BYTE op_code, BYTE dummy)
 /*
  *	EXTRN, EXTERNAL, EXT and PUBLIC, ENT, ENTRY, GLOBAL, and ABS, ASEG
  */
-unsigned op_glob(BYTE op_code, BYTE dummy)
+WORD op_glob(BYTE op_code, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -543,7 +543,7 @@ unsigned op_glob(BYTE op_code, BYTE dummy)
 /*
  *	END
  */
-unsigned op_end(BYTE dummy1, BYTE dummy2)
+WORD op_end(BYTE dummy1, BYTE dummy2)
 {
 	UNUSED(dummy1);
 	UNUSED(dummy2);

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -31,10 +31,9 @@
 #include "z80a.h"
 #include "z80aglb.h"
 
-unsigned ldreg(BYTE, char *), ldixhl(BYTE, char *), ldiyhl(BYTE, char *);
-unsigned ldsp(char *), ldihl(BYTE, char *), ldiixy(BYTE, BYTE, char *);
-unsigned ldinn(char *), aluop(BYTE, char *);
-unsigned cbgrp_iixy(BYTE, BYTE, BYTE, char *);
+WORD ldreg(BYTE, char *), ldixhl(BYTE, char *), ldiyhl(BYTE, char *);
+WORD ldsp(char *), ldihl(BYTE, char *), ldiixy(BYTE, BYTE, char *);
+WORD ldinn(char *), aluop(BYTE, char *), cbgrp_iixy(BYTE, BYTE, BYTE, char *);
 
 /* z80amain.c */
 extern void asmerr(int);
@@ -51,7 +50,7 @@ extern BYTE get_reg(char *);
 /*
  *	process 1byte opcodes without arguments
  */
-unsigned op_1b(BYTE b1, BYTE dummy)
+WORD op_1b(BYTE b1, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -62,7 +61,7 @@ unsigned op_1b(BYTE b1, BYTE dummy)
 /*
  *	process 2byte opcodes without arguments
  */
-unsigned op_2b(BYTE b1, BYTE b2)
+WORD op_2b(BYTE b1, BYTE b2)
 {
 	ops[0] = b1;
 	ops[1] = b2;
@@ -72,7 +71,7 @@ unsigned op_2b(BYTE b1, BYTE b2)
 /*
  *	IM
  */
-unsigned op_im(BYTE base_op1, BYTE base_op2)
+WORD op_im(BYTE base_op1, BYTE base_op2)
 {
 	register WORD n;
 
@@ -99,10 +98,10 @@ unsigned op_im(BYTE base_op1, BYTE base_op2)
 /*
  *	PUSH and POP
  */
-unsigned op_pupo(BYTE base_op, BYTE dummy)
+WORD op_pupo(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	UNUSED(dummy);
 
@@ -136,9 +135,9 @@ unsigned op_pupo(BYTE base_op, BYTE dummy)
 /*
  *	EX
  */
-unsigned op_ex(BYTE base_ops, BYTE base_opd)
+WORD op_ex(BYTE base_ops, BYTE base_opd)
 {
-	register unsigned len;
+	register WORD len;
 
 	if (strcmp(operand, "DE,HL") == 0) {
 		len = 1;
@@ -168,7 +167,7 @@ unsigned op_ex(BYTE base_ops, BYTE base_opd)
 /*
  *	RST
  */
-unsigned op_rst(BYTE base_op, BYTE dummy)
+WORD op_rst(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -188,7 +187,7 @@ unsigned op_rst(BYTE base_op, BYTE dummy)
 /*
  *	RET
  */
-unsigned op_ret(BYTE base_op, BYTE base_opc)
+WORD op_ret(BYTE base_op, BYTE base_opc)
 {
 	register BYTE op;
 
@@ -218,12 +217,11 @@ unsigned op_ret(BYTE base_op, BYTE base_opc)
 /*
  *	JP and CALL
  */
-unsigned op_jpcall(BYTE base_op, BYTE base_opc)
+WORD op_jpcall(BYTE base_op, BYTE base_opc)
 {
 	register char *sec;
 	register BYTE op;
-	register WORD n;
-	register unsigned len;
+	register WORD len, n;
 
 	len = 0;			/* silence compiler */
 	sec = next_arg(operand, NULL);
@@ -299,7 +297,7 @@ unsigned op_jpcall(BYTE base_op, BYTE base_opc)
 /*
  *	JR
  */
-unsigned op_jr(BYTE base_op, BYTE base_opc)
+WORD op_jr(BYTE base_op, BYTE base_opc)
 {
 	register char *sec;
 	register BYTE op;
@@ -343,7 +341,7 @@ unsigned op_jr(BYTE base_op, BYTE base_opc)
 /*
  *	DJNZ
  */
-unsigned op_djnz(BYTE base_op, BYTE dummy)
+WORD op_djnz(BYTE base_op, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -357,12 +355,11 @@ unsigned op_djnz(BYTE base_op, BYTE dummy)
 /*
  *	LD
  */
-unsigned op_ld(BYTE base_op, BYTE dummy)
+WORD op_ld(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op;
-	register WORD n;
-	register unsigned len;
+	register WORD len, n;
 
 	UNUSED(dummy);
 
@@ -503,11 +500,10 @@ unsigned op_ld(BYTE base_op, BYTE dummy)
 /*
  *	LD [A,B,C,D,E,H,L],?
  */
-unsigned ldreg(BYTE base_op, char *sec)
+WORD ldreg(BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register WORD n;
-	register unsigned len;
+	register WORD len, n;
 
 	len = 0;			/* silence compiler */
 	switch (op = get_reg(sec)) {
@@ -603,10 +599,10 @@ unsigned ldreg(BYTE base_op, char *sec)
 /*
  *	LD IX[HL],? (undoc)
  */
-unsigned ldixhl(BYTE base_op, char *sec)
+WORD ldixhl(BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD IX[HL],A (undoc) */
@@ -644,10 +640,10 @@ unsigned ldixhl(BYTE base_op, char *sec)
 /*
  *	LD IY[HL],? (undoc)
  */
-unsigned ldiyhl(BYTE base_op, char *sec)
+WORD ldiyhl(BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD IY[HL],A (undoc) */
@@ -685,11 +681,10 @@ unsigned ldiyhl(BYTE base_op, char *sec)
 /*
  *	LD SP,?
  */
-unsigned ldsp(char *sec)
+WORD ldsp(char *sec)
 {
 	register BYTE op;
-	register WORD n;
-	register unsigned len;
+	register WORD len, n;
 
 	switch (op = get_reg(sec)) {
 	case REGHL:			/* LD SP,HL */
@@ -738,10 +733,10 @@ unsigned ldsp(char *sec)
 /*
  *	LD (HL),?
  */
-unsigned ldihl(BYTE base_op, char *sec)
+WORD ldihl(BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD (HL),A */
@@ -777,10 +772,10 @@ unsigned ldihl(BYTE base_op, char *sec)
 /*
  *	LD (I[XY]+d),?
  */
-unsigned ldiixy(BYTE prefix, BYTE base_op, char *sec)
+WORD ldiixy(BYTE prefix, BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD (I[XY]+d),A */
@@ -824,11 +819,10 @@ unsigned ldiixy(BYTE prefix, BYTE base_op, char *sec)
 /*
  *	LD (nn),?
  */
-unsigned ldinn(char *sec)
+WORD ldinn(char *sec)
 {
 	register BYTE op;
-	register WORD n;
-	register unsigned len;
+	register WORD len, n;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* LD (nn),A */
@@ -888,11 +882,11 @@ unsigned ldinn(char *sec)
 /*
  *	ADD ?,?
  */
-unsigned op_add(BYTE base_op, BYTE base_op16)
+WORD op_add(BYTE base_op, BYTE base_op16)
 {
 	register char *sec;
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	sec = next_arg(operand, NULL);
 	switch (get_reg(operand)) {
@@ -975,11 +969,11 @@ unsigned op_add(BYTE base_op, BYTE base_op16)
 /*
  *	SBC ?,? and ADC ?,?
  */
-unsigned op_sbadc(BYTE base_op, BYTE base_op16)
+WORD op_sbadc(BYTE base_op, BYTE base_op16)
 {
 	register char *sec;
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	sec = next_arg(operand, NULL);
 	switch (get_reg(operand)) {
@@ -1023,10 +1017,10 @@ unsigned op_sbadc(BYTE base_op, BYTE base_op16)
 /*
  *	DEC and INC
  */
-unsigned op_decinc(BYTE base_op, BYTE base_op16)
+WORD op_decinc(BYTE base_op, BYTE base_op16)
 {
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	switch (op = get_reg(operand)) {
 	case REGA:			/* INC/DEC A */
@@ -1093,7 +1087,7 @@ unsigned op_decinc(BYTE base_op, BYTE base_op16)
 /*
  *	SUB, AND, XOR, OR, CP
  */
-unsigned op_alu(BYTE base_op, BYTE dummy)
+WORD op_alu(BYTE base_op, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -1103,10 +1097,10 @@ unsigned op_alu(BYTE base_op, BYTE dummy)
 /*
  *	ADD A, ADC A, SUB, SBC A, AND, XOR, OR, CP
  */
-unsigned aluop(BYTE base_op, char *sec)
+WORD aluop(BYTE base_op, char *sec)
 {
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	switch (op = get_reg(sec)) {
 	case REGA:			/* ALUOP {A,}A */
@@ -1162,7 +1156,7 @@ unsigned aluop(BYTE base_op, char *sec)
 /*
  *	OUT
  */
-unsigned op_out(BYTE op_base, BYTE op_basec)
+WORD op_out(BYTE op_base, BYTE op_basec)
 {
 	register char *sec;
 	register BYTE op;
@@ -1228,7 +1222,7 @@ unsigned op_out(BYTE op_base, BYTE op_basec)
 /*
  *	IN
  */
-unsigned op_in(BYTE op_base, BYTE op_basec)
+WORD op_in(BYTE op_base, BYTE op_basec)
 {
 	register char *sec;
 	register BYTE op;
@@ -1295,11 +1289,11 @@ unsigned op_in(BYTE op_base, BYTE op_basec)
 /*
  *	RLC, RRC, RL, RR, SLA, SRA, SLL, SRL, BIT, RES, SET
  */
-unsigned op_cbgrp(BYTE base_op, BYTE dummy)
+WORD op_cbgrp(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op, bit;
-	register unsigned len;
+	register WORD len;
 
 	UNUSED(dummy);
 
@@ -1354,7 +1348,7 @@ unsigned op_cbgrp(BYTE base_op, BYTE dummy)
 /*
  *	CBOP {n,}(I[XY]+d){,reg}
  */
-unsigned cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
+WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 {
 	register char *tert;
 	register BYTE op;
@@ -1413,7 +1407,7 @@ unsigned cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 /*
  *	8080 MOV
  */
-unsigned op8080_mov(BYTE base_op, BYTE dummy)
+WORD op8080_mov(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op1, op2;
@@ -1469,7 +1463,7 @@ unsigned op8080_mov(BYTE base_op, BYTE dummy)
 /*
  *	8080 ADC, ADD, ANA, CMP, ORA, SBB, SUB, XRA
  */
-unsigned op8080_alu(BYTE base_op, BYTE dummy)
+WORD op8080_alu(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1500,7 +1494,7 @@ unsigned op8080_alu(BYTE base_op, BYTE dummy)
 /*
  *	8080 DCR and INR
  */
-unsigned op8080_dcrinr(BYTE base_op, BYTE dummy)
+WORD op8080_dcrinr(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1531,7 +1525,7 @@ unsigned op8080_dcrinr(BYTE base_op, BYTE dummy)
 /*
  *	8080 INX, DAD, DCX
  */
-unsigned op8080_reg16(BYTE base_op, BYTE dummy)
+WORD op8080_reg16(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1558,7 +1552,7 @@ unsigned op8080_reg16(BYTE base_op, BYTE dummy)
 /*
  *	8080 STAX and LDAX
  */
-unsigned op8080_regbd(BYTE base_op, BYTE dummy)
+WORD op8080_regbd(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1583,7 +1577,7 @@ unsigned op8080_regbd(BYTE base_op, BYTE dummy)
 /*
  *	8080 ACI, ADI, ANI, CPI, ORI, SBI, SUI, XRI, OUT, IN
  */
-unsigned op8080_imm(BYTE base_op, BYTE dummy)
+WORD op8080_imm(BYTE base_op, BYTE dummy)
 {
 	UNUSED(dummy);
 
@@ -1597,7 +1591,7 @@ unsigned op8080_imm(BYTE base_op, BYTE dummy)
 /*
  *	8080 RST
  */
-unsigned op8080_rst(BYTE base_op, BYTE dummy)
+WORD op8080_rst(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1616,7 +1610,7 @@ unsigned op8080_rst(BYTE base_op, BYTE dummy)
 /*
  *	8080 PUSH and POP
  */
-unsigned op8080_pupo(BYTE base_op, BYTE dummy)
+WORD op8080_pupo(BYTE base_op, BYTE dummy)
 {
 	register BYTE op;
 
@@ -1645,7 +1639,7 @@ unsigned op8080_pupo(BYTE base_op, BYTE dummy)
  *	     JMP, JNZ, JZ, JNC, JC, JPO, JPE, JP, JM
  *	     CALL, CNZ, CZ, CNC, CC, CPO, CPE, CP, CM
  */
-unsigned op8080_addr(BYTE base_op, BYTE dummy)
+WORD op8080_addr(BYTE base_op, BYTE dummy)
 {
 	register WORD n;
 
@@ -1663,11 +1657,11 @@ unsigned op8080_addr(BYTE base_op, BYTE dummy)
 /*
  *	8080 MVI
  */
-unsigned op8080_mvi(BYTE base_op, BYTE dummy)
+WORD op8080_mvi(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op;
-	register unsigned len;
+	register WORD len;
 
 	UNUSED(dummy);
 
@@ -1703,12 +1697,11 @@ unsigned op8080_mvi(BYTE base_op, BYTE dummy)
 /*
  *	8080 LXI
  */
-unsigned op8080_lxi(BYTE base_op, BYTE dummy)
+WORD op8080_lxi(BYTE base_op, BYTE dummy)
 {
 	register char *sec;
 	register BYTE op;
-	register WORD n;
-	register unsigned len;
+	register WORD len, n;
 
 	UNUSED(dummy);
 


### PR DESCRIPTION
1. inc_line in struct inc should be unsigned long.
2. op_count should be WORD because of DEFS. All op_* functions return a WORD.
3. Revert most unsigned changes, I had overdone this. They will never reach INT_MAX on 16-bit OS's. Keep line counters as unsigned long, since they actually break 16-bit.
4. Revert LENFN check change. filename's are LENFN + 1 sized.
5. tmp is back for real. Used by the expression parser and the macro code.
6. Size line and tmp to MAXLINE+2 and the other buffers to MAXLINE+1 to actually allow a source line with 128 characters.
7. Change reference counter to flag, since it is only used as that.