### PR TITLE
 change printing of size_t var to explicit cast to long long and %lld

### DIFF
--- a/iodevices/generic-at-modem.c
+++ b/iodevices/generic-at-modem.c
@@ -167,12 +167,12 @@ static void telnet_hdlr(telnet_t *telnet, telnet_event_t *ev, void *user_data) {
     case TELNET_EV_DATA:
 		if (ev->data.size) {
             if (ev->data.size != 1) {
-                LOGW(TAG, "LONGER THAN EXPECTED [%ld]", ev->data.size);
+                LOGW(TAG, "LONGER THAN EXPECTED [%lld]", (long long) ev->data.size);
             } else {
                 tn_recv = *(ev->data.buffer);
                 tn_len = ev->data.size;
             }
-            LOGD(TAG, "Telnet IN: %c[%ld]", tn_recv, ev->data.size);
+            LOGD(TAG, "Telnet IN: %c[%lld]", tn_recv, (long long) ev->data.size);
 		}
 		break;
     case TELNET_EV_SEND:
@@ -181,7 +181,7 @@ static void telnet_hdlr(telnet_t *telnet, telnet_event_t *ev, void *user_data) {
             for(i=0;i<(int)ev->data.size;i++) {
                 p += sprintf (p, "%d ", *(ev->data.buffer+i));
             }
-            LOGD(TAG, "Telnet OUT: %s[%ld]", buf, ev->data.size);
+            LOGD(TAG, "Telnet OUT: %s[%lld]", buf, (long long) ev->data.size);
 		}
 		write(*active_sfd, ev->data.buffer, ev->data.size);
 		break;

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -423,7 +423,7 @@ int factor(WORD *resultp)
 			if ((err = get_token()) != E_OK)
 				return(err);
 			else if (erru != E_OK)
-				return(E_UNDSYM);
+				return(erru);
 			else {
 				*resultp = value;
 				return(E_OK);


### PR DESCRIPTION
like cromemco-wdi.c

avoids a warning when compiling with -m32

The real fix would be to use "%zu" for size_t and "%zd" for ssize_t variables,
but this is a C99 feature and there was a commit removing use of C99 features.
