### PR TITLE
frontpanel: fix memory leaks, uninitialized variable and string allocation

### DIFF
--- a/frontpanel/lp_gfx.cpp
+++ b/frontpanel/lp_gfx.cpp
@@ -196,6 +196,7 @@ lpObject::~lpObject(void)
 
    delete[] elements;
   } 
+ if(name) delete[] name;
 }
 
 

--- a/frontpanel/lp_switch.cpp
+++ b/frontpanel/lp_switch.cpp
@@ -201,9 +201,17 @@ lpSwitch::lpSwitch(void)
 
 lpSwitch::~lpSwitch(void)
 {
+ int i;
+
  if(name) delete[] name;
  if(parms) delete parms;
 
+ if(object_ref_names)
+  {
+    for(i=0; i<num_object_refs;i++)
+      delete[] object_ref_names[i];
+    delete[] object_ref_names;
+  }
 }
 
 
@@ -712,6 +720,7 @@ Lpanel::addSwitchCallback(const char *name, void (*cbfunc)(int state, int val), 
     if(namelist[i]) delete[] namelist[i];
     // bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -756,6 +765,7 @@ Lpanel::bindSwitch8(const char *name, void *loc_down, void *loc_up, int start_bi
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -800,6 +810,7 @@ Lpanel::bindSwitch16(const char *name, void *loc_down, void *loc_up, int start_b
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -844,6 +855,7 @@ Lpanel::bindSwitch32(const char *name, void *loc_down, void *loc_up, int start_b
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -887,6 +899,7 @@ Lpanel::bindSwitch64(const char *name, void *loc_down, void *loc_up, int start_b
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }

--- a/frontpanel/lp_utils.cpp
+++ b/frontpanel/lp_utils.cpp
@@ -764,9 +764,14 @@ Parser::addArg(const char *s, const char *cpos1, const char *cpos2)
 
     if(results.stringlengths[results.num_args] < len+1)
      {
-	if(results.strings[results.num_args]) delete[] results.strings[results.num_args];
+       if(results.strings[results.num_args])
+	{
+	 delete[] results.strings[results.num_args];
+	 results.strings[results.num_args] = NULL;
+	}
      }
-    results.strings[results.num_args] = new char[ len + 1];
+    if (results.strings[results.num_args] == NULL)
+      results.strings[results.num_args] = new char[ len + 1];
     results.stringlengths[results.num_args] = len + 1;
     strncpy(results.strings[results.num_args], cpos1,len);
     results.strings[results.num_args][len] = 0;

--- a/frontpanel/lp_window.cpp
+++ b/frontpanel/lp_window.cpp
@@ -697,7 +697,6 @@ Lpanel::openWindow(const char *title)
 
   int status;
   
-  XVisualInfo *vi = NULL;
   XSetWindowAttributes swa;
   XSizeHints hints;
   XEvent ev;
@@ -798,9 +797,11 @@ Lpanel::destroyWindow(void)
 
  glXDestroyContext(dpy,cx);
  XDestroyWindow(dpy, window);
+ XFree(vi);
  XCloseDisplay(dpy);
  dpy = 0;
  cx = 0;
+ vi = NULL;
  window = 0;
 
 #endif

--- a/frontpanel/lpanel.cpp
+++ b/frontpanel/lpanel.cpp
@@ -312,6 +312,7 @@ Lpanel::Lpanel(void)		 // constructor
 #if defined (__MINGW32__) || defined (_WIN32) || defined (_WIN32_) || defined (__WIN32__)
 #else
  window = 0;
+ vi = NULL;
  cx = 0;
  dpy = 0;
 #endif
@@ -624,6 +625,7 @@ Lpanel::bindLight8(const char *name, void *loc, int start_bit_number)
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -671,6 +673,7 @@ Lpanel::bindLight8invert(const char *name, void *loc, int start_bit_number, uint
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -713,6 +716,7 @@ Lpanel::bindLight16(const char *name, void *loc, int start_bit_number)
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -752,6 +756,7 @@ Lpanel::bindLightfv(const char *name, void *loc)
     if(namelist[i]) delete[] namelist[i];
     // bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -797,6 +802,7 @@ Lpanel::bindLight16invert(const char *name, void *loc, int start_bit_number, uin
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -841,6 +847,7 @@ Lpanel::bindLight32(const char *name, void *loc, int start_bit_number)
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -886,6 +893,7 @@ Lpanel::bindLight32invert(const char *name, void *loc, int start_bit_number, uin
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -929,6 +937,7 @@ Lpanel::bindLight64(const char *name, void *loc, int start_bit_number)
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -974,6 +983,7 @@ Lpanel::bindLight64invert(const char *name, void *loc, int start_bit_number, uin
     if(namelist[i]) delete[] namelist[i];
     bitnum += bit_inc;
    }
+  delete[] namelist;
 
   return status;
 }
@@ -1193,7 +1203,7 @@ Lpanel::readConfig(const char *_fname)
 
  char *fname;
 
- fname = new char[strlen(config_root_path) + strlen(_fname) + 1];
+ fname = new char[strlen(config_root_path) + 1 + strlen(_fname) + 1];
  strcpy(fname, config_root_path);
  strcat(fname, "/");
  strcat(fname, _fname);
@@ -1866,6 +1876,7 @@ lpLight::lpLight(void)
   sampleDataFunc = sampleData8_error;
   drawFunc = drawLightGraphics;
   t1 = t2 = on_time = 1;
+  start_clock = 0;
   old_clock = 0;
   dirty = 0;
   state = 0;
@@ -2171,6 +2182,7 @@ Lpanel::smoothLight(const char *name, int nframes)
       }
     if(namelist[i]) delete namelist[i];
    }
+  delete[] namelist;
 
   return status;
 }

--- a/frontpanel/lpanel.h
+++ b/frontpanel/lpanel.h
@@ -135,6 +135,7 @@ class Lpanel
 #else
   Display	*dpy;		// Xwindows display
   Window	window;		// Xwindows window
+  XVisualInfo	*vi;
   GLXContext	cx;
   Atom		wmDeleteMessage; // for processing window close event
 #endif


### PR DESCRIPTION
All this stuff was found with valgrind, what a great tool!

1. The XVisualInfo *vi in Lpanel::openWindow was never freed with XFree(). Make vi an instance variable of Lpanel and free it in Lpanel::closeWindow.
2. The namelist allocated by xpand() was not deallocated by its users.
3. lpObject::name was not deallocated in the destructor.
4. lpSwitch::object_ref_names was not deallocated in the destructor.
5. Parser::addArg was trying to minimize string allocations by reusing existing ones, but always allocated a new string and leaked the old one if it was reusable.
6. lpLight::start_clock was not initialized in the constructor.
7. The allocation of fname in Lpanel::readConfig was one character short.