### PR TITLE
z80asm: clean up mac_subst and mac_next_parm, add buffer overflow checks

### DIFF
--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -255,6 +255,7 @@ struct inc {
 #define E_MACNST	25	/* macro expansion nested too deep */
 #define E_OUTLCL	26	/* too many local labels */
 #define E_LBLDIF	27	/* label address differs between passes */
+#define E_MACOVF	28	/* macro buffer overflow */
 
 /*
  *	definition of fatal errors

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -85,7 +85,8 @@ static const char *errmsg[] = {			/* error messages for asmerr */
 	"not in macro expansion",		/* 24 */
 	"macro expansion nested too deep",	/* 25 */
 	"too many local labels",		/* 26 */
-	"label address differs between passes"	/* 27 */
+	"label address differs between passes",	/* 27 */
+	"macro buffer overflow"			/* 28 */
 };
 
 static int nseq_flag;			/* flag for non-sequential ORG */


### PR DESCRIPTION
Clean up these most cryptic functions of the macro code. Add some comments.
Ensure that the buffers don't overflow during pass by value and dummy substitution.
