### PR TITLE
cpmsim/srccpm2: add -fm to assembler options

### DIFF
--- a/cpmsim/srccpm2/Makefile
+++ b/cpmsim/srccpm2/Makefile
@@ -11,10 +11,10 @@ putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
 
 bios.bin: bios.asm
-	z80asm -vl -sn -x bios.asm
+	z80asm -vl -sn -fm -x bios.asm
 
 boot.bin: boot.asm
-	z80asm -vl -sn boot.asm
+	z80asm -vl -sn -fm boot.asm
 
 clean:
 	rm -f *.lis bios.bin boot.bin putsys putsys.exe


### PR DESCRIPTION
Makefile assumed Mostek binary default output format.