### PR TITLE
cpmsim: change mknod to mkfifo in GNUmakefile and Makefile.*

### DIFF
--- a/cpmsim/srcsim/GNUmakefile
+++ b/cpmsim/srcsim/GNUmakefile
@@ -94,12 +94,12 @@ all: /tmp/.z80pack/cpmsim.auxin /tmp/.z80pack/cpmsim.auxout $(SIM)
 /tmp/.z80pack/cpmsim.auxin:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxin || \
-		mknod /tmp/.z80pack/cpmsim.auxin p
+		mkfifo /tmp/.z80pack/cpmsim.auxin
 
 /tmp/.z80pack/cpmsim.auxout:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxout || \
-		mknod /tmp/.z80pack/cpmsim.auxout p
+		mkfifo /tmp/.z80pack/cpmsim.auxout
 
 $(SIM): $(OBJS) $(MACHINE_LIBS)
 	$(CC) $(OBJS) $(LDFLAGS) -o $@

--- a/cpmsim/srcsim/Makefile.bsd
+++ b/cpmsim/srcsim/Makefile.bsd
@@ -77,12 +77,12 @@ all: /tmp/.z80pack/cpmsim.auxin /tmp/.z80pack/cpmsim.auxout $(SIM)
 /tmp/.z80pack/cpmsim.auxin:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxin || \
-		mknod /tmp/.z80pack/cpmsim.auxin p
+		mkfifo /tmp/.z80pack/cpmsim.auxin
 
 /tmp/.z80pack/cpmsim.auxout:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxout || \
-		mknod /tmp/.z80pack/cpmsim.auxout p
+		mkfifo /tmp/.z80pack/cpmsim.auxout
 
 $(SIM): $(OBJS)
 	$(CC) $(OBJS) $(LDFLAGS) -o $@

--- a/cpmsim/srcsim/Makefile.cygwin
+++ b/cpmsim/srcsim/Makefile.cygwin
@@ -77,12 +77,12 @@ all: /tmp/.z80pack/cpmsim.auxin /tmp/.z80pack/cpmsim.auxout $(SIM)
 /tmp/.z80pack/cpmsim.auxin:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxin || \
-		mknod /tmp/.z80pack/cpmsim.auxin p
+		mkfifo /tmp/.z80pack/cpmsim.auxin
 
 /tmp/.z80pack/cpmsim.auxout:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxout || \
-		mknod /tmp/.z80pack/cpmsim.auxout p
+		mkfifo /tmp/.z80pack/cpmsim.auxout
 
 $(SIM): $(OBJS)
 	$(CC) $(OBJS) $(LDFLAGS) -o $@

--- a/cpmsim/srcsim/Makefile.linux
+++ b/cpmsim/srcsim/Makefile.linux
@@ -77,12 +77,12 @@ all: /tmp/.z80pack/cpmsim.auxin /tmp/.z80pack/cpmsim.auxout $(SIM)
 /tmp/.z80pack/cpmsim.auxin:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxin || \
-		mknod /tmp/.z80pack/cpmsim.auxin p
+		mkfifo /tmp/.z80pack/cpmsim.auxin
 
 /tmp/.z80pack/cpmsim.auxout:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxout || \
-		mknod /tmp/.z80pack/cpmsim.auxout p
+		mkfifo /tmp/.z80pack/cpmsim.auxout
 
 $(SIM): $(OBJS)
 	$(CC) $(OBJS) $(LDFLAGS) -o $@

--- a/cpmsim/srcsim/Makefile.osx
+++ b/cpmsim/srcsim/Makefile.osx
@@ -77,12 +77,12 @@ all: /tmp/.z80pack/cpmsim.auxin /tmp/.z80pack/cpmsim.auxout $(SIM)
 /tmp/.z80pack/cpmsim.auxin:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxin || \
-		mknod /tmp/.z80pack/cpmsim.auxin p
+		mkfifo /tmp/.z80pack/cpmsim.auxin
 
 /tmp/.z80pack/cpmsim.auxout:
 	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
 	test -f /tmp/.z80pack/cpmsim.auxout || \
-		mknod /tmp/.z80pack/cpmsim.auxout p
+		mkfifo /tmp/.z80pack/cpmsim.auxout
 
 $(SIM): $(OBJS)
 	$(CC) $(OBJS) $(LDFLAGS) -o $@


### PR DESCRIPTION
In my reworking the GNUmakefile and Makefile.* I wrongly changed mkfifo in Makefile.bsd and Makefile.osx to mknod.
FreeBSD doesn't support "mknod <path> p".
Change mknod to mkfifo, since FreeBSD, Cygwin, OSX, and Linux all have it and this is also the POSIX way to create named pipes.

Or should this be removed from the Makefiles? iosim.c has code to create these named pipes.