### PR TITLE
frontpanel: remove #include <sys/timeb.h>

### DIFF
--- a/frontpanel/lp_utils.cpp
+++ b/frontpanel/lp_utils.cpp
@@ -28,7 +28,6 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 #include <sys/time.h>
-#include <sys/timeb.h>
 #include <time.h>
 #include <unistd.h>
 #include "lp_utils.h"


### PR DESCRIPTION
This is only intended for ftime(3), an old V7 routine, which isn't even used by the frontpanel library.

When compiling on FreeBSD it produced a warning that it is deprecated.