### PR TITLE
build fix for FreeBSD

### DIFF
--- a/iodevices/generic-at-modem.c
+++ b/iodevices/generic-at-modem.c
@@ -26,8 +26,9 @@
 #include <sys/poll.h>
 #include <sys/time.h>
 #include <netdb.h>
-#include <arpa/inet.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <arpa/inet.h>
 
 #include "libtelnet.h"
 


### PR DESCRIPTION
cromemcosim and imsaisim didn't compile on FreeBSD, because struct sockaddr_in[6] weren't declared.

Fix this by including <netinet/in.h> and move <arpa/inet.h> after the <netinet/*> includes as specified in the FreeBSD inet_ntop(3) manpage.