### PR TITLE
also allow (ix) notation for 0 offset

### DIFF
--- a/z80asm/Makefile
+++ b/z80asm/Makefile
@@ -2,6 +2,7 @@
 # by default compile on POSIX compatible systems
 # the alternative options are provided for old ANSI C89 systems
 #
+
 #CC = acc
 
 CWARNS = -Wall -Wextra -Wwrite-strings
@@ -48,7 +49,7 @@ z80arfun.o: z80arfun.c z80a.h z80aglb.h
 z80apfun.o: z80apfun.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80apfun.c
 
-z80aopc.o: z80aopc.c z80a.h
+z80aopc.o: z80aopc.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80aopc.c
 
 z80aglb.o: z80aglb.c z80a.h

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -23,8 +23,7 @@
  */
 
 /*
- *	this module contains all global variables other
- *	than CPU specific tables
+ *	this module contains all global variables
  */
 
 #include <stdio.h>

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -22,6 +22,10 @@
  *	25-OCT-2022 Intel-like macros (TE)
  */
 
+/*
+ *	expression parser and evaluator module
+ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -23,7 +23,7 @@
  */
 
 /*
- *	opcode tables and functions for setup and lookup
+ *	opcode tables module with setup and lookup functions
  */
 
 #include <stdlib.h>

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -192,22 +192,22 @@ WORD op_ret(BYTE base_op, BYTE base_opc)
 	register BYTE op;
 
 	switch (op = get_reg(operand)) {
-	case NOOPERA:		/* RET */
+	case NOOPERA:			/* RET */
 		ops[0] = base_op;
 		break;
-	case REGC:		/* RET C */
-	case FLGNC:		/* RET NC */
-	case FLGZ:		/* RET Z */
-	case FLGNZ:		/* RET NZ */
-	case FLGPE:		/* RET PE */
-	case FLGPO:		/* RET PO */
-	case FLGM:		/* RET M */
-	case FLGP:		/* RET P */
+	case REGC:			/* RET C */
+	case FLGNC:			/* RET NC */
+	case FLGZ:			/* RET Z */
+	case FLGNZ:			/* RET NZ */
+	case FLGPE:			/* RET PE */
+	case FLGPO:			/* RET PO */
+	case FLGM:			/* RET M */
+	case FLGP:			/* RET P */
 		if (op == REGC)
 			op = FLGC;
 		ops[0] = base_opc + (op & OPMASK3);
 		break;
-	default:		/* invalid operand */
+	default:			/* invalid operand */
 		ops[0] = 0;
 		asmerr(E_INVOPE);
 	}
@@ -1401,7 +1401,7 @@ WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 	register BYTE op;
 
 	tert = next_arg(sec, NULL);
-	if (tert == NULL) {	/* CBOP {n,}(I[XY]{[+-]d}) */
+	if (tert == NULL) {		/* CBOP {n,}(I[XY]{[+-]d}) */
 		if (pass == 2) {
 			ops[0] = prefix;
 			ops[1] = 0xcb;
@@ -1417,13 +1417,13 @@ WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 	}
 	if (undoc_flag && base_op != 0x40) { /* not for BIT */
 		switch (op = get_reg(tert)) {
-		case REGA:	/* CBOP {n,}(I[XY]{[+-]d}),A (undoc) */
-		case REGB:	/* CBOP {n,}(I[XY]{[+-]d}),B (undoc) */
-		case REGC:	/* CBOP {n,}(I[XY]{[+-]d}),C (undoc) */
-		case REGD:	/* CBOP {n,}(I[XY]{[+-]d}),D (undoc) */
-		case REGE:	/* CBOP {n,}(I[XY]{[+-]d}),E (undoc) */
-		case REGH:	/* CBOP {n,}(I[XY]{[+-]d}),H (undoc) */
-		case REGL:	/* CBOP {n,}(I[XY]{[+-]d}),L (undoc) */
+		case REGA:		/* CBOP {n,}(I[XY]{[+-]d}),A (undoc) */
+		case REGB:		/* CBOP {n,}(I[XY]{[+-]d}),B (undoc) */
+		case REGC:		/* CBOP {n,}(I[XY]{[+-]d}),C (undoc) */
+		case REGD:		/* CBOP {n,}(I[XY]{[+-]d}),D (undoc) */
+		case REGE:		/* CBOP {n,}(I[XY]{[+-]d}),E (undoc) */
+		case REGH:		/* CBOP {n,}(I[XY]{[+-]d}),H (undoc) */
+		case REGL:		/* CBOP {n,}(I[XY]{[+-]d}),L (undoc) */
 			if (pass == 2) {
 				ops[0] = prefix;
 				ops[1] = 0xcb;
@@ -1436,21 +1436,21 @@ WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 				ops[3] = base_op + bit + (op & OPMASK0);
 			}
 			break;
-		case NOOPERA:	/* missing operand */
+		case NOOPERA:		/* missing operand */
 			ops[0] = 0;
 			ops[1] = 0;
 			ops[2] = 0;
 			ops[3] = 0;
 			asmerr(E_MISOPE);
 			break;
-		default:	/* invalid operand */
+		default:		/* invalid operand */
 			ops[0] = 0;
 			ops[1] = 0;
 			ops[2] = 0;
 			ops[3] = 0;
 			asmerr(E_INVOPE);
 		}
-	} else {		/* invalid operand */
+	} else {			/* invalid operand */
 		ops[0] = 0;
 		ops[1] = 0;
 		ops[2] = 0;

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -476,6 +476,11 @@ WORD op_ld(BYTE base_op, BYTE dummy)
 			asmerr(E_INVOPE);
 		}
 		break;
+	case REGIIX:			/* LD (IX),r */
+	case REGIIY:			/* LD (IY),r */
+		len = ldiixy((op & XYMASK) ? 0xfd : 0xdd,
+			     base_op + (REGIHL & OPMASK3), sec);
+		break;
 	case NOOPERA:			/* missing operand */
 		len = 1;
 		ops[0] = 0;
@@ -557,6 +562,13 @@ WORD ldreg(BYTE base_op, char *sec)
 			ops[0] = 0;
 			asmerr(E_INVOPE);
 		}
+		break;
+	case REGIIX:			/* LD reg,(IX) */
+	case REGIIY:			/* LD reg,(IY) */
+		len = 3;
+		ops[0] = (op & XYMASK) ? 0xfd : 0xdd;
+		ops[1] = base_op + (REGIHL & OPMASK0);
+		ops[2] = 0;
 		break;
 	case NOREG:			/* operand isn't register */
 		if (*sec == '(' && *(sec + 1) == 'I'
@@ -773,7 +785,7 @@ WORD ldihl(BYTE base_op, char *sec)
 }
 
 /*
- *	LD (I[XY][+-]d),?
+ *	LD (I[XY]{[+-]d}),?
  */
 WORD ldiixy(BYTE prefix, BYTE base_op, char *sec)
 {
@@ -781,28 +793,36 @@ WORD ldiixy(BYTE prefix, BYTE base_op, char *sec)
 	register WORD len;
 
 	switch (op = get_reg(sec)) {
-	case REGA:			/* LD (I[XY][+-]d),A */
-	case REGB:			/* LD (I[XY][+-]d),B */
-	case REGC:			/* LD (I[XY][+-]d),C */
-	case REGD:			/* LD (I[XY][+-]d),D */
-	case REGE:			/* LD (I[XY][+-]d),E */
-	case REGH:			/* LD (I[XY][+-]d),H */
-	case REGL:			/* LD (I[XY][+-]d),L */
+	case REGA:			/* LD (I[XY]{[+-]d}),A */
+	case REGB:			/* LD (I[XY]{[+-]d}),B */
+	case REGC:			/* LD (I[XY]{[+-]d}),C */
+	case REGD:			/* LD (I[XY]{[+-]d}),D */
+	case REGE:			/* LD (I[XY]{[+-]d}),E */
+	case REGH:			/* LD (I[XY]{[+-]d}),H */
+	case REGL:			/* LD (I[XY]{[+-]d}),L */
 		len = 3;
 		if (pass == 2) {
 			ops[0] = prefix;
 			ops[1] = base_op + (op & OPMASK0);
-			operand[2] = '('; /* replace [XY] */
-			ops[2] = chk_sbyte(eval(&operand[2]));
+			if (operand[3] == ')' && operand[4] == '\0')
+				ops[2] = 0;
+			else {
+				operand[2] = '('; /* replace [XY] */
+				ops[2] = chk_sbyte(eval(&operand[2]));
+			}
 		}
 		break;
-	case NOREG:			/* LD (I[XY][+-]d),n */
+	case NOREG:			/* LD (I[XY]{[+-]d}),n */
 		len = 4;
 		if (pass == 2) {
 			ops[0] = prefix;
 			ops[1] = base_op - 0x40 + (REGIHL & OPMASK0);
-			operand[2] = '('; /* replace [XY] */
-			ops[2] = chk_sbyte(eval(&operand[2]));
+			if (operand[3] == ')' && operand[4] == '\0')
+				ops[2] = 0;
+			else {
+				operand[2] = '('; /* replace [XY] */
+				ops[2] = chk_sbyte(eval(&operand[2]));
+			}
 			ops[3] = chk_byte(eval(sec));
 		}
 		break;
@@ -1058,6 +1078,13 @@ WORD op_decinc(BYTE base_op, BYTE base_op16)
 		ops[0] = (op & XYMASK) ? 0xfd : 0xdd;
 		ops[1] = base_op + (op & OPMASK3);
 		break;
+	case REGIIX:			/* INC/DEC (IX) */
+	case REGIIY:			/* INC/DEC (IY) */
+		len = 3;
+		ops[0] = (op & XYMASK) ? 0xfd : 0xdd;
+		ops[1] = base_op + (REGIHL & OPMASK3);
+		ops[2] = 0;
+		break;
 	case NOREG:			/* operand isn't register */
 		if (operand[0] == '(' && operand[1] == 'I'
 		    && (operand[2] == 'X' || operand[2] == 'Y')
@@ -1125,6 +1152,13 @@ WORD aluop(BYTE base_op, char *sec)
 		len = 2;
 		ops[0] = (op & XYMASK) ? 0xfd : 0xdd;
 		ops[1] = base_op + (op & OPMASK0);
+		break;
+	case REGIIX:			/* ALUOP {A,}(IX) */
+	case REGIIY:			/* ALUOP {A,}(IY) */
+		len = 3;
+		ops[0] = (op & XYMASK) ? 0xfd : 0xdd;
+		ops[1] = base_op + (REGIHL & OPMASK0);
+		ops[2] = 0;
 		break;
 	case NOREG:			/* operand isn't register */
 		if (*sec == '(' && *(sec + 1) == 'I'
@@ -1326,11 +1360,17 @@ WORD op_cbgrp(BYTE base_op, BYTE dummy)
 		ops[0] = 0xcb;
 		ops[1] = base_op + bit + (op & OPMASK0);
 		break;
+	case REGIIX:			/* CBOP {n,}(IX) */
+	case REGIIY:			/* CBOP {n,}(IY) */
+		len = cbgrp_iixy((op & XYMASK) ? 0xfd : 0xdd,
+				 base_op, bit, sec);
+		break;
 	case NOREG:
 		if (*sec == '(' && *(sec + 1) == 'I'
 		    && (*(sec + 2) == 'X' || *(sec + 2) == 'Y')
-		    && (*(sec + 3) == '+' || *(sec + 3) == '-'))
-					/* CBOP {n,}(I[XY][+-]d){,reg} */
+		    && (*(sec + 3) == '+' || *(sec + 3) == '-'
+					  || *(sec + 3) == ')'))
+					/* CBOP {n,}(I[XY]{[+-]d}){,reg} */
 			len = cbgrp_iixy(*(sec + 2) == 'Y' ? 0xfd : 0xdd,
 					 base_op, bit, sec);
 		else {			/* invalid operand */
@@ -1353,7 +1393,7 @@ WORD op_cbgrp(BYTE base_op, BYTE dummy)
 }
 
 /*
- *	CBOP {n,}(I[XY][+-]d){,reg}
+ *	CBOP {n,}(I[XY]{[+-]d}){,reg}
  */
 WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 {
@@ -1361,52 +1401,61 @@ WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 	register BYTE op;
 
 	tert = next_arg(sec, NULL);
-	if (tert != NULL) {
-		if (undoc_flag && base_op != 0x40) { /* not for BIT */
-			switch (op = get_reg(tert)) {
-			case REGA:	/* CBOP {n,}(I[XY][+-]d),A (undoc) */
-			case REGB:	/* CBOP {n,}(I[XY][+-]d),B (undoc) */
-			case REGC:	/* CBOP {n,}(I[XY][+-]d),C (undoc) */
-			case REGD:	/* CBOP {n,}(I[XY][+-]d),D (undoc) */
-			case REGE:	/* CBOP {n,}(I[XY][+-]d),E (undoc) */
-			case REGH:	/* CBOP {n,}(I[XY][+-]d),H (undoc) */
-			case REGL:	/* CBOP {n,}(I[XY][+-]d),L (undoc) */
-				if (pass == 2) {
-					ops[0] = prefix;
-					ops[1] = 0xcb;
+	if (tert == NULL) {	/* CBOP {n,}(I[XY]{[+-]d}) */
+		if (pass == 2) {
+			ops[0] = prefix;
+			ops[1] = 0xcb;
+			if (*(sec + 3) == ')' && *(sec + 4) == '\0')
+				ops[2] = 0;
+			else {
+				*(sec + 2) = '('; /* replace [XY] */
+				ops[2] = chk_sbyte(eval(sec + 2));
+			}
+			ops[3] = base_op + bit + (REGIHL & OPMASK0);
+		}
+		return(4);
+	}
+	if (undoc_flag && base_op != 0x40) { /* not for BIT */
+		switch (op = get_reg(tert)) {
+		case REGA:	/* CBOP {n,}(I[XY]{[+-]d}),A (undoc) */
+		case REGB:	/* CBOP {n,}(I[XY]{[+-]d}),B (undoc) */
+		case REGC:	/* CBOP {n,}(I[XY]{[+-]d}),C (undoc) */
+		case REGD:	/* CBOP {n,}(I[XY]{[+-]d}),D (undoc) */
+		case REGE:	/* CBOP {n,}(I[XY]{[+-]d}),E (undoc) */
+		case REGH:	/* CBOP {n,}(I[XY]{[+-]d}),H (undoc) */
+		case REGL:	/* CBOP {n,}(I[XY]{[+-]d}),L (undoc) */
+			if (pass == 2) {
+				ops[0] = prefix;
+				ops[1] = 0xcb;
+				if (*(sec + 3) == ')' && *(sec + 4) == '\0')
+					ops[2] = 0;
+				else {
 					*(sec + 2) = '('; /* replace [XY] */
 					ops[2] = chk_sbyte(eval(sec + 2));
-					ops[3] = base_op + bit
-							 + (op & OPMASK0);
 				}
-				break;
-			case NOOPERA:	/* missing operand */
-				ops[0] = 0;
-				ops[1] = 0;
-				ops[2] = 0;
-				ops[3] = 0;
-				asmerr(E_MISOPE);
-				break;
-			default:	/* invalid operand */
-				ops[0] = 0;
-				ops[1] = 0;
-				ops[2] = 0;
-				ops[3] = 0;
-				asmerr(E_INVOPE);
+				ops[3] = base_op + bit + (op & OPMASK0);
 			}
-		} else {		/* invalid operand */
+			break;
+		case NOOPERA:	/* missing operand */
+			ops[0] = 0;
+			ops[1] = 0;
+			ops[2] = 0;
+			ops[3] = 0;
+			asmerr(E_MISOPE);
+			break;
+		default:	/* invalid operand */
 			ops[0] = 0;
 			ops[1] = 0;
 			ops[2] = 0;
 			ops[3] = 0;
 			asmerr(E_INVOPE);
 		}
-	} else if (pass == 2) {		/* CBOP {n,}(I[XY][+-]d) */
-		ops[0] = prefix;
-		ops[1] = 0xcb;
-		*(sec + 2) = '(';	/* replace [XY] */
-		ops[2] = chk_sbyte(eval(sec + 2));
-		ops[3] = base_op + bit + (REGIHL & OPMASK0);
+	} else {		/* invalid operand */
+		ops[0] = 0;
+		ops[1] = 0;
+		ops[2] = 0;
+		ops[3] = 0;
+		asmerr(E_INVOPE);
 	}
 	return(4);
 }

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -23,7 +23,7 @@
  */
 
 /*
- *	symbol table functions
+ *	symbol table module
  */
 
 #include <stdlib.h>

--- a/z80core/simdis.c
+++ b/z80core/simdis.c
@@ -750,16 +750,26 @@ static int ddfd(const char *s, WORD a)
 				getmem(a + 2));
 			return(3);
 		case 0x34:
-			sprintf(Disass_Str, "INC\t(%s%c%02X)",
-				ireg[6], sign, off);
+			if (off == 0)
+				sprintf(Disass_Str, "INC\t(%s)", ireg[6]);
+			else
+				sprintf(Disass_Str, "INC\t(%s%c%02X)",
+					ireg[6], sign, off);
 			return(3);
 		case 0x35:
-			sprintf(Disass_Str, "DEC\t(%s%c%02X)",
-				ireg[6], sign, off);
+			if (off == 0)
+				sprintf(Disass_Str, "DEC\t(%s)", ireg[6]);
+			else
+				sprintf(Disass_Str, "DEC\t(%s%c%02X)",
+					ireg[6], sign, off);
 			return(3);
 		case 0x36:
-			sprintf(Disass_Str, "LD\t(%s%c%02X),%02X",
-				ireg[6], sign, off, getmem(a + 3));
+			if (off == 0)
+				sprintf(Disass_Str, "LD\t(%s),%02X",
+					ireg[6], getmem(a + 3));
+			else
+				sprintf(Disass_Str, "LD\t(%s%c%02X),%02X",
+					ireg[6], sign, off, getmem(a + 3));
 			return(4);
 		case 0x39:
 			sprintf(Disass_Str, "ADD\t%s,SP", ireg[6]);
@@ -774,12 +784,20 @@ static int ddfd(const char *s, WORD a)
 			strcpy(Disass_Str, "NOP*");
 			return(1);
 		} else if (r1 == 6) {
-			sprintf(Disass_Str, "LD\t(%s%c%02X),%s",
-				ireg[r1], sign, off, reg[r2]);
+			if (off == 0)
+				sprintf(Disass_Str, "LD\t(%s),%s",
+					ireg[r1], reg[r2]);
+			else
+				sprintf(Disass_Str, "LD\t(%s%c%02X),%s",
+					ireg[r1], sign, off, reg[r2]);
 			return(3);
 		} else if (r2 == 6) {
-			sprintf(Disass_Str, "LD\t%s,(%s%c%02X)",
-				reg[r1], ireg[r2], sign, off);
+			if (off == 0)
+				sprintf(Disass_Str, "LD\t%s,(%s)",
+					reg[r1], ireg[r2]);
+			else
+				sprintf(Disass_Str, "LD\t%s,(%s%c%02X)",
+					reg[r1], ireg[r2], sign, off);
 			return(3);
 		} else {				/* undocumented */
 			sprintf(Disass_Str, "LD*\t%s,%s", ireg[r1], ireg[r2]);
@@ -790,8 +808,12 @@ static int ddfd(const char *s, WORD a)
 			strcpy(Disass_Str, "NOP*");
 			return(1);
 		} else if (r2 == 6) {
-			sprintf(Disass_Str, "%s(%s%c%02X)", aluins[r1],
-				ireg[r2], sign, off);
+			if (off == 0)
+				sprintf(Disass_Str, "%s(%s)", aluins[r1],
+					ireg[r2]);
+			else
+				sprintf(Disass_Str, "%s(%s%c%02X)", aluins[r1],
+					ireg[r2], sign, off);
 			return(3);
 		} else {				/* undocumented */
 			sprintf(Disass_Str, "%s%s", aluinsu[r1], ireg[r2]);
@@ -803,9 +825,22 @@ static int ddfd(const char *s, WORD a)
 			b4 = getmem(a + 3);
 			if ((b4 & 7) == 6) {
 				if (b4 < 0x40)
-					sprintf(Disass_Str, "%s\t(%s%c%02X)",
-						rsins[b4 >> 3],
-						ireg[6], sign, off);
+					if (off == 0)
+						sprintf(Disass_Str,
+							"%s\t(%s)",
+							rsins[b4 >> 3],
+							ireg[6]);
+					else
+						sprintf(Disass_Str,
+							"%s\t(%s%c%02X)",
+							rsins[b4 >> 3],
+							ireg[6], sign, off);
+				else if (off == 0)
+					sprintf(Disass_Str,
+						"%s\t%c,(%s)",
+						bitins[b4 >> 6],
+						((b4 >> 3) & 7) + '0',
+						ireg[6]);
 				else
 					sprintf(Disass_Str,
 						"%s\t%c,(%s%c%02X)",
@@ -814,17 +849,36 @@ static int ddfd(const char *s, WORD a)
 						ireg[6], sign, off);
 			} else {
 				if (b4 < 0x40)		/* undocumented */
-					sprintf(Disass_Str,
-						"%s\t(%s%c%02X),%s",
-						rsinsu[b4 >> 3],
-						ireg[6], sign, off,
-						reg[b4 & 7]);
+					if (off == 0)
+						sprintf(Disass_Str,
+							"%s\t(%s),%s",
+							rsinsu[b4 >> 3],
+							ireg[6], reg[b4 & 7]);
+					else		/* undocumented */
+						sprintf(Disass_Str,
+							"%s\t(%s%c%02X),%s",
+							rsinsu[b4 >> 3],
+							ireg[6], sign, off,
+							reg[b4 & 7]);
 				else if (b4 < 0x80)	/* undocumented */
+					if (off == 0)
+						sprintf(Disass_Str,
+							"%s*\t%c,(%s)",
+							bitins[b4 >> 6],
+							((b4 >> 3) & 7) + '0',
+							ireg[6]);
+					else		/* undocumented */
+						sprintf(Disass_Str,
+							"%s*\t%c,(%s%c%02X)",
+							bitins[b4 >> 6],
+							((b4 >> 3) & 7) + '0',
+							ireg[6], sign, off);
+				else if (off == 0)	/* undocumented */
 					sprintf(Disass_Str,
-						"%s*\t%c,(%s%c%02X)",
+						"%s*\t%c,(%s),%s",
 						bitins[b4 >> 6],
 						((b4 >> 3) & 7) + '0',
-						ireg[6], sign, off);
+						ireg[6], reg[b4 & 7]);
 				else			/* undocumented */
 					sprintf(Disass_Str,
 						"%s*\t%c,(%s%c%02X),%s",

--- a/z80sim/z80opsall.asm
+++ b/z80sim/z80opsall.asm
@@ -1,5 +1,4 @@
-	TITLE	'Z80 Instruction Set in alphabetical order (incl. undocumented)'
-
+	TITLE	'Z80 Instr. in order (incl. undoc''d and all index variants)'
 IND	EQU	5
 M	EQU	10H
 N	EQU	20H
@@ -7,8 +6,12 @@ DIS	EQU	30H
 
 Z80OPS:
 	ADC	A,(HL)
+	ADC	A,(IX)
 	ADC	A,(IX+IND)
+	ADC	A,(IX-IND)
+	ADC	A,(IY)
 	ADC	A,(IY+IND)
+	ADC	A,(IY-IND)
 	ADC	A,A
 	ADC	A,B
 	ADC	A,C
@@ -26,8 +29,12 @@ Z80OPS:
 	ADC	HL,HL
 	ADC	HL,SP
 	ADD	A,(HL)
+	ADD	A,(IX)
 	ADD	A,(IX+IND)
+	ADD	A,(IX-IND)
+	ADD	A,(IY)
 	ADD	A,(IY+IND)
+	ADD	A,(IY-IND)
 	ADD	A,A
 	ADD	A,B
 	ADD	A,C
@@ -53,8 +60,12 @@ Z80OPS:
 	ADD	IY,IY
 	ADD	IY,SP
 	AND	(HL)
+	AND	(IX)
 	AND	(IX+IND)
+	AND	(IX-IND)
+	AND	(IY)
 	AND	(IY+IND)
+	AND	(IY-IND)
 	AND	A
 	AND	B
 	AND	C
@@ -68,8 +79,12 @@ Z80OPS:
 	AND	L
 	AND	N
 	BIT	0,(HL)
+	BIT	0,(IX)
 	BIT	0,(IX+IND)
+	BIT	0,(IX-IND)
+	BIT	0,(IY)
 	BIT	0,(IY+IND)
+	BIT	0,(IY-IND)
 	BIT	0,A
 	BIT	0,B
 	BIT	0,C
@@ -78,8 +93,12 @@ Z80OPS:
 	BIT	0,H
 	BIT	0,L
 	BIT	1,(HL)
+	BIT	1,(IX)
 	BIT	1,(IX+IND)
+	BIT	1,(IX-IND)
+	BIT	1,(IY)
 	BIT	1,(IY+IND)
+	BIT	1,(IY-IND)
 	BIT	1,A
 	BIT	1,B
 	BIT	1,C
@@ -88,8 +107,12 @@ Z80OPS:
 	BIT	1,H
 	BIT	1,L
 	BIT	2,(HL)
+	BIT	2,(IX)
 	BIT	2,(IX+IND)
+	BIT	2,(IX-IND)
+	BIT	2,(IY)
 	BIT	2,(IY+IND)
+	BIT	2,(IY-IND)
 	BIT	2,A
 	BIT	2,B
 	BIT	2,C
@@ -98,8 +121,12 @@ Z80OPS:
 	BIT	2,H
 	BIT	2,L
 	BIT	3,(HL)
+	BIT	3,(IX)
 	BIT	3,(IX+IND)
+	BIT	3,(IX-IND)
+	BIT	3,(IY)
 	BIT	3,(IY+IND)
+	BIT	3,(IY-IND)
 	BIT	3,A
 	BIT	3,B
 	BIT	3,C
@@ -108,8 +135,12 @@ Z80OPS:
 	BIT	3,H
 	BIT	3,L
 	BIT	4,(HL)
+	BIT	4,(IX)
 	BIT	4,(IX+IND)
+	BIT	4,(IX-IND)
+	BIT	4,(IY)
 	BIT	4,(IY+IND)
+	BIT	4,(IY-IND)
 	BIT	4,A
 	BIT	4,B
 	BIT	4,C
@@ -118,8 +149,12 @@ Z80OPS:
 	BIT	4,H
 	BIT	4,L
 	BIT	5,(HL)
+	BIT	5,(IX)
 	BIT	5,(IX+IND)
+	BIT	5,(IX-IND)
+	BIT	5,(IY)
 	BIT	5,(IY+IND)
+	BIT	5,(IY-IND)
 	BIT	5,A
 	BIT	5,B
 	BIT	5,C
@@ -128,8 +163,12 @@ Z80OPS:
 	BIT	5,H
 	BIT	5,L
 	BIT	6,(HL)
+	BIT	6,(IX)
 	BIT	6,(IX+IND)
+	BIT	6,(IX-IND)
+	BIT	6,(IY)
 	BIT	6,(IY+IND)
+	BIT	6,(IY-IND)
 	BIT	6,A
 	BIT	6,B
 	BIT	6,C
@@ -138,8 +177,12 @@ Z80OPS:
 	BIT	6,H
 	BIT	6,L
 	BIT	7,(HL)
+	BIT	7,(IX)
 	BIT	7,(IX+IND)
+	BIT	7,(IX-IND)
+	BIT	7,(IY)
 	BIT	7,(IY+IND)
+	BIT	7,(IY-IND)
 	BIT	7,A
 	BIT	7,B
 	BIT	7,C
@@ -158,8 +201,12 @@ Z80OPS:
 	CALL	Z,NN
 	CCF
 	CP	(HL)
+	CP	(IX)
 	CP	(IX+IND)
+	CP	(IX-IND)
+	CP	(IY)
 	CP	(IY+IND)
+	CP	(IY-IND)
 	CP	A
 	CP	B
 	CP	C
@@ -179,8 +226,12 @@ Z80OPS:
 	CPL
 	DAA
 	DEC	(HL)
+	DEC	(IX)
 	DEC	(IX+IND)
+	DEC	(IX-IND)
+	DEC	(IY)
 	DEC	(IY+IND)
+	DEC	(IY-IND)
 	DEC	A
 	DEC	B
 	DEC	BC
@@ -221,8 +272,12 @@ Z80OPS:
 	IN	H,(C)
 	IN	L,(C)
 	INC	(HL)
+	INC	(IX)
 	INC	(IX+IND)
+	INC	(IX-IND)
+	INC	(IY)
 	INC	(IY+IND)
+	INC	(IY-IND)
 	INC	A
 	INC	B
 	INC	BC
@@ -271,6 +326,14 @@ Z80OPS:
 	LD	(HL),H
 	LD	(HL),L
 	LD	(HL),N
+	LD	(IX),A
+	LD	(IX),B
+	LD	(IX),C
+	LD	(IX),D
+	LD	(IX),E
+	LD	(IX),H
+	LD	(IX),L
+	LD	(IX),N
 	LD	(IX+IND),A
 	LD	(IX+IND),B
 	LD	(IX+IND),C
@@ -279,6 +342,22 @@ Z80OPS:
 	LD	(IX+IND),H
 	LD	(IX+IND),L
 	LD	(IX+IND),N
+	LD	(IX-IND),A
+	LD	(IX-IND),B
+	LD	(IX-IND),C
+	LD	(IX-IND),D
+	LD	(IX-IND),E
+	LD	(IX-IND),H
+	LD	(IX-IND),L
+	LD	(IX-IND),N
+	LD	(IY),A
+	LD	(IY),B
+	LD	(IY),C
+	LD	(IY),D
+	LD	(IY),E
+	LD	(IY),H
+	LD	(IY),L
+	LD	(IY),N
 	LD	(IY+IND),A
 	LD	(IY+IND),B
 	LD	(IY+IND),C
@@ -287,6 +366,14 @@ Z80OPS:
 	LD	(IY+IND),H
 	LD	(IY+IND),L
 	LD	(IY+IND),N
+	LD	(IY-IND),A
+	LD	(IY-IND),B
+	LD	(IY-IND),C
+	LD	(IY-IND),D
+	LD	(IY-IND),E
+	LD	(IY-IND),H
+	LD	(IY-IND),L
+	LD	(IY-IND),N
 	LD	(NN),A
 	LD	(NN),BC
 	LD	(NN),DE
@@ -297,8 +384,12 @@ Z80OPS:
 	LD	A,(BC)
 	LD	A,(DE)
 	LD	A,(HL)
+	LD	A,(IX)
 	LD	A,(IX+IND)
+	LD	A,(IX-IND)
+	LD	A,(IY)
 	LD	A,(IY+IND)
+	LD	A,(IY-IND)
 	LD	A,(NN)
 	LD	A,A
 	LD	A,B
@@ -314,8 +405,12 @@ Z80OPS:
 	LD	A,L
 	LD	A,N
 	LD	B,(HL)
+	LD	B,(IX)
 	LD	B,(IX+IND)
+	LD	B,(IX-IND)
+	LD	B,(IY)
 	LD	B,(IY+IND)
+	LD	B,(IY-IND)
 	LD	B,A
 	LD	B,B
 	LD	B,C
@@ -331,8 +426,12 @@ Z80OPS:
 	LD	BC,(NN)
 	LD	BC,NN
 	LD	C,(HL)
+	LD	C,(IX)
 	LD	C,(IX+IND)
+	LD	C,(IX-IND)
+	LD	C,(IY)
 	LD	C,(IY+IND)
+	LD	C,(IY-IND)
 	LD	C,A
 	LD	C,B
 	LD	C,C
@@ -346,8 +445,12 @@ Z80OPS:
 	LD	C,L
 	LD	C,N
 	LD	D,(HL)
+	LD	D,(IX)
 	LD	D,(IX+IND)
+	LD	D,(IX-IND)
+	LD	D,(IY)
 	LD	D,(IY+IND)
+	LD	D,(IY-IND)
 	LD	D,A
 	LD	D,B
 	LD	D,C
@@ -363,8 +466,12 @@ Z80OPS:
 	LD	DE,(NN)
 	LD	DE,NN
 	LD	E,(HL)
+	LD	E,(IX)
 	LD	E,(IX+IND)
+	LD	E,(IX-IND)
+	LD	E,(IY)
 	LD	E,(IY+IND)
+	LD	E,(IY-IND)
 	LD	E,A
 	LD	E,B
 	LD	E,C
@@ -378,8 +485,12 @@ Z80OPS:
 	LD	E,L
 	LD	E,N
 	LD	H,(HL)
+	LD	H,(IX)
 	LD	H,(IX+IND)
+	LD	H,(IX-IND)
+	LD	H,(IY)
 	LD	H,(IY+IND)
+	LD	H,(IY-IND)
 	LD	H,A
 	LD	H,B
 	LD	H,C
@@ -428,8 +539,12 @@ Z80OPS:
 	LD	IYL,IYL			; Undocumented
 	LD	IYL,N			; Undocumented
 	LD	L,(HL)
+	LD	L,(IX)
 	LD	L,(IX+IND)
+	LD	L,(IX-IND)
+	LD	L,(IY)
 	LD	L,(IY+IND)
+	LD	L,(IY-IND)
 	LD	L,A
 	LD	L,B
 	LD	L,C
@@ -450,8 +565,12 @@ Z80OPS:
 	NEG
 	NOP
 	OR	(HL)
+	OR	(IX)
 	OR	(IX+IND)
+	OR	(IX-IND)
+	OR	(IY)
 	OR	(IY+IND)
+	OR	(IY-IND)
 	OR	A
 	OR	B
 	OR	C
@@ -490,6 +609,14 @@ Z80OPS:
 	PUSH	IX
 	PUSH	IY
 	RES	0,(HL)
+	RES	0,(IX)
+	RES	0,(IX),A		; Undocumented
+	RES	0,(IX),B		; Undocumented
+	RES	0,(IX),C		; Undocumented
+	RES	0,(IX),D		; Undocumented
+	RES	0,(IX),E		; Undocumented
+	RES	0,(IX),H		; Undocumented
+	RES	0,(IX),L		; Undocumented
 	RES	0,(IX+IND)
 	RES	0,(IX+IND),A		; Undocumented
 	RES	0,(IX+IND),B		; Undocumented
@@ -498,6 +625,22 @@ Z80OPS:
 	RES	0,(IX+IND),E		; Undocumented
 	RES	0,(IX+IND),H		; Undocumented
 	RES	0,(IX+IND),L		; Undocumented
+	RES	0,(IX-IND)
+	RES	0,(IX-IND),A		; Undocumented
+	RES	0,(IX-IND),B		; Undocumented
+	RES	0,(IX-IND),C		; Undocumented
+	RES	0,(IX-IND),D		; Undocumented
+	RES	0,(IX-IND),E		; Undocumented
+	RES	0,(IX-IND),H		; Undocumented
+	RES	0,(IX-IND),L		; Undocumented
+	RES	0,(IY)
+	RES	0,(IY),A		; Undocumented
+	RES	0,(IY),B		; Undocumented
+	RES	0,(IY),C		; Undocumented
+	RES	0,(IY),D		; Undocumented
+	RES	0,(IY),E		; Undocumented
+	RES	0,(IY),H		; Undocumented
+	RES	0,(IY),L		; Undocumented
 	RES	0,(IY+IND)
 	RES	0,(IY+IND),A		; Undocumented
 	RES	0,(IY+IND),B		; Undocumented
@@ -506,6 +649,14 @@ Z80OPS:
 	RES	0,(IY+IND),E		; Undocumented
 	RES	0,(IY+IND),H		; Undocumented
 	RES	0,(IY+IND),L		; Undocumented
+	RES	0,(IY-IND)
+	RES	0,(IY-IND),A		; Undocumented
+	RES	0,(IY-IND),B		; Undocumented
+	RES	0,(IY-IND),C		; Undocumented
+	RES	0,(IY-IND),D		; Undocumented
+	RES	0,(IY-IND),E		; Undocumented
+	RES	0,(IY-IND),H		; Undocumented
+	RES	0,(IY-IND),L		; Undocumented
 	RES	0,A
 	RES	0,B
 	RES	0,C
@@ -514,6 +665,14 @@ Z80OPS:
 	RES	0,H
 	RES	0,L
 	RES	1,(HL)
+	RES	1,(IX)
+	RES	1,(IX),A		; Undocumented
+	RES	1,(IX),B		; Undocumented
+	RES	1,(IX),C		; Undocumented
+	RES	1,(IX),D		; Undocumented
+	RES	1,(IX),E		; Undocumented
+	RES	1,(IX),H		; Undocumented
+	RES	1,(IX),L		; Undocumented
 	RES	1,(IX+IND)
 	RES	1,(IX+IND),A		; Undocumented
 	RES	1,(IX+IND),B		; Undocumented
@@ -522,6 +681,22 @@ Z80OPS:
 	RES	1,(IX+IND),E		; Undocumented
 	RES	1,(IX+IND),H		; Undocumented
 	RES	1,(IX+IND),L		; Undocumented
+	RES	1,(IX-IND)
+	RES	1,(IX-IND),A		; Undocumented
+	RES	1,(IX-IND),B		; Undocumented
+	RES	1,(IX-IND),C		; Undocumented
+	RES	1,(IX-IND),D		; Undocumented
+	RES	1,(IX-IND),E		; Undocumented
+	RES	1,(IX-IND),H		; Undocumented
+	RES	1,(IX-IND),L		; Undocumented
+	RES	1,(IY)
+	RES	1,(IY),A		; Undocumented
+	RES	1,(IY),B		; Undocumented
+	RES	1,(IY),C		; Undocumented
+	RES	1,(IY),D		; Undocumented
+	RES	1,(IY),E		; Undocumented
+	RES	1,(IY),H		; Undocumented
+	RES	1,(IY),L		; Undocumented
 	RES	1,(IY+IND)
 	RES	1,(IY+IND),A		; Undocumented
 	RES	1,(IY+IND),B		; Undocumented
@@ -530,6 +705,14 @@ Z80OPS:
 	RES	1,(IY+IND),E		; Undocumented
 	RES	1,(IY+IND),H		; Undocumented
 	RES	1,(IY+IND),L		; Undocumented
+	RES	1,(IY-IND)
+	RES	1,(IY-IND),A		; Undocumented
+	RES	1,(IY-IND),B		; Undocumented
+	RES	1,(IY-IND),C		; Undocumented
+	RES	1,(IY-IND),D		; Undocumented
+	RES	1,(IY-IND),E		; Undocumented
+	RES	1,(IY-IND),H		; Undocumented
+	RES	1,(IY-IND),L		; Undocumented
 	RES	1,A
 	RES	1,B
 	RES	1,C
@@ -538,6 +721,14 @@ Z80OPS:
 	RES	1,H
 	RES	1,L
 	RES	2,(HL)
+	RES	2,(IX)
+	RES	2,(IX),A		; Undocumented
+	RES	2,(IX),B		; Undocumented
+	RES	2,(IX),C		; Undocumented
+	RES	2,(IX),D		; Undocumented
+	RES	2,(IX),E		; Undocumented
+	RES	2,(IX),H		; Undocumented
+	RES	2,(IX),L		; Undocumented
 	RES	2,(IX+IND)
 	RES	2,(IX+IND),A		; Undocumented
 	RES	2,(IX+IND),B		; Undocumented
@@ -546,6 +737,22 @@ Z80OPS:
 	RES	2,(IX+IND),E		; Undocumented
 	RES	2,(IX+IND),H		; Undocumented
 	RES	2,(IX+IND),L		; Undocumented
+	RES	2,(IX-IND)
+	RES	2,(IX-IND),A		; Undocumented
+	RES	2,(IX-IND),B		; Undocumented
+	RES	2,(IX-IND),C		; Undocumented
+	RES	2,(IX-IND),D		; Undocumented
+	RES	2,(IX-IND),E		; Undocumented
+	RES	2,(IX-IND),H		; Undocumented
+	RES	2,(IX-IND),L		; Undocumented
+	RES	2,(IY)
+	RES	2,(IY),A		; Undocumented
+	RES	2,(IY),B		; Undocumented
+	RES	2,(IY),C		; Undocumented
+	RES	2,(IY),D		; Undocumented
+	RES	2,(IY),E		; Undocumented
+	RES	2,(IY),H		; Undocumented
+	RES	2,(IY),L		; Undocumented
 	RES	2,(IY+IND)
 	RES	2,(IY+IND),A		; Undocumented
 	RES	2,(IY+IND),B		; Undocumented
@@ -554,6 +761,14 @@ Z80OPS:
 	RES	2,(IY+IND),E		; Undocumented
 	RES	2,(IY+IND),H		; Undocumented
 	RES	2,(IY+IND),L		; Undocumented
+	RES	2,(IY-IND)
+	RES	2,(IY-IND),A		; Undocumented
+	RES	2,(IY-IND),B		; Undocumented
+	RES	2,(IY-IND),C		; Undocumented
+	RES	2,(IY-IND),D		; Undocumented
+	RES	2,(IY-IND),E		; Undocumented
+	RES	2,(IY-IND),H		; Undocumented
+	RES	2,(IY-IND),L		; Undocumented
 	RES	2,A
 	RES	2,B
 	RES	2,C
@@ -562,6 +777,14 @@ Z80OPS:
 	RES	2,H
 	RES	2,L
 	RES	3,(HL)
+	RES	3,(IX)
+	RES	3,(IX),A		; Undocumented
+	RES	3,(IX),B		; Undocumented
+	RES	3,(IX),C		; Undocumented
+	RES	3,(IX),D		; Undocumented
+	RES	3,(IX),E		; Undocumented
+	RES	3,(IX),H		; Undocumented
+	RES	3,(IX),L		; Undocumented
 	RES	3,(IX+IND)
 	RES	3,(IX+IND),A		; Undocumented
 	RES	3,(IX+IND),B		; Undocumented
@@ -570,6 +793,22 @@ Z80OPS:
 	RES	3,(IX+IND),E		; Undocumented
 	RES	3,(IX+IND),H		; Undocumented
 	RES	3,(IX+IND),L		; Undocumented
+	RES	3,(IX-IND)
+	RES	3,(IX-IND),A		; Undocumented
+	RES	3,(IX-IND),B		; Undocumented
+	RES	3,(IX-IND),C		; Undocumented
+	RES	3,(IX-IND),D		; Undocumented
+	RES	3,(IX-IND),E		; Undocumented
+	RES	3,(IX-IND),H		; Undocumented
+	RES	3,(IX-IND),L		; Undocumented
+	RES	3,(IY)
+	RES	3,(IY),A		; Undocumented
+	RES	3,(IY),B		; Undocumented
+	RES	3,(IY),C		; Undocumented
+	RES	3,(IY),D		; Undocumented
+	RES	3,(IY),E		; Undocumented
+	RES	3,(IY),H		; Undocumented
+	RES	3,(IY),L		; Undocumented
 	RES	3,(IY+IND)
 	RES	3,(IY+IND),A		; Undocumented
 	RES	3,(IY+IND),B		; Undocumented
@@ -578,6 +817,14 @@ Z80OPS:
 	RES	3,(IY+IND),E		; Undocumented
 	RES	3,(IY+IND),H		; Undocumented
 	RES	3,(IY+IND),L		; Undocumented
+	RES	3,(IY-IND)
+	RES	3,(IY-IND),A		; Undocumented
+	RES	3,(IY-IND),B		; Undocumented
+	RES	3,(IY-IND),C		; Undocumented
+	RES	3,(IY-IND),D		; Undocumented
+	RES	3,(IY-IND),E		; Undocumented
+	RES	3,(IY-IND),H		; Undocumented
+	RES	3,(IY-IND),L		; Undocumented
 	RES	3,A
 	RES	3,B
 	RES	3,C
@@ -586,6 +833,14 @@ Z80OPS:
 	RES	3,H
 	RES	3,L
 	RES	4,(HL)
+	RES	4,(IX)
+	RES	4,(IX),A		; Undocumented
+	RES	4,(IX),B		; Undocumented
+	RES	4,(IX),C		; Undocumented
+	RES	4,(IX),D		; Undocumented
+	RES	4,(IX),E		; Undocumented
+	RES	4,(IX),H		; Undocumented
+	RES	4,(IX),L		; Undocumented
 	RES	4,(IX+IND)
 	RES	4,(IX+IND),A		; Undocumented
 	RES	4,(IX+IND),B		; Undocumented
@@ -594,6 +849,22 @@ Z80OPS:
 	RES	4,(IX+IND),E		; Undocumented
 	RES	4,(IX+IND),H		; Undocumented
 	RES	4,(IX+IND),L		; Undocumented
+	RES	4,(IX-IND)
+	RES	4,(IX-IND),A		; Undocumented
+	RES	4,(IX-IND),B		; Undocumented
+	RES	4,(IX-IND),C		; Undocumented
+	RES	4,(IX-IND),D		; Undocumented
+	RES	4,(IX-IND),E		; Undocumented
+	RES	4,(IX-IND),H		; Undocumented
+	RES	4,(IX-IND),L		; Undocumented
+	RES	4,(IY)
+	RES	4,(IY),A		; Undocumented
+	RES	4,(IY),B		; Undocumented
+	RES	4,(IY),C		; Undocumented
+	RES	4,(IY),D		; Undocumented
+	RES	4,(IY),E		; Undocumented
+	RES	4,(IY),H		; Undocumented
+	RES	4,(IY),L		; Undocumented
 	RES	4,(IY+IND)
 	RES	4,(IY+IND),A		; Undocumented
 	RES	4,(IY+IND),B		; Undocumented
@@ -602,6 +873,14 @@ Z80OPS:
 	RES	4,(IY+IND),E		; Undocumented
 	RES	4,(IY+IND),H		; Undocumented
 	RES	4,(IY+IND),L		; Undocumented
+	RES	4,(IY-IND)
+	RES	4,(IY-IND),A		; Undocumented
+	RES	4,(IY-IND),B		; Undocumented
+	RES	4,(IY-IND),C		; Undocumented
+	RES	4,(IY-IND),D		; Undocumented
+	RES	4,(IY-IND),E		; Undocumented
+	RES	4,(IY-IND),H		; Undocumented
+	RES	4,(IY-IND),L		; Undocumented
 	RES	4,A
 	RES	4,B
 	RES	4,C
@@ -610,6 +889,14 @@ Z80OPS:
 	RES	4,H
 	RES	4,L
 	RES	5,(HL)
+	RES	5,(IX)
+	RES	5,(IX),A		; Undocumented
+	RES	5,(IX),B		; Undocumented
+	RES	5,(IX),C		; Undocumented
+	RES	5,(IX),D		; Undocumented
+	RES	5,(IX),E		; Undocumented
+	RES	5,(IX),H		; Undocumented
+	RES	5,(IX),L		; Undocumented
 	RES	5,(IX+IND)
 	RES	5,(IX+IND),A		; Undocumented
 	RES	5,(IX+IND),B		; Undocumented
@@ -618,6 +905,22 @@ Z80OPS:
 	RES	5,(IX+IND),E		; Undocumented
 	RES	5,(IX+IND),H		; Undocumented
 	RES	5,(IX+IND),L		; Undocumented
+	RES	5,(IX-IND)
+	RES	5,(IX-IND),A		; Undocumented
+	RES	5,(IX-IND),B		; Undocumented
+	RES	5,(IX-IND),C		; Undocumented
+	RES	5,(IX-IND),D		; Undocumented
+	RES	5,(IX-IND),E		; Undocumented
+	RES	5,(IX-IND),H		; Undocumented
+	RES	5,(IX-IND),L		; Undocumented
+	RES	5,(IY)
+	RES	5,(IY),A		; Undocumented
+	RES	5,(IY),B		; Undocumented
+	RES	5,(IY),C		; Undocumented
+	RES	5,(IY),D		; Undocumented
+	RES	5,(IY),E		; Undocumented
+	RES	5,(IY),H		; Undocumented
+	RES	5,(IY),L		; Undocumented
 	RES	5,(IY+IND)
 	RES	5,(IY+IND),A		; Undocumented
 	RES	5,(IY+IND),B		; Undocumented
@@ -626,6 +929,14 @@ Z80OPS:
 	RES	5,(IY+IND),E		; Undocumented
 	RES	5,(IY+IND),H		; Undocumented
 	RES	5,(IY+IND),L		; Undocumented
+	RES	5,(IY-IND)
+	RES	5,(IY-IND),A		; Undocumented
+	RES	5,(IY-IND),B		; Undocumented
+	RES	5,(IY-IND),C		; Undocumented
+	RES	5,(IY-IND),D		; Undocumented
+	RES	5,(IY-IND),E		; Undocumented
+	RES	5,(IY-IND),H		; Undocumented
+	RES	5,(IY-IND),L		; Undocumented
 	RES	5,A
 	RES	5,B
 	RES	5,C
@@ -634,6 +945,14 @@ Z80OPS:
 	RES	5,H
 	RES	5,L
 	RES	6,(HL)
+	RES	6,(IX)
+	RES	6,(IX),A		; Undocumented
+	RES	6,(IX),B		; Undocumented
+	RES	6,(IX),C		; Undocumented
+	RES	6,(IX),D		; Undocumented
+	RES	6,(IX),E		; Undocumented
+	RES	6,(IX),H		; Undocumented
+	RES	6,(IX),L		; Undocumented
 	RES	6,(IX+IND)
 	RES	6,(IX+IND),A		; Undocumented
 	RES	6,(IX+IND),B		; Undocumented
@@ -642,6 +961,22 @@ Z80OPS:
 	RES	6,(IX+IND),E		; Undocumented
 	RES	6,(IX+IND),H		; Undocumented
 	RES	6,(IX+IND),L		; Undocumented
+	RES	6,(IX-IND)
+	RES	6,(IX-IND),A		; Undocumented
+	RES	6,(IX-IND),B		; Undocumented
+	RES	6,(IX-IND),C		; Undocumented
+	RES	6,(IX-IND),D		; Undocumented
+	RES	6,(IX-IND),E		; Undocumented
+	RES	6,(IX-IND),H		; Undocumented
+	RES	6,(IX-IND),L		; Undocumented
+	RES	6,(IY)
+	RES	6,(IY),A		; Undocumented
+	RES	6,(IY),B		; Undocumented
+	RES	6,(IY),C		; Undocumented
+	RES	6,(IY),D		; Undocumented
+	RES	6,(IY),E		; Undocumented
+	RES	6,(IY),H		; Undocumented
+	RES	6,(IY),L		; Undocumented
 	RES	6,(IY+IND)
 	RES	6,(IY+IND),A		; Undocumented
 	RES	6,(IY+IND),B		; Undocumented
@@ -650,6 +985,14 @@ Z80OPS:
 	RES	6,(IY+IND),E		; Undocumented
 	RES	6,(IY+IND),H		; Undocumented
 	RES	6,(IY+IND),L		; Undocumented
+	RES	6,(IY-IND)
+	RES	6,(IY-IND),A		; Undocumented
+	RES	6,(IY-IND),B		; Undocumented
+	RES	6,(IY-IND),C		; Undocumented
+	RES	6,(IY-IND),D		; Undocumented
+	RES	6,(IY-IND),E		; Undocumented
+	RES	6,(IY-IND),H		; Undocumented
+	RES	6,(IY-IND),L		; Undocumented
 	RES	6,A
 	RES	6,B
 	RES	6,C
@@ -658,6 +1001,14 @@ Z80OPS:
 	RES	6,H
 	RES	6,L
 	RES	7,(HL)
+	RES	7,(IX)
+	RES	7,(IX),A		; Undocumented
+	RES	7,(IX),B		; Undocumented
+	RES	7,(IX),C		; Undocumented
+	RES	7,(IX),D		; Undocumented
+	RES	7,(IX),E		; Undocumented
+	RES	7,(IX),H		; Undocumented
+	RES	7,(IX),L		; Undocumented
 	RES	7,(IX+IND)
 	RES	7,(IX+IND),A		; Undocumented
 	RES	7,(IX+IND),B		; Undocumented
@@ -666,6 +1017,22 @@ Z80OPS:
 	RES	7,(IX+IND),E		; Undocumented
 	RES	7,(IX+IND),H		; Undocumented
 	RES	7,(IX+IND),L		; Undocumented
+	RES	7,(IX-IND)
+	RES	7,(IX-IND),A		; Undocumented
+	RES	7,(IX-IND),B		; Undocumented
+	RES	7,(IX-IND),C		; Undocumented
+	RES	7,(IX-IND),D		; Undocumented
+	RES	7,(IX-IND),E		; Undocumented
+	RES	7,(IX-IND),H		; Undocumented
+	RES	7,(IX-IND),L		; Undocumented
+	RES	7,(IY)
+	RES	7,(IY),A		; Undocumented
+	RES	7,(IY),B		; Undocumented
+	RES	7,(IY),C		; Undocumented
+	RES	7,(IY),D		; Undocumented
+	RES	7,(IY),E		; Undocumented
+	RES	7,(IY),H		; Undocumented
+	RES	7,(IY),L		; Undocumented
 	RES	7,(IY+IND)
 	RES	7,(IY+IND),A		; Undocumented
 	RES	7,(IY+IND),B		; Undocumented
@@ -674,6 +1041,14 @@ Z80OPS:
 	RES	7,(IY+IND),E		; Undocumented
 	RES	7,(IY+IND),H		; Undocumented
 	RES	7,(IY+IND),L		; Undocumented
+	RES	7,(IY-IND)
+	RES	7,(IY-IND),A		; Undocumented
+	RES	7,(IY-IND),B		; Undocumented
+	RES	7,(IY-IND),C		; Undocumented
+	RES	7,(IY-IND),D		; Undocumented
+	RES	7,(IY-IND),E		; Undocumented
+	RES	7,(IY-IND),H		; Undocumented
+	RES	7,(IY-IND),L		; Undocumented
 	RES	7,A
 	RES	7,B
 	RES	7,C
@@ -693,6 +1068,14 @@ Z80OPS:
 	RETI
 	RETN
 	RL	(HL)
+	RL	(IX)
+	RL	(IX),A			; Undocumented
+	RL	(IX),B			; Undocumented
+	RL	(IX),C			; Undocumented
+	RL	(IX),D			; Undocumented
+	RL	(IX),E			; Undocumented
+	RL	(IX),H			; Undocumented
+	RL	(IX),L			; Undocumented
 	RL	(IX+IND)
 	RL	(IX+IND),A		; Undocumented
 	RL	(IX+IND),B		; Undocumented
@@ -701,6 +1084,22 @@ Z80OPS:
 	RL	(IX+IND),E		; Undocumented
 	RL	(IX+IND),H		; Undocumented
 	RL	(IX+IND),L		; Undocumented
+	RL	(IX-IND)
+	RL	(IX-IND),A		; Undocumented
+	RL	(IX-IND),B		; Undocumented
+	RL	(IX-IND),C		; Undocumented
+	RL	(IX-IND),D		; Undocumented
+	RL	(IX-IND),E		; Undocumented
+	RL	(IX-IND),H		; Undocumented
+	RL	(IX-IND),L		; Undocumented
+	RL	(IY)
+	RL	(IY),A			; Undocumented
+	RL	(IY),B			; Undocumented
+	RL	(IY),C			; Undocumented
+	RL	(IY),D			; Undocumented
+	RL	(IY),E			; Undocumented
+	RL	(IY),H			; Undocumented
+	RL	(IY),L			; Undocumented
 	RL	(IY+IND)
 	RL	(IY+IND),A		; Undocumented
 	RL	(IY+IND),B		; Undocumented
@@ -709,6 +1108,14 @@ Z80OPS:
 	RL	(IY+IND),E		; Undocumented
 	RL	(IY+IND),H		; Undocumented
 	RL	(IY+IND),L		; Undocumented
+	RL	(IY-IND)
+	RL	(IY-IND),A		; Undocumented
+	RL	(IY-IND),B		; Undocumented
+	RL	(IY-IND),C		; Undocumented
+	RL	(IY-IND),D		; Undocumented
+	RL	(IY-IND),E		; Undocumented
+	RL	(IY-IND),H		; Undocumented
+	RL	(IY-IND),L		; Undocumented
 	RL	A
 	RL	B
 	RL	C
@@ -718,6 +1125,14 @@ Z80OPS:
 	RL	L
 	RLA
 	RLC	(HL)
+	RLC	(IX)
+	RLC	(IX),A			; Undocumented
+	RLC	(IX),B			; Undocumented
+	RLC	(IX),C			; Undocumented
+	RLC	(IX),D			; Undocumented
+	RLC	(IX),E			; Undocumented
+	RLC	(IX),H			; Undocumented
+	RLC	(IX),L			; Undocumented
 	RLC	(IX+IND)
 	RLC	(IX+IND),A		; Undocumented
 	RLC	(IX+IND),B		; Undocumented
@@ -726,6 +1141,22 @@ Z80OPS:
 	RLC	(IX+IND),E		; Undocumented
 	RLC	(IX+IND),H		; Undocumented
 	RLC	(IX+IND),L		; Undocumented
+	RLC	(IX-IND)
+	RLC	(IX-IND),A		; Undocumented
+	RLC	(IX-IND),B		; Undocumented
+	RLC	(IX-IND),C		; Undocumented
+	RLC	(IX-IND),D		; Undocumented
+	RLC	(IX-IND),E		; Undocumented
+	RLC	(IX-IND),H		; Undocumented
+	RLC	(IX-IND),L		; Undocumented
+	RLC	(IY)
+	RLC	(IY),A			; Undocumented
+	RLC	(IY),B			; Undocumented
+	RLC	(IY),C			; Undocumented
+	RLC	(IY),D			; Undocumented
+	RLC	(IY),E			; Undocumented
+	RLC	(IY),H			; Undocumented
+	RLC	(IY),L			; Undocumented
 	RLC	(IY+IND)
 	RLC	(IY+IND),A		; Undocumented
 	RLC	(IY+IND),B		; Undocumented
@@ -734,6 +1165,14 @@ Z80OPS:
 	RLC	(IY+IND),E		; Undocumented
 	RLC	(IY+IND),H		; Undocumented
 	RLC	(IY+IND),L		; Undocumented
+	RLC	(IY-IND)
+	RLC	(IY-IND),A		; Undocumented
+	RLC	(IY-IND),B		; Undocumented
+	RLC	(IY-IND),C		; Undocumented
+	RLC	(IY-IND),D		; Undocumented
+	RLC	(IY-IND),E		; Undocumented
+	RLC	(IY-IND),H		; Undocumented
+	RLC	(IY-IND),L		; Undocumented
 	RLC	A
 	RLC	B
 	RLC	C
@@ -744,6 +1183,14 @@ Z80OPS:
 	RLCA
 	RLD
 	RR	(HL)
+	RR	(IX)
+	RR	(IX),A			; Undocumented
+	RR	(IX),B			; Undocumented
+	RR	(IX),C			; Undocumented
+	RR	(IX),D			; Undocumented
+	RR	(IX),E			; Undocumented
+	RR	(IX),H			; Undocumented
+	RR	(IX),L			; Undocumented
 	RR	(IX+IND)
 	RR	(IX+IND),A		; Undocumented
 	RR	(IX+IND),B		; Undocumented
@@ -752,6 +1199,22 @@ Z80OPS:
 	RR	(IX+IND),E		; Undocumented
 	RR	(IX+IND),H		; Undocumented
 	RR	(IX+IND),L		; Undocumented
+	RR	(IX-IND)
+	RR	(IX-IND),A		; Undocumented
+	RR	(IX-IND),B		; Undocumented
+	RR	(IX-IND),C		; Undocumented
+	RR	(IX-IND),D		; Undocumented
+	RR	(IX-IND),E		; Undocumented
+	RR	(IX-IND),H		; Undocumented
+	RR	(IX-IND),L		; Undocumented
+	RR	(IY)
+	RR	(IY),A			; Undocumented
+	RR	(IY),B			; Undocumented
+	RR	(IY),C			; Undocumented
+	RR	(IY),D			; Undocumented
+	RR	(IY),E			; Undocumented
+	RR	(IY),H			; Undocumented
+	RR	(IY),L			; Undocumented
 	RR	(IY+IND)
 	RR	(IY+IND),A		; Undocumented
 	RR	(IY+IND),B		; Undocumented
@@ -760,6 +1223,14 @@ Z80OPS:
 	RR	(IY+IND),E		; Undocumented
 	RR	(IY+IND),H		; Undocumented
 	RR	(IY+IND),L		; Undocumented
+	RR	(IY-IND)
+	RR	(IY-IND),A		; Undocumented
+	RR	(IY-IND),B		; Undocumented
+	RR	(IY-IND),C		; Undocumented
+	RR	(IY-IND),D		; Undocumented
+	RR	(IY-IND),E		; Undocumented
+	RR	(IY-IND),H		; Undocumented
+	RR	(IY-IND),L		; Undocumented
 	RR	A
 	RR	B
 	RR	C
@@ -769,6 +1240,14 @@ Z80OPS:
 	RR	L
 	RRA
 	RRC	(HL)
+	RRC	(IX)
+	RRC	(IX),A			; Undocumented
+	RRC	(IX),B			; Undocumented
+	RRC	(IX),C			; Undocumented
+	RRC	(IX),D			; Undocumented
+	RRC	(IX),E			; Undocumented
+	RRC	(IX),H			; Undocumented
+	RRC	(IX),L			; Undocumented
 	RRC	(IX+IND)
 	RRC	(IX+IND),A		; Undocumented
 	RRC	(IX+IND),B		; Undocumented
@@ -777,6 +1256,22 @@ Z80OPS:
 	RRC	(IX+IND),E		; Undocumented
 	RRC	(IX+IND),H		; Undocumented
 	RRC	(IX+IND),L		; Undocumented
+	RRC	(IX-IND)
+	RRC	(IX-IND),A		; Undocumented
+	RRC	(IX-IND),B		; Undocumented
+	RRC	(IX-IND),C		; Undocumented
+	RRC	(IX-IND),D		; Undocumented
+	RRC	(IX-IND),E		; Undocumented
+	RRC	(IX-IND),H		; Undocumented
+	RRC	(IX-IND),L		; Undocumented
+	RRC	(IY)
+	RRC	(IY),A			; Undocumented
+	RRC	(IY),B			; Undocumented
+	RRC	(IY),C			; Undocumented
+	RRC	(IY),D			; Undocumented
+	RRC	(IY),E			; Undocumented
+	RRC	(IY),H			; Undocumented
+	RRC	(IY),L			; Undocumented
 	RRC	(IY+IND)
 	RRC	(IY+IND),A		; Undocumented
 	RRC	(IY+IND),B		; Undocumented
@@ -785,6 +1280,14 @@ Z80OPS:
 	RRC	(IY+IND),E		; Undocumented
 	RRC	(IY+IND),H		; Undocumented
 	RRC	(IY+IND),L		; Undocumented
+	RRC	(IY-IND)
+	RRC	(IY-IND),A		; Undocumented
+	RRC	(IY-IND),B		; Undocumented
+	RRC	(IY-IND),C		; Undocumented
+	RRC	(IY-IND),D		; Undocumented
+	RRC	(IY-IND),E		; Undocumented
+	RRC	(IY-IND),H		; Undocumented
+	RRC	(IY-IND),L		; Undocumented
 	RRC	A
 	RRC	B
 	RRC	C
@@ -803,8 +1306,12 @@ Z80OPS:
 	RST	38H
 	RST	8
 	SBC	A,(HL)
+	SBC	A,(IX)
 	SBC	A,(IX+IND)
+	SBC	A,(IX-IND)
+	SBC	A,(IY)
 	SBC	A,(IY+IND)
+	SBC	A,(IY-IND)
 	SBC	A,A
 	SBC	A,B
 	SBC	A,C
@@ -823,6 +1330,14 @@ Z80OPS:
 	SBC	HL,SP
 	SCF
 	SET	0,(HL)
+	SET	0,(IX)
+	SET	0,(IX),A		; Undocumented
+	SET	0,(IX),B		; Undocumented
+	SET	0,(IX),C		; Undocumented
+	SET	0,(IX),D		; Undocumented
+	SET	0,(IX),E		; Undocumented
+	SET	0,(IX),H		; Undocumented
+	SET	0,(IX),L		; Undocumented
 	SET	0,(IX+IND)
 	SET	0,(IX+IND),A		; Undocumented
 	SET	0,(IX+IND),B		; Undocumented
@@ -831,6 +1346,22 @@ Z80OPS:
 	SET	0,(IX+IND),E		; Undocumented
 	SET	0,(IX+IND),H		; Undocumented
 	SET	0,(IX+IND),L		; Undocumented
+	SET	0,(IX-IND)
+	SET	0,(IX-IND),A		; Undocumented
+	SET	0,(IX-IND),B		; Undocumented
+	SET	0,(IX-IND),C		; Undocumented
+	SET	0,(IX-IND),D		; Undocumented
+	SET	0,(IX-IND),E		; Undocumented
+	SET	0,(IX-IND),H		; Undocumented
+	SET	0,(IX-IND),L		; Undocumented
+	SET	0,(IY)
+	SET	0,(IY),A		; Undocumented
+	SET	0,(IY),B		; Undocumented
+	SET	0,(IY),C		; Undocumented
+	SET	0,(IY),D		; Undocumented
+	SET	0,(IY),E		; Undocumented
+	SET	0,(IY),H		; Undocumented
+	SET	0,(IY),L		; Undocumented
 	SET	0,(IY+IND)
 	SET	0,(IY+IND),A		; Undocumented
 	SET	0,(IY+IND),B		; Undocumented
@@ -839,6 +1370,14 @@ Z80OPS:
 	SET	0,(IY+IND),E		; Undocumented
 	SET	0,(IY+IND),H		; Undocumented
 	SET	0,(IY+IND),L		; Undocumented
+	SET	0,(IY-IND)
+	SET	0,(IY-IND),A		; Undocumented
+	SET	0,(IY-IND),B		; Undocumented
+	SET	0,(IY-IND),C		; Undocumented
+	SET	0,(IY-IND),D		; Undocumented
+	SET	0,(IY-IND),E		; Undocumented
+	SET	0,(IY-IND),H		; Undocumented
+	SET	0,(IY-IND),L		; Undocumented
 	SET	0,A
 	SET	0,B
 	SET	0,C
@@ -847,6 +1386,14 @@ Z80OPS:
 	SET	0,H
 	SET	0,L
 	SET	1,(HL)
+	SET	1,(IX)
+	SET	1,(IX),A		; Undocumented
+	SET	1,(IX),B		; Undocumented
+	SET	1,(IX),C		; Undocumented
+	SET	1,(IX),D		; Undocumented
+	SET	1,(IX),E		; Undocumented
+	SET	1,(IX),H		; Undocumented
+	SET	1,(IX),L		; Undocumented
 	SET	1,(IX+IND)
 	SET	1,(IX+IND),A		; Undocumented
 	SET	1,(IX+IND),B		; Undocumented
@@ -855,6 +1402,22 @@ Z80OPS:
 	SET	1,(IX+IND),E		; Undocumented
 	SET	1,(IX+IND),H		; Undocumented
 	SET	1,(IX+IND),L		; Undocumented
+	SET	1,(IX-IND)
+	SET	1,(IX-IND),A		; Undocumented
+	SET	1,(IX-IND),B		; Undocumented
+	SET	1,(IX-IND),C		; Undocumented
+	SET	1,(IX-IND),D		; Undocumented
+	SET	1,(IX-IND),E		; Undocumented
+	SET	1,(IX-IND),H		; Undocumented
+	SET	1,(IX-IND),L		; Undocumented
+	SET	1,(IY)
+	SET	1,(IY),A		; Undocumented
+	SET	1,(IY),B		; Undocumented
+	SET	1,(IY),C		; Undocumented
+	SET	1,(IY),D		; Undocumented
+	SET	1,(IY),E		; Undocumented
+	SET	1,(IY),H		; Undocumented
+	SET	1,(IY),L		; Undocumented
 	SET	1,(IY+IND)
 	SET	1,(IY+IND),A		; Undocumented
 	SET	1,(IY+IND),B		; Undocumented
@@ -863,6 +1426,14 @@ Z80OPS:
 	SET	1,(IY+IND),E		; Undocumented
 	SET	1,(IY+IND),H		; Undocumented
 	SET	1,(IY+IND),L		; Undocumented
+	SET	1,(IY-IND)
+	SET	1,(IY-IND),A		; Undocumented
+	SET	1,(IY-IND),B		; Undocumented
+	SET	1,(IY-IND),C		; Undocumented
+	SET	1,(IY-IND),D		; Undocumented
+	SET	1,(IY-IND),E		; Undocumented
+	SET	1,(IY-IND),H		; Undocumented
+	SET	1,(IY-IND),L		; Undocumented
 	SET	1,A
 	SET	1,B
 	SET	1,C
@@ -871,6 +1442,14 @@ Z80OPS:
 	SET	1,H
 	SET	1,L
 	SET	2,(HL)
+	SET	2,(IX)
+	SET	2,(IX),A		; Undocumented
+	SET	2,(IX),B		; Undocumented
+	SET	2,(IX),C		; Undocumented
+	SET	2,(IX),D		; Undocumented
+	SET	2,(IX),E		; Undocumented
+	SET	2,(IX),H		; Undocumented
+	SET	2,(IX),L		; Undocumented
 	SET	2,(IX+IND)
 	SET	2,(IX+IND),A		; Undocumented
 	SET	2,(IX+IND),B		; Undocumented
@@ -879,6 +1458,22 @@ Z80OPS:
 	SET	2,(IX+IND),E		; Undocumented
 	SET	2,(IX+IND),H		; Undocumented
 	SET	2,(IX+IND),L		; Undocumented
+	SET	2,(IX-IND)
+	SET	2,(IX-IND),A		; Undocumented
+	SET	2,(IX-IND),B		; Undocumented
+	SET	2,(IX-IND),C		; Undocumented
+	SET	2,(IX-IND),D		; Undocumented
+	SET	2,(IX-IND),E		; Undocumented
+	SET	2,(IX-IND),H		; Undocumented
+	SET	2,(IX-IND),L		; Undocumented
+	SET	2,(IY)
+	SET	2,(IY),A		; Undocumented
+	SET	2,(IY),B		; Undocumented
+	SET	2,(IY),C		; Undocumented
+	SET	2,(IY),D		; Undocumented
+	SET	2,(IY),E		; Undocumented
+	SET	2,(IY),H		; Undocumented
+	SET	2,(IY),L		; Undocumented
 	SET	2,(IY+IND)
 	SET	2,(IY+IND),A		; Undocumented
 	SET	2,(IY+IND),B		; Undocumented
@@ -887,6 +1482,14 @@ Z80OPS:
 	SET	2,(IY+IND),E		; Undocumented
 	SET	2,(IY+IND),H		; Undocumented
 	SET	2,(IY+IND),L		; Undocumented
+	SET	2,(IY-IND)
+	SET	2,(IY-IND),A		; Undocumented
+	SET	2,(IY-IND),B		; Undocumented
+	SET	2,(IY-IND),C		; Undocumented
+	SET	2,(IY-IND),D		; Undocumented
+	SET	2,(IY-IND),E		; Undocumented
+	SET	2,(IY-IND),H		; Undocumented
+	SET	2,(IY-IND),L		; Undocumented
 	SET	2,A
 	SET	2,B
 	SET	2,C
@@ -895,6 +1498,14 @@ Z80OPS:
 	SET	2,H
 	SET	2,L
 	SET	3,(HL)
+	SET	3,(IX)
+	SET	3,(IX),A		; Undocumented
+	SET	3,(IX),B		; Undocumented
+	SET	3,(IX),C		; Undocumented
+	SET	3,(IX),D		; Undocumented
+	SET	3,(IX),E		; Undocumented
+	SET	3,(IX),H		; Undocumented
+	SET	3,(IX),L		; Undocumented
 	SET	3,(IX+IND)
 	SET	3,(IX+IND),A		; Undocumented
 	SET	3,(IX+IND),B		; Undocumented
@@ -903,6 +1514,22 @@ Z80OPS:
 	SET	3,(IX+IND),E		; Undocumented
 	SET	3,(IX+IND),H		; Undocumented
 	SET	3,(IX+IND),L		; Undocumented
+	SET	3,(IX-IND)
+	SET	3,(IX-IND),A		; Undocumented
+	SET	3,(IX-IND),B		; Undocumented
+	SET	3,(IX-IND),C		; Undocumented
+	SET	3,(IX-IND),D		; Undocumented
+	SET	3,(IX-IND),E		; Undocumented
+	SET	3,(IX-IND),H		; Undocumented
+	SET	3,(IX-IND),L		; Undocumented
+	SET	3,(IY)
+	SET	3,(IY),A		; Undocumented
+	SET	3,(IY),B		; Undocumented
+	SET	3,(IY),C		; Undocumented
+	SET	3,(IY),D		; Undocumented
+	SET	3,(IY),E		; Undocumented
+	SET	3,(IY),H		; Undocumented
+	SET	3,(IY),L		; Undocumented
 	SET	3,(IY+IND)
 	SET	3,(IY+IND),A		; Undocumented
 	SET	3,(IY+IND),B		; Undocumented
@@ -911,6 +1538,14 @@ Z80OPS:
 	SET	3,(IY+IND),E		; Undocumented
 	SET	3,(IY+IND),H		; Undocumented
 	SET	3,(IY+IND),L		; Undocumented
+	SET	3,(IY-IND)
+	SET	3,(IY-IND),A		; Undocumented
+	SET	3,(IY-IND),B		; Undocumented
+	SET	3,(IY-IND),C		; Undocumented
+	SET	3,(IY-IND),D		; Undocumented
+	SET	3,(IY-IND),E		; Undocumented
+	SET	3,(IY-IND),H		; Undocumented
+	SET	3,(IY-IND),L		; Undocumented
 	SET	3,A
 	SET	3,B
 	SET	3,C
@@ -919,6 +1554,14 @@ Z80OPS:
 	SET	3,H
 	SET	3,L
 	SET	4,(HL)
+	SET	4,(IX)
+	SET	4,(IX),A		; Undocumented
+	SET	4,(IX),B		; Undocumented
+	SET	4,(IX),C		; Undocumented
+	SET	4,(IX),D		; Undocumented
+	SET	4,(IX),E		; Undocumented
+	SET	4,(IX),H		; Undocumented
+	SET	4,(IX),L		; Undocumented
 	SET	4,(IX+IND)
 	SET	4,(IX+IND),A		; Undocumented
 	SET	4,(IX+IND),B		; Undocumented
@@ -927,6 +1570,22 @@ Z80OPS:
 	SET	4,(IX+IND),E		; Undocumented
 	SET	4,(IX+IND),H		; Undocumented
 	SET	4,(IX+IND),L		; Undocumented
+	SET	4,(IX-IND)
+	SET	4,(IX-IND),A		; Undocumented
+	SET	4,(IX-IND),B		; Undocumented
+	SET	4,(IX-IND),C		; Undocumented
+	SET	4,(IX-IND),D		; Undocumented
+	SET	4,(IX-IND),E		; Undocumented
+	SET	4,(IX-IND),H		; Undocumented
+	SET	4,(IX-IND),L		; Undocumented
+	SET	4,(IY)
+	SET	4,(IY),A		; Undocumented
+	SET	4,(IY),B		; Undocumented
+	SET	4,(IY),C		; Undocumented
+	SET	4,(IY),D		; Undocumented
+	SET	4,(IY),E		; Undocumented
+	SET	4,(IY),H		; Undocumented
+	SET	4,(IY),L		; Undocumented
 	SET	4,(IY+IND)
 	SET	4,(IY+IND),A		; Undocumented
 	SET	4,(IY+IND),B		; Undocumented
@@ -935,6 +1594,14 @@ Z80OPS:
 	SET	4,(IY+IND),E		; Undocumented
 	SET	4,(IY+IND),H		; Undocumented
 	SET	4,(IY+IND),L		; Undocumented
+	SET	4,(IY-IND)
+	SET	4,(IY-IND),A		; Undocumented
+	SET	4,(IY-IND),B		; Undocumented
+	SET	4,(IY-IND),C		; Undocumented
+	SET	4,(IY-IND),D		; Undocumented
+	SET	4,(IY-IND),E		; Undocumented
+	SET	4,(IY-IND),H		; Undocumented
+	SET	4,(IY-IND),L		; Undocumented
 	SET	4,A
 	SET	4,B
 	SET	4,C
@@ -943,6 +1610,14 @@ Z80OPS:
 	SET	4,H
 	SET	4,L
 	SET	5,(HL)
+	SET	5,(IX)
+	SET	5,(IX),A		; Undocumented
+	SET	5,(IX),B		; Undocumented
+	SET	5,(IX),C		; Undocumented
+	SET	5,(IX),D		; Undocumented
+	SET	5,(IX),E		; Undocumented
+	SET	5,(IX),H		; Undocumented
+	SET	5,(IX),L		; Undocumented
 	SET	5,(IX+IND)
 	SET	5,(IX+IND),A		; Undocumented
 	SET	5,(IX+IND),B		; Undocumented
@@ -951,6 +1626,22 @@ Z80OPS:
 	SET	5,(IX+IND),E		; Undocumented
 	SET	5,(IX+IND),H		; Undocumented
 	SET	5,(IX+IND),L		; Undocumented
+	SET	5,(IX-IND)
+	SET	5,(IX-IND),A		; Undocumented
+	SET	5,(IX-IND),B		; Undocumented
+	SET	5,(IX-IND),C		; Undocumented
+	SET	5,(IX-IND),D		; Undocumented
+	SET	5,(IX-IND),E		; Undocumented
+	SET	5,(IX-IND),H		; Undocumented
+	SET	5,(IX-IND),L		; Undocumented
+	SET	5,(IY)
+	SET	5,(IY),A		; Undocumented
+	SET	5,(IY),B		; Undocumented
+	SET	5,(IY),C		; Undocumented
+	SET	5,(IY),D		; Undocumented
+	SET	5,(IY),E		; Undocumented
+	SET	5,(IY),H		; Undocumented
+	SET	5,(IY),L		; Undocumented
 	SET	5,(IY+IND)
 	SET	5,(IY+IND),A		; Undocumented
 	SET	5,(IY+IND),B		; Undocumented
@@ -959,6 +1650,14 @@ Z80OPS:
 	SET	5,(IY+IND),E		; Undocumented
 	SET	5,(IY+IND),H		; Undocumented
 	SET	5,(IY+IND),L		; Undocumented
+	SET	5,(IY-IND)
+	SET	5,(IY-IND),A		; Undocumented
+	SET	5,(IY-IND),B		; Undocumented
+	SET	5,(IY-IND),C		; Undocumented
+	SET	5,(IY-IND),D		; Undocumented
+	SET	5,(IY-IND),E		; Undocumented
+	SET	5,(IY-IND),H		; Undocumented
+	SET	5,(IY-IND),L		; Undocumented
 	SET	5,A
 	SET	5,B
 	SET	5,C
@@ -967,6 +1666,14 @@ Z80OPS:
 	SET	5,H
 	SET	5,L
 	SET	6,(HL)
+	SET	6,(IX)
+	SET	6,(IX),A		; Undocumented
+	SET	6,(IX),B		; Undocumented
+	SET	6,(IX),C		; Undocumented
+	SET	6,(IX),D		; Undocumented
+	SET	6,(IX),E		; Undocumented
+	SET	6,(IX),H		; Undocumented
+	SET	6,(IX),L		; Undocumented
 	SET	6,(IX+IND)
 	SET	6,(IX+IND),A		; Undocumented
 	SET	6,(IX+IND),B		; Undocumented
@@ -975,6 +1682,22 @@ Z80OPS:
 	SET	6,(IX+IND),E		; Undocumented
 	SET	6,(IX+IND),H		; Undocumented
 	SET	6,(IX+IND),L		; Undocumented
+	SET	6,(IX-IND)
+	SET	6,(IX-IND),A		; Undocumented
+	SET	6,(IX-IND),B		; Undocumented
+	SET	6,(IX-IND),C		; Undocumented
+	SET	6,(IX-IND),D		; Undocumented
+	SET	6,(IX-IND),E		; Undocumented
+	SET	6,(IX-IND),H		; Undocumented
+	SET	6,(IX-IND),L		; Undocumented
+	SET	6,(IY)
+	SET	6,(IY),A		; Undocumented
+	SET	6,(IY),B		; Undocumented
+	SET	6,(IY),C		; Undocumented
+	SET	6,(IY),D		; Undocumented
+	SET	6,(IY),E		; Undocumented
+	SET	6,(IY),H		; Undocumented
+	SET	6,(IY),L		; Undocumented
 	SET	6,(IY+IND)
 	SET	6,(IY+IND),A		; Undocumented
 	SET	6,(IY+IND),B		; Undocumented
@@ -983,6 +1706,14 @@ Z80OPS:
 	SET	6,(IY+IND),E		; Undocumented
 	SET	6,(IY+IND),H		; Undocumented
 	SET	6,(IY+IND),L		; Undocumented
+	SET	6,(IY-IND)
+	SET	6,(IY-IND),A		; Undocumented
+	SET	6,(IY-IND),B		; Undocumented
+	SET	6,(IY-IND),C		; Undocumented
+	SET	6,(IY-IND),D		; Undocumented
+	SET	6,(IY-IND),E		; Undocumented
+	SET	6,(IY-IND),H		; Undocumented
+	SET	6,(IY-IND),L		; Undocumented
 	SET	6,A
 	SET	6,B
 	SET	6,C
@@ -991,6 +1722,14 @@ Z80OPS:
 	SET	6,H
 	SET	6,L
 	SET	7,(HL)
+	SET	7,(IX)
+	SET	7,(IX),A		; Undocumented
+	SET	7,(IX),B		; Undocumented
+	SET	7,(IX),C		; Undocumented
+	SET	7,(IX),D		; Undocumented
+	SET	7,(IX),E		; Undocumented
+	SET	7,(IX),H		; Undocumented
+	SET	7,(IX),L		; Undocumented
 	SET	7,(IX+IND)
 	SET	7,(IX+IND),A		; Undocumented
 	SET	7,(IX+IND),B		; Undocumented
@@ -999,6 +1738,22 @@ Z80OPS:
 	SET	7,(IX+IND),E		; Undocumented
 	SET	7,(IX+IND),H		; Undocumented
 	SET	7,(IX+IND),L		; Undocumented
+	SET	7,(IX-IND)
+	SET	7,(IX-IND),A		; Undocumented
+	SET	7,(IX-IND),B		; Undocumented
+	SET	7,(IX-IND),C		; Undocumented
+	SET	7,(IX-IND),D		; Undocumented
+	SET	7,(IX-IND),E		; Undocumented
+	SET	7,(IX-IND),H		; Undocumented
+	SET	7,(IX-IND),L		; Undocumented
+	SET	7,(IY)
+	SET	7,(IY),A		; Undocumented
+	SET	7,(IY),B		; Undocumented
+	SET	7,(IY),C		; Undocumented
+	SET	7,(IY),D		; Undocumented
+	SET	7,(IY),E		; Undocumented
+	SET	7,(IY),H		; Undocumented
+	SET	7,(IY),L		; Undocumented
 	SET	7,(IY+IND)
 	SET	7,(IY+IND),A		; Undocumented
 	SET	7,(IY+IND),B		; Undocumented
@@ -1007,6 +1762,14 @@ Z80OPS:
 	SET	7,(IY+IND),E		; Undocumented
 	SET	7,(IY+IND),H		; Undocumented
 	SET	7,(IY+IND),L		; Undocumented
+	SET	7,(IY-IND)
+	SET	7,(IY-IND),A		; Undocumented
+	SET	7,(IY-IND),B		; Undocumented
+	SET	7,(IY-IND),C		; Undocumented
+	SET	7,(IY-IND),D		; Undocumented
+	SET	7,(IY-IND),E		; Undocumented
+	SET	7,(IY-IND),H		; Undocumented
+	SET	7,(IY-IND),L		; Undocumented
 	SET	7,A
 	SET	7,B
 	SET	7,C
@@ -1015,6 +1778,14 @@ Z80OPS:
 	SET	7,H
 	SET	7,L
 	SLA	(HL)
+	SLA	(IX)
+	SLA	(IX),A			; Undocumented
+	SLA	(IX),B			; Undocumented
+	SLA	(IX),C			; Undocumented
+	SLA	(IX),D			; Undocumented
+	SLA	(IX),E			; Undocumented
+	SLA	(IX),H			; Undocumented
+	SLA	(IX),L			; Undocumented
 	SLA	(IX+IND)
 	SLA	(IX+IND),A		; Undocumented
 	SLA	(IX+IND),B		; Undocumented
@@ -1023,6 +1794,22 @@ Z80OPS:
 	SLA	(IX+IND),E		; Undocumented
 	SLA	(IX+IND),H		; Undocumented
 	SLA	(IX+IND),L		; Undocumented
+	SLA	(IX-IND)
+	SLA	(IX-IND),A		; Undocumented
+	SLA	(IX-IND),B		; Undocumented
+	SLA	(IX-IND),C		; Undocumented
+	SLA	(IX-IND),D		; Undocumented
+	SLA	(IX-IND),E		; Undocumented
+	SLA	(IX-IND),H		; Undocumented
+	SLA	(IX-IND),L		; Undocumented
+	SLA	(IY)
+	SLA	(IY),A			; Undocumented
+	SLA	(IY),B			; Undocumented
+	SLA	(IY),C			; Undocumented
+	SLA	(IY),D			; Undocumented
+	SLA	(IY),E			; Undocumented
+	SLA	(IY),H			; Undocumented
+	SLA	(IY),L			; Undocumented
 	SLA	(IY+IND)
 	SLA	(IY+IND),A		; Undocumented
 	SLA	(IY+IND),B		; Undocumented
@@ -1031,6 +1818,14 @@ Z80OPS:
 	SLA	(IY+IND),E		; Undocumented
 	SLA	(IY+IND),H		; Undocumented
 	SLA	(IY+IND),L		; Undocumented
+	SLA	(IY-IND)
+	SLA	(IY-IND),A		; Undocumented
+	SLA	(IY-IND),B		; Undocumented
+	SLA	(IY-IND),C		; Undocumented
+	SLA	(IY-IND),D		; Undocumented
+	SLA	(IY-IND),E		; Undocumented
+	SLA	(IY-IND),H		; Undocumented
+	SLA	(IY-IND),L		; Undocumented
 	SLA	A
 	SLA	B
 	SLA	C
@@ -1039,6 +1834,14 @@ Z80OPS:
 	SLA	H
 	SLA	L
 	SLL	(HL)			; Undocumented
+	SLL	(IX)			; Undocumented
+	SLL	(IX),A			; Undocumented
+	SLL	(IX),B			; Undocumented
+	SLL	(IX),C			; Undocumented
+	SLL	(IX),D			; Undocumented
+	SLL	(IX),E			; Undocumented
+	SLL	(IX),H			; Undocumented
+	SLL	(IX),L			; Undocumented
 	SLL	(IX+IND)		; Undocumented
 	SLL	(IX+IND),A		; Undocumented
 	SLL	(IX+IND),B		; Undocumented
@@ -1047,6 +1850,22 @@ Z80OPS:
 	SLL	(IX+IND),E		; Undocumented
 	SLL	(IX+IND),H		; Undocumented
 	SLL	(IX+IND),L		; Undocumented
+	SLL	(IX-IND)		; Undocumented
+	SLL	(IX-IND),A		; Undocumented
+	SLL	(IX-IND),B		; Undocumented
+	SLL	(IX-IND),C		; Undocumented
+	SLL	(IX-IND),D		; Undocumented
+	SLL	(IX-IND),E		; Undocumented
+	SLL	(IX-IND),H		; Undocumented
+	SLL	(IX-IND),L		; Undocumented
+	SLL	(IY)			; Undocumented
+	SLL	(IY),A			; Undocumented
+	SLL	(IY),B			; Undocumented
+	SLL	(IY),C			; Undocumented
+	SLL	(IY),D			; Undocumented
+	SLL	(IY),E			; Undocumented
+	SLL	(IY),H			; Undocumented
+	SLL	(IY),L			; Undocumented
 	SLL	(IY+IND)		; Undocumented
 	SLL	(IY+IND),A		; Undocumented
 	SLL	(IY+IND),B		; Undocumented
@@ -1055,6 +1874,14 @@ Z80OPS:
 	SLL	(IY+IND),E		; Undocumented
 	SLL	(IY+IND),H		; Undocumented
 	SLL	(IY+IND),L		; Undocumented
+	SLL	(IY-IND)		; Undocumented
+	SLL	(IY-IND),A		; Undocumented
+	SLL	(IY-IND),B		; Undocumented
+	SLL	(IY-IND),C		; Undocumented
+	SLL	(IY-IND),D		; Undocumented
+	SLL	(IY-IND),E		; Undocumented
+	SLL	(IY-IND),H		; Undocumented
+	SLL	(IY-IND),L		; Undocumented
 	SLL	A			; Undocumented
 	SLL	B			; Undocumented
 	SLL	C			; Undocumented
@@ -1063,6 +1890,14 @@ Z80OPS:
 	SLL	H			; Undocumented
 	SLL	L			; Undocumented
 	SRA	(HL)
+	SRA	(IX)
+	SRA	(IX),A			; Undocumented
+	SRA	(IX),B			; Undocumented
+	SRA	(IX),C			; Undocumented
+	SRA	(IX),D			; Undocumented
+	SRA	(IX),E			; Undocumented
+	SRA	(IX),H			; Undocumented
+	SRA	(IX),L			; Undocumented
 	SRA	(IX+IND)
 	SRA	(IX+IND),A		; Undocumented
 	SRA	(IX+IND),B		; Undocumented
@@ -1071,6 +1906,22 @@ Z80OPS:
 	SRA	(IX+IND),E		; Undocumented
 	SRA	(IX+IND),H		; Undocumented
 	SRA	(IX+IND),L		; Undocumented
+	SRA	(IX-IND)
+	SRA	(IX-IND),A		; Undocumented
+	SRA	(IX-IND),B		; Undocumented
+	SRA	(IX-IND),C		; Undocumented
+	SRA	(IX-IND),D		; Undocumented
+	SRA	(IX-IND),E		; Undocumented
+	SRA	(IX-IND),H		; Undocumented
+	SRA	(IX-IND),L		; Undocumented
+	SRA	(IY)
+	SRA	(IY),A			; Undocumented
+	SRA	(IY),B			; Undocumented
+	SRA	(IY),C			; Undocumented
+	SRA	(IY),D			; Undocumented
+	SRA	(IY),E			; Undocumented
+	SRA	(IY),H			; Undocumented
+	SRA	(IY),L			; Undocumented
 	SRA	(IY+IND)
 	SRA	(IY+IND),A		; Undocumented
 	SRA	(IY+IND),B		; Undocumented
@@ -1079,6 +1930,14 @@ Z80OPS:
 	SRA	(IY+IND),E		; Undocumented
 	SRA	(IY+IND),H		; Undocumented
 	SRA	(IY+IND),L		; Undocumented
+	SRA	(IY-IND)
+	SRA	(IY-IND),A		; Undocumented
+	SRA	(IY-IND),B		; Undocumented
+	SRA	(IY-IND),C		; Undocumented
+	SRA	(IY-IND),D		; Undocumented
+	SRA	(IY-IND),E		; Undocumented
+	SRA	(IY-IND),H		; Undocumented
+	SRA	(IY-IND),L		; Undocumented
 	SRA	A
 	SRA	B
 	SRA	C
@@ -1087,6 +1946,14 @@ Z80OPS:
 	SRA	H
 	SRA	L
 	SRL	(HL)
+	SRL	(IX)
+	SRL	(IX),A			; Undocumented
+	SRL	(IX),B			; Undocumented
+	SRL	(IX),C			; Undocumented
+	SRL	(IX),D			; Undocumented
+	SRL	(IX),E			; Undocumented
+	SRL	(IX),H			; Undocumented
+	SRL	(IX),L			; Undocumented
 	SRL	(IX+IND)
 	SRL	(IX+IND),A		; Undocumented
 	SRL	(IX+IND),B		; Undocumented
@@ -1095,6 +1962,22 @@ Z80OPS:
 	SRL	(IX+IND),E		; Undocumented
 	SRL	(IX+IND),H		; Undocumented
 	SRL	(IX+IND),L		; Undocumented
+	SRL	(IX-IND)
+	SRL	(IX-IND),A		; Undocumented
+	SRL	(IX-IND),B		; Undocumented
+	SRL	(IX-IND),C		; Undocumented
+	SRL	(IX-IND),D		; Undocumented
+	SRL	(IX-IND),E		; Undocumented
+	SRL	(IX-IND),H		; Undocumented
+	SRL	(IX-IND),L		; Undocumented
+	SRL	(IY)
+	SRL	(IY),A			; Undocumented
+	SRL	(IY),B			; Undocumented
+	SRL	(IY),C			; Undocumented
+	SRL	(IY),D			; Undocumented
+	SRL	(IY),E			; Undocumented
+	SRL	(IY),H			; Undocumented
+	SRL	(IY),L			; Undocumented
 	SRL	(IY+IND)
 	SRL	(IY+IND),A		; Undocumented
 	SRL	(IY+IND),B		; Undocumented
@@ -1103,6 +1986,14 @@ Z80OPS:
 	SRL	(IY+IND),E		; Undocumented
 	SRL	(IY+IND),H		; Undocumented
 	SRL	(IY+IND),L		; Undocumented
+	SRL	(IY-IND)
+	SRL	(IY-IND),A		; Undocumented
+	SRL	(IY-IND),B		; Undocumented
+	SRL	(IY-IND),C		; Undocumented
+	SRL	(IY-IND),D		; Undocumented
+	SRL	(IY-IND),E		; Undocumented
+	SRL	(IY-IND),H		; Undocumented
+	SRL	(IY-IND),L		; Undocumented
 	SRL	A
 	SRL	B
 	SRL	C
@@ -1111,8 +2002,12 @@ Z80OPS:
 	SRL	H
 	SRL	L
 	SUB	(HL)
+	SUB	(IX)
 	SUB	(IX+IND)
+	SUB	(IX-IND)
+	SUB	(IY)
 	SUB	(IY+IND)
+	SUB	(IY-IND)
 	SUB	A
 	SUB	B
 	SUB	C
@@ -1126,8 +2021,12 @@ Z80OPS:
 	SUB	L
 	SUB	N
 	XOR	(HL)
+	XOR	(IX)
 	XOR	(IX+IND)
+	XOR	(IX-IND)
+	XOR	(IY)
 	XOR	(IY+IND)
+	XOR	(IY-IND)
 	XOR	A
 	XOR	B
 	XOR	C
@@ -1342,117 +2241,341 @@ Z80OPS:
 	DEFB	0EDH,0FDH		; NOP
 	DEFB	0EDH,0FEH		; NOP
 	DEFB	0EDH,0FFH		; NOP
+	DEFB	0DDH,0CBH,000H,040H	; BIT 0,(IX)
 	DEFB	0DDH,0CBH,IND,040H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,040H	; BIT 0,(IX-IND)
+	DEFB	0DDH,0CBH,000H,041H	; BIT 0,(IX)
 	DEFB	0DDH,0CBH,IND,041H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,041H	; BIT 0,(IX-IND)
+	DEFB	0DDH,0CBH,000H,042H	; BIT 0,(IX)
 	DEFB	0DDH,0CBH,IND,042H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,042H	; BIT 0,(IX-IND)
+	DEFB	0DDH,0CBH,000H,043H	; BIT 0,(IX)
 	DEFB	0DDH,0CBH,IND,043H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,043H	; BIT 0,(IX-IND)
+	DEFB	0DDH,0CBH,000H,044H	; BIT 0,(IX)
 	DEFB	0DDH,0CBH,IND,044H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,044H	; BIT 0,(IX-IND)
+	DEFB	0DDH,0CBH,000H,045H	; BIT 0,(IX)
 	DEFB	0DDH,0CBH,IND,045H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,045H	; BIT 0,(IX-IND)
+	DEFB	0DDH,0CBH,000H,047H	; BIT 0,(IX)
 	DEFB	0DDH,0CBH,IND,047H	; BIT 0,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,047H	; BIT 0,(IX-IND)
+	DEFB	0DDH,0CBH,000H,048H	; BIT 1,(IX)
 	DEFB	0DDH,0CBH,IND,048H	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,048H	; BIT 1,(IX-IND)
+	DEFB	0DDH,0CBH,000H,049H	; BIT 1,(IX)
 	DEFB	0DDH,0CBH,IND,049H	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,049H	; BIT 1,(IX-IND)
+	DEFB	0DDH,0CBH,000H,04AH	; BIT 1,(IX)
 	DEFB	0DDH,0CBH,IND,04AH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,04AH	; BIT 1,(IX-IND)
+	DEFB	0DDH,0CBH,000H,04BH	; BIT 1,(IX)
 	DEFB	0DDH,0CBH,IND,04BH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,04BH	; BIT 1,(IX-IND)
+	DEFB	0DDH,0CBH,000H,04CH	; BIT 1,(IX)
 	DEFB	0DDH,0CBH,IND,04CH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,04CH	; BIT 1,(IX-IND)
+	DEFB	0DDH,0CBH,000H,04DH	; BIT 1,(IX)
 	DEFB	0DDH,0CBH,IND,04DH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,04DH	; BIT 1,(IX-IND)
+	DEFB	0DDH,0CBH,000H,04FH	; BIT 1,(IX)
 	DEFB	0DDH,0CBH,IND,04FH	; BIT 1,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,04FH	; BIT 1,(IX-IND)
+	DEFB	0DDH,0CBH,000H,050H	; BIT 2,(IX)
 	DEFB	0DDH,0CBH,IND,050H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,050H	; BIT 2,(IX-IND)
+	DEFB	0DDH,0CBH,000H,051H	; BIT 2,(IX)
 	DEFB	0DDH,0CBH,IND,051H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,051H	; BIT 2,(IX-IND)
+	DEFB	0DDH,0CBH,000H,052H	; BIT 2,(IX)
 	DEFB	0DDH,0CBH,IND,052H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,052H	; BIT 2,(IX-IND)
+	DEFB	0DDH,0CBH,000H,053H	; BIT 2,(IX)
 	DEFB	0DDH,0CBH,IND,053H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,053H	; BIT 2,(IX-IND)
+	DEFB	0DDH,0CBH,000H,054H	; BIT 2,(IX)
 	DEFB	0DDH,0CBH,IND,054H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,054H	; BIT 2,(IX-IND)
+	DEFB	0DDH,0CBH,000H,055H	; BIT 2,(IX)
 	DEFB	0DDH,0CBH,IND,055H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,055H	; BIT 2,(IX-IND)
+	DEFB	0DDH,0CBH,000H,057H	; BIT 2,(IX)
 	DEFB	0DDH,0CBH,IND,057H	; BIT 2,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,057H	; BIT 2,(IX-IND)
+	DEFB	0DDH,0CBH,000H,058H	; BIT 3,(IX)
 	DEFB	0DDH,0CBH,IND,058H	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,058H	; BIT 3,(IX-IND)
+	DEFB	0DDH,0CBH,000H,059H	; BIT 3,(IX)
 	DEFB	0DDH,0CBH,IND,059H	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,059H	; BIT 3,(IX-IND)
+	DEFB	0DDH,0CBH,000H,05AH	; BIT 3,(IX)
 	DEFB	0DDH,0CBH,IND,05AH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,05AH	; BIT 3,(IX-IND)
+	DEFB	0DDH,0CBH,000H,05BH	; BIT 3,(IX)
 	DEFB	0DDH,0CBH,IND,05BH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,05BH	; BIT 3,(IX-IND)
+	DEFB	0DDH,0CBH,000H,05CH	; BIT 3,(IX)
 	DEFB	0DDH,0CBH,IND,05CH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,05CH	; BIT 3,(IX-IND)
+	DEFB	0DDH,0CBH,000H,05DH	; BIT 3,(IX)
 	DEFB	0DDH,0CBH,IND,05DH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,05DH	; BIT 3,(IX-IND)
+	DEFB	0DDH,0CBH,000H,05FH	; BIT 3,(IX)
 	DEFB	0DDH,0CBH,IND,05FH	; BIT 3,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,05FH	; BIT 3,(IX-IND)
+	DEFB	0DDH,0CBH,000H,060H	; BIT 4,(IX)
 	DEFB	0DDH,0CBH,IND,060H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,060H	; BIT 4,(IX-IND)
+	DEFB	0DDH,0CBH,000H,061H	; BIT 4,(IX)
 	DEFB	0DDH,0CBH,IND,061H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,061H	; BIT 4,(IX-IND)
+	DEFB	0DDH,0CBH,000H,062H	; BIT 4,(IX)
 	DEFB	0DDH,0CBH,IND,062H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,062H	; BIT 4,(IX-IND)
+	DEFB	0DDH,0CBH,000H,063H	; BIT 4,(IX)
 	DEFB	0DDH,0CBH,IND,063H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,063H	; BIT 4,(IX-IND)
+	DEFB	0DDH,0CBH,000H,064H	; BIT 4,(IX)
 	DEFB	0DDH,0CBH,IND,064H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,064H	; BIT 4,(IX-IND)
+	DEFB	0DDH,0CBH,000H,065H	; BIT 4,(IX)
 	DEFB	0DDH,0CBH,IND,065H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,065H	; BIT 4,(IX-IND)
+	DEFB	0DDH,0CBH,000H,067H	; BIT 4,(IX)
 	DEFB	0DDH,0CBH,IND,067H	; BIT 4,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,067H	; BIT 4,(IX-IND)
+	DEFB	0DDH,0CBH,000H,068H	; BIT 5,(IX)
 	DEFB	0DDH,0CBH,IND,068H	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,068H	; BIT 5,(IX-IND)
+	DEFB	0DDH,0CBH,000H,069H	; BIT 5,(IX)
 	DEFB	0DDH,0CBH,IND,069H	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,069H	; BIT 5,(IX-IND)
+	DEFB	0DDH,0CBH,000H,06AH	; BIT 5,(IX)
 	DEFB	0DDH,0CBH,IND,06AH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,06AH	; BIT 5,(IX-IND)
+	DEFB	0DDH,0CBH,000H,06BH	; BIT 5,(IX)
 	DEFB	0DDH,0CBH,IND,06BH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,06BH	; BIT 5,(IX-IND)
+	DEFB	0DDH,0CBH,000H,06CH	; BIT 5,(IX)
 	DEFB	0DDH,0CBH,IND,06CH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,06CH	; BIT 5,(IX-IND)
+	DEFB	0DDH,0CBH,000H,06DH	; BIT 5,(IX)
 	DEFB	0DDH,0CBH,IND,06DH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,06DH	; BIT 5,(IX-IND)
+	DEFB	0DDH,0CBH,000H,06FH	; BIT 5,(IX)
 	DEFB	0DDH,0CBH,IND,06FH	; BIT 5,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,06FH	; BIT 5,(IX-IND)
+	DEFB	0DDH,0CBH,000H,070H	; BIT 6,(IX)
 	DEFB	0DDH,0CBH,IND,070H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,070H	; BIT 6,(IX-IND)
+	DEFB	0DDH,0CBH,000H,071H	; BIT 6,(IX)
 	DEFB	0DDH,0CBH,IND,071H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,071H	; BIT 6,(IX-IND)
+	DEFB	0DDH,0CBH,000H,072H	; BIT 6,(IX)
 	DEFB	0DDH,0CBH,IND,072H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,072H	; BIT 6,(IX-IND)
+	DEFB	0DDH,0CBH,000H,073H	; BIT 6,(IX)
 	DEFB	0DDH,0CBH,IND,073H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,073H	; BIT 6,(IX-IND)
+	DEFB	0DDH,0CBH,000H,074H	; BIT 6,(IX)
 	DEFB	0DDH,0CBH,IND,074H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,074H	; BIT 6,(IX-IND)
+	DEFB	0DDH,0CBH,000H,075H	; BIT 6,(IX)
 	DEFB	0DDH,0CBH,IND,075H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,075H	; BIT 6,(IX-IND)
+	DEFB	0DDH,0CBH,000H,077H	; BIT 6,(IX)
 	DEFB	0DDH,0CBH,IND,077H	; BIT 6,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,077H	; BIT 6,(IX-IND)
+	DEFB	0DDH,0CBH,000H,078H	; BIT 7,(IX)
 	DEFB	0DDH,0CBH,IND,078H	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,078H	; BIT 7,(IX-IND)
+	DEFB	0DDH,0CBH,000H,079H	; BIT 7,(IX)
 	DEFB	0DDH,0CBH,IND,079H	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,079H	; BIT 7,(IX-IND)
+	DEFB	0DDH,0CBH,000H,07AH	; BIT 7,(IX)
 	DEFB	0DDH,0CBH,IND,07AH	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,07AH	; BIT 7,(IX-IND)
+	DEFB	0DDH,0CBH,000H,07BH	; BIT 7,(IX)
 	DEFB	0DDH,0CBH,IND,07BH	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,07BH	; BIT 7,(IX-IND)
+	DEFB	0DDH,0CBH,000H,07CH	; BIT 7,(IX)
 	DEFB	0DDH,0CBH,IND,07CH	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,07CH	; BIT 7,(IX-IND)
+	DEFB	0DDH,0CBH,000H,07DH	; BIT 7,(IX)
 	DEFB	0DDH,0CBH,IND,07DH	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,07DH	; BIT 7,(IX-IND)
+	DEFB	0DDH,0CBH,000H,07FH	; BIT 7,(IX)
 	DEFB	0DDH,0CBH,IND,07FH	; BIT 7,(IX+IND)
+	DEFB	0DDH,0CBH,-IND,07FH	; BIT 7,(IX-IND)
+	DEFB	0FDH,0CBH,000H,040H	; BIT 0,(IY)
 	DEFB	0FDH,0CBH,IND,040H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,040H	; BIT 0,(IY-IND)
+	DEFB	0FDH,0CBH,000H,041H	; BIT 0,(IY)
 	DEFB	0FDH,0CBH,IND,041H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,041H	; BIT 0,(IY-IND)
+	DEFB	0FDH,0CBH,000H,042H	; BIT 0,(IY)
 	DEFB	0FDH,0CBH,IND,042H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,042H	; BIT 0,(IY-IND)
+	DEFB	0FDH,0CBH,000H,043H	; BIT 0,(IY)
 	DEFB	0FDH,0CBH,IND,043H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,043H	; BIT 0,(IY-IND)
+	DEFB	0FDH,0CBH,000H,044H	; BIT 0,(IY)
 	DEFB	0FDH,0CBH,IND,044H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,044H	; BIT 0,(IY-IND)
+	DEFB	0FDH,0CBH,000H,045H	; BIT 0,(IY)
 	DEFB	0FDH,0CBH,IND,045H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,045H	; BIT 0,(IY-IND)
+	DEFB	0FDH,0CBH,000H,047H	; BIT 0,(IY)
 	DEFB	0FDH,0CBH,IND,047H	; BIT 0,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,047H	; BIT 0,(IY-IND)
+	DEFB	0FDH,0CBH,000H,048H	; BIT 1,(IY)
 	DEFB	0FDH,0CBH,IND,048H	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,048H	; BIT 1,(IY-IND)
+	DEFB	0FDH,0CBH,000H,049H	; BIT 1,(IY)
 	DEFB	0FDH,0CBH,IND,049H	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,049H	; BIT 1,(IY-IND)
+	DEFB	0FDH,0CBH,000H,04AH	; BIT 1,(IY)
 	DEFB	0FDH,0CBH,IND,04AH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,04AH	; BIT 1,(IY-IND)
+	DEFB	0FDH,0CBH,000H,04BH	; BIT 1,(IY)
 	DEFB	0FDH,0CBH,IND,04BH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,04BH	; BIT 1,(IY-IND)
+	DEFB	0FDH,0CBH,000H,04CH	; BIT 1,(IY)
 	DEFB	0FDH,0CBH,IND,04CH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,04CH	; BIT 1,(IY-IND)
+	DEFB	0FDH,0CBH,000H,04DH	; BIT 1,(IY)
 	DEFB	0FDH,0CBH,IND,04DH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,04DH	; BIT 1,(IY-IND)
+	DEFB	0FDH,0CBH,000H,04FH	; BIT 1,(IY)
 	DEFB	0FDH,0CBH,IND,04FH	; BIT 1,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,04FH	; BIT 1,(IY-IND)
+	DEFB	0FDH,0CBH,000H,050H	; BIT 2,(IY)
 	DEFB	0FDH,0CBH,IND,050H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,050H	; BIT 2,(IY-IND)
+	DEFB	0FDH,0CBH,000H,051H	; BIT 2,(IY)
 	DEFB	0FDH,0CBH,IND,051H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,051H	; BIT 2,(IY-IND)
+	DEFB	0FDH,0CBH,000H,052H	; BIT 2,(IY)
 	DEFB	0FDH,0CBH,IND,052H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,052H	; BIT 2,(IY-IND)
+	DEFB	0FDH,0CBH,000H,053H	; BIT 2,(IY)
 	DEFB	0FDH,0CBH,IND,053H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,053H	; BIT 2,(IY-IND)
+	DEFB	0FDH,0CBH,000H,054H	; BIT 2,(IY)
 	DEFB	0FDH,0CBH,IND,054H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,054H	; BIT 2,(IY-IND)
+	DEFB	0FDH,0CBH,000H,055H	; BIT 2,(IY)
 	DEFB	0FDH,0CBH,IND,055H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,055H	; BIT 2,(IY-IND)
+	DEFB	0FDH,0CBH,000H,057H	; BIT 2,(IY)
 	DEFB	0FDH,0CBH,IND,057H	; BIT 2,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,057H	; BIT 2,(IY-IND)
+	DEFB	0FDH,0CBH,000H,058H	; BIT 3,(IY)
 	DEFB	0FDH,0CBH,IND,058H	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,058H	; BIT 3,(IY-IND)
+	DEFB	0FDH,0CBH,000H,059H	; BIT 3,(IY)
 	DEFB	0FDH,0CBH,IND,059H	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,059H	; BIT 3,(IY-IND)
+	DEFB	0FDH,0CBH,000H,05AH	; BIT 3,(IY)
 	DEFB	0FDH,0CBH,IND,05AH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,05AH	; BIT 3,(IY-IND)
+	DEFB	0FDH,0CBH,000H,05BH	; BIT 3,(IY)
 	DEFB	0FDH,0CBH,IND,05BH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,05BH	; BIT 3,(IY-IND)
+	DEFB	0FDH,0CBH,000H,05CH	; BIT 3,(IY)
 	DEFB	0FDH,0CBH,IND,05CH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,05CH	; BIT 3,(IY-IND)
+	DEFB	0FDH,0CBH,000H,05DH	; BIT 3,(IY)
 	DEFB	0FDH,0CBH,IND,05DH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,05DH	; BIT 3,(IY-IND)
+	DEFB	0FDH,0CBH,000H,05FH	; BIT 3,(IY)
 	DEFB	0FDH,0CBH,IND,05FH	; BIT 3,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,05FH	; BIT 3,(IY-IND)
+	DEFB	0FDH,0CBH,000H,060H	; BIT 4,(IY)
 	DEFB	0FDH,0CBH,IND,060H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,060H	; BIT 4,(IY-IND)
+	DEFB	0FDH,0CBH,000H,061H	; BIT 4,(IY)
 	DEFB	0FDH,0CBH,IND,061H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,061H	; BIT 4,(IY-IND)
+	DEFB	0FDH,0CBH,000H,062H	; BIT 4,(IY)
 	DEFB	0FDH,0CBH,IND,062H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,062H	; BIT 4,(IY-IND)
+	DEFB	0FDH,0CBH,000H,063H	; BIT 4,(IY)
 	DEFB	0FDH,0CBH,IND,063H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,063H	; BIT 4,(IY-IND)
+	DEFB	0FDH,0CBH,000H,064H	; BIT 4,(IY)
 	DEFB	0FDH,0CBH,IND,064H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,064H	; BIT 4,(IY-IND)
+	DEFB	0FDH,0CBH,000H,065H	; BIT 4,(IY)
 	DEFB	0FDH,0CBH,IND,065H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,065H	; BIT 4,(IY-IND)
+	DEFB	0FDH,0CBH,000H,067H	; BIT 4,(IY)
 	DEFB	0FDH,0CBH,IND,067H	; BIT 4,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,067H	; BIT 4,(IY-IND)
+	DEFB	0FDH,0CBH,000H,068H	; BIT 5,(IY)
 	DEFB	0FDH,0CBH,IND,068H	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,068H	; BIT 5,(IY-IND)
+	DEFB	0FDH,0CBH,000H,069H	; BIT 5,(IY)
 	DEFB	0FDH,0CBH,IND,069H	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,069H	; BIT 5,(IY-IND)
+	DEFB	0FDH,0CBH,000H,06AH	; BIT 5,(IY)
 	DEFB	0FDH,0CBH,IND,06AH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,06AH	; BIT 5,(IY-IND)
+	DEFB	0FDH,0CBH,000H,06BH	; BIT 5,(IY)
 	DEFB	0FDH,0CBH,IND,06BH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,06BH	; BIT 5,(IY-IND)
+	DEFB	0FDH,0CBH,000H,06CH	; BIT 5,(IY)
 	DEFB	0FDH,0CBH,IND,06CH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,06CH	; BIT 5,(IY-IND)
+	DEFB	0FDH,0CBH,000H,06DH	; BIT 5,(IY)
 	DEFB	0FDH,0CBH,IND,06DH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,06DH	; BIT 5,(IY-IND)
+	DEFB	0FDH,0CBH,000H,06FH	; BIT 5,(IY)
 	DEFB	0FDH,0CBH,IND,06FH	; BIT 5,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,06FH	; BIT 5,(IY-IND)
+	DEFB	0FDH,0CBH,000H,070H	; BIT 6,(IY)
 	DEFB	0FDH,0CBH,IND,070H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,070H	; BIT 6,(IY-IND)
+	DEFB	0FDH,0CBH,000H,071H	; BIT 6,(IY)
 	DEFB	0FDH,0CBH,IND,071H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,071H	; BIT 6,(IY-IND)
+	DEFB	0FDH,0CBH,000H,072H	; BIT 6,(IY)
 	DEFB	0FDH,0CBH,IND,072H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,072H	; BIT 6,(IY-IND)
+	DEFB	0FDH,0CBH,000H,073H	; BIT 6,(IY)
 	DEFB	0FDH,0CBH,IND,073H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,073H	; BIT 6,(IY-IND)
+	DEFB	0FDH,0CBH,000H,074H	; BIT 6,(IY)
 	DEFB	0FDH,0CBH,IND,074H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,074H	; BIT 6,(IY-IND)
+	DEFB	0FDH,0CBH,000H,075H	; BIT 6,(IY)
 	DEFB	0FDH,0CBH,IND,075H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,075H	; BIT 6,(IY-IND)
+	DEFB	0FDH,0CBH,000H,077H	; BIT 6,(IY)
 	DEFB	0FDH,0CBH,IND,077H	; BIT 6,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,077H	; BIT 6,(IY-IND)
+	DEFB	0FDH,0CBH,000H,078H	; BIT 7,(IY)
 	DEFB	0FDH,0CBH,IND,078H	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,078H	; BIT 7,(IY-IND)
+	DEFB	0FDH,0CBH,000H,079H	; BIT 7,(IY)
 	DEFB	0FDH,0CBH,IND,079H	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,079H	; BIT 7,(IY-IND)
+	DEFB	0FDH,0CBH,000H,07AH	; BIT 7,(IY)
 	DEFB	0FDH,0CBH,IND,07AH	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,07AH	; BIT 7,(IY-IND)
+	DEFB	0FDH,0CBH,000H,07BH	; BIT 7,(IY)
 	DEFB	0FDH,0CBH,IND,07BH	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,07BH	; BIT 7,(IY-IND)
+	DEFB	0FDH,0CBH,000H,07CH	; BIT 7,(IY)
 	DEFB	0FDH,0CBH,IND,07CH	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,07CH	; BIT 7,(IY-IND)
+	DEFB	0FDH,0CBH,000H,07DH	; BIT 7,(IY)
 	DEFB	0FDH,0CBH,IND,07DH	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,07DH	; BIT 7,(IY-IND)
+	DEFB	0FDH,0CBH,000H,07FH	; BIT 7,(IY)
 	DEFB	0FDH,0CBH,IND,07FH	; BIT 7,(IY+IND)
+	DEFB	0FDH,0CBH,-IND,07FH	; BIT 7,(IY-IND)
 
 NN:	DEFS	2


### PR DESCRIPTION
Allow (ix) and (iy) for index register usage wihout offset in the assembler.
Change the disassembler to the same.
Add all variations (IX), (IX+5), (IX-5) to z80opsall.asm to test the assembler and disassembler.

I really opened a can of worms here :-)
But see for example, https://bitsavers.org/components/zilog/z80/03-0029-01_Z80_CPU_Technical_Manual_1977.pdf
page 67 (73 in the pdf) for (IX) notation.
I was looking for any example of (IX-d) notation, but all examples in the manuals I checked always used positive offsets...

Added some small clean up