### PR TITLE
z80asm: clean up z80arfun.c

### DIFF
--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -143,16 +143,17 @@ struct inc {
 #define REGHL		0041	/* register pair HL */
 #define REGAF		0061	/* register pair AF */
 #define REGPSW		0061	/* register pair AF (8080) */
-#define REGSP		0062	/* register SP */
-#define REGIBC		0003	/* register indirect BC */
-#define REGIDE		0023	/* register indirect DE */
-#define REGISP		0063	/* register indirect SP */
+#define REGAFA		0062	/* register pair AF' */
+#define REGSP		0063	/* register SP */
+#define REGIBC		0004	/* register indirect BC */
+#define REGIDE		0024	/* register indirect DE */
+#define REGISP		0064	/* register indirect SP */
 #define REGIX		0240	/* register IX */
 #define REGIIX		0260	/* register indirect IX */
 #define REGIY		0340	/* register IY */
 #define REGIIY		0360	/* register indirect IY */
-#define REGI		0004	/* register I */
-#define REGR		0014	/* register R */
+#define REGI		0005	/* register I */
+#define REGR		0015	/* register R */
 #define FLGNZ		0100	/* flag not zero */
 #define FLGZ		0110	/* flag zero */
 #define FLGNC		0120	/* flag no carry */

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -423,7 +423,7 @@ int process_line(char *l)
 		/* already listed INCLUDE */
 		if (op != NULL && (op->op_flags & OP_INCL))
 			lflag = 0;
-		if (expn_flag) {
+		if (errnum == E_OK && expn_flag) {
 			if (mac_list_flag == M_NONE)
 				lflag = 0;
 			else if (mac_list_flag == M_OPS

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -232,6 +232,7 @@ static struct ope opetab_z80[] = {
 	{ "(SP)",	REGISP,	0	  },
 	{ "A",		REGA,	0	  },
 	{ "AF",		REGAF,	0	  },
+	{ "AF'",	REGAFA,	0	  },
 	{ "B",		REGB,	0	  },
 	{ "BC",		REGBC,	0	  },
 	{ "C",		REGC,	0	  },


### PR DESCRIPTION
Convert op_ex() to use get_reg(). This function just looked out of place... and REGISP is now finally being used.

Convert two "if (get_reg() ==" to "switch(get_reg())". This didn't look right...

All asmerr()'s that don't depend on eval() return an opcode count of 0.

Always list a macro expansion line if an error occurred.

And I will never again say the assembler is done :-)