### PR TITLE
z80asm: limits part 2, add some comments

### DIFF
--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -3,9 +3,8 @@ Usage:
 z80asm -f{b|m|h} -s[n|a] -p<num> -e<num> -h<num> -x -8 -u
        -v -m -U -o<file> -l[<file>] -d<symbol> ... <file> ...
 
-A maximum of 512 source files is allowed. If the file name of a source
-doesn't have an extension the default extension ".asm" will be appended.
-Source files have a maximum path length of 2048 characters.
+If the file name of a source doesn't have an extension the default
+extension ".asm" will be appended.
 
 Option f:
 Format of the output file:
@@ -64,14 +63,12 @@ Convert everything to upper case for compatibility with old source code.
 Option o:
 To override the default name of the output file. Without this option the
 name of the output file becomes the name of the input file, but with the
-extension ".bin" or ".hex". The output file has a maximum path length of
-2048 characters.
+extension ".bin" or ".hex".
 
 Option l:
 Without this option no list file will be generated. With -l a list file
 with the name of the source file but extension ".lis" will be generated.
-An optional file name path (2048 characters maximum) may be added to
-this option.
+An optional file name path may be added to this option.
 
 Option d:
 This option predefines symbols with a value of 0 and may be used

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -25,7 +25,6 @@
 /*
  *	OS dependant definitions
  */
-#define LENFN		2048	/* max. filename length */
 #define READA		"r"	/* file open mode read ascii */
 #define WRITEA		"w"	/* file open mode write ascii */
 #define WRITEB		"wb"	/* file open mode write binary */
@@ -47,7 +46,6 @@
 #define LABSEP		':'	/* label separator */
 #define STRDEL		'\''	/* string delimiter */
 #define STRDEL2		'"'	/* the other string delimiter */
-#define MAXFN		512	/* max. no. source files */
 #define MAXLINE		128	/* max. line length source */
 #define PLENGTH		65	/* default lines/page in listing */
 #define SYMLEN		8	/* default max. symbol length */

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -51,9 +51,9 @@
 #define MAXLINE		128	/* max. line length source */
 #define PLENGTH		65	/* default lines/page in listing */
 #define SYMLEN		8	/* default max. symbol length */
-#define INCNEST		5	/* max. INCLUDE nesting depth */
+#define INCNEST		10	/* max. INCLUDE nesting depth */
 #define HASHSIZE	500	/* max. entries in symbol hash array */
-#define OPCARRAY	256	/* size of object buffer */
+#define OPCARRAY	128	/* size of object buffer */
 #define MAXHEX		32	/* max. no bytes/hex record */
 #define MACNEST		50	/* max. expansion nesting */
 
@@ -92,15 +92,6 @@ struct sym {
 	WORD sym_val;		/* symbol value */
 	int sym_refflg;		/* symbol reference flag */
 	struct sym *sym_next;	/* next entry */
-};
-
-/*
- *	structure nested INCLUDE's
- */
-struct inc {
-	unsigned long inc_line;	/* line counter for listing */
-	char *inc_fn;		/* filename */
-	FILE *inc_fp;		/* file pointer */
 };
 
 /*

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -29,10 +29,10 @@
 #include <stdio.h>
 #include "z80a.h"
 
-char *infiles[MAXFN],		/* source filenames */
+char **infiles,			/* source filenames */
      *srcfn,			/* filename of current processed source file */
-     objfn[LENFN + 1],		/* object filename */
-     lstfn[LENFN + 1],		/* listing filename */
+     *objfn,			/* object filename */
+     *lstfn,			/* listing filename */
      line[MAXLINE + 2],		/* buffer for one line of source */
      label[MAXLINE + 1],	/* buffer for label */
      opcode[MAXLINE + 1],	/* buffer for opcode */
@@ -58,6 +58,7 @@ int  list_flag,			/* flag for option -l */
      upcase_flag,		/* flag for option -U */
      mac_list_flag,		/* flag for option -m */
      i8080_flag,		/* flag for option -8 */
+     nfiles,			/* number of input files */
      radix,			/* current radix, set to 10 at start of pass */
      phs_flag,			/* flag for being inside a .PHASE block */
      pass,			/* processed pass */

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -26,10 +26,10 @@
  *	global variable declarations
  */
 
-extern char	*infiles[],
+extern char	**infiles,
 		*srcfn,
-		objfn[],
-		lstfn[],
+		*objfn,
+		*lstfn,
 		line[],
 		label[],
 		opcode[],
@@ -54,6 +54,7 @@ extern int	list_flag,
 		upcase_flag,
 		mac_list_flag,
 		i8080_flag,
+		nfiles,
 		radix,
 		phs_flag,
 		pass,

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -39,7 +39,9 @@ void init(void), options(int, char *[]);
 void usage(void), fatal(int, const char *);
 void do_pass(int), process_file(char *);
 int process_line(char *);
-void open_o_files(char *), get_fn(char *, char *, const char *);
+void open_o_files(char *);
+char *get_fn(char *, const char *, int);
+char *strsave(char *);
 char *get_symbol(char *, char *, int);
 char *get_operand(char *, char *, int);
 
@@ -116,8 +118,7 @@ void init(void)
  */
 void options(int argc, char *argv[])
 {
-	register char *s, *t;
-	register int i;
+	register char *s, *t, **p;
 
 	while (--argc > 0 && (*++argv)[0] == '-')
 		for (s = argv[0] + 1; *s != '\0'; s++)
@@ -128,14 +129,14 @@ void options(int argc, char *argv[])
 					usage();
 				}
 				if (obj_fmt == OBJ_HEX)
-					get_fn(objfn, s, OBJEXTHEX);
+					objfn = get_fn(s, OBJEXTHEX, 0);
 				else
-					get_fn(objfn, s, OBJEXTBIN);
+					objfn = get_fn(s, OBJEXTBIN, 0);
 				s += (strlen(s) - 1);
 				break;
 			case 'l':
 				if (*(s + 1) != '\0') {
-					get_fn(lstfn, ++s, LSTEXT);
+					lstfn = get_fn(++s, LSTEXT, 0);
 					s += (strlen(s) - 1);
 				}
 				list_flag = 1;
@@ -235,17 +236,15 @@ void options(int argc, char *argv[])
 				printf("unknown option %c\n", *s);
 				usage();
 			}
-	i = 0;
-	while (argc-- && i < MAXFN) {
-		if ((infiles[i] = (char *) malloc(LENFN + 1)) == NULL)
-			fatal(F_OUTMEM, "filenames");
-		get_fn(infiles[i], *argv++, SRCEXT);
-		i++;
-	}
-	if (i == 0) {
+	if (argc == 0) {
 		puts("no input file");
 		usage();
 	}
+	nfiles = argc;
+	if ((infiles = (char **) malloc(sizeof(char *) * nfiles)) == NULL)
+		fatal(F_OUTMEM, "input file names");
+	for (p = infiles; argc--; p++)
+		*p = get_fn(*argv++, SRCEXT, 0);
 }
 
 /*
@@ -271,24 +270,23 @@ void fatal(int i, const char *arg)
  */
 void do_pass(int p)
 {
-	register int fi;
+	register int i;
+	register char **ip;
 
 	pass = p;
 	radix = 10;
 	rpc = pc = 0;
-	fi = 0;
 	mac_start_pass();
 	if (ver_flag)
 		printf("Pass %d\n", pass);
 	if (pass == 1)				/* PASS 1 */
-		open_o_files(infiles[fi]);
+		open_o_files(*infiles);
 	else					/* PASS 2 */
 		obj_header();
-	while (infiles[fi] != NULL) {
+	for (i = 0, ip = infiles; i < nfiles; i++, ip++) {
 		if (ver_flag)
-			printf("   Read    %s\n", infiles[fi]);
-		process_file(infiles[fi]);
-		fi++;
+			printf("   Read    %s\n", *ip);
+		process_file(*ip);
 	}
 	mac_end_pass();
 	if (pass == 1) {			/* PASS 1 */
@@ -313,7 +311,7 @@ void process_file(char *fn)
 	register char *l, *s;
 
 	c_line = 0;
-	srcfn = fn;
+	srcfn = strsave(fn);
 	if ((srcfp = fopen(fn, READA)) == NULL)
 		fatal(F_FOPEN, fn);
 	do {
@@ -329,6 +327,7 @@ void process_file(char *fn)
 		}
 	} while (process_line(l));
 	fclose(srcfp);
+	free(srcfn);
 	if (mac_def_nest > 0)
 		asmerr(E_MISEMA);
 	if (phs_flag)
@@ -454,24 +453,11 @@ int process_line(char *l)
  */
 void open_o_files(char *source)
 {
-	register char *p;
-
-	if (*objfn == '\0')
-		strcpy(objfn, source);
-	if ((p = strrchr(objfn, PATHSEP)) != NULL)
-		p++;
-	else
-		p = objfn;
-	if ((p = strrchr(p, '.')) != NULL) {
+	if (objfn == NULL) {
 		if (obj_fmt == OBJ_HEX)
-			strcpy(p, OBJEXTHEX);
+			objfn = get_fn(source, OBJEXTHEX, 1);
 		else
-			strcpy(p, OBJEXTBIN);
-	} else {
-		if (obj_fmt == OBJ_HEX)
-			strcat(objfn, OBJEXTHEX);
-		else
-			strcat(objfn, OBJEXTBIN);
+			objfn = get_fn(source, OBJEXTBIN, 1);
 	}
 	if (obj_fmt == OBJ_HEX)
 		objfp = fopen(objfn, WRITEA);
@@ -480,16 +466,8 @@ void open_o_files(char *source)
 	if (objfp == NULL)
 		fatal(F_FOPEN, objfn);
 	if (list_flag) {
-		if (*lstfn == '\0')
-			strcpy(lstfn, source);
-		if ((p = strrchr(lstfn, PATHSEP)) != NULL)
-			p++;
-		else
-			p = lstfn;
-		if ((p = strrchr(p, '.')) != NULL)
-			strcpy(p, LSTEXT);
-		else
-			strcat(lstfn, LSTEXT);
+		if (lstfn == NULL)
+			lstfn = get_fn(source, LSTEXT, 1);
 		if ((lstfp = fopen(lstfn, WRITEA)) == NULL)
 			fatal(F_FOPEN, lstfn);
 		errfp = lstfp;
@@ -497,25 +475,45 @@ void open_o_files(char *source)
 }
 
 /*
- *	create a filename in "dest" from "src" and "ext"
+ *	return a filename created from "src" and "ext"
+ *	append "ext" if "src" has no extension
+ *	replace existing extension with "ext" if "replace" is 1
  */
-void get_fn(char *dest, char *src, const char *ext)
+char *get_fn(char *src, const char *ext, int replace)
 {
-	register int i;
-	register char *sp, *dp;
+	register char *sp, *ep, *dp;
+	register int n, m;
 
-	i = 0;
-	sp = src;
-	dp = dest;
-	while (i++ < LENFN && *sp != '\0')
-		*dp++ = *sp++;
-	*dp = '\0';
-	if ((dp = strrchr(dest, PATHSEP)) != NULL)
-		dp++;
+	if ((sp = strrchr(src, PATHSEP)) == NULL)
+		sp = src;
 	else
-		dp = dest;
-	if (strrchr(dp, '.') == NULL && (strlen(dest) + strlen(ext) <= LENFN))
-		strcat(dest, ext);
+		sp++;
+	if ((ep = strrchr(sp, '.')) == NULL)
+		n = strlen(src) + strlen(ext);
+	else
+		n = (m = ep - src) + (replace ? strlen(ext) : strlen(ep));
+	if ((dp = (char *) malloc(n + 1)) == NULL)
+		fatal(F_OUTMEM, "file name");
+	if (ep == NULL) {
+		strcpy(dp, src);
+		strcat(dp, ext);
+	} else {
+		strncpy(dp, src, m);
+		strcpy(dp + m, (replace ? ext : ep));
+	}
+	return(dp);
+}
+
+/*
+ *	save string into allocated memory
+ */
+char *strsave(char *s)
+{
+	register char *p;
+
+	if ((p = (char *) malloc(strlen(s) + 1)) == NULL)
+		fatal(F_OUTMEM, "strsave");
+	return(strcpy(p, s));
 }
 
 /*

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -311,7 +311,7 @@ void process_file(char *fn)
 	register char *l, *s;
 
 	c_line = 0;
-	srcfn = strsave(fn);
+	srcfn = fn;
 	if ((srcfp = fopen(fn, READA)) == NULL)
 		fatal(F_FOPEN, fn);
 	do {
@@ -327,7 +327,6 @@ void process_file(char *fn)
 		}
 	} while (process_line(l));
 	fclose(srcfp);
-	free(srcfn);
 	if (mac_def_nest > 0)
 		asmerr(E_MISEMA);
 	if (phs_flag)

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -41,7 +41,6 @@ void do_pass(int), process_file(char *);
 int process_line(char *);
 void open_o_files(char *);
 char *get_fn(char *, const char *, int);
-char *strsave(char *);
 char *get_symbol(char *, char *, int);
 char *get_operand(char *, char *, int);
 

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -420,9 +420,11 @@ int process_line(char *l)
 		if (gencode && (op == NULL || !(op->op_flags & OP_DS)))
 			obj_writeb(op_count);
 		lflag = 1;
-		/* already listed INCLUDE */
-		if (op != NULL && (op->op_flags & OP_INCL))
+		/* already listed INCLUDE, force eject page */
+		if (op != NULL && (op->op_flags & OP_INCL)) {
 			lflag = 0;
+			p_line = ppl + 1;
+		}
 		if (errnum == E_OK && expn_flag) {
 			if (mac_list_flag == M_NONE)
 				lflag = 0;

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -47,7 +47,7 @@ struct dum {					/* macro dummy */
 
 struct line {					/* macro source line */
 	char *line_text;			/* source line */
-	struct line *line_next;
+	struct line *line_next;			/* next line */
 };
 
 struct expn;
@@ -61,19 +61,19 @@ struct mac {					/* macro */
 	char *mac_irp;				/* IRP, IRPC character list */
 	struct dum *mac_dums, *mac_dums_last;	/* macro dummies */
 	struct line *mac_lines, *mac_lines_last; /* macro body */
-	struct mac *mac_prev, *mac_next;
+	struct mac *mac_prev, *mac_next;	/* prev./next macro in list */
 };
 
 struct parm {					/* expansion parameter */
 	char *parm_name;			/* dummy name */
 	char *parm_val;				/* parameter value */
-	struct parm *parm_next;
+	struct parm *parm_next;			/* next parameter in list */
 };
 
 struct loc {					/* expansion local label */
 	char *loc_name;				/* local label name */
 	char loc_val[8];			/* local label value ??xxxx */
-	struct loc *loc_next;
+	struct loc *loc_next;			/* next local label in list */
 };
 
 struct expn {					/* macro expansion */
@@ -86,7 +86,7 @@ struct expn {					/* macro expansion */
 	int expn_act_elselevel;			/* act_elselevel before expn */
 	WORD expn_iter;				/* curr. expansion iteration */
 	char *expn_irp;				/* IRP, IRPC character list */
-	struct expn *expn_next;
+	struct expn *expn_next;			/* next expansion in list */
 };
 
 static struct mac *mac_table;			/* MACRO table */

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -273,9 +273,9 @@ void mac_add_dum(struct mac *m, char *name)
 {
 	register struct dum *d;
 
-	d = (struct dum *) malloc(sizeof(struct dum));
-	if (d == NULL || (d->dum_name = strsave(name)) == NULL)
+	if ((d = (struct dum *) malloc(sizeof(struct dum))) == NULL)
 		fatal(F_OUTMEM, "macro dummy");
+	d->dum_name = strsave(name);
 	d->dum_next = NULL;
 	if (m->mac_dums == NULL)
 		m->mac_dums = d;
@@ -291,9 +291,9 @@ struct loc *expn_add_loc(struct expn *e, char *name)
 {
 	register struct loc *l;
 
-	l = (struct loc *) malloc(sizeof(struct loc));
-	if (l == NULL || (l->loc_name = strsave(name)) == NULL)
+	if ((l = (struct loc *) malloc(sizeof(struct loc))) == NULL)
 		fatal(F_OUTMEM, "macro local label");
+	l->loc_name = strsave(name);
 	l->loc_next = NULL;
 	if (e->expn_locs == NULL)
 		e->expn_locs = l;
@@ -438,9 +438,9 @@ void mac_add_line(struct opc *op, char *line)
 	register struct mac *m;
 
 	a_mode = A_NONE;
-	l = (struct line *) malloc(sizeof(struct line));
-	if (l == NULL || (l->line_text = strsave(line)) == NULL)
+	if ((l = (struct line *) malloc(sizeof(struct line))) == NULL)
 		fatal(F_OUTMEM, "macro body line");
+	l->line_text = strsave(line);
 	l->line_next = NULL;
 	m = mac_curr;
 	if (m->mac_lines == NULL)
@@ -821,9 +821,7 @@ void mac_start_irp(struct expn *e)
 	if (*e->expn_irp != '\0') {
 		if ((s = mac_next_parm(e->expn_irp)) != NULL) {
 			e->expn_irp = s;
-			if ((s = strsave(tmp)) == NULL)
-				fatal(F_OUTMEM, "IRP character list");
-			e->expn_parms->parm_val = s;
+			e->expn_parms->parm_val = strsave(tmp);
 		}
 	}
 }
@@ -845,11 +843,9 @@ int mac_rept_irp(struct expn *e)
 		if ((s = mac_next_parm(s)) == NULL)
 			return(0);
 		e->expn_irp = s;
-		if ((s = strsave(tmp)) == NULL)
-			fatal(F_OUTMEM, "IRP character list");
 		if (e->expn_parms->parm_val != NULL)
 			free(e->expn_parms->parm_val);
-		e->expn_parms->parm_val = s;
+		e->expn_parms->parm_val = strsave(tmp);
 		return(1);
 	}
 }
@@ -901,8 +897,7 @@ void mac_start_macro(struct expn *e)
 			asmerr(E_INVOPE);
 			return;
 		}
-		if ((p->parm_val = strsave(tmp)) == NULL)
-			fatal(F_OUTMEM, "parameter assignment");
+		p->parm_val = strsave(tmp);
 		p = p->parm_next;
 	}
 }
@@ -991,8 +986,7 @@ WORD op_mcond(BYTE op_code, BYTE dummy)
 			asmerr(E_MISOPE);
 			return(0);
 		}
-		if ((t = strsave(tmp)) == NULL)
-			fatal(F_OUTMEM, "macro IF parameter");
+		t = strsave(tmp);
 		s = mac_next_parm(s);
 		if (*s != '\0' && *s != COMMENT) {
 			asmerr(E_INVOPE);
@@ -1066,8 +1060,7 @@ WORD op_irp(BYTE op_code, BYTE dummy)
 		asmerr(E_INVOPE);
 		return(0);
 	}
-	if ((m->mac_irp = strsave(tmp)) == NULL)
-		fatal(F_OUTMEM, "IRP/IRPC character list");
+	m->mac_irp = strsave(tmp);
 	mac_curr = m;
 	mac_def_nest++;
 	return(0);

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -19,6 +19,7 @@
 
 /* z80amain.c */
 extern void fatal(int, const char *);
+extern char *strsave(char *);
 extern char *next_arg(char *, int *);
 
 /* z80anum.c */
@@ -98,18 +99,6 @@ static int mac_count;				/* number of macros defined */
 static struct expn *mac_expn;			/* macro expansion stack */
 static WORD mac_loc_cnt;			/* counter for LOCAL labels */
 static char tmp[MAXLINE + 2];			/* temporary buffer */
-
-/*
- *	save string into allocated memory
- */
-char *strsave(char *s)
-{
-	register char *p;
-
-	if ((p = (char *) malloc(strlen(s) + 1)) != NULL)
-		strcpy(p, s);
-	return(p);
-}
 
 /*
  *	verify that s is a legal symbol, also truncates to symlen

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -42,12 +42,12 @@ extern void asmerr(int);
 
 struct dum {					/* macro dummy */
 	char *dum_name;				/* dummy name */
-	struct dum *dum_next;
+	struct dum *dum_next;			/* next dummy in list */
 };
 
 struct line {					/* macro source line */
 	char *line_text;			/* source line */
-	struct line *line_next;			/* next line */
+	struct line *line_next;			/* next line in list */
 };
 
 struct expn;

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -243,6 +243,7 @@ void lst_line(char *l, WORD addr, WORD op_cnt, int expn_flag)
 		fprintf(lstfp, "%c%5lu %6lu\n", expn_flag ? '+' : ' ',
 			c_line, s_line);
 	}
+	/* reset p_line after EJECT when ppl is 0 */
 	if (p_line < 0)
 		p_line = 1;
 }

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -300,7 +300,6 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 	unsigned long inc_line;
 	char *inc_fn;
 	FILE *inc_fp;
-	static char fn[LENFN];
 	static int incnest;
 	static int page_done;
 
@@ -369,13 +368,12 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 		inc_fp = srcfp;
 		incnest++;
 		p = operand;
-		d = fn;
 		while (!IS_SPC(*p) && *p != COMMENT && *p != '\0')
-			*d++ = *p++;
-		*d = '\0';
+			p++;
+		*p = '\0';
 		if (ver_flag)
-			printf("   Include %s\n", fn);
-		process_file(fn);
+			printf("   Include %s\n", operand);
+		process_file(operand);
 		incnest--;
 		c_line = inc_line;
 		srcfn = inc_fn;

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -26,6 +26,7 @@
  *	processing of all PSEUDO ops except macro related
  */
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
@@ -35,6 +36,7 @@
 /* z80amain.c */
 extern void fatal(int, const char *);
 extern void process_file(char *);
+extern char *strsave(char *);
 extern char *next_arg(char *, int *);
 
 /* z80anum.c */
@@ -295,7 +297,7 @@ WORD op_dw(BYTE dummy1, BYTE dummy2)
  */
 WORD op_misc(BYTE op_code, BYTE dummy)
 {
-	register char *p, *d, c;
+	register char *p, *d, *fn, c;
 	register BYTE n;
 	unsigned long inc_line;
 	char *inc_fn;
@@ -371,9 +373,11 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 		while (!IS_SPC(*p) && *p != COMMENT && *p != '\0')
 			p++;
 		*p = '\0';
+		fn = strsave(operand);
 		if (ver_flag)
-			printf("   Include %s\n", operand);
-		process_file(operand);
+			printf("   Include %s\n", fn);
+		process_file(fn);
+		free(fn);
 		incnest--;
 		c_line = inc_line;
 		srcfn = inc_fn;

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -46,8 +46,6 @@ extern void instrset(int);
 
 /* z80aout.c */
 extern void asmerr(int);
-extern void lst_header(void);
-extern void lst_attl(void);
 extern void obj_org(WORD);
 extern void obj_fill(WORD);
 extern void obj_fill_value(WORD, WORD);
@@ -299,9 +297,11 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 {
 	register char *p, *d, c;
 	register BYTE n;
+	unsigned long inc_line;
+	char *inc_fn;
+	FILE *inc_fp;
 	static char fn[LENFN];
 	static int incnest;
-	static struct inc incl[INCNEST];
 	static int page_done;
 
 	UNUSED(dummy);
@@ -364,9 +364,9 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 			asmerr(E_INCNST);
 			break;
 		}
-		incl[incnest].inc_line = c_line;
-		incl[incnest].inc_fn = srcfn;
-		incl[incnest].inc_fp = srcfp;
+		inc_line = c_line;
+		inc_fn = srcfn;
+		inc_fp = srcfp;
 		incnest++;
 		p = operand;
 		d = fn;
@@ -377,15 +377,11 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 			printf("   Include %s\n", fn);
 		process_file(fn);
 		incnest--;
-		c_line = incl[incnest].inc_line;
-		srcfn = incl[incnest].inc_fn;
-		srcfp = incl[incnest].inc_fp;
+		c_line = inc_line;
+		srcfn = inc_fn;
+		srcfp = inc_fp;
 		if (ver_flag)
 			printf("   Resume  %s\n", srcfn);
-		if (list_flag && pass == 2) {
-			lst_header();
-			lst_attl();
-		}
 		break;
 	case 7:				/* TITLE */
 		if (pass == 2) {

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -1067,35 +1067,17 @@ WORD op_decinc(BYTE base_op, BYTE base_op16)
 }
 
 /*
- *	SUB {A,}, AND {A,}, XOR {A,}, OR {A,}, CP {A,}
+ *	SUB, AND, XOR, OR, CP
  */
 WORD op_alu(BYTE base_op, BYTE dummy)
 {
-	register char *sec;
-	register WORD len = 0;
-
 	UNUSED(dummy);
 
-	sec = next_arg(operand, NULL);
-	if (sec == NULL)		/* ALUOP ? */
-		len = aluop(base_op, operand);
-	else {
-		switch (get_reg(operand)) {
-		case REGA:		/* ALUOP A,? */
-			len = aluop(base_op, sec);
-			break;
-		case NOOPERA:		/* missing operand */
-			asmerr(E_MISOPE);
-			break;
-		default:		/* invalid operand */
-			asmerr(E_INVOPE);
-		}
-	}
-	return(len);
+	return(aluop(base_op, operand));
 }
 
 /*
- *	ADD A, ADC A, SUB {A}, SBC A, AND {A}, XOR {A}, OR {A}, CP {A}
+ *	ADD A, ADC A, SUB, SBC A, AND, XOR, OR, CP
  */
 WORD aluop(BYTE base_op, char *sec)
 {

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -1067,17 +1067,35 @@ WORD op_decinc(BYTE base_op, BYTE base_op16)
 }
 
 /*
- *	SUB, AND, XOR, OR, CP
+ *	SUB {A,}, AND {A,}, XOR {A,}, OR {A,}, CP {A,}
  */
 WORD op_alu(BYTE base_op, BYTE dummy)
 {
+	register char *sec;
+	register WORD len = 0;
+
 	UNUSED(dummy);
 
-	return(aluop(base_op, operand));
+	sec = next_arg(operand, NULL);
+	if (sec == NULL)		/* ALUOP ? */
+		len = aluop(base_op, operand);
+	else {
+		switch (get_reg(operand)) {
+		case REGA:		/* ALUOP A,? */
+			len = aluop(base_op, sec);
+			break;
+		case NOOPERA:		/* missing operand */
+			asmerr(E_MISOPE);
+			break;
+		default:		/* invalid operand */
+			asmerr(E_INVOPE);
+		}
+	}
+	return(len);
 }
 
 /*
- *	ADD A, ADC A, SUB, SBC A, AND, XOR, OR, CP
+ *	ADD A, ADC A, SUB {A}, SBC A, AND {A}, XOR {A}, OR {A}, CP {A}
  */
 WORD aluop(BYTE base_op, char *sec)
 {

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -883,7 +883,7 @@ WORD ldinn(char *sec)
 }
 
 /*
- *	ADD {?,}?
+ *	ADD ?,?
  */
 WORD op_add(BYTE base_op, BYTE base_op16)
 {
@@ -892,62 +892,18 @@ WORD op_add(BYTE base_op, BYTE base_op16)
 	register WORD len = 0;
 
 	sec = next_arg(operand, NULL);
-	if (sec == NULL)		/* ADD ? */
-		len = aluop(base_op, operand);
-	else {
-		switch (get_reg(operand)) {
-		case REGA:		/* ADD A,? */
-			len = aluop(base_op, sec);
-			break;
-		case REGHL:		/* ADD HL,? */
-			switch (op = get_reg(sec)) {
-			case REGBC:	/* ADD HL,BC */
-			case REGDE:	/* ADD HL,DE */
-			case REGHL:	/* ADD HL,HL */
-			case REGSP:	/* ADD HL,SP */
-				len = 1;
-				ops[0] = base_op16 + (op & OPMASK3);
-				break;
-			case NOOPERA:	/* missing operand */
-				asmerr(E_MISOPE);
-				break;
-			default:	/* invalid operand */
-				asmerr(E_INVOPE);
-			}
-			break;
-		case REGIX:		/* ADD IX,? */
-			switch (op = get_reg(sec)) {
-			case REGBC:	/* ADD IX,BC */
-			case REGDE:	/* ADD IX,DE */
-			case REGIX:	/* ADD IX,IX */
-			case REGSP:	/* ADD IX,SP */
-				len = 2;
-				ops[0] = 0xdd;
-				ops[1] = base_op16 + (op & OPMASK3);
-				break;
-			case NOOPERA:	/* missing operand */
-				asmerr(E_MISOPE);
-				break;
-			default:	/* invalid operand */
-				asmerr(E_INVOPE);
-			}
-			break;
-		case REGIY:		/* ADD IY,? */
-			switch (op = get_reg(sec)) {
-			case REGBC:	/* ADD IY,BC */
-			case REGDE:	/* ADD IY,DE */
-			case REGIY:	/* ADD IY,IY */
-			case REGSP:	/* ADD IY,SP */
-				len = 2;
-				ops[0] = 0xfd;
-				ops[1] = base_op16 + (op & OPMASK3);
-				break;
-			case NOOPERA:	/* missing operand */
-				asmerr(E_MISOPE);
-				break;
-			default:	/* invalid operand */
-				asmerr(E_INVOPE);
-			}
+	switch (get_reg(operand)) {
+	case REGA:			/* ADD A,? */
+		len = aluop(base_op, sec);
+		break;
+	case REGHL:			/* ADD HL,? */
+		switch (op = get_reg(sec)) {
+		case REGBC:		/* ADD HL,BC */
+		case REGDE:		/* ADD HL,DE */
+		case REGHL:		/* ADD HL,HL */
+		case REGSP:		/* ADD HL,SP */
+			len = 1;
+			ops[0] = base_op16 + (op & OPMASK3);
 			break;
 		case NOOPERA:		/* missing operand */
 			asmerr(E_MISOPE);
@@ -955,12 +911,52 @@ WORD op_add(BYTE base_op, BYTE base_op16)
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
 		}
+		break;
+	case REGIX:			/* ADD IX,? */
+		switch (op = get_reg(sec)) {
+		case REGBC:		/* ADD IX,BC */
+		case REGDE:		/* ADD IX,DE */
+		case REGIX:		/* ADD IX,IX */
+		case REGSP:		/* ADD IX,SP */
+			len = 2;
+			ops[0] = 0xdd;
+			ops[1] = base_op16 + (op & OPMASK3);
+			break;
+		case NOOPERA:		/* missing operand */
+			asmerr(E_MISOPE);
+			break;
+		default:		/* invalid operand */
+			asmerr(E_INVOPE);
+		}
+		break;
+	case REGIY:			/* ADD IY,? */
+		switch (op = get_reg(sec)) {
+		case REGBC:		/* ADD IY,BC */
+		case REGDE:		/* ADD IY,DE */
+		case REGIY:		/* ADD IY,IY */
+		case REGSP:		/* ADD IY,SP */
+			len = 2;
+			ops[0] = 0xfd;
+			ops[1] = base_op16 + (op & OPMASK3);
+			break;
+		case NOOPERA:		/* missing operand */
+			asmerr(E_MISOPE);
+			break;
+		default:		/* invalid operand */
+			asmerr(E_INVOPE);
+		}
+		break;
+	case NOOPERA:			/* missing operand */
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		asmerr(E_INVOPE);
 	}
 	return(len);
 }
 
 /*
- *	SBC {?,}? and ADC {?,}?
+ *	SBC ?,? and ADC ?,?
  */
 WORD op_sbadc(BYTE base_op, BYTE base_op16)
 {
@@ -969,29 +965,19 @@ WORD op_sbadc(BYTE base_op, BYTE base_op16)
 	register WORD len = 0;
 
 	sec = next_arg(operand, NULL);
-	if (sec == NULL)		/* SBC/ADC ? */
-		len = aluop(base_op, operand);
-	else {
-		switch (get_reg(operand)) {
-		case REGA:		/* SBC/ADC A,? */
-			len = aluop(base_op, sec);
-			break;
-		case REGHL:		/* SBC/ADC HL,? */
-			switch (op = get_reg(sec)) {
-			case REGBC:	/* SBC/ADC HL,BC */
-			case REGDE:	/* SBC/ADC HL,DE */
-			case REGHL:	/* SBC/ADC HL,HL */
-			case REGSP:	/* SBC/ADC HL,SP */
-				len = 2;
-				ops[0] = 0xed;
-				ops[1] = base_op16 + (op & OPMASK3);
-				break;
-			case NOOPERA:	/* missing operand */
-				asmerr(E_MISOPE);
-				break;
-			default:	/* invalid operand */
-				asmerr(E_INVOPE);
-			}
+	switch (get_reg(operand)) {
+	case REGA:			/* SBC/ADC A,? */
+		len = aluop(base_op, sec);
+		break;
+	case REGHL:			/* SBC/ADC HL,? */
+		switch (op = get_reg(sec)) {
+		case REGBC:		/* SBC/ADC HL,BC */
+		case REGDE:		/* SBC/ADC HL,DE */
+		case REGHL:		/* SBC/ADC HL,HL */
+		case REGSP:		/* SBC/ADC HL,SP */
+			len = 2;
+			ops[0] = 0xed;
+			ops[1] = base_op16 + (op & OPMASK3);
 			break;
 		case NOOPERA:		/* missing operand */
 			asmerr(E_MISOPE);
@@ -999,6 +985,12 @@ WORD op_sbadc(BYTE base_op, BYTE base_op16)
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
 		}
+		break;
+	case NOOPERA:			/* missing operand */
+		asmerr(E_MISOPE);
+		break;
+	default:			/* invalid operand */
+		asmerr(E_INVOPE);
 	}
 	return(len);
 }
@@ -1103,7 +1095,7 @@ WORD op_alu(BYTE base_op, BYTE dummy)
 }
 
 /*
- *	ADD {A}, ADC {A}, SUB {A}, SBC {A}, AND {A}, XOR {A}, OR {A}, CP {A}
+ *	ADD A, ADC A, SUB {A}, SBC A, AND {A}, XOR {A}, OR {A}, CP {A}
  */
 WORD aluop(BYTE base_op, char *sec)
 {


### PR DESCRIPTION
The ops array doesn't need to be larger than MAXLINE. The longest opcode sequence created is a DB with one long string.

Remove include nesting array. INCLUDE is a recursive call of process_file. Just keep line and file info on the stack. Keep nesting level check to detect infinite recursive includes.

Don't call lst_header and lst_attl in INCLUDE. Just force eject page in code already present in process_line. The only user of lst_* functions is now the main module.

Add comment to confusing line in lst_line.