### PR TITLE
z80asm: handle some corner cases, add source line limit documentation

### DIFF
--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -6,6 +6,9 @@ z80asm -f{b|m|h} -s[n|a] -p<num> -e<num> -h<num> -x -8 -u
 If the file name of a source doesn't have an extension the default
 extension ".asm" will be appended.
 
+Source lines have a maximum length of 128 characters, excluding the
+new line character. Any characters after this limit are ignored.
+
 Option f:
 Format of the output file:
 

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -324,7 +324,7 @@ void process_file(char *fn)
 			line[MAXLINE] = '\n';
 			if ((l = fgets(line, MAXLINE + 2, srcfp)) == NULL)
 				break;
-			if (line[MAXLINE] != '\n') {
+			if (line[MAXLINE] != '\n' && line[MAXLINE] != '\0') {
 				line[MAXLINE] = '\n';
 				while ((c = fgetc(srcfp)) != EOF && c != '\n')
 					;

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -42,7 +42,7 @@ int process_line(char *);
 void open_o_files(char *);
 char *get_fn(char *, const char *, int);
 char *get_symbol(char *, char *, int);
-char *get_operand(char *, char *, int);
+void get_operand(char *, char *, int);
 
 /* z80aout.c */
 extern void asmerr(int);
@@ -310,7 +310,7 @@ void do_pass(int p)
 void process_file(char *fn)
 {
 	register char *l, *s;
-	register int c;
+	register int i;
 
 	c_line = 0;
 	srcfn = fn;
@@ -321,12 +321,14 @@ void process_file(char *fn)
 		while (mac_exp_nest > 0 && (l = mac_expand()) == NULL)
 			;
 		if (l == NULL) {
-			line[MAXLINE] = '\n';
 			if ((l = fgets(line, MAXLINE + 2, srcfp)) == NULL)
 				break;
-			if (line[MAXLINE] != '\n' && line[MAXLINE] != '\0') {
-				line[MAXLINE] = '\n';
-				while ((c = fgetc(srcfp)) != EOF && c != '\n')
+			i = strlen(line) - 1;
+			if (line[i] == '\n')
+				line[i] = '\0';
+			else if (i == MAXLINE) {
+				line[i] = '\0';
+				while ((i = fgetc(srcfp)) != EOF && i != '\n')
 					;
 			}
 			if (upcase_flag)
@@ -387,7 +389,7 @@ int process_line(char *l)
 			if (gencode) {
 				if (lbl_flag)
 					put_label();
-				p = get_operand(operand, p, 1);
+				get_operand(operand, p, 1);
 				mac_call();
 				if (lbl_flag)
 					a_mode = A_STD;
@@ -401,7 +403,7 @@ int process_line(char *l)
 					if (gencode)
 						put_label();
 			}
-			p = get_operand(operand, p, op->op_flags & OP_NOPRE);
+			get_operand(operand, p, op->op_flags & OP_NOPRE);
 			if (operand[0] != '\0' && operand[0] != COMMENT
 					       && (op->op_flags & OP_NOOPR))
 				asmerr(E_INVOPE);
@@ -559,56 +561,49 @@ char *get_symbol(char *s, char *l, int lbl_flag)
  *	delimited strings are copied without changes
  *	if nopre_flag is 1 removes only leading white space
  */
-char *get_operand(char *s, char *l, int nopre_flag)
+void get_operand(char *s, char *l, int nopre_flag)
 {
 	register char *s0;
 	register char c;
 
-	s0 = s;
 	while (IS_SPC(*l))
 		l++;
 	if (nopre_flag) {
-		while (*l != '\n' && *l != '\0')
-			*s++ = *l++;
-	} else {
-		while (*l != '\0' && *l != COMMENT) {
-			if (IS_SPC(*l)) {
+		strcpy(s, l);
+		return;
+	}
+	s0 = s;
+	while (*l != '\0' && *l != COMMENT) {
+		if (IS_SPC(*l)) {
+			l++;
+			while (IS_SPC(*l))
 				l++;
-				while (IS_SPC(*l))
-					l++;
-				/* leave one space between symbols */
-				if (s > s0 && IS_SYM(*(s - 1)) && IS_SYM(*l))
-					*s++ = ' ';
-				continue;
-			}
-			if (*l != STRDEL && *l != STRDEL2) {
-				*s++ = TO_UPP(*l);
-				l++;
-				continue;
-			}
-			c = *l;
-			*s++ = *l++;
+			/* leave one space between symbols */
+			if (s > s0 && IS_SYM(*(s - 1)) && IS_SYM(*l))
+				*s++ = ' ';
+		} else if (*l == STRDEL || *l == STRDEL2) {
+			*s++ = c = *l++;
 			if (s - s0 == 6 && strncmp(s0, "AF,AF'", 6) == 0)
 				continue;
 			while (1) {
-				if (*l == '\n' || *l == '\0') {
-					/* undelimited string */
-					*s = '\0';
-					return(l);
-				}
-				if (*l == c) {
-					if (*(l + 1) == c) /* double delim? */
-						*s++ = *l++;
-					else
+				if (*l == '\0') /* undelimited string */
+					goto done;
+				else if (*l == c) {
+					if (*(l + 1) != c) /* double delim? */
 						break;
+					else
+						*s++ = *l++;
 				}
 				*s++ = *l++;
 			}
 			*s++ = *l++;
+		} else {
+			*s++ = TO_UPP(*l);
+			l++;
 		}
 	}
+done:
 	*s = '\0';
-	return(l);
 }
 
 /*

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -310,6 +310,7 @@ void do_pass(int p)
 void process_file(char *fn)
 {
 	register char *l, *s;
+	register int c;
 
 	c_line = 0;
 	srcfn = fn;
@@ -320,8 +321,14 @@ void process_file(char *fn)
 		while (mac_exp_nest > 0 && (l = mac_expand()) == NULL)
 			;
 		if (l == NULL) {
+			line[MAXLINE] = '\n';
 			if ((l = fgets(line, MAXLINE + 2, srcfp)) == NULL)
 				break;
+			if (line[MAXLINE] != '\n') {
+				line[MAXLINE] = '\n';
+				while ((c = fgetc(srcfp)) != EOF && c != '\n')
+					;
+			}
 			if (upcase_flag)
 				for (s = l; *s; s++)
 					*s = TO_UPP(*s);

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -212,6 +212,8 @@ void lst_line(char *l, WORD addr, WORD op_cnt, int expn_flag)
 	}
 	fprintf(lstfp, "%c%5lu %6lu %s", expn_flag ? '+' : ' ',
 		c_line, s_line, l);
+	if (*(l + strlen(l) - 1) != '\n')
+		fputc('\n', lstfp);
 	if (errnum != E_OK) {
 		fprintf(errfp, "=> %s\n", errmsg[errnum]);
 		errnum = E_OK;

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -210,10 +210,8 @@ void lst_line(char *l, WORD addr, WORD op_cnt, int expn_flag)
 			fputs("  ", lstfp);
 		fputc(' ', lstfp);
 	}
-	fprintf(lstfp, "%c%5lu %6lu %s", expn_flag ? '+' : ' ',
+	fprintf(lstfp, "%c%5lu %6lu %s\n", expn_flag ? '+' : ' ',
 		c_line, s_line, l);
-	if (*(l + strlen(l) - 1) != '\n')
-		fputc('\n', lstfp);
 	if (errnum != E_OK) {
 		fprintf(errfp, "=> %s\n", errmsg[errnum]);
 		errnum = E_OK;


### PR DESCRIPTION
You never know what stuff people will be feeding the assembler.

1. Skip any characters over the 128 character line limit.