### PR TITLE
z80asm: make proper use of "register" for old compilers

### DIFF
--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -117,7 +117,8 @@ void init(void)
  */
 void options(int argc, char *argv[])
 {
-	register char *s, *t, **p;
+	register char *s, *t;
+	register char **p;
 
 	while (--argc > 0 && (*++argv)[0] == '-')
 		for (s = argv[0] + 1; *s != '\0'; s++)
@@ -309,8 +310,9 @@ void do_pass(int p)
  */
 void process_file(char *fn)
 {
-	register char *l, *s;
+	register char *s;
 	register int i;
+	register char *l;
 
 	c_line = 0;
 	srcfn = fn;
@@ -351,10 +353,11 @@ void process_file(char *fn)
  */
 int process_line(char *l)
 {
-	register char *p;
-	register int old_genc, lbl_flag, expn_flag, lflag;
-	register WORD op_count;
 	register struct opc *op;
+	register int lbl_flag;
+	register WORD op_count;
+	char *p;
+	int old_genc, expn_flag, lflag;
 
 	/*
 	 *	need expn_flag and lbl_flag, since the conditions
@@ -490,8 +493,9 @@ void open_o_files(char *source)
  */
 char *get_fn(char *src, const char *ext, int replace)
 {
-	register char *sp, *ep, *dp;
-	register int n, m;
+	register char *sp, *dp;
+	register char *ep;
+	int n, m;
 
 	if ((sp = strrchr(src, PATHSEP)) == NULL)
 		sp = src;

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -222,18 +222,20 @@ struct mac *mac_new(char *name, void (*start)(struct expn *),
  */
 void mac_delete(struct mac *m)
 {
-	register struct dum *d, *d1;
-	register struct line *ln, *ln1;
+	register struct dum *d;
+	register struct line *l;
+	struct dum *d1;
+	struct line *l1;
 
 	for (d = m->mac_dums; d != NULL; d = d1) {
 		d1 = d->dum_next;
 		free(d->dum_name);
 		free(d);
 	}
-	for (ln = m->mac_lines; ln != NULL; ln = ln1) {
-		ln1 = ln->line_next;
-		free(ln->line_text);
-		free(ln);
+	for (l = m->mac_lines; l != NULL; l = l1) {
+		l1 = l->line_next;
+		free(l->line_text);
+		free(l);
 	}
 	if (m->mac_irp != NULL)
 		free(m->mac_irp);
@@ -309,9 +311,10 @@ struct loc *expn_add_loc(struct expn *e, char *name)
  */
 void mac_start_expn(struct mac *m)
 {
-	register struct expn *e, *e1;
-	register struct dum *d;
+	register struct expn *e;
 	register struct parm *p;
+	register struct dum *d;
+	struct expn *e1;
 
 	if (mac_exp_nest == MACNEST) {
 		/* abort macro expansion */
@@ -367,10 +370,12 @@ void mac_start_expn(struct mac *m)
  */
 void mac_end_expn(void)
 {
+	register struct parm *p;
+	register struct loc *l;
 	register struct expn *e;
-	register struct parm *p, *p1;
-	register struct loc *l, *l1;
-	register struct mac *m;
+	struct mac *m;
+	struct parm *p1;
+	struct loc *l1;
 
 	e = mac_expn;
 	for (p = e->expn_parms; p != NULL; p = p1) {
@@ -404,8 +409,9 @@ void mac_end_expn(void)
 int mac_rept_expn(void)
 {
 	register struct expn *e;
+	register struct loc *l;
 	register struct mac *m;
-	register struct loc *l, *l1;
+	struct loc *l1;
 
 	e = mac_expn;
 	e->expn_iter++;
@@ -496,11 +502,11 @@ const char *mac_get_local(struct expn *e, char *s)
 void mac_subst(char *t, char *s, struct expn *e,
 	       const char *(*getf)(struct expn *, char *))
 {
-	register char *s1, *t0, *t1, c;
 	register const char *v;
-	register int n, m;
-	int cat_flag;
-	int lit_flag;
+	register int m;
+	register int cat_flag;
+	char *s1, *t0, *t1, c;
+	int n, lit_flag;
 
 	if (*s == LINCOM || (*s == LINOPT && !IS_SYM(*(s + 1)))) {
 		strcpy(t, s);
@@ -700,9 +706,11 @@ void mac_call(void)
  */
 char *mac_next_parm(char *s)
 {
-	register char *t, *t1, c;
-	register int n, m;
-	register WORD w, v;
+	register char *t, c;
+	register int m;
+	WORD w, v;
+	int n;
+	char *t1;
 
 	t1 = t = tmp;
 	n = 0;		/* angle brackets nesting level */
@@ -1015,7 +1023,7 @@ WORD op_irp(BYTE op_code, BYTE dummy)
 {
 	register char *s, *t;
 	register int i;
-	register struct mac *m;
+	struct mac *m;
 
 	UNUSED(dummy);
 
@@ -1073,9 +1081,10 @@ WORD op_irp(BYTE op_code, BYTE dummy)
  */
 WORD op_local(BYTE dummy1, BYTE dummy2)
 {
-	register char *s, *s1, c;
+	register char *s, c;
 	register struct expn *e;
-	register struct loc *l;
+	char *s1;
+	struct loc *l;
 
 	UNUSED(dummy1);
 	UNUSED(dummy2);

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -141,8 +141,9 @@ void init_ctype(void)
  */
 BYTE search_opr(char *s)
 {
+	register struct opr *low, *mid;
+	register struct opr *high;
 	register int cond;
-	register struct opr *low, *high, *mid;
 
 	low = &oprtab[0];
 	high = &oprtab[no_operators - 1];
@@ -165,9 +166,10 @@ BYTE search_opr(char *s)
  */
 int get_token(void)
 {
-	register char *p1, *p2, *s;
-	register WORD n, m, base;
-	register struct sym *sp;
+	register char *s, *p1;
+	register char *p2;
+	WORD n, m, base;
+	struct sym *sp;
 
 	s = scan_pos;
 	tok_val = 0;
@@ -353,8 +355,8 @@ done:
 int factor(WORD *resultp)
 {
 	register int err, erru;
-	register BYTE opr_type;
 	register char *s;
+	BYTE opr_type;
 	WORD value;
 
 	switch (tok_type) {

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -379,8 +379,10 @@ static int no_operands;		/* current number of register/flags */
  */
 void instrset(int is)
 {
-	register struct opc *opc, *p, **q;
-	register int i, nopc;
+	register struct opc *p, **q;
+	register int i;
+	struct opc *opc;
+	int nopc;
 
 	nopc = 0;		/* silence compiler */
 	if (is == curr_instrset)
@@ -433,8 +435,9 @@ int opccmp(const void *p1, const void *p2)
  */
 struct opc *search_op(char *op_name)
 {
-	register int cond;
-	register struct opc **low, **high, **mid;
+	register struct opc **low, **mid;
+	register struct opc **high;
+	int cond;
 
 	low = opctab;
 	high = opctab + no_opcodes - 1;
@@ -459,8 +462,9 @@ struct opc *search_op(char *op_name)
  */
 BYTE get_reg(char *s)
 {
-	register int cond;
-	register struct ope *low, *high, *mid;
+	register struct ope *low, *mid;
+	register struct ope *high;
+	int cond;
 
 	if (s == NULL || *s == '\0')
 		return(NOOPERA);

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -38,7 +38,7 @@ void eof_hex(WORD);
 void flush_hex(void);
 void hex_record(BYTE);
 BYTE chksum(BYTE);
-void btoh(BYTE, char **);
+char *btoh(BYTE, char *);
 
 /* z80amain.c */
 extern void fatal(int, const char *);
@@ -527,17 +527,17 @@ void flush_hex(void)
 void hex_record(BYTE rec_type)
 {
 	register int i;
-	char *p;
+	register char *p;
 
 	p = hex_out;
 	*p++ = ':';
-	btoh(hex_cnt, &p);
-	btoh(hex_addr >> 8, &p);
-	btoh(hex_addr & 0xff, &p);
-	btoh(rec_type, &p);
+	p = btoh(hex_cnt, p);
+	p = btoh(hex_addr >> 8, p);
+	p = btoh(hex_addr & 0xff, p);
+	p = btoh(rec_type, p);
 	for (i = 0; i < hex_cnt; i++)
-		btoh(hex_buf[i], &p);
-	btoh(chksum(rec_type), &p);
+		p = btoh(hex_buf[i], p);
+	p = btoh(chksum(rec_type), p);
 	*p++ = '\n';
 	*p = '\0';
 	fputs(hex_out, objfp);
@@ -545,16 +545,17 @@ void hex_record(BYTE rec_type)
 
 /*
  *	convert BYTE into ASCII hex and copy to string at p
- *	increase p by 2
+ *	returns p increased by 2
  */
-void btoh(BYTE b, char **p)
+char *btoh(BYTE b, char *p)
 {
 	register char c;
 
 	c = b >> 4;
-	*(*p)++ = c + (c < 10 ? '0' : '7');
+	*p++ = c + (c < 10 ? '0' : '7');
 	c = b & 0xf;
-	*(*p)++ = c + (c < 10 ? '0' : '7');
+	*p++ = c + (c < 10 ? '0' : '7');
+	return(p);
 }
 
 /*

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -126,8 +126,8 @@ WORD op_pupo(BYTE base_op, BYTE dummy)
  */
 WORD op_ex(BYTE base_ops, BYTE base_opd)
 {
-	register char *sec;
 	register BYTE op;
+	register char *sec;
 	register WORD len = 0;
 
 	sec = next_arg(operand, NULL);
@@ -243,9 +243,9 @@ WORD op_ret(BYTE base_op, BYTE base_opc)
  */
 WORD op_jpcall(BYTE base_op, BYTE base_opc)
 {
-	register char *sec;
 	register BYTE op;
 	register WORD n;
+	register char *sec;
 	register WORD len = 0;
 
 	sec = next_arg(operand, NULL);
@@ -313,8 +313,8 @@ WORD op_jpcall(BYTE base_op, BYTE base_opc)
  */
 WORD op_jr(BYTE base_op, BYTE base_opc)
 {
-	register char *sec;
 	register BYTE op;
+	register char *sec;
 	register WORD len = 0;
 
 	sec = next_arg(operand, NULL);
@@ -369,9 +369,9 @@ WORD op_djnz(BYTE base_op, BYTE dummy)
  */
 WORD op_ld(BYTE base_op, BYTE dummy)
 {
-	register char *sec;
 	register BYTE op;
 	register WORD n;
+	register char *sec;
 	register WORD len = 0;
 
 	UNUSED(dummy);
@@ -887,8 +887,8 @@ WORD ldinn(char *sec)
  */
 WORD op_add(BYTE base_op, BYTE base_op16)
 {
-	register char *sec;
 	register BYTE op;
+	register char *sec;
 	register WORD len = 0;
 
 	sec = next_arg(operand, NULL);
@@ -960,8 +960,8 @@ WORD op_add(BYTE base_op, BYTE base_op16)
  */
 WORD op_sbadc(BYTE base_op, BYTE base_op16)
 {
-	register char *sec;
 	register BYTE op;
+	register char *sec;
 	register WORD len = 0;
 
 	sec = next_arg(operand, NULL);
@@ -1144,8 +1144,8 @@ WORD aluop(BYTE base_op, char *sec)
  */
 WORD op_out(BYTE op_base, BYTE op_basec)
 {
-	register char *sec;
 	register BYTE op;
+	register char *sec;
 	register WORD len = 0;
 
 	sec = next_arg(operand, NULL);
@@ -1200,8 +1200,8 @@ WORD op_out(BYTE op_base, BYTE op_basec)
  */
 WORD op_in(BYTE op_base, BYTE op_basec)
 {
-	register char *sec;
 	register BYTE op;
+	register char *sec;
 	register WORD len = 0;
 
 	sec = next_arg(operand, NULL);
@@ -1257,9 +1257,9 @@ WORD op_in(BYTE op_base, BYTE op_basec)
  */
 WORD op_cbgrp(BYTE base_op, BYTE dummy)
 {
-	register char *sec;
 	register BYTE op;
 	register BYTE bit = 0;
+	register char *sec;
 	register WORD len = 0;
 
 	UNUSED(dummy);
@@ -1319,8 +1319,8 @@ WORD op_cbgrp(BYTE base_op, BYTE dummy)
  */
 WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 {
-	register char *tert;
 	register BYTE op;
+	register char *tert;
 	register WORD len = 0;
 
 	tert = next_arg(sec, NULL);
@@ -1375,8 +1375,8 @@ WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
  */
 WORD op8080_mov(BYTE base_op, BYTE dummy)
 {
-	register char *sec;
 	register BYTE op1, op2;
+	register char *sec;
 	register WORD len = 0;
 
 	UNUSED(dummy);
@@ -1623,8 +1623,8 @@ WORD op8080_addr(BYTE base_op, BYTE dummy)
  */
 WORD op8080_mvi(BYTE base_op, BYTE dummy)
 {
-	register char *sec;
 	register BYTE op;
+	register char *sec;
 	register WORD len = 0;
 
 	UNUSED(dummy);
@@ -1659,9 +1659,9 @@ WORD op8080_mvi(BYTE base_op, BYTE dummy)
  */
 WORD op8080_lxi(BYTE base_op, BYTE dummy)
 {
-	register char *sec;
 	register BYTE op;
 	register WORD n;
+	register char *sec;
 	register WORD len = 0;
 
 	UNUSED(dummy);

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -86,8 +86,8 @@ struct sym *get_sym(char *sym_name)
  */
 struct sym *new_sym(char *sym_name)
 {
-	register int hashval, n;
 	register struct sym *sp;
+	register int n, hashval;
 
 	n = strlen(sym_name);
 	sp = (struct sym *) malloc(sizeof(struct sym));
@@ -149,8 +149,8 @@ int hash(char *name)
  */
 struct sym *first_sym(int sort_mode)
 {
-	register int i, j;
 	register struct sym *sp;
+	register int i, j;
 
 	if (symcnt == 0)
 		return(NULL);


### PR DESCRIPTION
1. Shuffle around the "register" declarations to make sense for the old MWC Coherent 8086 (2 register vars) & 386 (3 register vars) compilers. Modern compilers seem to ignore these anyway when optimizing, for example, if I compile z80asm with "gcc -Dregister=" I got exactly the same object code.
2. Make btoh() register friendly.

This saved 254 bytes of object code and makes the assembler probably a bit faster by using less memory oriented opcodes on Coherent 3.2.