### PR TITLE
z80asm: fix memory leak, no goto's, FALSE/TRUE for flags, misc stuff

### DIFF
--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -55,6 +55,13 @@
 #define MAXHEX		32	/* max. no bytes per HEX record */
 #define MACNEST		50	/* max. expansion nesting */
 
+#ifndef FALSE
+#define FALSE		0
+#endif
+#ifndef TRUE
+#define TRUE		1
+#endif
+
 /*
  *	types for working with op-codes, addresses, expressions,
  *	and bit flags and masks

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -65,7 +65,7 @@ int  list_flag,			/* flag for option -l */
      iflevel,			/* IF nesting level */
      act_iflevel,		/* active IF nesting level */
      act_elselevel,		/* active ELSE nesting level */
-     gencode = 1,		/* flag for conditional code */
+     gencode = TRUE,		/* flag for conditional code */
      nofalselist,		/* flag for false conditional listing */
      mac_def_nest,		/* macro definition nesting level */
      mac_exp_nest,		/* macro expansion nesting level */

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -139,7 +139,7 @@ void options(int argc, char *argv[])
 					lstfn = get_fn(++s, LSTEXT, 0);
 					s += (strlen(s) - 1);
 				}
-				list_flag = 1;
+				list_flag = TRUE;
 				break;
 			case 's':
 				if (*(s + 1) == '\0')
@@ -155,7 +155,7 @@ void options(int argc, char *argv[])
 				s += (strlen(s) - 1);
 				break;
 			case 'x':
-				nofill_flag = 1;
+				nofill_flag = TRUE;
 				break;
 			case 'f':
 				if (*(s + 1) == 'b')
@@ -185,13 +185,13 @@ void options(int argc, char *argv[])
 				put_sym(label, 0);
 				break;
 			case '8':
-				i8080_flag = 1;
+				i8080_flag = TRUE;
 				break;
 			case 'u':
-				undoc_flag = 1;
+				undoc_flag = TRUE;
 				break;
 			case 'v':
-				ver_flag = 1;
+				ver_flag = TRUE;
 				break;
 			case 'm':
 				if (mac_list_flag == M_OPS)
@@ -200,7 +200,7 @@ void options(int argc, char *argv[])
 					mac_list_flag = M_NONE;
 				break;
 			case 'U':
-				upcase_flag = 1;
+				upcase_flag = TRUE;
 				break;
 			case 'p':
 				if (*++s == '\0') {
@@ -430,22 +430,22 @@ int process_line(char *l)
 	if (pass == 2) {
 		if (gencode && (op == NULL || !(op->op_flags & OP_DS)))
 			obj_writeb(op_count);
-		lflag = 1;
+		lflag = TRUE;
 		/* already listed INCLUDE, force page eject */
 		if (op != NULL && (op->op_flags & OP_INCL)) {
-			lflag = 0;
+			lflag = FALSE;
 			p_line = ppl + 1;
 		}
 		if (errnum == E_OK && expn_flag) {
 			if (mac_list_flag == M_NONE)
-				lflag = 0;
+				lflag = FALSE;
 			else if (mac_list_flag == M_OPS
 				 && (op_count == 0 && a_mode != A_EQU
 						   && a_mode != A_DS))
-				lflag = 0;
+				lflag = FALSE;
 		}
 		if (nofalselist && !old_genc && !gencode)
-			lflag = 0;
+			lflag = FALSE;
 		if (lflag)
 			lst_line(l, pc, op_count, expn_flag);
 	}
@@ -590,9 +590,10 @@ void get_operand(char *s, char *l, int nopre_flag)
 			if (s - s0 == 6 && strncmp(s0, "AF,AF'", 6) == 0)
 				continue;
 			while (1) {
-				if (*l == '\0') /* undelimited string */
-					goto done;
-				else if (*l == c) {
+				if (*l == '\0') { /* undelimited string */
+					*s = '\0';
+					return;
+				} else if (*l == c) {
 					if (*(l + 1) != c) /* double delim? */
 						break;
 					else
@@ -606,7 +607,6 @@ void get_operand(char *s, char *l, int nopre_flag)
 			l++;
 		}
 	}
-done:
 	*s = '\0';
 }
 

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -134,7 +134,7 @@ void lst_header(void)
 	} else
 		p_line = 0;
 	fputc('\n', lstfp);
-	header_done = 1;
+	header_done = TRUE;
 }
 
 /*
@@ -149,7 +149,7 @@ void lst_attl(void)
 			"\nLOC   OBJECT CODE   LINE   STMT SOURCE CODE\n");
 	if (ppl != 0)
 		p_line += 2;
-	attl_done = 1;
+	attl_done = TRUE;
 }
 
 /*

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -437,6 +437,7 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 WORD op_cond(BYTE op_code, BYTE dummy)
 {
 	register char *p;
+	register int err = FALSE;
 
 	UNUSED(dummy);
 
@@ -457,13 +458,13 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 			break;
 		case 3:			/* IFEQ */
 		case 4:			/* IFNEQ */
-			p = next_arg(operand, NULL);
-			if (p == NULL) {
+			if ((p = next_arg(operand, NULL)) != NULL) {
+				if (eval(operand) != eval(p))
+					gencode = FALSE;
+			} else {
 				asmerr(E_MISOPE);
-				return(0);
+				err = TRUE;
 			}
-			if (eval(operand) != eval(p))
-				gencode = FALSE;
 			break;
 		case 5:			/* COND, IF, and IFT */
 		case 6:			/* IFE and IFF */
@@ -479,8 +480,10 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 			fatal(F_INTERN, "invalid opcode for function op_cond");
 			break;
 		}
-		if ((op_code & 1) == 0)	/* negate for inverse IF */
-			gencode = !gencode;
+		if (!err) {
+			if ((op_code & 1) == 0) /* negate for inverse IF */
+				gencode = !gencode;
+		}
 		act_iflevel = iflevel;
 	} else {
 		if (iflevel == 0) {

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -99,7 +99,7 @@ WORD op_org(BYTE op_code, BYTE dummy)
 		if (pass == 1) {	/* PASS 1 */
 			if (!load_flag) {
 				load_addr = n;
-				load_flag = 1;
+				load_flag = TRUE;
 			}
 		} else			/* PASS 2 */
 			obj_org(n);
@@ -109,7 +109,7 @@ WORD op_org(BYTE op_code, BYTE dummy)
 		if (phs_flag)
 			asmerr(E_PHSNST);
 		else {
-			phs_flag = 1;
+			phs_flag = TRUE;
 			pc = eval(operand);
 		}
 		break;
@@ -117,7 +117,7 @@ WORD op_org(BYTE op_code, BYTE dummy)
 		if (!phs_flag)
 			asmerr(E_MISPHS);
 		else {
-			phs_flag = 0;
+			phs_flag = FALSE;
 			pc = rpc;
 		}
 		break;
@@ -313,18 +313,18 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 					asmerr(E_VALOUT);
 				else
 					ppl = n;
-				page_done = 1;
+				page_done = TRUE;
 			}
 		} else if (pass == 2)
 			p_line = ppl - 1;
 		break;
 	case 2:				/* LIST and .LIST */
 		if (pass == 2)
-			list_flag = 1;
+			list_flag = TRUE;
 		break;
 	case 3:				/* NOLIST and .XLIST */
 		if (pass == 2)
-			list_flag = 0;
+			list_flag = FALSE;
 		break;
 	case 4:				/* .PRINTX */
 		p = operand;
@@ -418,11 +418,11 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 		break;
 	case 11:			/* .SFCOND */
 		if (pass == 2)
-			nofalselist = 1;
+			nofalselist = TRUE;
 		break;
 	case 12:			/* .LFCOND */
 		if (pass == 2)
-			nofalselist = 0;
+			nofalselist = FALSE;
 		break;
 	default:
 		fatal(F_INTERN, "invalid opcode for function op_misc");
@@ -453,7 +453,7 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 		case 1:			/* IFDEF */
 		case 2:			/* IFNDEF */
 			if (get_sym(operand) == NULL)
-				gencode = 0;
+				gencode = FALSE;
 			break;
 		case 3:			/* IFEQ */
 		case 4:			/* IFNEQ */
@@ -463,17 +463,17 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 				return(0);
 			}
 			if (eval(operand) != eval(p))
-				gencode = 0;
+				gencode = FALSE;
 			break;
 		case 5:			/* COND, IF, and IFT */
 		case 6:			/* IFE and IFF */
 			if (eval(operand) == 0)
-				gencode = 0;
+				gencode = FALSE;
 			break;
 		case 7:			/* IF1 */
 		case 8:			/* IF2 */
 			if (pass == 2)
-				gencode = 0;
+				gencode = FALSE;
 			break;
 		default:
 			fatal(F_INTERN, "invalid opcode for function op_cond");
@@ -499,7 +499,7 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 			break;
 		case 99:		/* ENDIF and ENDC */
 			if (iflevel == act_iflevel) {
-				gencode = 1;
+				gencode = TRUE;
 				act_elselevel = 0;
 				act_iflevel--;
 			}

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -246,7 +246,7 @@ WORD op_jpcall(BYTE base_op, BYTE base_opc)
 	register BYTE op;
 	register WORD n;
 	register char *sec;
-	register WORD len = 0;
+	WORD len = 0;
 
 	sec = next_arg(operand, NULL);
 	switch (op = get_reg(operand)) {
@@ -372,7 +372,7 @@ WORD op_ld(BYTE base_op, BYTE dummy)
 	register BYTE op;
 	register WORD n;
 	register char *sec;
-	register WORD len = 0;
+	WORD len = 0;
 
 	UNUSED(dummy);
 
@@ -1260,7 +1260,7 @@ WORD op_cbgrp(BYTE base_op, BYTE dummy)
 	register BYTE op;
 	register BYTE bit = 0;
 	register char *sec;
-	register WORD len = 0;
+	WORD len = 0;
 
 	UNUSED(dummy);
 
@@ -1377,7 +1377,7 @@ WORD op8080_mov(BYTE base_op, BYTE dummy)
 {
 	register BYTE op1, op2;
 	register char *sec;
-	register WORD len = 0;
+	WORD len = 0;
 
 	UNUSED(dummy);
 
@@ -1662,7 +1662,7 @@ WORD op8080_lxi(BYTE base_op, BYTE dummy)
 	register BYTE op;
 	register WORD n;
 	register char *sec;
-	register WORD len = 0;
+	WORD len = 0;
 
 	UNUSED(dummy);
 

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -76,7 +76,7 @@ struct sym *get_sym(char *sym_name)
 	register struct sym *sp;
 
 	if ((sp = look_sym(sym_name)) != NULL)
-		sp->sym_refflg = 1;
+		sp->sym_refflg = TRUE;
 	return(sp);
 }
 
@@ -98,7 +98,7 @@ struct sym *new_sym(char *sym_name)
 	hashval = hash(sym_name);
 	sp->sym_next = symtab[hashval];
 	symtab[hashval] = sp;
-	sp->sym_refflg = 0;
+	sp->sym_refflg = FALSE;
 	if (n > symmax)
 		symmax = n;
 	symcnt++;
@@ -151,7 +151,8 @@ int hash(char *name)
 struct sym *first_sym(int sort_mode)
 {
 	register struct sym *sp;
-	register int i, j;
+	register int j;
+	register int i;
 
 	if (symcnt == 0)
 		return(NULL);
@@ -170,8 +171,7 @@ struct sym *first_sym(int sort_mode)
 		if (symarray == NULL)
 			fatal(F_OUTMEM, "sorting symbol table");
 		for (i = 0, j = 0; i < HASHSIZE; i++)
-			for (sp = symtab[i]; sp != NULL;
-			     sp = sp->sym_next)
+			for (sp = symtab[i]; sp != NULL; sp = sp->sym_next)
 				symarray[j++] = sp;
 		qsort(symarray, symcnt, sizeof(struct sym *),
 		      sort_mode == SYM_SORTN ? namecmp : valcmp);


### PR DESCRIPTION
1. Fix memory leak detected by the clang static analyzer in op_irp().
2. Get rid of goto's.
3. Abort op_local() and op_macro() on error.
4. Move local label generation into expn_add_loc() and don't increase mac_loc_cnt if it reached its limit.
5. Use FALSE/TRUE for flags.
6. Some clean up

This commit started so simple: the clang static analyzer found a possible memory leak in op_irp().
Just a small fix involving a goto block... looked real ugly. Got rid of all goto's... and so forth...