### PR TITLE
fix problems found by clang static analyzer, load_hex(), LOG() uses

### DIFF
--- a/altairsim/srcsim/memory.c
+++ b/altairsim/srcsim/memory.c
@@ -52,7 +52,7 @@ void init_memory(void)
 {
 	register int i, j;
 	char fn[MAX_LFN];
-	char *pfn = fn;
+	char *pfn;
 
 	strcpy(fn, rompath);
 	strcat(fn, "/");

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -974,7 +974,7 @@ static void net_server_config(void)
 	strcat(&fn[0], "/net_server.conf");
 
 	if ((fp = fopen(fn, "r")) != NULL) {
-		LOG(TAG, "Server network configuration:\n");
+		LOG(TAG, "Server network configuration:\r\n");
 		s = &buf[0];
 		while (fgets(s, BUFSIZE, fp) != NULL) {
 			if ((*s == '\n') || (*s == '#'))
@@ -994,7 +994,7 @@ static void net_server_config(void)
 			while((*s == ' ') || (*s == '\t'))
 				s++;
 			ss_port[i - 1] = atoi(s);
-			LOG(TAG, "console %d listening on port %d, telnet = %s\n",
+			LOG(TAG, "console %d listening on port %d, telnet = %s\r\n",
 			    i, ss_port[i - 1],
 			    ((ss_telnet[i - 1] > 0) ? "on" : "off"));
 		}
@@ -1016,7 +1016,7 @@ static void net_client_config(void)
 	strcat(&fn[0], "/net_client.conf");
 
 	if ((fp = fopen(fn, "r")) != NULL) {
-		LOG(TAG, "Client network configuration:\n");
+		LOG(TAG, "Client network configuration:\r\n");
 		s = &buf[0];
 		while (fgets(s, BUFSIZE, fp) != NULL) {
 			if ((*s == '\n') || (*s == '#'))
@@ -1032,7 +1032,7 @@ static void net_client_config(void)
 			while((*s == ' ') || (*s == '\t'))
 				s++;
 			cs_port = atoi(s);
-			LOG(TAG, "Connecting to %s at port %d\n", cs_host,
+			LOG(TAG, "Connecting to %s at port %d\r\n", cs_host,
 			    cs_port);
 		}
 		fclose(fp);

--- a/cromemcosim/srcsim/memory.c
+++ b/cromemcosim/srcsim/memory.c
@@ -50,7 +50,7 @@ void init_memory(void)
 {
 	register int i, j;
 	char fn[MAX_LFN];
-	char *pfn = fn;
+	char *pfn;
 
 	strcpy(fn, rompath);
 	strcat(fn, "/");

--- a/frontpanel/lp_gfx.cpp
+++ b/frontpanel/lp_gfx.cpp
@@ -151,7 +151,7 @@ Lpanel::growAlphaObjects(void)
     new_alpha_objects[i] = alpha_objects[i];
 
   max_alpha_objects += 1;
-  if(alpha_objects) delete[] objects;
+  if(alpha_objects) delete[] alpha_objects;
   alpha_objects = new_alpha_objects;
 }
 

--- a/frontpanel/lp_utils.cpp
+++ b/frontpanel/lp_utils.cpp
@@ -995,7 +995,7 @@ Parser::parse(parser_result_t **returned_result)
 			    return (cp1-buff);
 			  }
 
-			   leadspace = 1;
+			   // leadspace = 1;
 			   if(results.num_args < rules[curr_rule].minvals)
 			    {
 				error=PARSER_ERR_TOO_FEW_VALS;
@@ -1048,7 +1048,7 @@ Parser::parse(parser_result_t **returned_result)
 		   cp1 = cp+1;
 
 		    state = PARSER_GETVAR;
-		    leadspace = 1;
+		    // leadspace = 1;
 		    cp1 = cp+1;
 		    cp2 = cp;
 		    return PARSER_OK;

--- a/frontpanel/lpanel.cpp
+++ b/frontpanel/lpanel.cpp
@@ -1211,6 +1211,7 @@ Lpanel::readConfig(const char *_fname)
  if( (fd=fopen(fname,"r")) == 0)
   {
     fprintf(stderr,"readFile: could not open file %s\n",fname);
+    delete[] fname;
     return 0;
   }
 

--- a/imsaisim/srcsim/memory.c
+++ b/imsaisim/srcsim/memory.c
@@ -154,7 +154,7 @@ void init_memory(void)
 {
 	register int i, j;
 	char fn[MAX_LFN];
-	char *pfn = fn;
+	char *pfn;
 
 	strcpy(fn, rompath);
 	strcat(fn, "/");

--- a/iodevices/apu/am9511.c
+++ b/iodevices/apu/am9511.c
@@ -791,8 +791,10 @@ void *am_create(int status, int data) {
     if (fpp == NULL)
 	return NULL;
     p = (struct am_context *)malloc(sizeof (struct am_context));
-    if (p == NULL)
+    if (p == NULL) {
+	free(fpp);
 	return NULL;
+    }
     p->fptmp = fpp;
     am_reset(p);
     return (void *)p;

--- a/iodevices/cromemco-hal.c
+++ b/iodevices/cromemco-hal.c
@@ -67,7 +67,7 @@ void null_out(int dev, BYTE data) {
 
 #ifdef HAS_NETSERVER
 int net_tty_alive(int dev) {
-    // LOG(TAG, "WEBTTY %d: %d", dev, net_device_alive(dev));
+    // LOG(TAG, "WEBTTY %d: %d\r\n", dev, net_device_alive(dev));
     return net_device_alive((net_device_t) dev); /* WEBTTY is only alive if websocket is connected */
 }
 void net_tty_status(int dev, BYTE *stat) {

--- a/iodevices/cromemco-wdi.c
+++ b/iodevices/cromemco-wdi.c
@@ -287,7 +287,7 @@ again:
                 LOGW(TAG, "INIT: HDD FILE DOES NOT EXIST - %s : %s [%d]", fn, strerror(errno), errno);
                 wdi.hd[unit]._fault = 0; /* SET FAULT */
                 wdi.hd[unit].online = 0;
-                LOG(TAG, "HD%d: OFFLINE - NO FILE '%s'\n\r", unit, wdi.hd[unit].fn);
+                LOG(TAG, "HD%d: OFFLINE - NO FILE '%s'\r\n", unit, wdi.hd[unit].fn);
                 continue;
             }
         }
@@ -323,10 +323,10 @@ again:
             LOGW(TAG, "UNKNOWN DISK IMAGE SIZE [%lld] FOR %s", (long long) s.st_size, wdi.hd[unit].fn);
         }
 
-        LOG(TAG, "HD%d:[%s]='%s'\n\r", unit, wdi.hd[unit].type_s, wdi.hd[unit].fn);
+        LOG(TAG, "HD%d:[%s]='%s'\r\n", unit, wdi.hd[unit].type_s, wdi.hd[unit].fn);
     }
 
-    LOG(TAG, "\n\r");
+    LOG(TAG, "\r\n");
 
     wdi.unit = 0;
 }

--- a/iodevices/generic-at-modem.c
+++ b/iodevices/generic-at-modem.c
@@ -271,7 +271,7 @@ int open_socket(void) {
     void *addrptr = NULL;
     uint16_t port = 0;
     struct sockaddr_in *sktv4 = NULL;
-    struct sockaddr_in6 *sktv6 = NULL;
+    /* struct sockaddr_in6 *sktv6 = NULL; */
     int on = 1;
 
     memset(&hints, 0, sizeof(struct addrinfo));
@@ -296,9 +296,11 @@ int open_socket(void) {
                 addrptr = &sktv4->sin_addr;
                 break;
             case AF_INET6:
+                /*
                 sktv6 = (struct sockaddr_in6 *)rp->ai_addr;
                 port = sktv6->sin6_port;
                 addrptr = &sktv6->sin6_addr;
+                */
                 LOGE(TAG, "Not expecting IPV6 addresses");
                 return 1;
                 break;
@@ -1069,7 +1071,7 @@ int time_diff_sec(struct timeval *t1, struct timeval *t2)
 	/* normalize result */
 	if (usec < 0L) {
 		sec--;
-		usec += 1000000L;
+		/* usec += 1000000L; */
 	}
     return sec;
 }
@@ -1366,7 +1368,7 @@ void modem_device_init(void) {
 #endif
     char *modem_init_string;
     if ((modem_init_string = getenv("MODEM.init")) != NULL) {
-        LOG(TAG, "MODEM.init string: %s\n", modem_init_string);
+        LOG(TAG, "MODEM.init string: %s\r\n", modem_init_string);
         while (*modem_init_string) {
             modem_device_send(0, *modem_init_string++);
         }

--- a/mosteksim/srcsim/config.c
+++ b/mosteksim/srcsim/config.c
@@ -39,12 +39,12 @@ void config(void)
 			t2 = strtok(NULL, "= \t\r\n");
 
 			if (0 == strcmp(t1, "bootrom")) {
-				LOG(TAG, "\nBoot ROM: %s\r\n\r\n", t2);
+				LOG(TAG, "\r\nBoot ROM: %s\r\n\r\n", t2);
 				strcpy(xfn, t2);
 				x_flag = 1;
 			}
 			else if (0 == strcmp(t1, "drive0")) {
-				LOG(TAG, "\nDrive 0: %s\r\n", t2);
+				LOG(TAG, "\r\nDrive 0: %s\r\n", t2);
 			}
 			else if (0 == strcmp(t1, "drive1")) {
 				LOG(TAG, "Drive 1: %s\r\n", t2);

--- a/mosteksim/srcsim/config.c
+++ b/mosteksim/srcsim/config.c
@@ -39,21 +39,21 @@ void config(void)
 			t2 = strtok(NULL, "= \t\r\n");
 
 			if (0 == strcmp(t1, "bootrom")) {
-				LOG(TAG, "\nBoot ROM: %s\n\n", t2);
+				LOG(TAG, "\nBoot ROM: %s\r\n\r\n", t2);
 				strcpy(xfn, t2);
 				x_flag = 1;
 			}
 			else if (0 == strcmp(t1, "drive0")) {
-				LOG(TAG, "\nDrive 0: %s\n", t2);
+				LOG(TAG, "\nDrive 0: %s\r\n", t2);
 			}
 			else if (0 == strcmp(t1, "drive1")) {
-				LOG(TAG, "Drive 1: %s\n", t2);
+				LOG(TAG, "Drive 1: %s\r\n", t2);
 			}
 			else if (0 == strcmp(t1, "drive2")) {
-				LOG(TAG, "Drive 2: %s\n", t2);
+				LOG(TAG, "Drive 2: %s\r\n", t2);
 			}
 			else if (0 == strcmp(t1, "drive3")) {
-				LOG(TAG, "Drive 3: %s\n", t2);
+				LOG(TAG, "Drive 3: %s\r\n", t2);
 			}
 			else {
 				LOGW(TAG, "unknown command: %s",s);

--- a/webfrontend/netsrv.c
+++ b/webfrontend/netsrv.c
@@ -502,7 +502,7 @@ int UploadHandler(HttpdConnection_t *conn, void *path) {
 
 		strncat(output, req->args[0], MAX_LFN - strlen(output));
 
-		filelen = 0;
+		//filelen = 0;
 		filelen = mg_store_body(conn, output);
 
         LOGI(TAG, "%d bytes written to %s, received %d", filelen, output, (int) req->len);

--- a/z80core/sim0.c
+++ b/z80core/sim0.c
@@ -489,46 +489,52 @@ void reset_cpu(void)
  */
 static void save_core(void)
 {
+	register FILE *fp;
 	register int i;
 	int fd;
-	BYTE d;
 
-	if ((fd = open("core.z80", O_WRONLY | O_CREAT, 0600)) == -1) {
+	if ((fd = open("core.z80", O_WRONLY | O_CREAT, 0600)) == -1
+	    || (fp = fdopen(fd, "w")) == NULL) {
+		if (fd >= 0)
+			close(fd);
 		puts("can't open file core.z80");
 		return;
 	}
 
-	write(fd, (char *) &A, sizeof(A));
-	write(fd, (char *) &F, sizeof(F));
-	write(fd, (char *) &B, sizeof(B));
-	write(fd, (char *) &C, sizeof(C));
-	write(fd, (char *) &D, sizeof(D));
-	write(fd, (char *) &E, sizeof(E));
-	write(fd, (char *) &H, sizeof(H));
-	write(fd, (char *) &L, sizeof(L));
-	write(fd, (char *) &A_, sizeof(A_));
-	write(fd, (char *) &F_, sizeof(F_));
-	write(fd, (char *) &B_, sizeof(B_));
-	write(fd, (char *) &C_, sizeof(C_));
-	write(fd, (char *) &D_, sizeof(D_));
-	write(fd, (char *) &E_, sizeof(E_));
-	write(fd, (char *) &H_, sizeof(H_));
-	write(fd, (char *) &L_, sizeof(L_));
-	write(fd, (char *) &I, sizeof(I));
-	write(fd, (char *) &IFF, sizeof(IFF));
-	write(fd, (char *) &R, sizeof(R));
-	write(fd, (char *) &R_, sizeof(R_));
-	write(fd, (char *) &PC, sizeof(PC));
-	write(fd, (char *) &SP, sizeof(SP));
-	write(fd, (char *) &IX, sizeof(IX));
-	write(fd, (char *) &IY, sizeof(IY));
+	fwrite(&A, sizeof(A), 1, fp);
+	fwrite(&F, sizeof(F), 1, fp);
+	fwrite(&B, sizeof(B), 1, fp);
+	fwrite(&C, sizeof(C), 1, fp);
+	fwrite(&D, sizeof(D), 1, fp);
+	fwrite(&E, sizeof(E), 1, fp);
+	fwrite(&H, sizeof(H), 1, fp);
+	fwrite(&L, sizeof(L), 1, fp);
+	fwrite(&A_, sizeof(A_), 1, fp);
+	fwrite(&F_, sizeof(F_), 1, fp);
+	fwrite(&B_, sizeof(B_), 1, fp);
+	fwrite(&C_, sizeof(C_), 1, fp);
+	fwrite(&D_, sizeof(D_), 1, fp);
+	fwrite(&E_, sizeof(E_), 1, fp);
+	fwrite(&H_, sizeof(H_), 1, fp);
+	fwrite(&L_, sizeof(L_), 1, fp);
+	fwrite(&I, sizeof(I), 1, fp);
+	fwrite(&IFF, sizeof(IFF), 1, fp);
+	fwrite(&R, sizeof(R), 1, fp);
+	fwrite(&R_, sizeof(R_), 1, fp);
+	fwrite(&PC, sizeof(PC), 1, fp);
+	fwrite(&SP, sizeof(SP), 1, fp);
+	fwrite(&IX, sizeof(IX), 1, fp);
+	fwrite(&IY, sizeof(IY), 1, fp);
 
-	for (i = 0; i < 65536; i++) {
-		d = getmem(i);
-		write(fd, &d, 1);
+	for (i = 0; i < 65536; i++)
+		fputc(getmem(i), fp);
+
+	if (ferror(fp)) {
+		fclose(fp);
+		puts("error writing core.z80");
+		return;
 	}
-
-	close(fd);
+	fclose(fp);
 }
 
 /*
@@ -536,46 +542,47 @@ static void save_core(void)
  */
 int load_core(void)
 {
+	register FILE *fp;
 	register int i;
-	int fd;
-	BYTE d;
 
-	if ((fd = open("core.z80", O_RDONLY)) == -1) {
+	if ((fp = fopen("core.z80", "r")) == NULL) {
 		puts("can't open file core.z80");
 		return(1);
 	}
 
-	read(fd, (char *) &A, sizeof(A));
-	read(fd, (char *) &F, sizeof(F));
-	read(fd, (char *) &B, sizeof(B));
-	read(fd, (char *) &C, sizeof(C));
-	read(fd, (char *) &D, sizeof(D));
-	read(fd, (char *) &E, sizeof(E));
-	read(fd, (char *) &H, sizeof(H));
-	read(fd, (char *) &L, sizeof(L));
-	read(fd, (char *) &A_, sizeof(A_));
-	read(fd, (char *) &F_, sizeof(F_));
-	read(fd, (char *) &B_, sizeof(B_));
-	read(fd, (char *) &C_, sizeof(C_));
-	read(fd, (char *) &D_, sizeof(D_));
-	read(fd, (char *) &E_, sizeof(E_));
-	read(fd, (char *) &H_, sizeof(H_));
-	read(fd, (char *) &L_, sizeof(L_));
-	read(fd, (char *) &I, sizeof(I));
-	read(fd, (char *) &IFF, sizeof(IFF));
-	read(fd, (char *) &R, sizeof(R));
-	read(fd, (char *) &R_, sizeof(R_));
-	read(fd, (char *) &PC, sizeof(PC));
-	read(fd, (char *) &SP, sizeof(SP));
-	read(fd, (char *) &IX, sizeof(IX));
-	read(fd, (char *) &IY, sizeof(IY));
+	fread(&A, sizeof(A), 1, fp);
+	fread(&F, sizeof(F), 1, fp);
+	fread(&B, sizeof(B), 1, fp);
+	fread(&C, sizeof(C), 1, fp);
+	fread(&D, sizeof(D), 1, fp);
+	fread(&E, sizeof(E), 1, fp);
+	fread(&H, sizeof(H), 1, fp);
+	fread(&L, sizeof(L), 1, fp);
+	fread(&A_, sizeof(A_), 1, fp);
+	fread(&F_, sizeof(F_), 1, fp);
+	fread(&B_, sizeof(B_), 1, fp);
+	fread(&C_, sizeof(C_), 1, fp);
+	fread(&D_, sizeof(D_), 1, fp);
+	fread(&E_, sizeof(E_), 1, fp);
+	fread(&H_, sizeof(H_), 1, fp);
+	fread(&L_, sizeof(L_), 1, fp);
+	fread(&I, sizeof(I), 1, fp);
+	fread(&IFF, sizeof(IFF), 1, fp);
+	fread(&R, sizeof(R), 1, fp);
+	fread(&R_, sizeof(R_), 1, fp);
+	fread(&PC, sizeof(PC), 1, fp);
+	fread(&SP, sizeof(SP), 1, fp);
+	fread(&IX, sizeof(IX), 1, fp);
+	fread(&IY, sizeof(IY), 1, fp);
 
-	for (i = 0; i < 65536; i++) {
-		read(fd, &d, 1);
-		putmem(i, d);
+	for (i = 0; i < 65536; i++)
+		putmem(i, getc(fp));
+
+	if (ferror(fp)) {
+		fclose(fp);
+		puts("error reading core.z80");
+		return(1);
 	}
-
-	close(fd);
-
+	fclose(fp);
 	return(0);
 }

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -284,7 +284,7 @@ static int load_hex(char *fn, WORD start, int size)
 	register int i;
 	FILE *fp;
 	char inbuf[BUFSIZE];
-	unsigned char outbuf[BUFSIZE / 2];
+	BYTE outbuf[BUFSIZE / 2];
 	char *s0;
 	int count, n;
 	int addr = 0;

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -280,7 +280,7 @@ static int load_mos(char *fn, WORD start, int size)
 static int load_hex(char *fn, WORD start, int size)
 {
 	register char *s;
-	register unsigned char *p;
+	register BYTE *p;
 	register int i;
 	FILE *fp;
 	char inbuf[BUFSIZE];

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -72,7 +72,6 @@ static const char *TAG = "func";
 int load_file(char *, WORD, int);
 static int load_mos(char *, WORD, int);
 static int load_hex(char *, WORD, int);
-static int checksum(char *);
 
 /*
  *	atoi for hexadecimal numbers
@@ -179,7 +178,7 @@ int time_diff(struct timeval *t1, struct timeval *t2)
 int load_file(char *fn, WORD start, int size)
 {
 	BYTE d;
-	int fd;
+	int fd, n;
 
 	if (strlen(fn) == 0) {
 		LOGE(TAG, "no input file given");
@@ -187,12 +186,16 @@ int load_file(char *fn, WORD start, int size)
 	}
 
 	if ((fd = open(fn, O_RDONLY)) == -1) {
-		LOGE(TAG, "can't open file %s\n", fn);
+		LOGE(TAG, "can't open file %s", fn);
 		return(1);
 	}
 
-	read(fd, (char *) &d, 1);	/* read first byte of file */
+	n = read(fd, (char *) &d, 1);	/* read first byte of file */
 	close(fd);
+	if (n != 1) {
+		LOGE(TAG, "invalid file %s", fn);
+		return(1);
+	}
 
 	if (size > 0)
 		LOGD(TAG, "LOAD in Range: %04Xh - %04Xh",
@@ -217,44 +220,48 @@ int load_file(char *fn, WORD start, int size)
 static int load_mos(char *fn, WORD start, int size)
 {
 	register int i;
-	int fd;
+	int c, c2;
+	FILE *fp;
 	int laddr, count;
-	BYTE fileb[3];
 
-	if ((fd = open(fn, O_RDONLY)) == -1) {
-		LOGE(TAG, "can't open file %s\n", fn);
+	if ((fp = fopen(fn, "r")) == NULL) {
+		LOGE(TAG, "can't open file %s", fn);
 		return(1);
 	}
 
-	read(fd, (char *) fileb, 3);	/* read load address */
-	laddr = (fileb[2] << 8) + fileb[1];
+	/* read load address */
+	if ((c = getc(fp)) == EOF || c != 0xff
+	    || (c = getc(fp)) == EOF || (c2 = getc(fp)) == EOF) {
+		LOGE(TAG, "invalid Mostek file %s", fn);
+		return(1);
+	}
+	laddr = (c2 << 8) | c;
 
 	if (size < 0)
 		laddr = start;
 	if (size > 0 && laddr < start) {
-		LOGW(TAG, "tried to load mos file outside "
-		     "expected address range. "
-		     "Address: %04X", laddr);
+		LOGW(TAG, "tried to load Mostek file outside "
+		     "expected address range. Address: %04X", laddr);
 		return(1);
 	}
 
 	count = 0;
 	for (i = laddr; i < 65536; i++) {
-		if (read(fd, fileb, 1) == 1) {
+		if ((c = getc(fp)) != EOF) {
 			if (size > 0 && i >= (start + size)) {
-				LOGW(TAG, "tried to load mos file outside "
+				LOGW(TAG, "tried to load Mostek file outside "
 				     "expected address range. "
 				     "Address: %04X", i);
 				return(1);
 			}
 			count++;
-			putmem(i, fileb[0]);
+			putmem(i, (BYTE) c);
 		} else {
 			break;
 		}
 	}
 
-	close(fd);
+	fclose(fp);
 
 	PC = laddr;
 
@@ -272,58 +279,84 @@ static int load_mos(char *fn, WORD start, int size)
  */
 static int load_hex(char *fn, WORD start, int size)
 {
+	register char *s;
+	register unsigned char *p;
 	register int i;
 	FILE *fp;
-	char buf[BUFSIZE];
-	char *s;
-	int count = 0;
+	char inbuf[BUFSIZE];
+	unsigned char outbuf[BUFSIZE / 2];
+	char *s0;
+	int count, n;
 	int addr = 0;
 	int saddr = 0xffff;
 	int eaddr = 0;
-	int data;
+	int chksum;
 
 	if ((fp = fopen(fn, "r")) == NULL) {
 		LOGE(TAG, "can't open file %s\n", fn);
 		return(1);
 	}
 
-	while (fgets(&buf[0], BUFSIZE, fp) != NULL) {
-		s = &buf[0];
+	while (fgets(inbuf, BUFSIZE, fp) != NULL) {
+		s = inbuf;
 		while (isspace((unsigned char) *s))
 			s++;
 		if (*s != ':')
 			continue;
-		if (checksum(s + 1) != 0) {
-			LOGE(TAG, "invalid checksum in HEX record: %s", s);
+		s0 = s++;
+
+		p = outbuf;
+		n = 0;
+		chksum = 0;
+		while (*s != '\r' && *s != '\n' && *s != '\0') {
+			if (!(*s >= '0' && *s <= '9')
+			    && !(*s >= 'A' && *s <= 'F')) {
+				LOGE(TAG, "invalid character in "
+				     "HEX record %s", s0);
+				fclose(fp);
+				return(1);
+			}
+			*p = (*s <= '9' ? *s - '0' : *s - 'A' + 10) << 4;
+			s++;
+			if (*s == '\r' || *s == '\n' || *s == '\0') {
+				LOGE(TAG, "odd number of characters in "
+				     "HEX record %s", s0);
+				fclose(fp);
+				return(1);
+			}
+			else if (!(*s >= '0' && *s <= '9')
+				 && !(*s >= 'A' && *s <= 'F')) {
+				LOGE(TAG, "invalid character in "
+				     "HEX record %s", s0);
+				fclose(fp);
+				return(1);
+			}
+			*p |= (*s <= '9' ? *s - '0' : *s - 'A' + 10);
+			s++;
+			chksum += *p++;
+			n++;
+		}
+		if (n < 5) {
+			LOGE(TAG, "invalid HEX record %s", s0);
+			fclose(fp);
 			return(1);
 		}
-		s++;
-		count = (*s <= '9') ? (*s - '0') << 4
-				    : (*s - 'A' + 10) << 4;
-		s++;
-		count += (*s <= '9') ? (*s - '0')
-				     : (*s - 'A' + 10);
-		s++;
-		addr = (*s <= '9') ? (*s - '0') << 4
-				   : (*s - 'A' + 10) << 4;
-		s++;
-		addr += (*s <= '9') ? (*s - '0')
-				    : (*s - 'A' + 10);
-		s++;
-		addr *= 256;
-		addr += (*s <= '9') ? (*s - '0') << 4
-				    : (*s - 'A' + 10) << 4;
-		s++;
-		addr += (*s <= '9') ? (*s - '0')
-				    : (*s - 'A' + 10);
-		s++;
-		data = (*s <= '9') ? (*s - '0') << 4
-				   : (*s - 'A' + 10) << 4;
-		s++;
-		data += (*s <= '9') ? (*s - '0')
-				    : (*s - 'A' + 10);
-		s++;
-		if (data == 1)
+		if ((chksum & 255) != 0) {
+			LOGE(TAG, "invalid checksum in HEX record %s", s0);
+			fclose(fp);
+			return(1);
+		}
+
+		p = outbuf;
+		count = *p++;
+		if (count + 5 != n) {
+			LOGE(TAG, "invalid count in HEX record %s", s0);
+			fclose(fp);
+			return(1);
+		}
+		addr = *p++;
+		addr = (addr << 8) | *p++;
+		if (*p++ == 1)
 			break;
 
 		if (size > 0) {
@@ -333,6 +366,7 @@ static int load_hex(char *fn, WORD start, int size)
 				     "expected address range. "
 				     "Address: %04X-%04X",
 				     addr, addr + count - 1);
+				fclose(fp);
 				return(1);
 			}
 		}
@@ -341,23 +375,17 @@ static int load_hex(char *fn, WORD start, int size)
 			saddr = addr;
 		if (addr >= eaddr)
 			eaddr = addr + count - 1;
-		for (i = 0; i < count; i++) {
-			data = (*s <= '9') ? (*s - '0') << 4
-					   : (*s - 'A' + 10) << 4;
-			s++;
-			data += (*s <= '9') ? (*s - '0')
-					    : (*s - 'A' + 10);
-			s++;
-			putmem(addr + i, data);
-		}
+		for (i = 0; i < count; i++)
+			putmem(addr + i, *p++);
 		addr = 0;
 	}
 
 	fclose(fp);
-
-	PC = addr ? addr : saddr;
-
-	count = eaddr - saddr + 1;
+	if (saddr > eaddr)
+		saddr = eaddr = count = 0;
+	else
+		count = eaddr - saddr + 1;
+	PC = (addr != 0 ? addr : saddr);
 	LOG(TAG, "Loader statistics for file %s:\r\n", fn);
 	LOG(TAG, "START : %04XH\r\n", saddr);
 	LOG(TAG, "END   : %04XH\r\n", eaddr);
@@ -365,30 +393,6 @@ static int load_hex(char *fn, WORD start, int size)
 	LOG(TAG, "LOADED: %04XH (%d)\r\n\r\n", count & 0xffff, count & 0xffff);
 
 	return(0);
-}
-
-/*
- *	Verify checksum of Intel HEX records
- */
-static int checksum(char *s)
-{
-	int chk = 0;
-
-	while ((*s != '\r') && (*s != '\n')) {
-		chk += (*s <= '9') ?
-			(*s - '0') << 4 :
-			(*s - 'A' + 10) << 4;
-		s++;
-		chk += (*s <= '9') ?
-			(*s - '0') :
-			(*s - 'A' + 10);
-		s++;
-	}
-
-	if ((chk & 255) == 0)
-		return(0);
-	else
-		return(1);
 }
 
 /*


### PR DESCRIPTION
I used the clang static analyzer over the entire project, and it found some problems. Mostly nothing dangerous, except 4.

1. It really didn't like load_hex() in simfun.c since it didn't check that the characters are hexadecimal digits. I rewrote it to check for all things that could possible be wrong with HEX files.
2. While at it, changed load_mos() to use buffered I/O and add an error check in load_file(). Also changed save_core() and load_core() to use buffered I/O and added an error check.
3. pfn in init_memory() in altairsim/cromemcosim/imsaisim was initialized and immediately overwritten. Removed initialization.
4. frontpanel Lpanel::growAlphaObjects was freeing the wrong object.
5. frontpanel Lpanel::readConfig wasn't freeing fname after failure of opening the config file.
6. frontpanel Parser::parse sets a local variable that isn't used, since the code returns immediately after setting it. Commented out the setting. I think it was an instance variable of Parser in a previous incarnation of the code.
7. iodevices/apu/am9511.c wasn't freeing an allocation if an error occured.
8. Commented out some dead code in iodevices/generic-at-modem.c.
9. webfrontend/netsrv.c was setting a variable two times in a row, commented out the first assignment.
10. LOG was sometimes used with \n instead of \r\n. Made this consistent everywhere. Also replaced some \n\r with \r\n. I don't really understand while it is used with \r\n (perhaps something to do with the web code?)