### PR TITLE
Move shared history to HISTORY files, assembler major version bump, top level Makefile

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,0 +1,39 @@
+28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
+11-JAN-89 Release 1.1
+08-FEB-89 Release 1.2
+13-MAR-89 Release 1.3
+09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
+20-DEC-90 Release 1.5  Ported to COHERENT 3.0
+10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
+		       and some optimisation
+25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
+02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
+18-NOV-06 Release 1.9  modified to work with CP/M sources
+08-DEC-06 Release 1.10 modified MMU for working with CP/NET
+17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
+25-DEC-06 Release 1.12 CPU speed option
+19-FEB-07 Release 1.13 various improvements
+06-OCT-07 Release 1.14 bug fixes and improvements
+06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
+25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
+20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
+24-JAN-14 Release 1.18 bug fixes and improvements
+02-MAR-14 Release 1.19 source cleanup and improvements
+14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
+29-MAR-14 Release 1.21 many improvements
+29-MAY-14 Release 1.22 improved networking and bugfixes
+04-JUN-14 Release 1.23 added 8080 emulation
+06-SEP-14 Release 1.24 bugfixes and improvements
+18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
+18-APR-15 Release 1.26 bugfixes and improvements
+18-JAN-16 Release 1.27 bugfixes and improvements
+05-MAY-16 Release 1.28 improved usability
+20-NOV-16 Release 1.29 bugfixes and improvements
+15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
+28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
+12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
+07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
+16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
+03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
+21-DEC-17 Release 1.36 bugfixes and improvements
+06-JAN-21 Release 1.37 bugfixes and improvements

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ IMSAI_8080 = \
 IMSAI_Z80 = \
 	imsaisim/roms/basic4k.asm
 
+help:
+	@echo "This Makefile is primary for developers."
+	@echo "Please consult the files in the doc directory."
+
 all: z80asm cpmtools libs bioses misc machines
 
 z80asm:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Developer Makefile to easily build/clean everything.
-# Don't use indiscriminately, because "make tools" will install files.
+# Don't use indiscriminately, because "make all" will install files.
 #
 # Targets:
 #	all - build all tools and simulators
@@ -10,6 +10,7 @@
 DESTDIR=${HOME}/bin
 #DESTDIR=/usr/local/bin
 
+TOOLS = z80asm cpmsim/srctools
 LIBS = frontpanel webfrontend/civetweb
 BIOSES = cpmsim/srccpm2 cpmsim/srccpm3 cpmsim/srcmpm cpmsim/srcucsd-iv \
 	imsaisim/srcucsd-iv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,123 @@
+# Developer Makefile to easily build/clean everything.
+# Don't use indiscriminately, because "make tools" will install files.
+#
+# Targets:
+#	all - build all tools and simulators
+#	reassemble - reassemble all ROMs and assembler programs
+#	clean
+#	allclean
+
+DESTDIR=${HOME}/bin
+#DESTDIR=/usr/local/bin
+
+LIBS = frontpanel webfrontend/civetweb
+BIOSES = cpmsim/srccpm2 cpmsim/srccpm3 cpmsim/srcmpm cpmsim/srcucsd-iv \
+	imsaisim/srcucsd-iv
+MISC = z80sim
+MACHINES = altairsim cpmsim cromemcosim imsaisim mosteksim z80sim
+
+Z80ASM_FLAGS = -p0 -e16 -l -sn
+
+ALTAIR_8080 = \
+	altairsim/basic8k78.asm \
+	altairsim/dzmation.asm \
+	altairsim/fdct1.asm \
+	altairsim/killbits.asm \
+	altairsim/killbits2.asm \
+	altairsim/kscope.asm \
+	altairsim/life.asm \
+	altairsim/microchess.asm \
+	altairsim/roms/als8-rom.asm \
+	altairsim/roms/apple.asm \
+	altairsim/roms/bootromt.asm \
+	altairsim/roms/bootromt-old.asm \
+	altairsim/roms/cuter-mits.asm \
+	altairsim/roms/dbl.asm \
+	altairsim/roms/mbl.asm \
+	altairsim/roms/miniboot.asm \
+	altairsim/roms/tinybasic-1.0.asm \
+	altairsim/roms/tinybasic-2.0.asm \
+	altairsim/roms/turnmon.asm
+
+ALTAIR_Z80 = \
+	altairsim/roms/umzapex.asm \
+	altairsim/roms/zapple.asm
+
+CROMEMCO_8080 = \
+	cromemcosim/dzmation.asm \
+	cromemcosim/kscope.asm \
+	cromemcosim/life.asm \
+	cromemcosim/microchess.asm \
+	cromemcosim/roms/z1mon-1.0.asm
+
+CROMEMCO_Z80 = \
+	cromemcosim/roms/rdos1.asm \
+	cromemcosim/roms/rdos252.asm \
+	cromemcosim/roms/z1mon-1.4.asm
+
+IMSAI_8080 = \
+	imsaisim/dzmation.asm \
+	imsaisim/kscope.asm \
+	imsaisim/life.asm \
+	imsaisim/microchess.asm \
+	imsaisim/roms/basic8k.asm \
+	imsaisim/roms/memon80.asm \
+	imsaisim/roms/viofm1.asm \
+	imsaisim/scs1.asm
+
+IMSAI_Z80 = \
+	imsaisim/roms/basic4k.asm
+
+all: z80asm cpmtools libs bioses misc machines
+
+z80asm:
+	$(MAKE) -C z80asm "DESTDIR=$(DESTDIR)" install
+
+cpmtools:
+	$(MAKE) -C cpmsim/srctools "DESTDIR=$(DESTDIR)" install
+
+libs:
+	@set -e; for subdir in $(LIBS); do \
+		$(MAKE) -C $$subdir; \
+	done
+
+bioses:
+	@set -e; for subdir in $(BIOSES); do \
+		$(MAKE) -C $$subdir; \
+	done
+
+misc:
+	@set -e; for subdir in $(MISC); do \
+		$(MAKE) -C $$subdir; \
+	done
+
+machines:
+	@set -e; for subdir in $(MACHINES); do \
+		$(MAKE) -C $$subdir/srcsim; \
+	done
+
+reassemble: z80asm
+	@set -e; for file in $(ALTAIR_8080) $(CROMEMCO_8080) $(IMSAI_8080); do \
+		z80asm -8 $(Z80ASM_FLAGS) "$$file"; \
+	done
+	@set -e; for file in $(ALTAIR_Z80) $(CROMEMCO_Z80) $(IMSAI_Z80); do \
+		z80asm $(Z80ASM_FLAGS) "$$file"; \
+	done
+
+clean:
+	@set -e; for subdir in $(TOOLS) $(LIBS) $(BIOSES) $(MISC); do \
+		$(MAKE) -C $$subdir clean; \
+	done
+	@set -e; for subdir in $(MACHINES); do \
+		$(MAKE) -C $$subdir/srcsim clean; \
+	done
+
+allclean:
+	@set -e; for subdir in $(TOOLS) $(LIBS) $(BIOSES) $(MISC); do \
+		$(MAKE) -C $$subdir allclean; \
+	done
+	@set -e; for subdir in $(MACHINES); do \
+		$(MAKE) -C $$subdir/srcsim allclean; \
+	done
+
+.PHONY: all z80asm cpmtools libs bioses misc machines reassemble clean allclean

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ IMSAI_Z80 = \
 	imsaisim/roms/basic4k.asm
 
 help:
-	@echo "This Makefile is primary for developers."
+	@echo "This Makefile is primarily for developers."
 	@echo "Please consult the files in the doc directory."
 
 all: z80asm cpmtools libs bioses misc machines

--- a/cpmsim/srccpm2/Makefile
+++ b/cpmsim/srccpm2/Makefile
@@ -16,3 +16,7 @@ boot.bin: boot.asm
 
 clean:
 	rm -f *.lis bios.bin boot.bin putsys putsys.exe
+
+allclean: clean
+
+.PHONY: all clean allclean

--- a/cpmsim/srccpm3/Makefile
+++ b/cpmsim/srccpm3/Makefile
@@ -13,3 +13,7 @@ boot.bin: boot.asm
 
 clean:
 	rm -f *.lis putsys boot.bin
+
+allclean: clean
+
+.PHONY: all clean allclean

--- a/cpmsim/srcmpm/Makefile
+++ b/cpmsim/srcmpm/Makefile
@@ -13,3 +13,7 @@ boot.bin: boot.asm
 
 clean:
 	rm -f *.lis putsys boot.bin
+
+allclean: clean
+
+.PHONY: all clean allclean

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -2,47 +2,6 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2022 by Udo Munk
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 some improvements here and there
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 20-JUL-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/cpmsim/srcsim/simctl.c
+++ b/cpmsim/srcsim/simctl.c
@@ -2,47 +2,6 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2022 by Udo Munk
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 some improvements here and there
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 20-JUL-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 #include <unistd.h>

--- a/cpmsim/srctools/Makefile
+++ b/cpmsim/srctools/Makefile
@@ -1,8 +1,8 @@
 #
 # some places where the tools usually are installed
 #
-INSTALLDIR=${HOME}/bin
-#INSTALLDIR=/usr/local/bin
+DESTDIR=${HOME}/bin
+#DESTDIR=/usr/local/bin
 
 CWARNS= -Wall -Wextra -Wwrite-strings
 CFLAGS= -O3 $(CWARNS)
@@ -14,7 +14,7 @@ all: test mkdskimg bin2hex cpmsend cpmrecv ptp2bin
 	@echo
 
 test:
-	@test -d ${INSTALLDIR} || (echo "${INSTALLDIR} doesn't exist, fix INSTALLDIR"; exit 1)
+	@test -d ${DESTDIR} || (echo "${DESTDIR} doesn't exist, fix DESTDIR"; exit 1)
 
 mkdskimg: mkdskimg.c
 	$(CC) $(CFLAGS) -o mkdskimg mkdskimg.c
@@ -31,17 +31,21 @@ cpmrecv: cpmrecv.c
 ptp2bin: ptp2bin.c
 	$(CC) $(CFLAGS) -o ptp2bin ptp2bin.c
 
-install:
-	cp mkdskimg ${INSTALLDIR}
-	cp bin2hex ${INSTALLDIR}
-	cp cpmsend ${INSTALLDIR}
-	cp cpmrecv ${INSTALLDIR}
-	cp ptp2bin ${INSTALLDIR}
+install: all
+	cp mkdskimg ${DESTDIR}
+	cp bin2hex ${DESTDIR}
+	cp cpmsend ${DESTDIR}
+	cp cpmrecv ${DESTDIR}
+	cp ptp2bin ${DESTDIR}
 	@echo
-	@echo "Tools installed in ${INSTALLDIR}, make sure it is"
+	@echo "Tools installed in ${DESTDIR}, make sure it is"
 	@echo "included in the systems search PATH"
 	@echo
 
 clean:
 	rm -f mkdskimg mkdskimg.exe bin2hex bin2hex.exe cpmrecv cpmrecv.exe \
 	cpmsend cpmsend.exe ptp2bin ptp2bin.exe
+
+allclean: clean
+
+.PHONY: all test install clean allclean

--- a/cpmsim/srcucsd-iv/Makefile
+++ b/cpmsim/srcucsd-iv/Makefile
@@ -16,3 +16,7 @@ putsys: putsys.c
 
 clean:
 	rm -f *.lis *.bin putsys putsys.exe
+
+allclean: clean
+
+.PHONY: all clean allclean

--- a/imsaisim/srcucsd-iv/Makefile
+++ b/imsaisim/srcucsd-iv/Makefile
@@ -16,3 +16,7 @@ putsys: putsys.c
 
 clean:
 	rm -f *.lis *.bin putsys putsys.exe
+
+allclean: clean
+
+.PHONY: all clean allclean

--- a/webfrontend/civetweb/Makefile
+++ b/webfrontend/civetweb/Makefile
@@ -331,6 +331,8 @@ clean:
 	$(RMRF) $(CPROG)
 	$(RMF) $(UNIT_TEST_PROG)
 
+allclean: clean
+
 distclean: clean
 	@$(RMRF) VS2012/Debug VS2012/*/Debug  VS2012/*/*/Debug
 	@$(RMRF) VS2012/Release VS2012/*/Release  VS2012/*/*/Release
@@ -384,5 +386,5 @@ $(BUILD_RESOURCES) : $(WINDOWS_RESOURCES)
 indent:
 	astyle --suffix=none --style=linux --indent=spaces=4 --lineend=linux  include/*.h src/*.c src/*.cpp src/*.inl examples/*/*.c  examples/*/*.cpp
 
-.PHONY: all help build install clean lib so
+.PHONY: default all help build unit_test install install-headers install-lib install-slib lib slib clean distclean allclean indent
 

--- a/z80asm/HISTORY
+++ b/z80asm/HISTORY
@@ -1,0 +1,16 @@
+17-SEP-1987 Development under Digital Research CP/M 2.2
+28-JUN-1988 Switched to Unix System V.3
+22-OCT-2006 changed to ANSI C for modern POSIX OS's
+03-FEB-2007 more ANSI C conformance and reduced compiler warnings
+18-MAR-2007 use default output file extension dependent on format
+04-OCT-2008 fixed comment bug, ';' string argument now working
+22-FEB-2014 fixed is...() compiler warnings
+13-JAN-2016 fixed buffer overflow, new expression parser from Didier
+02-OCT-2017 bug fixes in expression parser from Didier
+28-OCT-2017 added variable symbol length and other improvements
+15-MAY-2018 mark unreferenced symbols in listing
+30-JUL-2021 fix verbose option
+28-JAN-2022 added syntax check for OUT (n),A
+24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
+04-OCT-2022 new expression parser (TE)
+25-OCT-2022 Intel-like macros (TE)

--- a/z80asm/Makefile
+++ b/z80asm/Makefile
@@ -58,6 +58,10 @@ z80aglb.o: z80aglb.c z80a.h
 clean:
 	rm -f core *.o z80asm
 
+allclean: clean
+
 install: z80asm
 	strip z80asm
 	cp z80asm ${DESTDIR}
+
+.PHONY: clean allclean install

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	21-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*
@@ -33,9 +15,10 @@
 /*
  *	various constants
  */
-#define REL		"1.11-dev"
-#define COPYR		"Copyright (C) 1987-2022 by Udo Munk" \
-			" & 2022 by Thomas Eberhardt"
+#define COPYR		"Copyright (C) 1987-2024 by Udo Munk" \
+			" & 2022-2024 by Thomas Eberhardt"
+#define RELEASE		"2.0-dev"
+
 #define SRCEXT		".asm"	/* filename extension source */
 #define OBJEXTBIN	".bin"	/* filename extension object */
 #define OBJEXTHEX	".hex"	/* filename extension HEX */

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	21-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	21-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	21-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*
@@ -90,7 +72,7 @@ int main(int argc, char *argv[])
 	init();
 	options(argc, argv);
 	instrset(i8080_flag ? INSTR_8080 : INSTR_Z80);
-	printf("Z80 - Macro - Assembler Release %s\n%s\n", REL, COPYR);
+	printf("Z80/8080-Macro-Assembler  Release %s\n%s\n", RELEASE, COPYR);
 	do_pass(1);
 	do_pass(2);
 	if (list_flag) {

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -1,9 +1,6 @@
 /*
- *	Z80 - Macro - Assembler - Intel-like macro implementation
+ *	Z80/8080-Macro-Assembler - Intel-like macro implementation
  *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	21-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	21-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2024 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	21-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*
@@ -125,7 +107,7 @@ void lst_header(void)
 		fputc('\f', lstfp);
 	if (!header_done || ppl != 0)
 		fprintf(lstfp, "Z80/8080-Macro-Assembler  Release %s\t%.24s",
-			REL, ctime(&tloc));
+			RELEASE, ctime(&tloc));
 	if (ppl != 0) {
 		fprintf(lstfp, "\tPage %d\n", ++page);
 		fprintf(lstfp, "Source file: %s\n", srcfn);

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	22-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	22-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -1,25 +1,7 @@
 /*
- *	Z80 - Macro - Assembler
+ *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
  *	Copyright (C) 2022 by Thomas Eberhardt
- *
- *	History:
- *	17-SEP-1987 Development under Digital Research CP/M 2.2
- *	28-JUN-1988 Switched to Unix System V.3
- *	22-OCT-2006 changed to ANSI C for modern POSIX OS's
- *	03-FEB-2007 more ANSI C conformance and reduced compiler warnings
- *	18-MAR-2007 use default output file extension dependent on format
- *	04-OCT-2008 fixed comment bug, ';' string argument now working
- *	22-FEB-2014 fixed is...() compiler warnings
- *	13-JAN-2016 fixed buffer overflow, new expression parser from Didier
- *	02-OCT-2017 bug fixes in expression parser from Didier
- *	28-OCT-2017 added variable symbol length and other improvements
- *	15-MAY-2018 mark unreferenced symbols in listing
- *	30-JUL-2021 fix verbose option
- *	28-JAN-2022 added syntax check for OUT (n),A
- *	24-SEP-2022 added undocumented Z80 instructions and 8080 mode (TE)
- *	04-OCT-2022 new expression parser (TE)
- *	25-OCT-2022 Intel-like macros (TE)
  */
 
 /*

--- a/z80core/sim0.c
+++ b/z80core/sim0.c
@@ -4,47 +4,6 @@
  * Copyright (C) 1987-2022 Udo Munk
  * Copyright (C) 2021 David McNaughton
  * Copyright (C) 2022 Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -2,47 +2,6 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2024 by Udo Munk
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 #include <unistd.h>

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -2,47 +2,6 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2024 by Udo Munk
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 #include <unistd.h>

--- a/z80core/sim2.c
+++ b/z80core/sim2.c
@@ -3,47 +3,6 @@
  *
  * Copyright (C) 1987-2021 by Udo Munk
  * Copyright (C) 2022 by Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -3,47 +3,6 @@
  *
  * Copyright (C) 1987-2021 by Udo Munk
  * Copyright (C) 2022 by Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/sim4.c
+++ b/z80core/sim4.c
@@ -3,47 +3,6 @@
  *
  * Copyright (C) 1987-2021 by Udo Munk
  * Copyright (C) 2022 by Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -3,47 +3,6 @@
  *
  * Copyright (C) 1987-2021 by Udo Munk
  * Copyright (C) 2022 by Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/sim6.c
+++ b/z80core/sim6.c
@@ -3,47 +3,6 @@
  *
  * Copyright (C) 1987-2021 by Udo Munk
  * Copyright (C) 2022 by Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/sim7.c
+++ b/z80core/sim7.c
@@ -3,47 +3,6 @@
  *
  * Copyright (C) 1987-2021 by Udo Munk
  * Copyright (C) 2022 by Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -2,47 +2,6 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2022 by Udo Munk
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory managemment, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 #define COPYR	"Copyright (C) 1987-2022 by Udo Munk"

--- a/z80core/simdis.c
+++ b/z80core/simdis.c
@@ -5,47 +5,6 @@
  * Parts Copyright (C) 2008 by Justin Clancy
  * 8080 disassembler Copyright (C) 2018 by Christophe Staiesse
  * Copyright (c) 2022 by Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -3,47 +3,6 @@
  *
  * Copyright (C) 1987-2021 Udo Munk
  * Copyright (C) 2021 David McNaughton
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -4,47 +4,6 @@
  * Copyright (C) 1987-2021 Udo Munk
  * Copyright (C) 2021 David McNaughton
  * Copyright (C) 2022 Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -4,47 +4,6 @@
  * Copyright (C) 1987-2021 Udo Munk
  * Copyright (C) 2021 David McNaughton
  * Copyright (C) 2022 Thomas Eberhardt
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -2,47 +2,6 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2022 by Udo Munk
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80core/simint.c
+++ b/z80core/simint.c
@@ -2,47 +2,6 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80sim/Makefile
+++ b/z80sim/Makefile
@@ -14,3 +14,7 @@ z80opsall.hex: z80opsall.asm
 
 clean:
 	rm -f *.hex *.lis
+
+allclean: clean
+
+.PHONY: all clean allclean

--- a/z80sim/srcsim/iosim.c
+++ b/z80sim/srcsim/iosim.c
@@ -5,47 +5,6 @@
  *
  * This module of the simulator contains a simple terminal I/O
  * simulation as an example.
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -4,47 +4,6 @@
  * Copyright (C) 1987-2022 by Udo Munk
  *
  * This is the configuration I'm using for software testing and debugging
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory managemment, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -5,47 +5,6 @@
  *
  * With this configuration the simulated CPU runs with the
  * highest possible speed
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory managemment, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 /*

--- a/z80sim/srcsim/simctl.c
+++ b/z80sim/srcsim/simctl.c
@@ -5,47 +5,6 @@
  *
  * This module contains the user interface for the Z80-CPU simulation,
  * here we just call the ICE.
- *
- * History:
- * 28-SEP-87 Development on TARGON/35 with AT&T Unix System V.3
- * 11-JAN-89 Release 1.1
- * 08-FEB-89 Release 1.2
- * 13-MAR-89 Release 1.3
- * 09-FEB-90 Release 1.4  Ported to TARGON/31 M10/30
- * 20-DEC-90 Release 1.5  Ported to COHERENT 3.0
- * 10-JUN-92 Release 1.6  long casting problem solved with COHERENT 3.2
- *			  and some optimisation
- * 25-JUN-92 Release 1.7  comments in english and ported to COHERENT 4.0
- * 02-OCT-06 Release 1.8  modified to compile on modern POSIX OS's
- * 18-NOV-06 Release 1.9  modified to work with CP/M sources
- * 08-DEC-06 Release 1.10 modified MMU for working with CP/NET
- * 17-DEC-06 Release 1.11 TCP/IP sockets for CP/NET
- * 25-DEC-06 Release 1.12 CPU speed option
- * 19-FEB-07 Release 1.13 various improvements
- * 06-OCT-07 Release 1.14 bug fixes and improvements
- * 06-AUG-08 Release 1.15 many improvements and Windows support via Cygwin
- * 25-AUG-08 Release 1.16 console status I/O loop detection and line discipline
- * 20-OCT-08 Release 1.17 frontpanel integrated and Altair/IMSAI emulations
- * 24-JAN-14 Release 1.18 bug fixes and improvements
- * 02-MAR-14 Release 1.19 source cleanup and improvements
- * 14-MAR-14 Release 1.20 added Tarbell SD FDC and printer port to Altair
- * 29-MAR-14 Release 1.21 many improvements
- * 29-MAY-14 Release 1.22 improved networking and bugfixes
- * 04-JUN-14 Release 1.23 added 8080 emulation
- * 06-SEP-14 Release 1.24 bugfixes and improvements
- * 18-FEB-15 Release 1.25 bugfixes, improvements, added Cromemco Z-1
- * 18-APR-15 Release 1.26 bugfixes and improvements
- * 18-JAN-16 Release 1.27 bugfixes and improvements
- * 05-MAY-16 Release 1.28 improved usability
- * 20-NOV-16 Release 1.29 bugfixes and improvements
- * 15-DEC-16 Release 1.30 improved memory management, machine cycle correct CPUs
- * 28-DEC-16 Release 1.31 improved memory management, reimplemented MMUs
- * 12-JAN-17 Release 1.32 improved configurations, front panel, added IMSAI VIO
- * 07-FEB-17 Release 1.33 bugfixes, improvements, better front panels
- * 16-MAR-17 Release 1.34 improvements, added ProcTec VDM-1
- * 03-AUG-17 Release 1.35 added UNIX sockets, bugfixes, improvements
- * 21-DEC-17 Release 1.36 bugfixes and improvements
- * 06-JAN-21 Release 1.37 bugfixes and improvements
  */
 
 #include <unistd.h>


### PR DESCRIPTION
Hi, I've made some changes to hopefully make releasing easier,. Version numbers are now only in:
z80asm/z80a.h, z80core/simcore.h and HISTORY.

I've noticed that https://www.autometer.de/unix4fun is gone, do you have a new website?

z80asm:
1. Bump major version because of 8080 mode, new expression parser and macros.
2. Rename REL to RELEASE to be consistent with z80core.
3. Move assembler global history to a separate HISTORY file.
4. Change assembler name like 4d9ff517d7911098389ecf9d1555672c6574f6a0.

all:
1. Move global history to a new HISTORY file to simplify releasing.
2. Add allclean and .PHONY to all make files for consistency.
3. Change INSTALLDIR to DESTDIR in cpmsim/srctools/Makefile for consistency.
4. Add global Makefile to easily build/clean everything and reassemble all ROMs and assembler programs.
