### PR TITLE
Work

### DIFF
--- a/frontpanel/lp_utils.cpp
+++ b/frontpanel/lp_utils.cpp
@@ -518,7 +518,7 @@ int xpand(const char *s, char **namelist[] )
 
     ival = from_ival;
 
-    sprintf(format, "%%0%dd",ndigits);
+    snprintf(format, sizeof(format), "%%0%dd",ndigits);
 
    max_names = ( (max(ival, to_ival)) - (min(ival,to_ival))) / abs(inc_ival) + 1;
 
@@ -529,7 +529,7 @@ int xpand(const char *s, char **namelist[] )
    do
     {
      obuf[0]=0;
-     sprintf(dbuf,format,ival);
+     snprintf(dbuf,sizeof(dbuf),format,ival);
      if(prefix) strcpy(obuf,prefix);
      strcat(obuf,dbuf);
      if(suffix) strcat(obuf,suffix);
@@ -540,7 +540,7 @@ int xpand(const char *s, char **namelist[] )
      ival += inc_ival;
     } while (ival != to_ival);
 
-     sprintf(dbuf,format,ival);
+     snprintf(dbuf,sizeof(dbuf),format,ival);
      obuf[0]=0;
      if(prefix) strcpy(obuf,prefix);
      strcat(obuf,dbuf);

--- a/frontpanel/lp_window.cpp
+++ b/frontpanel/lp_window.cpp
@@ -988,7 +988,7 @@ Lpanel::draw_stats(void)
   glDisable(GL_DEPTH_TEST);
 
   glColor3f(1.,1.,0.);
-  sprintf(perf_txt,"fps:%d sps:%d",frames_per_second, samples_per_second);
+  snprintf(perf_txt,sizeof(perf_txt),"fps:%d sps:%d",frames_per_second, samples_per_second);
   printStringAt(perf_txt, bbox.xyz_min[0] + .2, bbox.xyz_min[1] + .2);
 
   glMatrixMode(GL_PROJECTION);
@@ -1050,6 +1050,6 @@ Lpanel::make_cursor_text(void)
 {
  cursor_textpos[0] = (bbox.xyz_max[0] + bbox.xyz_min[0]) * .5;
  cursor_textpos[1] = bbox.xyz_min[1] + .1;
- sprintf(cursor_txt,"cursor position=%7.3f,%7.3f", cursor[0], cursor[1]);
+ snprintf(cursor_txt,sizeof(cursor_txt),"cursor position=%7.3f,%7.3f", cursor[0], cursor[1]);
 }
 

--- a/webfrontend/civetweb/src/md5.inl
+++ b/webfrontend/civetweb/src/md5.inl
@@ -131,6 +131,7 @@ MD5_STATIC void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
  */
 
 #if !defined(MD5_STATIC)
+#include <stdint.h>
 #include <string.h>
 #endif
 
@@ -239,7 +240,7 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 			 * On little-endian machines, we can process properly aligned
 			 * data without copying it.
 			 */
-			if (!((data - (const md5_byte_t *)0) & 3)) {
+			if (!(((uintptr_t)data) & 3)) {
 				/* data are properly aligned, a direct assignment is possible */
 				/* cast through a (void *) should avoid a compiler warning,
 				   see


### PR DESCRIPTION
Change sprintf(3) usage in frontpanel to snprintf(3) to silence Apple clang security warnings.
Apply upstream commit to civetweb to silence undefined pointer difference warning.