### PR TITLE
Cleanup and some fixes

### DIFF
--- a/altairsim/srcsim/iosim.c
+++ b/altairsim/srcsim/iosim.c
@@ -842,7 +842,7 @@ static void hwctl_out(BYTE data)
 
 	if (data & 1) {
 		newact.sa_handler = int_timer;
-		memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+		sigemptyset(&newact.sa_mask);
 		newact.sa_flags = 0;
 		sigaction(SIGALRM, &newact, NULL);
 		tim.it_value.tv_sec = 0;
@@ -852,7 +852,7 @@ static void hwctl_out(BYTE data)
 		setitimer(ITIMER_REAL, &tim, NULL);
 	} else {
 		newact.sa_handler = SIG_IGN;
-		memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+		sigemptyset(&newact.sa_mask);
 		newact.sa_flags = 0;
 		sigaction(SIGALRM, &newact, NULL);
 		tim.it_value.tv_sec = 0;

--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -91,7 +91,7 @@ void mon(void)
 
 	if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
 		LOGE(TAG, "frontpanel error");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	fp_addQuitCallback(quit_callback);

--- a/cpmsim/srccpm2/putsys.c
+++ b/cpmsim/srccpm2/putsys.c
@@ -36,21 +36,21 @@ int main(void)
 	/* open drive A for writing */
 	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
 		perror("file ../disks/drivea.dsk");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
 		perror("file boot.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read and check 3 byte header */
 	if (read(fd, (char *) header, 3) != 3) {
 		perror("file boot.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if (header[0] != 0xff || header[1] != 0 || header[2] != 0) {
 		puts("start address of boot.bin <> 0");
-		exit(0);
+		exit(EXIT_SUCCESS);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
@@ -61,7 +61,7 @@ int main(void)
 	/* open CP/M system file (cpm.bin) for reading */
 	if ((fd = open("cpm.bin", O_RDONLY)) == -1) {
 		perror("file cpm.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* position to CCP in cpm.bin, needed if created with SAVE or similar */
 	lseek(fd, (long) 17 * 128, SEEK_SET);
@@ -69,7 +69,7 @@ int main(void)
 	for (i = 0; i < 44; i++) {
 		if (read(fd, (char *) sector, 128) != 128) {
 			perror("file cpm.bin");
-			exit(1);
+			exit(EXIT_FAILURE);
 		}
 		write(drivea, (char *) sector, 128);
 	}
@@ -77,16 +77,16 @@ int main(void)
 	/* open BIOS (bios.bin) for reading */
 	if ((fd = open("bios.bin", O_RDONLY)) == -1) {
 		perror("file bios.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read and check 3 byte header */
 	if (read(fd, (char *) header, 3) != 3) {
 		perror("file bios.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if (header[0] != 0xff) {
 		puts("unknown format of bios.bin");
-		exit(0);
+		exit(EXIT_SUCCESS);
 	}
 	/* read BIOS from bios.bin and write it to disk in drive A */
 	i = 0;
@@ -104,5 +104,5 @@ int main(void)
 stop:
 	close(fd);
 	close(drivea);
-	return(0);
+	return(EXIT_SUCCESS);
 }

--- a/cpmsim/srccpm3/putsys.c
+++ b/cpmsim/srccpm3/putsys.c
@@ -34,12 +34,12 @@ int main(void)
 	/* open drive A for writing */
 	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
 		perror("file ../disks/drivea.dsk");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
 		perror("file boot.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
@@ -50,7 +50,7 @@ int main(void)
 	/* open CP/M 3 cpmldr file (cpmldr.bin) for reading */
 	if ((fd = open("cpmldr.bin", O_RDONLY)) == -1) {
 		perror("file cpmldr.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read from cpmldr.bin and write to disk in drive A */
 	while (read(fd, (char *) sector, 128) == 128)
@@ -62,7 +62,7 @@ int main(void)
 	/* open CP/M 3 ccp file (ccp.bin) for reading */
 	if ((fd = open("ccp.bin", O_RDONLY)) == -1) {
 		perror("file ccp.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read from ccp.bin and write to disk in drive A */
 	while (read(fd, (char *) sector, 128) == 128)
@@ -70,5 +70,5 @@ int main(void)
 	write(drivea, (char *) sector, 128);
 	close(fd);
 	close(drivea);
-	return(0);
+	return(EXIT_SUCCESS);
 }

--- a/cpmsim/srcmpm/putsys.c
+++ b/cpmsim/srcmpm/putsys.c
@@ -29,12 +29,12 @@ int main(void)
 	/* open drive A for writing */
 	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
 		perror("file ../disks/drivea.dsk");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
 		perror("file boot.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
@@ -45,7 +45,7 @@ int main(void)
 	/* open MP/M 2 mpmldr file (mpmldr.bin) for reading */
 	if ((fd = open("mpmldr.bin", O_RDONLY)) == -1) {
 		perror("file mpmldr.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read from mpmldr.bin and write to disk in drive A */
 	while (read(fd, (char *) sector, 128) == 128)
@@ -53,5 +53,5 @@ int main(void)
 	write(drivea, (char *) sector, 128);
 	close(fd);
 	close(drivea);
-	return(0);
+	return(EXIT_SUCCESS);
 }

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -904,7 +904,7 @@ void init_io(void)
 
 #ifdef TCPASYNC
 	newact.sa_handler = int_io;
-	memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+	sigemptyset(&newact.sa_mask);
 	newact.sa_flags = 0;
 	sigaction(SIGIO, &newact, NULL);
 #endif
@@ -2396,7 +2396,7 @@ static void time_out(BYTE data)
 	if (data == 1) {
 		timer = 1;
 		newact.sa_handler = int_timer;
-		memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+		sigemptyset(&newact.sa_mask);
 		newact.sa_flags = 0;
 		sigaction(SIGALRM, &newact, NULL);
 		tim.it_value.tv_sec = 0;
@@ -2407,7 +2407,7 @@ static void time_out(BYTE data)
 	} else {
 		timer = 0;
 		newact.sa_handler = SIG_IGN;
-		memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+		sigemptyset(&newact.sa_mask);
 		newact.sa_flags = 0;
 		sigaction(SIGALRM, &newact, NULL);
 		tim.it_value.tv_sec = 0;

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -873,7 +873,7 @@ void init_io(void)
 	switch (pid_rec) {
 	case -1:
 		LOGE(TAG, "can't fork");
-		exit(1);
+		exit(EXIT_FAILURE);
 	case 0:
 		/* . might not be in path, so check that first */
 		if (access("./cpmrecv", X_OK) == 0)
@@ -886,15 +886,15 @@ void init_io(void)
 		/* if not cry and die */
 		LOGE(TAG, "can't exec cpmrecv process, compile/install the tools dude");
 		kill(0, SIGQUIT);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if ((auxin = open("/tmp/.z80pack/cpmsim.auxin", O_RDONLY | O_NDELAY)) == -1) {
 		LOGE(TAG, "can't open pipe auxin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if ((auxout = open("/tmp/.z80pack/cpmsim.auxout", O_WRONLY)) == -1) {
 		LOGE(TAG, "can't open pipe auxout");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 #endif
 
@@ -930,19 +930,19 @@ static void init_server_socket(int n)
 		return;
 	if ((ss[n] = socket(PF_INET, SOCK_STREAM, 0)) == -1) {
 		LOGE(TAG, "can't create server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if (setsockopt(ss[n], SOL_SOCKET, SO_REUSEADDR, (void *) &on,
 	    sizeof(on)) == -1) {
 		LOGE(TAG, "can't setsockopt SO_REUSEADDR on server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 #ifdef TCPASYNC
 	fcntl(ss[n], F_SETOWN, getpid());
 	i = fcntl(ss[n], F_GETFL, 0);
 	if (fcntl(ss[n], F_SETFL, i | FASYNC) == -1) {
 		LOGE(TAG, "can't fcntl FASYNC on server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 #endif
 	memset((void *) &sin, 0, sizeof(sin));
@@ -951,11 +951,11 @@ static void init_server_socket(int n)
 	sin.sin_port = htons(ss_port[n]);
 	if (bind(ss[n], (struct sockaddr *) &sin, sizeof(sin)) == -1) {
 		LOGE(TAG, "can't bind server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if (listen(ss[n], 0) == -1) {
 		LOGE(TAG, "can't listen on server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 }
 

--- a/cpmsim/srcsim/simctl.c
+++ b/cpmsim/srcsim/simctl.c
@@ -30,7 +30,7 @@ void mon(void)
 {
 	/* load boot code into memory */
 	if (boot(0))
-		exit(1);
+		exit(EXIT_FAILURE);
 
 	/* empty buffer for teletype */
 	fflush(stdout);

--- a/cpmsim/srctools/bin2hex.c
+++ b/cpmsim/srctools/bin2hex.c
@@ -62,16 +62,16 @@ int main(int argc,char *argv[])/*Main routine*/
     case 'v':
       printf("%s - BINARY to Intel HEX file convertor version 1.00\n"\
              "(c)BCL Vysoke Myto 2001 (benedikt@lphard.cz)\n",argv[0]);
-      return 0;
+      return EXIT_SUCCESS;
     case '?':
       help (argv[0]);
-      return 1;
+      return EXIT_FAILURE;
   }
 
   if ((argc - optind) != 2) {
     printf("ERROR: Missing input/output file.\n");
     help(argv[0]);
-    return 1;
+    return EXIT_FAILURE;
   }
   ifile = argv[optind];
   ofile = argv[optind+1];
@@ -79,19 +79,19 @@ int main(int argc,char *argv[])/*Main routine*/
   /*Open file check*/
   if((inp = fopen(ifile, "rb")) == NULL){
     printf("ERROR: Cannot open input file.\n");
-    return 1;
+    return EXIT_FAILURE;
   }
   fseek (inp, foffset, SEEK_SET);
 
   if (append == 0) {
     if((outp = fopen(ofile, "wt")) == NULL){
       printf("ERROR: Cannot open output file.\n");
-      return 1;
+      return EXIT_FAILURE;
     }
   } else {
     if((outp = fopen(ofile, "at")) == NULL){
       printf("ERROR: Cannot re-open output file.\n");
-      return 1;
+      return EXIT_FAILURE;
     }
     fseek (outp, 0, SEEK_END);
   }
@@ -157,5 +157,5 @@ int main(int argc,char *argv[])/*Main routine*/
 
   fclose(inp);
   fclose(outp);
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/cpmsim/srctools/cpmrecv.c
+++ b/cpmsim/srctools/cpmrecv.c
@@ -31,11 +31,11 @@ int main(int argc, char *argv[])
 
 	if (argc != 2) {
 		puts("usage: cpmrecv filename &");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if ((fdin = open("/tmp/.z80pack/cpmsim.auxout", O_RDONLY)) == -1) {
 		perror("pipe auxout");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	signal(SIGINT, SIG_IGN);
@@ -48,18 +48,18 @@ int main(int argc, char *argv[])
 				if (fdout == 0) {
 				  if ((fdout = creat(argv[1], 0644)) == -1) {
 					perror(argv[1]);
-					exit(1);
+					exit(EXIT_FAILURE);
 				  }
 				}
 				write(fdout, &c, 1);
 			}
 		} else {
 			close(fdout);
-			return(0);
+			return(EXIT_SUCCESS);
 		}
 	}
 
-	return(0);
+	return(EXIT_SUCCESS);
 }
 
 void int_handler(int sig)
@@ -68,5 +68,5 @@ void int_handler(int sig)
 
 	close(fdin);
 	close(fdout);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/cpmsim/srctools/cpmsend.c
+++ b/cpmsim/srctools/cpmsend.c
@@ -28,15 +28,15 @@ int main(int argc,char *argv[])
 
 	if (argc != 2) {
 		puts("usage: cpmsend filename &");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if ((fdin = open(argv[1], O_RDONLY)) == -1) {
 		perror(argv[1]);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if ((fdout = open("/tmp/.z80pack/cpmsim.auxin", O_WRONLY)) == -1) {
 		perror("pipe auxin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	while ((readn = read(fdin, buf, BUFSIZ)) == BUFSIZ)
 		sendbuf(BUFSIZ);
@@ -44,7 +44,7 @@ int main(int argc,char *argv[])
 		sendbuf(readn);
 	close(fdin);
 	close(fdout);
-	return(0);
+	return(EXIT_SUCCESS);
 }
 
 void sendbuf(int size)

--- a/cpmsim/srctools/mkdskimg.c
+++ b/cpmsim/srctools/mkdskimg.c
@@ -54,14 +54,14 @@ int main(int argc, char *argv[])
 
 	if (argc != 2) {
 		puts(usage);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	i = *argv[1];
 	if (argc != 2 ||
 	    (i != 'a' && i != 'b' && i != 'c' && i != 'd' && i != 'i'
 	     && i != 'j' && i != 'p')) {
 		puts(usage);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	dn[5] = drive = (char) i;
 	if (stat(ddir, &sb) == 0 && S_ISDIR(sb.st_mode)) {
@@ -74,11 +74,11 @@ int main(int argc, char *argv[])
 	memset((char *) sector, 0xe5, 128);
 	if (open(fn, O_RDONLY) != -1) {
 		printf("disk file %s exists, aborting\n", fn);
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if ((fd = creat(fn, 0644)) == -1) {
 		perror("disk file");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if (drive <= 'd') {
 		for (i = 0; i < TRACK * SECTOR; i++)
@@ -91,5 +91,5 @@ int main(int argc, char *argv[])
 			write(fd, (char *) sector, 128);
 	}
 	close(fd);
-	return(0);
+	return(EXIT_SUCCESS);
 }

--- a/cpmsim/srctools/ptp2bin.c
+++ b/cpmsim/srctools/ptp2bin.c
@@ -23,17 +23,17 @@ int main(int argc, char *argv[])
 
 	if (argc != 3) {
 		printf("usage: %s infile outfile\n", pn);
-		return(1);
+		return(EXIT_FAILURE);
 	}
 
 	if ((fdin = open(argv[1], O_RDONLY)) == -1) {
 		perror(argv[1]);
-		return(1);
+		return(EXIT_FAILURE);
 	}
 
 	if ((fdout = open(argv[2], O_WRONLY|O_CREAT, 0644)) == -1) {
 		perror(argv[2]);
-		return(1);
+		return(EXIT_FAILURE);
 	}
 
 	while (read(fdin, &c, 1) == 1) {
@@ -49,5 +49,5 @@ int main(int argc, char *argv[])
 	close(fdin);
 	close(fdout);
 
-	return(0);
+	return(EXIT_SUCCESS);
 }

--- a/cpmsim/srcucsd-iv/putsys.c
+++ b/cpmsim/srcucsd-iv/putsys.c
@@ -30,12 +30,12 @@ int main(void)
 	/* open drive A for writing */
 	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
 		perror("file ../disks/drivea.dsk");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
 		perror("file boot.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
@@ -48,7 +48,7 @@ int main(void)
 	/* open BIOS (bios.bin) for reading */
 	if ((fd = open("bios.bin", O_RDONLY)) == -1) {
 		perror("file bios.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read BIOS from bios.bin and write it to disk in drive A */
 	i = 0;
@@ -66,5 +66,5 @@ int main(void)
 stop:
 	close(fd);
 	close(drivea);
-	return(0);
+	return(EXIT_SUCCESS);
 }

--- a/cromemcosim/srcsim/iosim.c
+++ b/cromemcosim/srcsim/iosim.c
@@ -635,7 +635,7 @@ void init_io(void)
 	/* initialise TCP/IP networking */
 #ifdef TCPASYNC
 	newact.sa_handler = sigio_tcp_server_socket;
-	memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+	sigemptyset(&newact.sa_mask);
 	newact.sa_flags = 0;
 	sigaction(SIGIO, &newact, NULL);
 #endif
@@ -672,7 +672,7 @@ void init_io(void)
 #else
 	newact.sa_handler = SIG_IGN;
 #endif
-	memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+	sigemptyset(&newact.sa_mask);
 	newact.sa_flags = 0;
 	sigaction(SIGALRM, &newact, NULL);
 	tim.it_value.tv_sec = 5;
@@ -1272,7 +1272,7 @@ void ice_go(void)
 	set_unix_terminal();
 
 	newact.sa_handler = interrupt;
-	memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+	sigemptyset(&newact.sa_mask);
 	newact.sa_flags = 0;
 	sigaction(SIGALRM, &newact, NULL);
 }
@@ -1285,7 +1285,7 @@ void ice_break(void)
 	static struct sigaction newact;
 
 	newact.sa_handler = SIG_IGN;
-	memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+	sigemptyset(&newact.sa_mask);
 	newact.sa_flags = 0;
 	sigaction(SIGALRM, &newact, NULL);
 

--- a/cromemcosim/srcsim/iosim.c
+++ b/cromemcosim/srcsim/iosim.c
@@ -654,7 +654,7 @@ void init_io(void)
 	/* create the thread for timer and interrupt handling */
 	if (pthread_create(&thread, NULL, timing, (void *) NULL)) {
 		LOGE(TAG, "can't create timing thread");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 #ifdef HAS_MODEM

--- a/cromemcosim/srcsim/memory.c
+++ b/cromemcosim/srcsim/memory.c
@@ -70,7 +70,7 @@ void init_memory(void)
 	for (i = 0; i < MAXSEG; i++) {
 		if ((memory[i] = (BYTE *) malloc(SEGSIZ)) == NULL) {
 			LOGE(TAG, "can't allocate memory for bank %d", i);
-			exit(1);
+			exit(EXIT_FAILURE);
 		}
 	}
 

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -89,7 +89,7 @@ void mon(void)
 
 	if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
 		LOGE(TAG, "frontpanel error");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	fp_addQuitCallback(quit_callback);

--- a/frontpanel/lp_window.cpp
+++ b/frontpanel/lp_window.cpp
@@ -179,7 +179,7 @@ Lpanel::WndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
 		switch (kcode) 
 		{
 		  case VK_ESCAPE:
-			//exit(0);
+			//exit(EXIT_SUCCESS);
 			break;
 		  case 'c':
 		  case 'C':
@@ -323,7 +323,7 @@ Lpanel::WndProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
 			   if(quit_callbackfunc) 
 				(*quit_callbackfunc)();
 			   else
-				  exit(0);
+				  exit(EXIT_SUCCESS);
 			return 0;  
 		   break;
 
@@ -386,7 +386,7 @@ MSG msg;
 		    }
 		   else
 		    { XCloseDisplay(dpy);
-		      exit(0);
+		      exit(EXIT_SUCCESS);
 		    }
 		 }
 		break;
@@ -439,7 +439,7 @@ MSG msg;
 		switch (key) 
 		{
 		  case XK_Escape:
-			//exit(0);
+			//exit(EXIT_SUCCESS);
 			break;
 		  case XK_Shift_L:
 		  case XK_Shift_R:

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -936,7 +936,7 @@ static void hwctl_out(BYTE data)
 
         if (data & 1) {
 		newact.sa_handler = int_timer;
-		memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+		sigemptyset(&newact.sa_mask);
 		newact.sa_flags = 0;
 		sigaction(SIGALRM, &newact, NULL);
 		tim.it_value.tv_sec = 0;
@@ -946,7 +946,7 @@ static void hwctl_out(BYTE data)
 		setitimer(ITIMER_REAL, &tim, NULL);
 	} else {
 		newact.sa_handler = SIG_IGN;
-		memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+		sigemptyset(&newact.sa_mask);
 		newact.sa_flags = 0;
 		sigaction(SIGALRM, &newact, NULL);
 		tim.it_value.tv_sec = 0;

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -92,7 +92,7 @@ void mon(void)
 	putchar('\n');
 	if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
 		LOGE(TAG, "frontpanel error");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	fp_addQuitCallback(quit_callback);

--- a/imsaisim/srcucsd-iv/putsys.c
+++ b/imsaisim/srcucsd-iv/putsys.c
@@ -30,12 +30,12 @@ int main(void)
 	/* open drive A for writing */
 	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
 		perror("file ../disks/drivea.dsk");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
 		perror("file boot.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
@@ -48,7 +48,7 @@ int main(void)
 	/* open BIOS (bios.bin) for reading */
 	if ((fd = open("bios.bin", O_RDONLY)) == -1) {
 		perror("file bios.bin");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	/* read BIOS from bios.bin and write it to disk in drive A */
 	i = 0;
@@ -66,5 +66,5 @@ int main(void)
 stop:
 	close(fd);
 	close(drivea);
-	return(0);
+	return(EXIT_SUCCESS);
 }

--- a/iodevices/altair-88-dcdd.c
+++ b/iodevices/altair-88-dcdd.c
@@ -230,7 +230,7 @@ void altair_dsk_select_out(BYTE data)
 			if (pthread_create(&thread, NULL, timing,
 			    (void *) NULL)) {
 				LOGE(TAG, "can't create timing thread");
-				exit(1);
+				exit(EXIT_FAILURE);
 			}
 		}
 		LOGD(TAG, "enabled, disk = %d", disk);

--- a/iodevices/cromemco-88ccc.c
+++ b/iodevices/cromemco-88ccc.c
@@ -128,7 +128,7 @@ void cromemco_88ccc_ctrl_a_out(BYTE data)
 			if (thread == 0) {
 				if (pthread_create(&thread, NULL, store_image, (void *) NULL)) {
 					LOGE(TAG, "can't create thread");
-					exit(1);
+					exit(EXIT_FAILURE);
 				}
 			} else {
 				LOGW(TAG, "Transfer with 88CCC already in progess.");

--- a/iodevices/cromemco-dazzler.c
+++ b/iodevices/cromemco-dazzler.c
@@ -757,7 +757,7 @@ void cromemco_dazzler_ctl_out(BYTE data)
 			if (pthread_create(&thread, NULL, update_display,
 			    (void *) NULL)) {
 				LOGE(TAG, "can't create thread");
-				exit(1);
+				exit(EXIT_FAILURE);
 			}
 		}
 	} else {

--- a/iodevices/cromemco-hal.c
+++ b/iodevices/cromemco-hal.c
@@ -106,7 +106,7 @@ void stdio_status(int dev, BYTE *stat) {
         *stat |= 2;
     if (p[0].revents & POLLNVAL) {
         LOGE(TAG, "can't use terminal, try 'screen simulation ...'");
-        exit(1);
+        exit(EXIT_FAILURE);
         // cpu_error = IOERROR;
         // cpu_state = STOPPED;
     }

--- a/iodevices/imsai-vio.c
+++ b/iodevices/imsai-vio.c
@@ -514,6 +514,6 @@ void imsai_vio_init(void)
 
 	if (pthread_create(&thread, NULL, update_display, (void *) NULL)) {
 		LOGE(TAG, "can't create thread");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 }

--- a/iodevices/proctec-vdm.c
+++ b/iodevices/proctec-vdm.c
@@ -257,7 +257,7 @@ static void vdm_init(void)
 
 	if (pthread_create(&thread, NULL, update_display, (void *) NULL)) {
 		LOGE(TAG, "can't create thread");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 }
 

--- a/iodevices/unix_network.c
+++ b/iodevices/unix_network.c
@@ -62,15 +62,15 @@ void init_unix_server_socket(struct unix_connectors *p, const char *fn)
 	strncpy(sun.sun_path, socket_path, sizeof(sun.sun_path));
 	if ((p->ss = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
 		LOGE(TAG, "can't create server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if (bind(p->ss, (struct sockaddr *)&sun, sizeof(sun)) == -1) {
 		LOGE(TAG, "can't bind server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if (listen(p->ss, 0) == -1) {
 		LOGE(TAG, "can't listen on server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 }
 
@@ -92,14 +92,14 @@ void init_tcp_server_socket(struct net_connectors *p)
 	/* create TCP/IP socket */
 	if ((p->ss = socket(PF_INET, SOCK_STREAM, 0)) == -1) {
 		LOGE(TAG, "can't create server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	/* set socket options */
 	if (setsockopt(p->ss, SOL_SOCKET, SO_REUSEADDR, (void *) &on,
 	    sizeof(on)) == -1) {
 		LOGE(TAG, "can't setsockopt SO_REUSEADDR on server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 #ifdef TCPASYNC
@@ -108,7 +108,7 @@ void init_tcp_server_socket(struct net_connectors *p)
 	n = fcntl(p->ss, F_GETFL, 0);
 	if (fcntl(p->ss, F_SETFL, n | FASYNC) == -1) {
 		LOGE(TAG, "can't fcntl FASYNC on server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 #endif
 
@@ -119,11 +119,11 @@ void init_tcp_server_socket(struct net_connectors *p)
 	sin.sin_port = htons(p->port);
 	if (bind(p->ss, (struct sockaddr *) &sin, sizeof(sin)) == -1) {
 		LOGE(TAG, "can't bind server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 	if (listen(p->ss, 0) == -1) {
 		LOGE(TAG, "can't listen on server socket");
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	LOG(TAG, "telnet console listening on port %d\r\n", p->port);

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -259,6 +259,15 @@ struct sym {
 #define UNUSED(x)	(void)(x)
 
 /*
+ *	attribute for declaring that a function doesn't return
+ */
+#if __GNUC__ > 2 || __clang__
+#define NORETURN	__attribute__ ((noreturn))
+#else
+#define NORETURN
+#endif
+
+/*
  *	macros for character classification and conversion
  */
 #define IS_FSYM(c)	(ctype[(BYTE) (c)] & C_FSYM)

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -18,7 +18,7 @@
 #include "z80aglb.h"
 
 void init(void), options(int, char *[]);
-void usage(void), fatal(int, const char *);
+void usage(void), fatal(int, const char *) NORETURN;
 void do_pass(int), process_file(char *);
 int process_line(char *);
 void open_o_files(char *);
@@ -264,10 +264,10 @@ void fatal(int i, const char *arg)
 {
 	printf(errmsg[i], arg);
 	putchar('\n');
-	if (objfp != NULL) {
+	if (objfp != NULL)
 		fclose(objfp);
+	if (objfn != NULL)
 		unlink(objfn);
-	}
 	exit(EXIT_FAILURE);
 }
 

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -268,7 +268,7 @@ void fatal(int i, const char *arg)
 		fclose(objfp);
 		unlink(objfn);
 	}
-	exit(1);
+	exit(EXIT_FAILURE);
 }
 
 /*

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -1,6 +1,6 @@
 /*
  *	Z80/8080-Macro-Assembler - Intel-like macro implementation
- *	Copyright (C) 2022 by Thomas Eberhardt
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*
@@ -15,7 +15,7 @@
 #include "z80aglb.h"
 
 /* z80amain.c */
-extern void fatal(int, const char *);
+extern void fatal(int, const char *) NORETURN;
 extern char *strsave(char *);
 extern char *next_arg(char *, int *);
 
@@ -161,7 +161,6 @@ char *mac_first(int sort_mode, int *rp)
 	default:
 		fatal(F_INTERN, "unknown sort mode in mac_first");
 	}
-	return(NULL);		/* silence compiler */
 }
 
 /*
@@ -1036,7 +1035,6 @@ WORD op_mcond(BYTE op_code, BYTE dummy)
 		break;
 	default:
 		fatal(F_INTERN, "invalid opcode for function op_mcond");
-		break;
 	}
 	if (!err) {
 		if ((op_code & 1) == 0)	/* negate for inverse IF */
@@ -1061,7 +1059,6 @@ WORD op_irp(BYTE op_code, BYTE dummy)
 	UNUSED(dummy);
 
 	a_mode = A_NONE;
-	m = NULL;			/* silence compiler */
 	switch(op_code) {
 	case 1:				/* IRP */
 		m = mac_new(NULL, mac_start_irp, mac_rept_irp);
@@ -1071,7 +1068,6 @@ WORD op_irp(BYTE op_code, BYTE dummy)
 		break;
 	default:
 		fatal(F_INTERN, "invalid opcode for function op_irp");
-		break;
 	}
 	s = operand;
 	t = tmp;

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -1,7 +1,7 @@
 /*
  *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (C) 2022 by Thomas Eberhardt
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*
@@ -17,7 +17,7 @@
 int opccmp(const void *, const void *);
 
 /* z80amain.c */
-extern void fatal(int, const char *);
+extern void fatal(int, const char *) NORETURN;
 
 /* z80amfun.c */
 extern WORD op_endm(BYTE, BYTE), op_exitm(BYTE, BYTE), op_irp(BYTE, BYTE);
@@ -366,7 +366,6 @@ void instrset(int is)
 	struct opc *opc;
 	int nopc;
 
-	nopc = 0;		/* silence compiler */
 	if (is == curr_instrset)
 		return;
 	switch (is) {

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -25,7 +25,7 @@ BYTE chksum(BYTE);
 char *btoh(BYTE, char *);
 
 /* z80amain.c */
-extern void fatal(int, const char *);
+extern void fatal(int, const char *) NORETURN;
 
 /* z80amfun.c */
 extern char *mac_first(int, int *);

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -1,7 +1,7 @@
 /*
  *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (C) 2022 by Thomas Eberhardt
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*
@@ -16,7 +16,7 @@
 #include "z80aglb.h"
 
 /* z80amain.c */
-extern void fatal(int, const char *);
+extern void fatal(int, const char *) NORETURN;
 extern void process_file(char *);
 extern char *strsave(char *);
 extern char *next_arg(char *, int *);

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -1,7 +1,7 @@
 /*
  *	Z80/8080-Macro-Assembler
  *	Copyright (C) 1987-2022 by Udo Munk
- *	Copyright (C) 2022 by Thomas Eberhardt
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*
@@ -22,7 +22,7 @@ int namecmp(const void *, const void *);
 int valcmp(const void *, const void *);
 
 /* z80amain.c */
-extern void fatal(int, const char *);
+extern void fatal(int, const char *) NORETURN;
 
 /* z80aout.c */
 extern void asmerr(int);
@@ -162,7 +162,6 @@ struct sym *first_sym(int sort_mode)
 	default:
 		fatal(F_INTERN, "unknown sort mode in first_sym");
 	}
-	return(NULL);		/* silence compiler */
 }
 
 /*

--- a/z80core/log.h
+++ b/z80core/log.h
@@ -46,6 +46,7 @@ static void _log_write(log_level_t level, const char* tag, const char* format, .
     va_list args;
     va_start(args, format);
     vprintf(format, args);
+    va_end(args);
 }
 
 static inline uint32_t _log_timestamp(void) {

--- a/z80core/sim0.c
+++ b/z80core/sim0.c
@@ -282,7 +282,7 @@ usage:
 #ifdef HAS_BANKED_ROM
 				puts("\t-R = enable banked ROM");
 #endif
-				exit(1);
+				exit(EXIT_FAILURE);
 			}
 
 	putchar('\n');
@@ -372,10 +372,10 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 
 	if (l_flag) {		/* load core */
 		if (load_core())
-			return(1);
+			return(EXIT_FAILURE);
 	} else if (x_flag) { 	/* OR load memory from file */
 		if (load_file(xfn, 0, 0)) /* don't care where it loads */
-			return(1);
+			return(EXIT_FAILURE);
 	}
 
 	int_on();		/* initialize UNIX interrupts */
@@ -389,7 +389,7 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 	exit_io();		/* stop I/O devices */
 	int_off();		/* stop UNIX interrupts */
 
-	return(0);
+	return(EXIT_SUCCESS);
 }
 
 /*

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -859,7 +859,7 @@ static void do_clock(void)
 	cpu_state = CONTIN_RUN;		/* initialise CPU */
 	cpu_error = NONE;
 	newact.sa_handler = timeout;	/* set timer interrupt handler */
-	memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+	sigemptyset(&newact.sa_mask);
 	newact.sa_flags = 0;
 	sigaction(SIGALRM, &newact, NULL);
 	tim.it_value.tv_sec = 3;	/* start 3 second timer */

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -102,7 +102,7 @@ void ice_cmd_loop(int go_flag)
 			if (fgets(cmd, LENCMD, stdin) == NULL) {
 				putchar('\n');
 				eoj = 0;
-				break;
+				continue;
 			}
 		}
 		switch (tolower((unsigned char) *cmd)) {

--- a/z80core/simint.c
+++ b/z80core/simint.c
@@ -79,5 +79,5 @@ static void term_int(int sig)
 	int_off();
 	tcsetattr(0, TCSADRAIN, &old_term);
 	puts("\nKilled by user");
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/z80core/simint.c
+++ b/z80core/simint.c
@@ -32,7 +32,7 @@ void int_on(void)
 	static struct sigaction newact;
 
 	newact.sa_handler = user_int;
-	memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+	sigemptyset(&newact.sa_mask);
 	newact.sa_flags = 0;
 	sigaction(SIGINT, &newact, NULL);
 	newact.sa_handler = quit_int;
@@ -45,7 +45,7 @@ void int_off(void)
 {
 	static struct sigaction newact;
 
-	memset((void *) &newact.sa_mask, 0, sizeof(newact.sa_mask));
+	sigemptyset(&newact.sa_mask);
 	newact.sa_flags = 0;
 	newact.sa_handler = SIG_IGN;
 	sigaction(SIGALRM, &newact, NULL);

--- a/z80sim/srcsim/iosim.c
+++ b/z80sim/srcsim/iosim.c
@@ -143,8 +143,8 @@ static void io_trap_out(BYTE data)
 }
 
 /*
- * 	I/O function port 0 read:
- * 	Read status from stdin:
+ *	I/O function port 0 read:
+ *	Read status from stdin:
  *	bit 0 = 0, character available for input from stdin
  *	bit 7 = 0, transmitter ready to write character to stdout
  *		   always true
@@ -154,16 +154,16 @@ static BYTE p000_in(void)
 	struct pollfd p[1];
 	BYTE tty_stat = 0x01;
 
-        p[0].fd = fileno(stdin);
-        p[0].events = POLLIN;
-        p[0].revents = 0;
-        poll(p, 1, 0);
+	p[0].fd = fileno(stdin);
+	p[0].events = POLLIN;
+	p[0].revents = 0;
+	poll(p, 1, 0);
 	if (p[0].revents & POLLIN)
 		tty_stat &= ~1;
-        if (p[0].revents & POLLNVAL) {
-                cpu_error = IOERROR;
-                cpu_state = STOPPED;
-        }
+	if (p[0].revents & POLLNVAL) {
+		cpu_error = IOERROR;
+		cpu_state = STOPPED;
+	}
 	return(tty_stat);
 }
 


### PR DESCRIPTION
Use EXIT_SUCCESS / EXIT_FAILURE and sigemptyset().
Missing va_end() in z80core/log.h.
Don't use exit() in signal handler in cpmrecv.c, switch to sigaction().
Other small cleanups to silence compiler/analyzer warnings.