### PR TITLE
Style work

### DIFF
--- a/altairsim/srcsim/iosim.c
+++ b/altairsim/srcsim/iosim.c
@@ -684,7 +684,7 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 		io_data = (*port_in[io_port]) ();
 #endif
 
-	return(io_data);
+	return (io_data);
 }
 
 /*
@@ -726,7 +726,7 @@ static BYTE io_trap_in(void)
 		cpu_error = IOTRAPIN;
 		cpu_state = STOPPED;
 	}
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 #if 0		/* currently not used */
@@ -737,7 +737,7 @@ static BYTE io_trap_in(void)
  */
 static BYTE io_no_card_in(void)
 {
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 #endif
 
@@ -773,9 +773,9 @@ static void io_no_card_out(BYTE data)
 static BYTE fp_in(void)
 {
 #ifdef FRONTPANEL
-	return(address_switch >> 8);
+	return (address_switch >> 8);
 #else
-	return(fp_port);
+	return (fp_port);
 #endif
 }
 
@@ -804,7 +804,7 @@ static void int_timer(int sig)
  */
 static BYTE hwctl_in(void)
 {
-	return(hwctl_lock);
+	return (hwctl_lock);
 }
 
 /*
@@ -866,7 +866,7 @@ static void hwctl_out(BYTE data)
  */
 static BYTE lpt_data_in(void)
 {
-	return((BYTE) 0);
+	return ((BYTE) 0);
 }
 
 /*
@@ -904,7 +904,7 @@ again:
  */
 static BYTE lpt_status_in(void)
 {
-	return((BYTE) 3);
+	return ((BYTE) 3);
 }
 
 /*
@@ -922,7 +922,7 @@ static BYTE kbd_status_in(void)
 {
 	extern int proctec_kbd_status;
 
-	return((BYTE) proctec_kbd_status);
+	return ((BYTE) proctec_kbd_status);
 }
 
 /*
@@ -934,12 +934,12 @@ static BYTE kbd_data_in(void)
 	int data;
 
 	if (proctec_kbd_data == -1)
-		return((BYTE) 0);
+		return ((BYTE) 0);
 
 	/* take over data and reset status */
 	data = proctec_kbd_data;
 	proctec_kbd_data = -1;
 	proctec_kbd_status = 1;
 
-	return((BYTE) data);
+	return ((BYTE) data);
 }

--- a/altairsim/srcsim/memory.h
+++ b/altairsim/srcsim/memory.h
@@ -108,7 +108,7 @@ static inline BYTE memrdr(WORD addr)
 	wait_step();
 #endif
 
-	return(data);
+	return (data);
 }
 
 /*
@@ -118,15 +118,15 @@ static inline BYTE dma_read(WORD addr)
 {
 	if (tarbell_rom_active && tarbell_rom_enabled) {
 		if (addr <= 0x001f)
-			return(tarbell_rom[addr]);
+			return (tarbell_rom[addr]);
 		else
 			tarbell_rom_active = 0;
 	}
 
 	if (p_tab[addr >> 8] != MEM_NONE)
-		return(memory[addr]);
+		return (memory[addr]);
 	else
-		return(0xff);
+		return (0xff);
 }
 
 static inline void dma_write(WORD addr, BYTE data)
@@ -142,13 +142,13 @@ static inline BYTE getmem(WORD addr)
 {
 	if (tarbell_rom_active && tarbell_rom_enabled) {
 		if (addr <= 0x001f)
-			return(tarbell_rom[addr]);
+			return (tarbell_rom[addr]);
 	}
 
 	if (p_tab[addr >> 8] != MEM_NONE)
-		return(memory[addr]);
+		return (memory[addr]);
 	else
-		return(0xff);
+		return (0xff);
 }
 
 static inline void putmem(WORD addr, BYTE data)
@@ -163,13 +163,13 @@ static inline BYTE fp_read(WORD addr)
 {
 	if (tarbell_rom_active && tarbell_rom_enabled) {
 		if (addr <= 0x001f)
-			return(tarbell_rom[addr]);
+			return (tarbell_rom[addr]);
 		else
 			tarbell_rom_active = 0;
 	}
 
 	if (p_tab[addr >> 8] != MEM_NONE)
-		return(memory[addr]);
+		return (memory[addr]);
 	else
-		return(0xff);
+		return (0xff);
 }

--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -375,12 +375,12 @@ int wait_step(void)
 	if (cpu_state != SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
 		m1_step = 0;
-		return(ret);
+		return (ret);
 	}
 
 	if ((cpu_bus & CPU_M1) && !m1_step) {
 		cpu_bus &= ~CPU_M1;
-		return(ret);
+		return (ret);
 	}
 
 	cpu_switch = 3;
@@ -397,7 +397,7 @@ int wait_step(void)
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = 0;
-	return(ret);
+	return (ret);
 }
 
 /*

--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -278,7 +278,7 @@ void run_cpu(void)
 {
 	cpu_state = CONTIN_RUN;
 	cpu_error = NONE;
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;
@@ -298,7 +298,7 @@ void step_cpu(void)
 {
 	cpu_state = SINGLE_STEP;
 	cpu_error = NONE;
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;

--- a/cpmsim/srccpm2/putsys.c
+++ b/cpmsim/srccpm2/putsys.c
@@ -104,5 +104,5 @@ int main(void)
 stop:
 	close(fd);
 	close(drivea);
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }

--- a/cpmsim/srccpm3/putsys.c
+++ b/cpmsim/srccpm3/putsys.c
@@ -70,5 +70,5 @@ int main(void)
 	write(drivea, (char *) sector, 128);
 	close(fd);
 	close(drivea);
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }

--- a/cpmsim/srcmpm/putsys.c
+++ b/cpmsim/srcmpm/putsys.c
@@ -53,5 +53,5 @@ int main(void)
 	write(drivea, (char *) sector, 128);
 	close(fd);
 	close(drivea);
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -1117,7 +1117,7 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 
 	io_port = addrl;
 	io_data = (*port_in[addrl]) ();
-	return(io_data);
+	return (io_data);
 }
 
 /*
@@ -1146,7 +1146,7 @@ static BYTE io_trap_in(void)
 		cpu_error = IOTRAPIN;
 		cpu_state = STOPPED;
 	}
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 /*
@@ -1181,9 +1181,9 @@ static BYTE cons_in(void)
 	p[0].revents = 0;
 	poll(p, 1, 0);
 	if (p[0].revents & POLLIN)
-		return((BYTE) 0xff);
+		return ((BYTE) 0xff);
 	else
-		return((BYTE) 0x00);
+		return ((BYTE) 0x00);
 }
 
 /*
@@ -1204,7 +1204,7 @@ static BYTE cons1_in(void)
 	int on = 1;
 
 	if (ss[0] == 0)
-		return(status);
+		return (status);
 
 	p[0].fd = ss[0];
 	p[0].events = POLLIN;
@@ -1247,7 +1247,7 @@ ss0_done:
 		if (p[0].revents & POLLHUP) {
 			close(ssc[0]);
 			ssc[0] = 0;
-			return(0);
+			return (0);
 		}
 		if (p[0].revents & POLLIN)
 			status |= 1;
@@ -1255,7 +1255,7 @@ ss0_done:
 			status |= 2;
 	}
 #endif
-	return(status);
+	return (status);
 }
 
 /*
@@ -1276,7 +1276,7 @@ static BYTE cons2_in(void)
 	int on = 1;
 
 	if (ss[1] == 0)
-		return(status);
+		return (status);
 
 	p[0].fd = ss[1];
 	p[0].events = POLLIN;
@@ -1319,7 +1319,7 @@ ss1_done:
 		if (p[0].revents & POLLHUP) {
 			close(ssc[1]);
 			ssc[1] = 0;
-			return(0);
+			return (0);
 		}
 		if (p[0].revents & POLLIN)
 			status |= 1;
@@ -1327,7 +1327,7 @@ ss1_done:
 			status |= 2;
 	}
 #endif
-	return(status);
+	return (status);
 }
 
 /*
@@ -1348,7 +1348,7 @@ static BYTE cons3_in(void)
 	int on = 1;
 
 	if (ss[2] == 0)
-		return(status);
+		return (status);
 
 	p[0].fd = ss[2];
 	p[0].events = POLLIN;
@@ -1391,7 +1391,7 @@ ss2_done:
 		if (p[0].revents & POLLHUP) {
 			close(ssc[2]);
 			ssc[2] = 0;
-			return(0);
+			return (0);
 		}
 		if (p[0].revents & POLLIN)
 			status |= 1;
@@ -1399,7 +1399,7 @@ ss2_done:
 			status |= 2;
 	}
 #endif
-	return(status);
+	return (status);
 }
 
 /*
@@ -1420,7 +1420,7 @@ static BYTE cons4_in(void)
 	int on = 1;
 
 	if (ss[3] == 0)
-		return(status);
+		return (status);
 
 	p[0].fd = ss[3];
 	p[0].events = POLLIN;
@@ -1463,7 +1463,7 @@ ss3_done:
 		if (p[0].revents & POLLHUP) {
 			close(ssc[3]);
 			ssc[3] = 0;
-			return(0);
+			return (0);
 		}
 		if (p[0].revents & POLLIN)
 			status |= 1;
@@ -1471,7 +1471,7 @@ ss3_done:
 			status |= 2;
 	}
 #endif
-	return(status);
+	return (status);
 }
 
 /*
@@ -1494,7 +1494,7 @@ static BYTE nets1_in(void)
 			LOGE(TAG, "can't create client socket");
 			cpu_error = IOERROR;
 			cpu_state = STOPPED;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		}
 		memset((void *) &sin, 0, sizeof(sin));
 		memcpy((void *) &sin.sin_addr, (void *) host->h_addr, host->h_length);
@@ -1504,7 +1504,7 @@ static BYTE nets1_in(void)
 			LOGE(TAG, "can't connect client socket");
 			cpu_error = IOERROR;
 			cpu_state = STOPPED;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		}
 		if (setsockopt(cs, IPPROTO_TCP, TCP_NODELAY,
 		    (void *)&on, sizeof(on)) == -1) {
@@ -1520,7 +1520,7 @@ static BYTE nets1_in(void)
 		if (p[0].revents & POLLHUP) {
 			close(cs);
 			cs = 0;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		}
 		if (p[0].revents & POLLIN)
 			status |= 1;
@@ -1528,7 +1528,7 @@ static BYTE nets1_in(void)
 			status |= 2;
 	}
 #endif
-	return(status);
+	return (status);
 }
 
 /*
@@ -1594,7 +1594,7 @@ static BYTE cond_in(void)
 
 	busy_loop_cnt[0] = 0;
 	read(0, &c, 1);
-	return((BYTE) c);
+	return ((BYTE) c);
 }
 
 /*
@@ -1610,12 +1610,12 @@ static BYTE cond1_in(void)
 		if ((errno == EAGAIN) || (errno == EINTR)) {
 			close(ssc[0]);
 			ssc[0] = 0;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		} else {
 			LOGE(TAG, "can't read console 1");
 			cpu_error = IOERROR;
 			cpu_state = STOPPED;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		}
 	}
 	if (ss_telnet[0] && (c == '\r'))
@@ -1630,7 +1630,7 @@ static BYTE cond1_in(void)
 #else
 	c = 0;
 #endif
-	return((BYTE) c);
+	return ((BYTE) c);
 }
 
 /*
@@ -1646,12 +1646,12 @@ static BYTE cond2_in(void)
 		if ((errno == EAGAIN) || (errno == EINTR)) {
 			close(ssc[1]);
 			ssc[1] = 0;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		} else {
 			LOGE(TAG, "can't read console 2");
 			cpu_error = IOERROR;
 			cpu_state = STOPPED;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		}
 	}
 	if (ss_telnet[1] && (c == '\r'))
@@ -1666,7 +1666,7 @@ static BYTE cond2_in(void)
 #else
 	c = 0;
 #endif
-	return((BYTE) c);
+	return ((BYTE) c);
 }
 
 /*
@@ -1682,12 +1682,12 @@ static BYTE cond3_in(void)
 		if ((errno == EAGAIN) || (errno == EINTR)) {
 			close(ssc[2]);
 			ssc[2] = 0;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		} else {
 			LOGE(TAG, "can't read console 3");
 			cpu_error = IOERROR;
 			cpu_state = STOPPED;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		}
 	}
 	if (ss_telnet[2] && (c == '\r'))
@@ -1702,7 +1702,7 @@ static BYTE cond3_in(void)
 #else
 	c = 0;
 #endif
-	return((BYTE) c);
+	return ((BYTE) c);
 }
 
 /*
@@ -1718,12 +1718,12 @@ static BYTE cond4_in(void)
 		if ((errno == EAGAIN) || (errno == EINTR)) {
 			close(ssc[3]);
 			ssc[3] = 0;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		} else {
 			LOGE(TAG, "can't read console 4");
 			cpu_error = IOERROR;
 			cpu_state = STOPPED;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		}
 	}
 	if (ss_telnet[3] && (c == '\r'))
@@ -1738,7 +1738,7 @@ static BYTE cond4_in(void)
 #else
 	c = 0;
 #endif
-	return((BYTE) c);
+	return ((BYTE) c);
 }
 
 /*
@@ -1753,7 +1753,7 @@ static BYTE netd1_in(void)
 		LOGE(TAG, "can't read client socket");
 		cpu_error = IOERROR;
 		cpu_state = STOPPED;
-		return((BYTE) 0);
+		return ((BYTE) 0);
 	}
 #ifdef CNETDEBUG
 	if (cdirection != 1) {
@@ -1765,7 +1765,7 @@ static BYTE netd1_in(void)
 #else
 	c = 0;
 #endif
-	return((BYTE) c);
+	return ((BYTE) c);
 }
 
 /*
@@ -1927,7 +1927,7 @@ again:
  */
 static BYTE prts_in(void)
 {
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 /*
@@ -1945,7 +1945,7 @@ static void prts_out(BYTE data)
  */
 static BYTE prtd_in(void)
 {
-	return((BYTE) 0x1a);	/* CP/M EOF */
+	return ((BYTE) 0x1a);	/* CP/M EOF */
 }
 
 /*
@@ -1985,9 +1985,9 @@ again:
 static BYTE auxs_in(void)
 {
 #ifdef PIPES
-	return((BYTE) aux_in_eof);
+	return ((BYTE) aux_in_eof);
 #else
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 #endif
 }
 
@@ -2014,10 +2014,10 @@ static BYTE auxd_in(void)
 
 #ifdef PIPES
 	if (read(auxin, &c, 1) == 1)
-		return((BYTE) c);
+		return ((BYTE) c);
 	else {
 		aux_in_eof = 0xff;
-		return((BYTE) 0x1a);	/* CP/M EOF */
+		return ((BYTE) 0x1a);	/* CP/M EOF */
 	}
 #else
 	if (aux_in == 0) {
@@ -2025,27 +2025,27 @@ static BYTE auxd_in(void)
 			LOGE(TAG, "can't open auxiliaryin.txt");
 			cpu_error = IOERROR;
 			cpu_state = STOPPED;
-			return((BYTE) 0);
+			return ((BYTE) 0);
 		}
 	}
 
 	if (aux_in_lf) {
 		aux_in_lf = 0;
-		return((BYTE) '\n');
+		return ((BYTE) '\n');
 	}
 
 	if (read(aux_in, &c, 1) != 1) {
 		close(aux_in);
 		aux_in = 0;
-		return((BYTE) 0x1a);
+		return ((BYTE) 0x1a);
 	}
 
 	if (c == '\n') {
 		aux_in_lf = 1;
-		return((BYTE) '\r');
+		return ((BYTE) '\r');
 	}
 
-	return((BYTE) c);
+	return ((BYTE) c);
 #endif
 }
 
@@ -2091,7 +2091,7 @@ static void auxd_out(BYTE data)
  */
 static BYTE fdcd_in(void)
 {
-	return((BYTE) drive);
+	return ((BYTE) drive);
 }
 
 /*
@@ -2109,7 +2109,7 @@ static void fdcd_out(BYTE data)
  */
 static BYTE fdct_in(void)
 {
-	return((BYTE) track);
+	return ((BYTE) track);
 }
 
 /*
@@ -2127,7 +2127,7 @@ static void fdct_out(BYTE data)
  */
 static BYTE fdcs_in(void)
 {
-	return((BYTE) sector & 0xff);
+	return ((BYTE) sector & 0xff);
 }
 
 /*
@@ -2145,7 +2145,7 @@ static void fdcs_out(BYTE data)
  */
 static BYTE fdcsh_in(void)
 {
-	return((BYTE) (sector >> 8));
+	return ((BYTE) (sector >> 8));
 }
 
 /*
@@ -2163,7 +2163,7 @@ static void fdcsh_out(BYTE data)
  */
 static BYTE fdco_in(void)
 {
-	return((BYTE) 0);
+	return ((BYTE) 0);
 }
 
 /*
@@ -2235,7 +2235,7 @@ static void fdco_out(BYTE data)
  */
 static BYTE fdcx_in(void)
 {
-	return((BYTE) status);
+	return ((BYTE) status);
 }
 
 /*
@@ -2253,7 +2253,7 @@ static void fdcx_out(BYTE data)
  */
 static BYTE dmal_in(void)
 {
-	return((BYTE) dmadl);
+	return ((BYTE) dmadl);
 }
 
 /*
@@ -2271,7 +2271,7 @@ static void dmal_out(BYTE data)
  */
 static BYTE dmah_in(void)
 {
-	return((BYTE) dmadh);
+	return ((BYTE) dmadh);
 }
 
 /*
@@ -2289,7 +2289,7 @@ static void dmah_out(BYTE data)
  */
 static BYTE mmui_in(void)
 {
-	return((BYTE) maxbnk);
+	return ((BYTE) maxbnk);
 }
 
 /*
@@ -2334,7 +2334,7 @@ static void mmui_out(BYTE data)
  */
 static BYTE mmus_in(void)
 {
-	return((BYTE) selbnk);
+	return ((BYTE) selbnk);
 }
 
 /*
@@ -2358,7 +2358,7 @@ static void mmus_out(BYTE data)
  */
 static BYTE mmuc_in(void)
 {
-	return((BYTE) (segsize >> 8));
+	return ((BYTE) (segsize >> 8));
 }
 
 /*
@@ -2382,7 +2382,7 @@ static void mmuc_out(BYTE data)
  */
 static BYTE mmup_in(void)
 {
-	return(wp_common);
+	return (wp_common);
 }
 
 /*
@@ -2432,7 +2432,7 @@ static void time_out(BYTE data)
  */
 static BYTE time_in(void)
 {
-	return(timer);
+	return (timer);
 }
 
 /*
@@ -2454,7 +2454,7 @@ static void delay_out(BYTE data)
  */
 static BYTE delay_in(void)
 {
-	return((BYTE) 0);
+	return ((BYTE) 0);
 }
 
 /*
@@ -2496,7 +2496,7 @@ static void hwctl_out(BYTE data)
  */
 static BYTE hwctl_in(void)
 {
-	return(hwctl_lock);
+	return (hwctl_lock);
 }
 
 /*
@@ -2512,7 +2512,7 @@ static void speedl_out(BYTE data)
  */
 static BYTE speedl_in(void)
 {
-	return(f_flag & 0xff);
+	return (f_flag & 0xff);
 }
 
 /*
@@ -2530,7 +2530,7 @@ static void speedh_out(BYTE data)
  */
 static BYTE speedh_in(void)
 {
-	return(f_flag  >> 8);
+	return (f_flag  >> 8);
 }
 
 /*

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -850,6 +850,7 @@ void init_io(void)
 	case -1:
 		LOGE(TAG, "can't fork");
 		exit(EXIT_FAILURE);
+		break;
 	case 0:
 		/* . might not be in path, so check that first */
 		if (access("./cpmrecv", X_OK) == 0)
@@ -863,6 +864,7 @@ void init_io(void)
 		LOGE(TAG, "can't exec cpmrecv process, compile/install the tools dude");
 		kill(0, SIGQUIT);
 		exit(EXIT_FAILURE);
+		break;
 	}
 	if ((auxin = open("/tmp/.z80pack/cpmsim.auxin", O_RDONLY | O_NDELAY)) == -1) {
 		LOGE(TAG, "can't open pipe auxin");

--- a/cpmsim/srcsim/memory.h
+++ b/cpmsim/srcsim/memory.h
@@ -62,12 +62,12 @@ static inline void memwrt(WORD addr, BYTE data)
 static inline BYTE memrdr(WORD addr)
 {
 	if (selbnk == 0)
-		return(*(memory[0] + addr));
+		return (*(memory[0] + addr));
 
 	if (addr >= segsize)
-		return(*(memory[0] + addr));
+		return (*(memory[0] + addr));
 	else
-		return(*(memory[selbnk] + addr));
+		return (*(memory[selbnk] + addr));
 }
 
 /*
@@ -93,12 +93,12 @@ static inline void dma_write(WORD addr, BYTE data)
 static inline BYTE dma_read(WORD addr)
 {
 	if (selbnk == 0)
-		return(*(memory[0] + addr));
+		return (*(memory[0] + addr));
 
 	if (addr >= segsize)
-		return(*(memory[0] + addr));
+		return (*(memory[0] + addr));
 	else
-		return(*(memory[selbnk] + addr));
+		return (*(memory[selbnk] + addr));
 }
 
 /*
@@ -119,10 +119,10 @@ static inline void putmem(WORD addr, BYTE data)
 static inline BYTE getmem(WORD addr)
 {
 	if (selbnk == 0)
-		return(*(memory[0] + addr));
+		return (*(memory[0] + addr));
 
 	if (addr >= segsize)
-		return(*(memory[0] + addr));
+		return (*(memory[0] + addr));
 	else
-		return(*(memory[selbnk] + addr));
+		return (*(memory[selbnk] + addr));
 }

--- a/cpmsim/srcsim/simctl.c
+++ b/cpmsim/srcsim/simctl.c
@@ -53,7 +53,7 @@ void mon(void)
 	/* start CPU emulation */
 	cpu_state = CONTIN_RUN;
 	cpu_error = NONE;
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;

--- a/cpmsim/srcsim/simctl.c
+++ b/cpmsim/srcsim/simctl.c
@@ -132,9 +132,9 @@ int boot(int level)
 	/* on first boot we can run from core or file */
 	if (level == 0) {
 		if (l_flag)
-			return(0);
+			return (0);
 		if (x_flag)
-			return(0);
+			return (0);
 	}
 
 	/* else load boot code from disk */
@@ -158,17 +158,17 @@ int boot(int level)
 	if ((fd = open(fn, O_RDONLY)) == -1) {
 		LOGE(TAG, "can't open file %s", fn);
 		close(fd);
-		return(1);
+		return (1);
 	}
 	if (read(fd, buf, 128) != 128) {
 		LOGE(TAG, "can't read file %s", fn);
 		close(fd);
-		return(1);
+		return (1);
 	}
 	close(fd);
 
 	for (i = 0; i < 128; i++)
 		putmem(i, buf[i]);
 
-	return(0);
+	return (0);
 }

--- a/cpmsim/srctools/cpmrecv.c
+++ b/cpmsim/srctools/cpmrecv.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 	close(fdin);
 	if (fdout)
 		close(fdout);
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }
 
 void int_handler(int sig)

--- a/cpmsim/srctools/cpmsend.c
+++ b/cpmsim/srctools/cpmsend.c
@@ -44,7 +44,7 @@ int main(int argc,char *argv[])
 		sendbuf(readn);
 	close(fdin);
 	close(fdout);
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }
 
 void sendbuf(int size)

--- a/cpmsim/srctools/mkdskimg.c
+++ b/cpmsim/srctools/mkdskimg.c
@@ -91,5 +91,5 @@ int main(int argc, char *argv[])
 			write(fd, (char *) sector, 128);
 	}
 	close(fd);
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }

--- a/cpmsim/srctools/ptp2bin.c
+++ b/cpmsim/srctools/ptp2bin.c
@@ -23,17 +23,17 @@ int main(int argc, char *argv[])
 
 	if (argc != 3) {
 		printf("usage: %s infile outfile\n", pn);
-		return(EXIT_FAILURE);
+		return (EXIT_FAILURE);
 	}
 
 	if ((fdin = open(argv[1], O_RDONLY)) == -1) {
 		perror(argv[1]);
-		return(EXIT_FAILURE);
+		return (EXIT_FAILURE);
 	}
 
 	if ((fdout = open(argv[2], O_WRONLY|O_CREAT, 0644)) == -1) {
 		perror(argv[2]);
-		return(EXIT_FAILURE);
+		return (EXIT_FAILURE);
 	}
 
 	while (read(fdin, &c, 1) == 1) {
@@ -49,5 +49,5 @@ int main(int argc, char *argv[])
 	close(fdin);
 	close(fdout);
 
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }

--- a/cpmsim/srcucsd-iv/putsys.c
+++ b/cpmsim/srcucsd-iv/putsys.c
@@ -66,5 +66,5 @@ int main(void)
 stop:
 	close(fd);
 	close(drivea);
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }

--- a/cromemcosim/srcsim/iosim.c
+++ b/cromemcosim/srcsim/iosim.c
@@ -758,7 +758,7 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 		io_data = (*port_in[io_port]) ();
 #endif
 
-	return(io_data);
+	return (io_data);
 }
 
 /*
@@ -800,7 +800,7 @@ static BYTE io_trap_in(void)
 		cpu_error = IOTRAPIN;
 		cpu_state = STOPPED;
 	}
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 /*
@@ -825,9 +825,9 @@ static void io_trap_out(BYTE data)
 static BYTE fp_in(void)
 {
 #ifdef FRONTPANEL
-	return(address_switch >> 8);
+	return (address_switch >> 8);
 #else
-	return(fp_port);
+	return (fp_port);
 #endif
 }
 
@@ -849,7 +849,7 @@ static void fp_out(BYTE data)
  */
 static BYTE hwctl_in(void)
 {
-	return(hwctl_lock);
+	return (hwctl_lock);
 }
 
 /*
@@ -885,7 +885,7 @@ static void hwctl_out(BYTE data)
  */
 static BYTE mmu_in(void)
 {
-	return(bankio);
+	return (bankio);
 }
 
 /*

--- a/cromemcosim/srcsim/memory.h
+++ b/cromemcosim/srcsim/memory.h
@@ -128,14 +128,14 @@ static inline BYTE memrdr(WORD addr)
 	fp_sampleData();
 	wait_step();
 
-	return(fp_led_data);
+	return (fp_led_data);
 #else
 	if (fdc_rom_active && (addr >> 13) == 0x6) { /* Covers C000 to DFFF */
-		return(*(fdc_banked_rom + addr - 0xC000));
+		return (*(fdc_banked_rom + addr - 0xC000));
 	} else if(selbnk || p_tab[addr >> 8] != MEM_NONE) {
-		return(*(memory[selbnk] + addr));
+		return (*(memory[selbnk] + addr));
 	} else {
-		return(0xff);
+		return (0xff);
 	}
 #endif
 }
@@ -146,11 +146,11 @@ static inline BYTE memrdr(WORD addr)
 static inline BYTE dma_read(WORD addr)
 {
 	if (fdc_rom_active && (addr >> 13) == 0x6) { /* Covers C000 to DFFF */
-		return(*(fdc_banked_rom + addr - 0xC000));
+		return (*(fdc_banked_rom + addr - 0xC000));
 	} else if(selbnk || p_tab[addr >> 8] != MEM_NONE) {
-		return(*(memory[selbnk] + addr));
+		return (*(memory[selbnk] + addr));
 	} else {
-		return(0xff);
+		return (0xff);
 	}
 }
 
@@ -169,11 +169,11 @@ static inline void dma_write(WORD addr, BYTE data)
 static inline BYTE getmem(WORD addr)
 {
 	if (fdc_rom_active && (addr >> 13) == 0x6) { /* Covers C000 to DFFF */
-		return(*(fdc_banked_rom + addr - 0xC000));
+		return (*(fdc_banked_rom + addr - 0xC000));
 	} else if(selbnk || p_tab[addr >> 8] != MEM_NONE) {
-		return(*(memory[selbnk] + addr));
+		return (*(memory[selbnk] + addr));
 	} else {
-		return(0xff);
+		return (0xff);
 	}
 }
 

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -379,12 +379,12 @@ int wait_step(void)
 	if (cpu_state != SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
 		m1_step = 0;
-		return(ret);
+		return (ret);
 	}
 
 	if ((cpu_bus & CPU_M1) && !m1_step) {
 		cpu_bus &= ~CPU_M1;
-		return(ret);
+		return (ret);
 	}
 
 	cpu_switch = 3;
@@ -401,7 +401,7 @@ int wait_step(void)
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = 0;
-	return(ret);
+	return (ret);
 }
 
 /*

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -284,7 +284,7 @@ void run_cpu(void)
 {
 	cpu_state = CONTIN_RUN;
 	cpu_error = NONE;
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;
@@ -303,7 +303,7 @@ void step_cpu(void)
 {
 	cpu_state = SINGLE_STEP;
 	cpu_error = NONE;
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -776,7 +776,7 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 		io_data = (*port_in[io_port]) ();
 #endif
 
-	return(io_data);
+	return (io_data);
 }
 
 /*
@@ -818,7 +818,7 @@ static BYTE io_trap_in(void)
 		cpu_error = IOTRAPIN;
 		cpu_state = STOPPED;
 	}
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 /*
@@ -828,7 +828,7 @@ static BYTE io_trap_in(void)
  */
 static BYTE io_no_card_in(void)
 {
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 /*
@@ -863,9 +863,9 @@ static void io_no_card_out(BYTE data)
 static BYTE fp_in(void)
 {
 #ifdef FRONTPANEL
-	return(address_switch >> 8);
+	return (address_switch >> 8);
 #else
-	return(fp_port);
+	return (fp_port);
 #endif
 }
 
@@ -898,7 +898,7 @@ static void int_timer(int sig)
  */
 static BYTE hwctl_in(void)
 {
-	return(hwctl_lock);
+	return (hwctl_lock);
 }
 
 /*
@@ -1001,7 +1001,7 @@ again:
  */
 static BYTE lpt_in(void)
 {
-	return((BYTE) 0xf4);
+	return ((BYTE) 0xf4);
 }
 
 /*
@@ -1011,7 +1011,7 @@ static BYTE lpt_in(void)
  */
 static BYTE io_pport_in(void)
 {
-	return((BYTE) 0);
+	return ((BYTE) 0);
 }
 
 /*
@@ -1019,7 +1019,7 @@ static BYTE io_pport_in(void)
  */
 static BYTE mmu_in(void)
 {
-	return(selbnk);
+	return (selbnk);
 }
 
 /*

--- a/imsaisim/srcsim/memory.c
+++ b/imsaisim/srcsim/memory.c
@@ -307,5 +307,5 @@ BYTE ctrl_port_in(void)
 		cyclecount = 3;
 	}
 #endif
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }

--- a/imsaisim/srcsim/memory.h
+++ b/imsaisim/srcsim/memory.h
@@ -149,7 +149,7 @@ static inline BYTE memrdr(WORD addr)
 	if(cyclecount && --cyclecount == 0) 
 		groupswap();
 
-	return(data);
+	return (data);
 }
 
 /*
@@ -167,11 +167,11 @@ static inline BYTE dma_read(WORD addr)
 
 	if ((selbnk == 0) || (addr >= SEGSIZ)) {
 		if (p_tab[addr >> 8] != MEM_NONE)
-			return(_MEMMAPPED(addr));
+			return (_MEMMAPPED(addr));
 		else
-			return(0xff);
+			return (0xff);
 	} else {
-		return(*(banks[selbnk] + addr));
+		return (*(banks[selbnk] + addr));
 	}
 }
 
@@ -200,11 +200,11 @@ static inline BYTE getmem(WORD addr)
 {
 	if ((selbnk == 0) || (addr >= SEGSIZ)) {
 		if (p_tab[addr >> 8] != MEM_NONE)
-			return(_MEMMAPPED(addr));
+			return (_MEMMAPPED(addr));
 		else
-			return(0xff);
+			return (0xff);
 	} else {
-		return(*(banks[selbnk] + addr));
+		return (*(banks[selbnk] + addr));
 	}
 }
 

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -281,7 +281,7 @@ void run_cpu(void)
 {
 	cpu_state = CONTIN_RUN;
 	cpu_error = NONE;
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;
@@ -301,7 +301,7 @@ void step_cpu(void)
 {
 	cpu_state = SINGLE_STEP;
 	cpu_error = NONE;
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -377,12 +377,12 @@ int wait_step(void)
 	if (cpu_state != SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
 		m1_step = 0;
-		return(ret);
+		return (ret);
 	}
 
 	if ((cpu_bus & CPU_M1) && !m1_step) {
 		cpu_bus &= ~CPU_M1;
-		return(ret);
+		return (ret);
 	}
 
 	cpu_switch = 3;
@@ -399,7 +399,7 @@ int wait_step(void)
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = 0;
-	return(ret);
+	return (ret);
 }
 
 /*

--- a/imsaisim/srcucsd-iv/putsys.c
+++ b/imsaisim/srcucsd-iv/putsys.c
@@ -66,5 +66,5 @@ int main(void)
 stop:
 	close(fd);
 	close(drivea);
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }

--- a/iodevices/altair-88-2sio.c
+++ b/iodevices/altair-88-2sio.c
@@ -77,7 +77,7 @@ BYTE altair_sio1_status_in(void)
 	tdiff = time_diff(&sio1_t1, &sio1_t2);
 	if (sio1_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME/sio1_baud_rate))
-			return(sio1_stat);
+			return (sio1_stat);
 
 	p[0].fd = fileno(stdin);
 	p[0].events = POLLIN;
@@ -94,7 +94,7 @@ BYTE altair_sio1_status_in(void)
 
 	gettimeofday(&sio1_t1, NULL);
 
-	return(sio1_stat);
+	return (sio1_stat);
 }
 
 /*
@@ -124,7 +124,7 @@ again:
 	p[0].revents = 0;
 	poll(p, 1, 0);
 	if (!(p[0].revents & POLLIN))
-		return(last);
+		return (last);
 
 	if (read(fileno(stdin), &data, 1) == 0) {
 		/* try to reopen tty, input redirection exhausted */
@@ -140,7 +140,7 @@ again:
 	if (sio1_upper_case)
 		data = toupper(data);
 	last = data;
-	return(data);
+	return (data);
 }
 
 /*
@@ -204,7 +204,7 @@ BYTE altair_sio2_status_in(void)
 	tdiff = time_diff(&sio2_t1, &sio2_t2);
 	if (sio2_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME/sio2_baud_rate))
-			return(sio2_stat);
+			return (sio2_stat);
 
 	/* if socket is connected check for I/O */
 	if (ucons[1].ssc != 0) {
@@ -220,7 +220,7 @@ BYTE altair_sio2_status_in(void)
 
 	gettimeofday(&sio2_t1, NULL);
 
-	return(sio2_stat);
+	return (sio2_stat);
 }
 
 /*
@@ -245,7 +245,7 @@ BYTE altair_sio2_data_in(void)
 
 	/* if not connected return last */
 	if (ucons[1].ssc == 0)
-		return(last);
+		return (last);
 
 	/* if no input waiting return last */
 	p[0].fd = ucons[1].ssc;
@@ -253,13 +253,13 @@ BYTE altair_sio2_data_in(void)
 	p[0].revents = 0;
 	poll(p, 1, 0);
 	if (!(p[0].revents & POLLIN))
-		return(last);
+		return (last);
 
 	if (read(ucons[1].ssc, &data, 1) != 1) {
 		/* EOF, close socket and return last */
 		close(ucons[1].ssc);
 		ucons[1].ssc = 0;
-		return(last);
+		return (last);
 	}
 
 	gettimeofday(&sio2_t1, NULL);
@@ -269,7 +269,7 @@ BYTE altair_sio2_data_in(void)
 	if (sio2_upper_case)
 		data = toupper(data);
 	last = data;
-	return(data);
+	return (data);
 }
 
 /*

--- a/iodevices/altair-88-dcdd.c
+++ b/iodevices/altair-88-dcdd.c
@@ -124,15 +124,15 @@ static int dsk_check(void)
 	strcat(fn, "/");
 	strcat(fn, disks[disk]);
 	if ((fd = open(fn, O_RDONLY)) == -1)
-		return(0);
+		return (0);
 
 	/* check for correct image size */
 	fstat(fd, &s);
 	close(fd);
 	if (s.st_size != 337568)
-		return(0);
+		return (0);
 	else
-		return(1);
+		return (1);
 }
 
 /*
@@ -276,7 +276,7 @@ BYTE altair_dsk_status_in(void)
 		}
 	}
 
-	return(status);
+	return (status);
 }
 
 /*
@@ -377,7 +377,7 @@ BYTE altair_dsk_sec_in(void)
 		status |= NRDA;
 		status |= ENWD;
 		pthread_mutex_unlock(&mustatus);
-		return(0xff);
+		return (0xff);
 	} else {
 		if (sec != rwsec) {
 			rwsec = sec;
@@ -392,7 +392,7 @@ BYTE altair_dsk_sec_in(void)
 		}
 	}
 
-	return(sectrue + (rwsec << 1));
+	return (sectrue + (rwsec << 1));
 }
 
 /*
@@ -454,7 +454,7 @@ BYTE altair_dsk_data_in(void)
 
 	/* no more data? */
 	if (dcnt == SEC_SZ)
-		return(0xff);
+		return (0xff);
 
 	/* return byte from buffer and increment counter */
 	data = buf[dcnt++];
@@ -463,7 +463,7 @@ BYTE altair_dsk_data_in(void)
 		status |= NRDA;	/* no more data to read */
 		pthread_mutex_unlock(&mustatus);
 	}
-	return(data);
+	return (data);
 }
 
 /*

--- a/iodevices/altair-88-sio.c
+++ b/iodevices/altair-88-sio.c
@@ -82,7 +82,7 @@ BYTE altair_sio0_status_in(void)
 	tdiff = time_diff(&sio0_t1, &sio0_t2);
 	if (sio0_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME/sio0_baud_rate))
-			return(sio0_stat);
+			return (sio0_stat);
 
 	p[0].fd = fileno(stdin);
 	p[0].events = POLLIN;
@@ -106,7 +106,7 @@ BYTE altair_sio0_status_in(void)
 
 	gettimeofday(&sio0_t1, NULL);
 
-	return(sio0_stat);
+	return (sio0_stat);
 }
 
 /*
@@ -136,7 +136,7 @@ again:
 	p[0].revents = 0;
 	poll(p, 1, 0);
 	if (!(p[0].revents & POLLIN))
-		return(last);
+		return (last);
 
 	if (read(fileno(stdin), &data, 1) == 0) {
 		/* try to reopen tty, input redirection exhausted */
@@ -155,7 +155,7 @@ again:
 	if (sio0_upper_case)
 		data = toupper(data);
 	last = data;
-	return(data);
+	return (data);
 }
 
 /*
@@ -224,7 +224,7 @@ BYTE altair_sio3_status_in(void)
 	tdiff = time_diff(&sio3_t1, &sio3_t2);
 	if (sio3_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME/sio3_baud_rate))
-			return(sio3_stat);
+			return (sio3_stat);
 
 	/* if socket is connected check for I/O */
 	if (ucons[0].ssc != 0) {
@@ -240,7 +240,7 @@ BYTE altair_sio3_status_in(void)
 
 	gettimeofday(&sio3_t1, NULL);
 
-	return(sio3_stat);
+	return (sio3_stat);
 }
 
 /*
@@ -262,7 +262,7 @@ BYTE altair_sio3_data_in(void)
 
 	/* if not connected return last */
 	if (ucons[0].ssc == 0)
-		return(last);
+		return (last);
 
 	/* if no input waiting return last */
 	p[0].fd = ucons[0].ssc;
@@ -270,13 +270,13 @@ BYTE altair_sio3_data_in(void)
 	p[0].revents = 0;
 	poll(p, 1, 0);
 	if (!(p[0].revents & POLLIN))
-		return(last);
+		return (last);
 
 	if (read(ucons[0].ssc, &data, 1) != 1) {
 		/* EOF, close socket and return last */
 		close(ucons[0].ssc);
 		ucons[0].ssc = 0;
-		return(last);
+		return (last);
 	}
 
 	gettimeofday(&sio3_t1, NULL);
@@ -284,7 +284,7 @@ BYTE altair_sio3_data_in(void)
 
 	/* process read data */
 	last = data;
-	return(data);
+	return (data);
 }
 
 /*

--- a/iodevices/cromemco-88ccc.c
+++ b/iodevices/cromemco-88ccc.c
@@ -160,7 +160,7 @@ void cromemco_88ccc_ctrl_c_out(BYTE data)
 BYTE cromemco_88ccc_ctrl_a_in(void)
 {
 	/* return flags along with state in the msb */
-	return(flags | (state << 7));
+	return (flags | (state << 7));
 }
 
 #endif /* HAS_CYCLOPS */

--- a/iodevices/cromemco-dazzler.c
+++ b/iodevices/cromemco-dazzler.c
@@ -779,9 +779,9 @@ void cromemco_dazzler_ctl_out(BYTE data)
 BYTE cromemco_dazzler_flags_in(void)
 {
 	if (thread != 0)
-		return(flags);
+		return (flags);
 	else
-		return((BYTE) 0xff);
+		return ((BYTE) 0xff);
 }
 
 void cromemco_dazzler_format_out(BYTE data)

--- a/iodevices/cromemco-fdc.c
+++ b/iodevices/cromemco-fdc.c
@@ -487,7 +487,6 @@ BYTE cromemco_fdc_data_in(void)
 		}
 		/* return next byte from buffer and increment counter */
 		return(buf[dcnt++]);
-		break;
 
 	case FDC_READADR:	/* read disk address */
 		/* first byte? */
@@ -508,11 +507,9 @@ BYTE cromemco_fdc_data_in(void)
 		}
 		/* return next byte from buffer and increment counter */
 		return(buf[dcnt++]);
-		break;
 
 	default:
 		return((BYTE) 0);
-		break;
 	}
 }
 

--- a/iodevices/cromemco-fdc.c
+++ b/iodevices/cromemco-fdc.c
@@ -286,7 +286,7 @@ long get_pos(void)
 	else	/* double sided, double density */
 		pos = ((fdc_track * 2 + side) * disks[disk].sectors
 		       + fdc_sec - 1) * SEC_SZDD;
-	return(pos);
+	return (pos);
 }
 
 /*
@@ -327,7 +327,7 @@ BYTE cromemco_fdc_diskflags_in(void)
 	if (headloaded)
 		ret |= 32;
 
-	return(ret);
+	return (ret);
 }
 
 /*
@@ -402,7 +402,7 @@ BYTE cromemco_fdc_data_in(void)
 				fdc_flags |= 1;		/* set EOJ */
 				fdc_flags &= ~128;	/* reset DRQ */
 				fdc_stat = 0x80;	/* not ready */
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 			/* try to open disk image */
 			dsk_path();
@@ -413,7 +413,7 @@ BYTE cromemco_fdc_data_in(void)
 				fdc_flags |= 1;		/* set EOJ */
 				fdc_flags &= ~128;	/* reset DRQ */
 				fdc_stat = 0x80;	/* not ready */
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 			/* get drive and disk geometry */
 			config_disk(fd);
@@ -423,7 +423,7 @@ BYTE cromemco_fdc_data_in(void)
 				fdc_flags &= ~128;	/* reset DRQ */
 				fdc_stat = 0x10;	/* sector not found */
 				close(fd);
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 			/* check track/sector */
 			if ((fdc_track == 0) && (side == 0))
@@ -438,7 +438,7 @@ BYTE cromemco_fdc_data_in(void)
 				fdc_flags &= ~128;	/* reset DRQ */
 				fdc_stat = 0x10;	/* sector not found */
 				close(fd);
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 			/* seek to sector */
 			pos = get_pos();
@@ -448,7 +448,7 @@ BYTE cromemco_fdc_data_in(void)
 				fdc_flags &= ~128;	/* reset DRQ */
 				fdc_stat = 0x10;	/* sector not found */
 				close(fd);
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 			/* read the sector */
 			if (read(fd, &buf[0], secsz) != secsz) {
@@ -457,7 +457,7 @@ BYTE cromemco_fdc_data_in(void)
 				fdc_flags &= ~128;	/* reset DRQ */
 				fdc_stat = 0x10;	/* sector not found */
 				close(fd);
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 			close(fd);
 		}
@@ -481,12 +481,12 @@ BYTE cromemco_fdc_data_in(void)
 				} else {
 					dcnt = 0;	/* read next sector */
 					fdc_sec++;
-					return(buf[secsz - 1]);
+					return (buf[secsz - 1]);
 				}
 			}
 		}
 		/* return next byte from buffer and increment counter */
-		return(buf[dcnt++]);
+		return (buf[dcnt++]);
 
 	case FDC_READADR:	/* read disk address */
 		/* first byte? */
@@ -506,10 +506,10 @@ BYTE cromemco_fdc_data_in(void)
 			fdc_stat = 0;
 		}
 		/* return next byte from buffer and increment counter */
-		return(buf[dcnt++]);
+		return (buf[dcnt++]);
 
 	default:
-		return((BYTE) 0);
+		return ((BYTE) 0);
 	}
 }
 
@@ -722,7 +722,7 @@ void cromemco_fdc_data_out(BYTE data)
  */
 BYTE cromemco_fdc_sector_in(void)
 {
-	return(fdc_sec);
+	return (fdc_sec);
 }
 
 /*
@@ -738,7 +738,7 @@ void cromemco_fdc_sector_out(BYTE data)
  */
 BYTE cromemco_fdc_track_in(void)
 {
-	return(fdc_track);
+	return (fdc_track);
 }
 
 /*
@@ -820,7 +820,7 @@ BYTE cromemco_fdc_aux_in(void)
 		fdc_aux |= 1;
 #endif
 
-	return(fdc_aux);
+	return (fdc_aux);
 }
 
 /*
@@ -900,7 +900,7 @@ BYTE cromemco_fdc_status_in(void)
 			fdc_stat &= ~4;
 	}
 
-	return(fdc_stat);
+	return (fdc_stat);
 }
 
 /*

--- a/iodevices/cromemco-hal.c
+++ b/iodevices/cromemco-hal.c
@@ -126,7 +126,7 @@ again:
     p[0].revents = 0;
     poll(p, 1, 0);
     if (!(p[0].revents & POLLIN))
-        return(-1);
+        return (-1);
 
     if (read(fileno(stdin), &data, 1) == 0) {
         /* try to reopen tty, input redirection exhausted */
@@ -188,7 +188,7 @@ int scktsrv_in(int dev) {
 
 	/* if not connected return last */
 	if (ncons[dev].ssc == 0)
-		return(-1);
+		return (-1);
 
 	/* if no input waiting return last */
 	p[0].fd = ncons[dev].ssc;
@@ -196,19 +196,19 @@ int scktsrv_in(int dev) {
 	p[0].revents = 0;
 	poll(p, 1, 0);
 	if (!(p[0].revents & POLLIN))
-		return(-1);
+		return (-1);
 
 	if (read(ncons[dev].ssc, &data, 1) != 1) {
         if ((errno == EAGAIN) || (errno == EINTR)) {
             /* EOF, close socket and return last */
             close(ncons[dev].ssc);
             ncons[dev].ssc = 0;
-            return(-1);
+            return (-1);
         } else {
             LOGE(TAG, "can't read tcpsocket %d data", dev);
             cpu_error = IOERROR;
             cpu_state = STOPPED;
-            return(0);
+            return (0);
         }
 	}
 

--- a/iodevices/cromemco-tu-art.c
+++ b/iodevices/cromemco-tu-art.c
@@ -86,7 +86,7 @@ BYTE cromemco_tuart_0a_status_in(void)
 	if (uart0a_int_pending)
 		status |= 32;
 
-	return(status);
+	return (status);
 }
 
 /*
@@ -119,7 +119,7 @@ BYTE cromemco_tuart_0a_data_in(void)
 
 	/* process read data */
 	last = data;
-	return((BYTE) data);
+	return ((BYTE) data);
 }
 
 void cromemco_tuart_0a_data_out(BYTE data)
@@ -170,7 +170,7 @@ void cromemco_tuart_0a_command_out(BYTE data)
  */
 BYTE cromemco_tuart_0a_interrupt_in(void)
 {
-	return((BYTE) uart0a_int);
+	return ((BYTE) uart0a_int);
 }
 
 /*
@@ -196,7 +196,7 @@ void cromemco_tuart_0a_interrupt_out(BYTE data)
 
 BYTE cromemco_tuart_0a_parallel_in(void)
 {
-	return((BYTE) 0);
+	return ((BYTE) 0);
 }
 
 void cromemco_tuart_0a_parallel_out(BYTE data)
@@ -252,7 +252,7 @@ BYTE cromemco_tuart_1a_status_in(void)
 	if (uart1a_int_pending)
 		status |= 32;
 
-	return(status);
+	return (status);
 }
 
 void cromemco_tuart_1a_baud_out(BYTE data)
@@ -274,7 +274,7 @@ BYTE cromemco_tuart_1a_data_in(void)
 	}
 
 	last = data;
-	return((BYTE) data);
+	return ((BYTE) data);
 }
 
 void cromemco_tuart_1a_data_out(BYTE data)
@@ -298,7 +298,7 @@ void cromemco_tuart_1a_command_out(BYTE data)
 
 BYTE cromemco_tuart_1a_interrupt_in(void)
 {
-	return((BYTE) uart1a_int);
+	return ((BYTE) uart1a_int);
 }
 
 void cromemco_tuart_1a_interrupt_out(BYTE data)
@@ -309,9 +309,9 @@ void cromemco_tuart_1a_interrupt_out(BYTE data)
 BYTE cromemco_tuart_1a_parallel_in(void)
 {
 	if (uart1a_lpt_busy == 0)
-		return((BYTE) ~0x20);
+		return ((BYTE) ~0x20);
 	else
-		return((BYTE) 0xff);
+		return ((BYTE) 0xff);
 }
 
 void cromemco_tuart_1a_parallel_out(BYTE data)
@@ -372,7 +372,7 @@ BYTE cromemco_tuart_1b_status_in(void)
 	if (uart1b_int_pending)
 		status |= 32;
 
-	return(status);
+	return (status);
 }
 
 void cromemco_tuart_1b_baud_out(BYTE data)
@@ -394,7 +394,7 @@ BYTE cromemco_tuart_1b_data_in(void)
 	}
 
 	last = data;
-	return((BYTE) data);
+	return ((BYTE) data);
 }
 
 void cromemco_tuart_1b_data_out(BYTE data)
@@ -418,7 +418,7 @@ void cromemco_tuart_1b_command_out(BYTE data)
 
 BYTE cromemco_tuart_1b_interrupt_in(void)
 {
-	return((BYTE) uart1b_int);
+	return ((BYTE) uart1b_int);
 }
 
 void cromemco_tuart_1b_interrupt_out(BYTE data)
@@ -429,9 +429,9 @@ void cromemco_tuart_1b_interrupt_out(BYTE data)
 BYTE cromemco_tuart_1b_parallel_in(void)
 {
 	if (uart1b_lpt_busy == 0)
-		return((BYTE) ~0x20);
+		return ((BYTE) ~0x20);
 	else
-		return((BYTE) 0xff);
+		return ((BYTE) 0xff);
 }
 
 void cromemco_tuart_1b_parallel_out(BYTE data)

--- a/iodevices/cromemco-wdi.c
+++ b/iodevices/cromemco-wdi.c
@@ -1005,6 +1005,7 @@ void cromemco_wdi_dma0_out(BYTE data)
                             break;
                         default:
                             cmd = "NOT IMPLEMENTED";
+			    break;
                     }
                     LOGD(TAG, "DMA WR6 = %02x - %s", data, cmd);
                 } else {

--- a/iodevices/cromemco-wdi.c
+++ b/iodevices/cromemco-wdi.c
@@ -468,7 +468,7 @@ Tstates_t wdi_dma_read(BYTE bus_ack)
 BYTE cromemco_wdi_pio0a_data_in(void)
 {
 	LOGW(TAG, "E0 IN:");
-	return((BYTE) 0xFF);
+	return ((BYTE) 0xFF);
 }
 BYTE cromemco_wdi_pio0b_data_in(void)
 {
@@ -495,17 +495,17 @@ BYTE cromemco_wdi_pio0b_data_in(void)
             break;
     }
     LOGD(TAG, "STATUS %d = %02x", bus, val);
-	return(val);
+	return (val);
 }
 BYTE cromemco_wdi_pio0a_cmd_in(void)
 {
 	LOGW(TAG, "E2 IN:");
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 BYTE cromemco_wdi_pio0b_cmd_in(void)
 {
 	LOGW(TAG, "E3 IN:");
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 BYTE cromemco_wdi_pio1a_data_in(void)
 {
@@ -527,7 +527,7 @@ BYTE cromemco_wdi_pio1a_data_in(void)
     val = (wdi.pio1.data_A & ~wdi.pio1.dir_A) | val;
 
     LOGD(TAG, "E4 IN: = %02x", val);
-	return(val);
+	return (val);
 }
 BYTE cromemco_wdi_pio1b_data_in(void)
 {
@@ -546,39 +546,39 @@ BYTE cromemco_wdi_pio1b_data_in(void)
     val = (wdi.pio1.data_B & ~wdi.pio1.dir_B) | val;
 
 	LOGD(TAG, "E5 IN: = %02x", val);
-	return(val);
+	return (val);
 }
 BYTE cromemco_wdi_pio1a_cmd_in(void)
 {
 	LOGW(TAG, "E6 IN:");
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 BYTE cromemco_wdi_pio1b_cmd_in(void)
 {
 	LOGW(TAG, "E7 IN:");
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 BYTE cromemco_wdi_dma0_in(void)
 {
     /* DMA READ STATUS NOT YET COMPLETE */
 	LOGE(TAG, "E8 IN: [%d]", wdi.dma.rr_state);
     if (wdi.dma.rr_state == RR_BASE) return wdi.dma.rr0.status;
-    else return((BYTE) 0xff);
+    else return ((BYTE) 0xff);
 }
 BYTE cromemco_wdi_dma1_in(void)
 {
 	LOGW(TAG, "E9 IN:");
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 BYTE cromemco_wdi_dma2_in(void)
 {
 	LOGW(TAG, "EA IN:");
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 BYTE cromemco_wdi_dma3_in(void)
 {
 	LOGW(TAG, "EB IN:");
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 BYTE cromemco_wdi_ctc0_in(void)
 {
@@ -596,7 +596,7 @@ BYTE cromemco_wdi_ctc0_in(void)
             wdi.ctc.T0 += index_ticks;
         }
     }
-	return(val);
+	return (val);
 }
 BYTE cromemco_wdi_ctc1_in(void)
 {
@@ -619,7 +619,7 @@ BYTE cromemco_wdi_ctc1_in(void)
         wdi.ctc.T1 = T;
     }
 
-	return(wdi.ctc.now1);
+	return (wdi.ctc.now1);
 }
 BYTE cromemco_wdi_ctc2_in(void)
 {
@@ -639,12 +639,12 @@ BYTE cromemco_wdi_ctc2_in(void)
     /* Only count seek complete if online */
     if (val > 0 && wdi.hd[wdi.unit].online) wdi.ctc.now2--;
 
-	return(val);
+	return (val);
 }
 BYTE cromemco_wdi_ctc3_in(void)
 {
 	LOGW(TAG, "EF IN:");
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 void command_bus_strobe(void)

--- a/iodevices/diskmanager.c
+++ b/iodevices/diskmanager.c
@@ -286,7 +286,7 @@ int LibraryHandler(HttpdConnection_t *conn, void *unused) {
 
     *file_start = '\0';
 
-    switch(req->method) {
+    switch (req->method) {
     case HTTP_GET:
         DirectoryHandler(conn, path);
         break;
@@ -358,7 +358,7 @@ int DiskHandler(HttpdConnection_t *conn, void *unused) {
     disk_err_t result;
     UNUSED(unused);
  
-    switch(req->method) {
+    switch (req->method) {
     case HTTP_GET:
         LOGD(TAG, "GET /disks");
         sendDisks(conn);
@@ -426,6 +426,7 @@ int DiskHandler(HttpdConnection_t *conn, void *unused) {
     default:
         httpdStartResponse(conn, 405);  /* http error code 'Method Not Allowed' */
         httpdEndHeaders(conn);
+	break;
 	}
 
     return 1;   

--- a/iodevices/generic-at-modem.c
+++ b/iodevices/generic-at-modem.c
@@ -303,11 +303,9 @@ int open_socket(void) {
                 */
                 LOGE(TAG, "Not expecting IPV6 addresses");
                 return 1;
-                break;
             default:
                 LOGE(TAG, "Not expecting address family type %d", rp->ai_family);
                 return 1;
-                break;
         }
 
         inet_ntop(rp->ai_family, addrptr, addr, 100);
@@ -742,7 +740,6 @@ int process_at_cmd(void) {
             }
             *at_err = 0;
             return 1; /* Not an error, just want to suppress the OK mesage */
-			break;
 		case 'S': /* ATSn */
             tmp_reg = strtol(at_ptr, &arg_ptr, BASE_DECIMAL);
 
@@ -1041,7 +1038,6 @@ int process_at_cmd(void) {
 		default:
 			strcpy(at_err, LF AT_ERROR CRLF);
 			return 1;
-			break;
 	}
   }
 
@@ -1332,7 +1328,7 @@ void modem_device_send(int i, char data) {
 			break;
 		default:
 			LOGE(TAG, "AT statemachine unknown [%d]", at_state);
-		break;
+			break;
 	}
 
     if (at_state == dat) gettimeofday(&at_t1, NULL);

--- a/iodevices/imsai-fif.c
+++ b/iodevices/imsai-fif.c
@@ -392,7 +392,7 @@ void disk_io(int addr)
 do_format:
 
 	/* try wanted disk operation */
-	switch(cmd) {
+	switch (cmd) {
 	case WRITE_SEC:
 		if (track >= maxtrk) {
 			dma_write(addr + DD_RESULT, 0xc5);

--- a/iodevices/imsai-fif.c
+++ b/iodevices/imsai-fif.c
@@ -129,7 +129,7 @@ char *dsk_path(void) {
 
 BYTE imsai_fif_in(void)
 {
-	return(0);
+	return (0);
 }
 
 void imsai_fif_out(BYTE data)

--- a/iodevices/imsai-hal.c
+++ b/iodevices/imsai-hal.c
@@ -79,14 +79,14 @@ int vio_kbd_in(void)
 	int data;
 
 	if (imsai_kbd_data == -1)
-		return(-1);
+		return (-1);
 
 	/* take over data and reset */
 	data = imsai_kbd_data;
 	imsai_kbd_data = -1;
 	imsai_kbd_status = 0;
 
-	return(data);
+	return (data);
 }
 void vio_kbd_out(BYTE data) {
     UNUSED(data);
@@ -168,7 +168,7 @@ again:
     p[0].revents = 0;
     poll(p, 1, 0);
     if (!(p[0].revents & POLLIN))
-        return(-1);
+        return (-1);
 
     if (read(fileno(stdin), &data, 1) == 0) {
         /* try to reopen tty, input redirection exhausted */
@@ -242,7 +242,7 @@ int scktsrv_in(void) {
 
 	/* if not connected return last */
 	if (ucons[0].ssc == 0)
-		return(-1);
+		return (-1);
 
 	/* if no input waiting return last */
 	p[0].fd = ucons[0].ssc;
@@ -250,13 +250,13 @@ int scktsrv_in(void) {
 	p[0].revents = 0;
 	poll(p, 1, 0);
 	if (!(p[0].revents & POLLIN))
-		return(-1);
+		return (-1);
 
 	if (read(ucons[0].ssc, &data, 1) != 1) {
 		/* EOF, close socket and return last */
 		close(ucons[0].ssc);
 		ucons[0].ssc = 0;
-		return(-1);
+		return (-1);
 	}
 
     return data;

--- a/iodevices/imsai-sio2.c
+++ b/iodevices/imsai-sio2.c
@@ -93,7 +93,7 @@ BYTE imsai_sio_nofun_in(void)
 	LOGD(TAG,"INVALID SIO PORT"); /* suppress TAG and _log_write warnings */
 				      /* won't be seen unless */
 				      /* LOG_LOCAL_LEVEL = DEBUG */
-	return((BYTE) 0);
+	return ((BYTE) 0);
 }
 
 void imsai_sio_nofun_out(BYTE data)
@@ -120,13 +120,13 @@ BYTE imsai_sio1a_status_in(void)
 	tdiff = time_diff(&sio1a_t1, &sio1a_t2);
 	if (sio1a_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME/sio1a_baud_rate))
-			return(sio1a_stat);
+			return (sio1a_stat);
 
 	hal_status_in(SIO1A, &sio1a_stat);
 
 	gettimeofday(&sio1a_t1, NULL);
 
-	return(sio1a_stat);
+	return (sio1a_stat);
 }
 
 /*
@@ -161,7 +161,7 @@ BYTE imsai_sio1a_data_in(void)
 	if (sio1a_upper_case)
 		data = toupper(data);
 	last = data;
-	return((BYTE) data);
+	return ((BYTE) data);
 }
 
 /*
@@ -199,13 +199,13 @@ BYTE imsai_sio1b_status_in(void)
 	tdiff = time_diff(&sio1b_t1, &sio1b_t2);
 	if (sio1b_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME/sio1b_baud_rate))
-			return(sio1b_stat);
+			return (sio1b_stat);
 
 	hal_status_in(SIO1B, &sio1b_stat);
 
 	gettimeofday(&sio1b_t1, NULL);
 
-	return(sio1b_stat);
+	return (sio1b_stat);
 }
 
 /*
@@ -237,7 +237,7 @@ BYTE imsai_sio1b_data_in(void)
 	if (sio1b_upper_case)
 		data = toupper(data);
 	last = data;
-	return((BYTE) data);
+	return ((BYTE) data);
 }
 
 /*
@@ -275,13 +275,13 @@ BYTE imsai_sio2a_status_in(void)
 	tdiff = time_diff(&sio2a_t1, &sio2a_t2);
 	if (sio2a_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME/sio2a_baud_rate))
-			return(sio2a_stat);
+			return (sio2a_stat);
 
 	hal_status_in(SIO2A, &sio2a_stat);
 
 	gettimeofday(&sio2a_t1, NULL);
 
-	return(sio2a_stat);
+	return (sio2a_stat);
 }
 
 /*
@@ -316,7 +316,7 @@ BYTE imsai_sio2a_data_in(void)
 	if (sio2a_upper_case)
 		data = toupper(data);
 	last = data;
-	return((BYTE)data);
+	return ((BYTE)data);
 }
 
 /*
@@ -357,13 +357,13 @@ BYTE imsai_sio2b_status_in(void)
 	tdiff = time_diff(&sio2b_t1, &sio2b_t2);
 	if (sio2b_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME/sio2b_baud_rate))
-			return(sio2b_stat);
+			return (sio2b_stat);
 
 	hal_status_in(SIO2B, &sio2b_stat);
 
 	gettimeofday(&sio2b_t1, NULL);
 
-	return(sio2b_stat);
+	return (sio2b_stat);
 }
 
 /*
@@ -398,7 +398,7 @@ BYTE imsai_sio2b_data_in(void)
 	if (sio2b_upper_case)
 		data = toupper(data);
 	last = data;
-	return((BYTE)data);
+	return ((BYTE)data);
 }
 
 /*
@@ -440,7 +440,7 @@ BYTE imsai_sio1_ctl_in(void)
 	int cd_a = hal_carrier_detect(SIO1A);
 	int cd_b = hal_carrier_detect(SIO1B);
 
-	return(0b10111011 | (cd_a << 2) | cd_b << 6);
+	return (0b10111011 | (cd_a << 2) | cd_b << 6);
 }
 
 BYTE imsai_sio2_ctl_in(void)
@@ -448,7 +448,7 @@ BYTE imsai_sio2_ctl_in(void)
 	int cd_a = hal_carrier_detect(SIO2A);
 	int cd_b = hal_carrier_detect(SIO2B);
 
-	return(0b10111011 | (cd_a << 2) | cd_b << 6);
+	return (0b10111011 | (cd_a << 2) | cd_b << 6);
 }
 
 /*

--- a/iodevices/libtelnet.c
+++ b/iodevices/libtelnet.c
@@ -1061,6 +1061,7 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
 				/* state update */
 				start = i + 1;
 				telnet->state = TELNET_STATE_DATA;
+				break;
 			}
 			break;
 

--- a/iodevices/mostek-cpu.c
+++ b/iodevices/mostek-cpu.c
@@ -43,7 +43,7 @@ BYTE sio_status_in(void)
 	if (p[0].revents & POLLOUT)
 		status |= 0x80;
 
-	return(status);
+	return (status);
 }
 
 /*
@@ -70,7 +70,7 @@ again:
 	p[0].revents = 0;
 	poll(p, 1, 0);
 	if (!(p[0].revents & POLLIN))
-		return(last);
+		return (last);
 
 	if (read(fileno(stdin), &data, 1) == 0) {
 		/* try to reopen tty, input redirection exhausted */
@@ -81,7 +81,7 @@ again:
 
 	/* process read data */
 	last = data;
-	return(data);
+	return (data);
 }
 
 /*
@@ -114,7 +114,7 @@ BYTE sio_handshake_in(void)
 	static BYTE handshake_data = 3;		/* DSR and RTS asserted */
 
 	handshake_data ^= 0x80;			/* toggle serial line each call */
-	return(handshake_data);
+	return (handshake_data);
 }
 
 /*

--- a/iodevices/mostek-fdc.c
+++ b/iodevices/mostek-fdc.c
@@ -346,7 +346,6 @@ BYTE fdc1771_data_in(void)
 
 		/* return byte from buffer and increment counter */
 		return(buf[dcnt++]);
-		break;
 
 	case FDC_READADR:	/* read disk address */
 
@@ -369,11 +368,9 @@ BYTE fdc1771_data_in(void)
 
 		/* return byte from buffer and increment counter */
 		return(buf[dcnt++]);
-		break;
 
 	default:
 		return((BYTE) 0);
-		break;
 	}
 }
 

--- a/iodevices/mostek-fdc.c
+++ b/iodevices/mostek-fdc.c
@@ -119,7 +119,7 @@ void get_disk_filename(void)
  */
 BYTE fdcBoard_stat_in(void)
 {
-	return(board_stat);
+	return (board_stat);
 }
 
 /*
@@ -127,7 +127,7 @@ BYTE fdcBoard_stat_in(void)
  */
 BYTE fdcBoard_ctl_in(void)
 {
-	return(board_ctl);
+	return (board_ctl);
 }
 
 /*
@@ -150,7 +150,7 @@ void fdcBoard_ctl_out(BYTE data)
 BYTE fdc1771_stat_in(void)
 {
 	board_stat &= ~sINTERRUPT;		/* read clears INTRQ */
-	return(fdc_stat);
+	return (fdc_stat);
 }
 
 /*
@@ -255,7 +255,7 @@ void fdc1771_cmd_out(BYTE data)
  */
 BYTE fdc1771_track_in(void)
 {
-	return(fdc_track);
+	return (fdc_track);
 }
 
 /*
@@ -271,7 +271,7 @@ void fdc1771_track_out(BYTE data)
  */
 BYTE fdc1771_sec_in(void)
 {
-	return(fdc_sec);
+	return (fdc_sec);
 }
 
 /*
@@ -300,14 +300,14 @@ BYTE fdc1771_data_in(void)
 			if ((fdc_track >= TRK) || (fdc_sec > SPT)) {
 				state = FDC_IDLE;	/* abort command */
 				fdc_stat = sRECORD_NOT_FOUND;
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 
 			/* check disk drive */
 			if ((disk < 0) || (disk > 3)) {
 				state = FDC_IDLE;	/* abort command */
 				fdc_stat = sNOT_READY;
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 
 			/* try to open disk image */
@@ -315,7 +315,7 @@ BYTE fdc1771_data_in(void)
 			if ((fd = open(fn, O_RDONLY)) == -1) {
 				state = FDC_IDLE;	/* abort command */
 				fdc_stat = sNOT_READY;
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 
 			/* seek to sector */
@@ -324,7 +324,7 @@ BYTE fdc1771_data_in(void)
 				state = FDC_IDLE;	/* abort command */
 				fdc_stat = sRECORD_NOT_FOUND;
 				close(fd);
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 
 			/* read the sector */
@@ -332,7 +332,7 @@ BYTE fdc1771_data_in(void)
 				state = FDC_IDLE;	/* abort read command */
 				fdc_stat = sRECORD_NOT_FOUND;
 				close(fd);
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 			close(fd);
 			board_stat = sINPUT_READY + sINTERRUPT;
@@ -345,7 +345,7 @@ BYTE fdc1771_data_in(void)
 		}
 
 		/* return byte from buffer and increment counter */
-		return(buf[dcnt++]);
+		return (buf[dcnt++]);
 
 	case FDC_READADR:	/* read disk address */
 
@@ -367,10 +367,10 @@ BYTE fdc1771_data_in(void)
 		}
 
 		/* return byte from buffer and increment counter */
-		return(buf[dcnt++]);
+		return (buf[dcnt++]);
 
 	default:
-		return((BYTE) 0);
+		return ((BYTE) 0);
 	}
 }
 

--- a/iodevices/rtc.c
+++ b/iodevices/rtc.c
@@ -98,7 +98,7 @@ BYTE clkd_in(void)
 
 	time(&Time);
 	t = localtime(&Time);
-	switch(clkcmd) {
+	switch (clkcmd) {
 	case 0:			/* seconds */
 		if (clkfmt)
 			val = t->tm_sec;

--- a/iodevices/rtc.c
+++ b/iodevices/rtc.c
@@ -52,7 +52,7 @@ static int get_date(struct tm *t)
 			val++;
 	}
 	val += t->tm_yday + 1;
-	return(val);
+	return (val);
 }
 
 /*
@@ -61,7 +61,7 @@ static int get_date(struct tm *t)
  */
 BYTE clkc_in(void)
 {
-	return(clkfmt);
+	return (clkfmt);
 }
 
 /*
@@ -145,7 +145,7 @@ BYTE clkd_in(void)
 		val = 0;
 		break;
 	}
-	return((BYTE) val);
+	return ((BYTE) val);
 }
 
 /*

--- a/iodevices/tarbell_fdc.c
+++ b/iodevices/tarbell_fdc.c
@@ -303,7 +303,6 @@ BYTE tarbell_data_in(void)
 
 		/* return byte from buffer and increment counter */
 		return(buf[dcnt++]);
-		break;
 
 	case FDC_READADR:	/* read disk address */
 
@@ -325,11 +324,9 @@ BYTE tarbell_data_in(void)
 
 		/* return byte from buffer and increment counter */
 		return(buf[dcnt++]);
-		break;
 
 	default:
 		return((BYTE) 0);
-		break;
 	}
 }
 

--- a/iodevices/tarbell_fdc.c
+++ b/iodevices/tarbell_fdc.c
@@ -102,7 +102,7 @@ void dsk_path(void) {
  */
 BYTE tarbell_stat_in(void)
 {
-	return(fdc_stat);
+	return (fdc_stat);
 }
 
 /*
@@ -202,7 +202,7 @@ void tarbell_cmd_out(BYTE data)
  */
 BYTE tarbell_track_in(void)
 {
-	return(fdc_track);
+	return (fdc_track);
 }
 
 /*
@@ -218,7 +218,7 @@ void tarbell_track_out(BYTE data)
  */
 BYTE tarbell_sec_in(void)
 {
-	return(fdc_sec);
+	return (fdc_sec);
 }
 
 /*
@@ -247,14 +247,14 @@ BYTE tarbell_data_in(void)
 			if ((fdc_track >= TRK) || (fdc_sec > SPT)) {
 				state = FDC_IDLE;	/* abort command */
 				fdc_stat = 0x10;	/* record not found */
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 
 			/* check disk drive */
 			if ((disk < 0) || (disk > 3)) {
 				state = FDC_IDLE;	/* abort command */
 				fdc_stat = 0x80;	/* not ready */
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 
 			/* try to open disk image */
@@ -264,7 +264,7 @@ BYTE tarbell_data_in(void)
 			if ((fd = open(fn, O_RDONLY)) == -1) {
 				state = FDC_IDLE;	/* abort command */
 				fdc_stat = 0x80;	/* not ready */
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 
 			/* check for correct image size */
@@ -273,7 +273,7 @@ BYTE tarbell_data_in(void)
 				state = FDC_IDLE;	/* abort command */
 				fdc_stat = 0x80;	/* not ready */
 				close(fd);
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 
 			/* seek to sector */
@@ -282,7 +282,7 @@ BYTE tarbell_data_in(void)
 				state = FDC_IDLE;	/* abort command */
 				fdc_stat = 0x10;	/* record not found */
 				close(fd);
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 
 			/* read the sector */
@@ -290,7 +290,7 @@ BYTE tarbell_data_in(void)
 				state = FDC_IDLE;	/* abort read command */
 				fdc_stat = 0x10;	/* record not found */
 				close(fd);
-				return((BYTE) 0);
+				return ((BYTE) 0);
 			}
 			close(fd);
 		}
@@ -302,7 +302,7 @@ BYTE tarbell_data_in(void)
 		}
 
 		/* return byte from buffer and increment counter */
-		return(buf[dcnt++]);
+		return (buf[dcnt++]);
 
 	case FDC_READADR:	/* read disk address */
 
@@ -323,10 +323,10 @@ BYTE tarbell_data_in(void)
 		}
 
 		/* return byte from buffer and increment counter */
-		return(buf[dcnt++]);
+		return (buf[dcnt++]);
 
 	default:
-		return((BYTE) 0);
+		return ((BYTE) 0);
 	}
 }
 
@@ -477,9 +477,9 @@ void tarbell_data_out(BYTE data)
 BYTE tarbell_wait_in(void)
 {
 	if (state == FDC_IDLE)
-		return((BYTE) 0);	/* don't wait for drive mechanics */
+		return ((BYTE) 0);	/* don't wait for drive mechanics */
 	else
-		return((BYTE) 0x80);	/* but wait on DRQ */
+		return ((BYTE) 0x80);	/* but wait on DRQ */
 }
 
 /*

--- a/mosteksim/srcsim/iosim.c
+++ b/mosteksim/srcsim/iosim.c
@@ -593,7 +593,7 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 	io_port = addrl;
 	io_data = (*port_in[addrl]) ();
 	LOGD(TAG, "input %02x from port %02x", io_data, io_port);
-	return(io_data);
+	return (io_data);
 }
 
 /*
@@ -622,7 +622,7 @@ static BYTE io_trap_in(void)
 		cpu_error = IOTRAPIN;
 		cpu_state = STOPPED;
 	}
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 /*
@@ -632,7 +632,7 @@ static BYTE io_trap_in(void)
  */
 static BYTE io_no_card_in(void)
 {
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 /*

--- a/mosteksim/srcsim/memory.h
+++ b/mosteksim/srcsim/memory.h
@@ -26,7 +26,7 @@ static inline void memwrt(WORD addr, BYTE data)
 
 static inline BYTE memrdr(WORD addr)
 {
-	return(memory[addr]);
+	return (memory[addr]);
 }
 
 /*
@@ -40,7 +40,7 @@ static inline void dma_write(WORD addr, BYTE data)
 
 static inline BYTE dma_read(WORD addr)
 {
-	return(memory[addr]);
+	return (memory[addr]);
 }
 
 /*
@@ -53,5 +53,5 @@ static inline void putmem(WORD addr, BYTE data)
 
 static inline BYTE getmem(WORD addr)
 {
-	return(memory[addr]);
+	return (memory[addr]);
 }

--- a/webfrontend/netsrv.c
+++ b/webfrontend/netsrv.c
@@ -246,7 +246,7 @@ int SystemHandler(HttpdConnection_t *conn, void *unused) {
 
 	const char *copyright = USR_CPR; /* a dirty fix to avoid the leading '\n' */
 
-    switch(req->method) {
+    switch (req->method) {
     case HTTP_GET:
 		LOGD(TAG, "Sending SYS: details.");
 
@@ -446,7 +446,7 @@ int DirectoryHandler(HttpdConnection_t *conn, void *path) {
     	showSize = true;
     }
 
-    switch(req->method) {
+    switch (req->method) {
     case HTTP_GET:
         pDir = opendir ((char *)path);
         if (pDir == NULL) {

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 		}
 		fclose(lstfp);
 	}
-	return(errors);
+	return (errors);
 }
 
 /*
@@ -456,9 +456,9 @@ int process_line(char *l)
 	if (gencode) {
 		pc += op_count;
 		rpc += op_count;
-		return(op == NULL || !(op->op_flags & OP_END));
+		return (op == NULL || !(op->op_flags & OP_END));
 	} else
-		return(TRUE);
+		return (TRUE);
 }
 
 /*
@@ -511,7 +511,7 @@ char *get_fn(char *src, const char *ext, int replace)
 		strncpy(dp, src, m);
 		strcpy(dp + m, (replace ? ext : ep));
 	}
-	return(dp);
+	return (dp);
 }
 
 /*
@@ -523,7 +523,7 @@ char *strsave(char *s)
 
 	if ((p = (char *) malloc(strlen(s) + 1)) == NULL)
 		fatal(F_OUTMEM, "strsave");
-	return(strcpy(p, s));
+	return (strcpy(p, s));
 }
 
 /*
@@ -552,7 +552,7 @@ char *get_symbol(char *s, char *l, int lbl_flag)
 			l++;
 	}
 	*s = '\0';
-	return(l);
+	return (l);
 }
 
 /*
@@ -654,7 +654,7 @@ char *next_arg(char *p, int *str_flag)
 	}
 	if (*p == ',') {
 		*p++ = '\0';			/* terminate previous arg */
-		return(p);
+		return (p);
 	} else
-		return(NULL);
+		return (NULL);
 }

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -237,6 +237,7 @@ void options(int argc, char *argv[])
 			default:
 				printf("unknown option %c\n", *s);
 				usage();
+				break;
 			}
 	if (argc == 0) {
 		puts("no input file");

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -138,7 +138,7 @@ char *mac_first(int sort_mode, int *rp)
 	if (mac_count == 0)
 		return(NULL);
 	mac_sort = sort_mode;
-	switch(sort_mode) {
+	switch (sort_mode) {
 	case SYM_UNSORT:
 		for (m = mac_table; m->mac_next != NULL; m = m->mac_next)
 			;
@@ -160,6 +160,7 @@ char *mac_first(int sort_mode, int *rp)
 		return(mac_array[mac_index]->mac_name);
 	default:
 		fatal(F_INTERN, "unknown sort mode in mac_first");
+		break;
 	}
 }
 
@@ -997,7 +998,7 @@ WORD op_mcond(BYTE op_code, BYTE dummy)
 	iflevel++;
 	if (!gencode)
 		return(0);
-	switch(op_code) {
+	switch (op_code) {
 	case 1:				/* IFB */
 	case 2:				/* IFNB */
 		if ((s = mac_next_parm(operand)) != NULL) {
@@ -1035,6 +1036,7 @@ WORD op_mcond(BYTE op_code, BYTE dummy)
 		break;
 	default:
 		fatal(F_INTERN, "invalid opcode for function op_mcond");
+		break;
 	}
 	if (!err) {
 		if ((op_code & 1) == 0)	/* negate for inverse IF */
@@ -1059,7 +1061,7 @@ WORD op_irp(BYTE op_code, BYTE dummy)
 	UNUSED(dummy);
 
 	a_mode = A_NONE;
-	switch(op_code) {
+	switch (op_code) {
 	case 1:				/* IRP */
 		m = mac_new(NULL, mac_start_irp, mac_rept_irp);
 		break;
@@ -1068,6 +1070,7 @@ WORD op_irp(BYTE op_code, BYTE dummy)
 		break;
 	default:
 		fatal(F_INTERN, "invalid opcode for function op_irp");
+		break;
 	}
 	s = operand;
 	t = tmp;

--- a/z80asm/z80amfun.c
+++ b/z80asm/z80amfun.c
@@ -106,7 +106,7 @@ int is_symbol(char *s)
 	register int i;
 
 	if (!IS_FSYM(*s))
-		return(FALSE);
+		return (FALSE);
 	s++;
 	i = 1;
 	while (IS_SYM(*s)) {
@@ -114,7 +114,7 @@ int is_symbol(char *s)
 			*s = '\0';
 		s++;
 	}
-	return(*s == '\0');
+	return (*s == '\0');
 }
 
 /*
@@ -122,8 +122,8 @@ int is_symbol(char *s)
  */
 int mac_compare(const void *p1, const void *p2)
 {
-	return(strcmp((*(const struct mac **) p1)->mac_name,
-		      (*(const struct mac **) p2)->mac_name));
+	return (strcmp((*(const struct mac **) p1)->mac_name,
+		       (*(const struct mac **) p2)->mac_name));
 }
 
 /*
@@ -136,7 +136,7 @@ char *mac_first(int sort_mode, int *rp)
 	register int i;
 
 	if (mac_count == 0)
-		return(NULL);
+		return (NULL);
 	mac_sort = sort_mode;
 	switch (sort_mode) {
 	case SYM_UNSORT:
@@ -144,7 +144,7 @@ char *mac_first(int sort_mode, int *rp)
 			;
 		mac_curr = m;
 		*rp = mac_curr->mac_refflg;
-		return(mac_curr->mac_name);
+		return (mac_curr->mac_name);
 	case SYM_SORTN:
 	case SYM_SORTA:
 		mac_array = (struct mac **) malloc(sizeof(struct mac *)
@@ -157,7 +157,7 @@ char *mac_first(int sort_mode, int *rp)
 		qsort(mac_array, mac_count, sizeof(struct mac *), mac_compare);
 		mac_index = 0;
 		*rp = mac_array[mac_index]->mac_refflg;
-		return(mac_array[mac_index]->mac_name);
+		return (mac_array[mac_index]->mac_name);
 	default:
 		fatal(F_INTERN, "unknown sort mode in mac_first");
 		break;
@@ -173,13 +173,13 @@ char *mac_next(int *rp)
 		mac_curr = mac_curr->mac_prev;
 		if (mac_curr != NULL) {
 			*rp = mac_curr->mac_refflg;
-			return(mac_curr->mac_name);
+			return (mac_curr->mac_name);
 		}
 	} else if (++mac_index < mac_count) {
 		*rp = mac_array[mac_index]->mac_refflg;
-		return(mac_array[mac_index]->mac_name);
+		return (mac_array[mac_index]->mac_name);
 	}
-	return(NULL);
+	return (NULL);
 }
 
 /*
@@ -211,7 +211,7 @@ struct mac *mac_new(char *name, void (*start)(struct expn *),
 	m->mac_dums_last = m->mac_dums = NULL;
 	m->mac_lines_last = m->mac_lines = NULL;
 	m->mac_next = m->mac_prev = NULL;
-	return(m);
+	return (m);
 }
 
 /*
@@ -447,10 +447,10 @@ int mac_rept_expn(void)
 		act_iflevel = e->expn_act_iflevel;
 		act_elselevel = e->expn_act_elselevel;
 		gencode = TRUE;
-		return(TRUE);
+		return (TRUE);
 	} else {
 		mac_end_expn();
-		return(FALSE);
+		return (FALSE);
 	}
 }
 
@@ -497,8 +497,8 @@ const char *mac_get_dummy(struct expn *e, char *s)
 
 	for (p = e->expn_parms; p != NULL; p = p->parm_next)
 		if (strncmp(p->parm_name, s, symlen) == 0)
-			return(p->parm_val == NULL ? "" : p->parm_val);
-	return(NULL);
+			return (p->parm_val == NULL ? "" : p->parm_val);
+	return (NULL);
 }
 
 /*
@@ -510,8 +510,8 @@ const char *mac_get_local(struct expn *e, char *s)
 
 	for (l = e->expn_locs; l != NULL; l = l->loc_next)
 		if (strncmp(l->loc_name, s, symlen) == 0)
-			return(l->loc_val);
-	return(NULL);
+			return (l->loc_val);
+	return (NULL);
 }
 
 /*
@@ -686,13 +686,13 @@ char *mac_expand(void)
 
 	e = mac_expn;
 	if (e->expn_line == NULL && !mac_rept_expn())
-		return(NULL);
+		return (NULL);
 	/* first substitute dummies with parameter values */
 	mac_subst(tmp, e->expn_line->line_text, e, mac_get_dummy);
 	/* next substitute local labels with ??xxxx */
 	mac_subst(line, tmp, e, mac_get_local);
 	e->expn_line = e->expn_line->line_next;
-	return(line);
+	return (line);
 }
 
 /*
@@ -706,9 +706,9 @@ int mac_lookup(char *opcode)
 	for (m = mac_table; m != NULL; m = m->mac_next)
 		if (strncmp(m->mac_name, opcode, symlen) == 0) {
 			mac_curr = m;
-			return(TRUE);
+			return (TRUE);
 		}
-	return(FALSE);
+	return (FALSE);
 }
 
 /*
@@ -745,7 +745,7 @@ char *mac_next_parm(char *s)
 			while (TRUE) {
 				if (*s == '\0') {
 					asmerr(E_MISDEL);
-					return(NULL);
+					return (NULL);
 				} else if (*s == c) {
 					if (*(s + 1) != c) /* double delim? */
 						break;
@@ -765,7 +765,7 @@ char *mac_next_parm(char *s)
 					while (TRUE) {
 						if (*s == '\0') {
 							asmerr(E_MISDEL);
-							return(NULL);
+							return (NULL);
 						} else if (*s == c) {
 							*t++ = *s++;
 							if (*s != c)
@@ -788,7 +788,7 @@ char *mac_next_parm(char *s)
 			t1 += m;
 			if (t1 - tmp > MAXLINE) {
 				asmerr(E_MACOVF);
-				return(NULL);
+				return (NULL);
 			}
 			/* generate digits backwards in current radix */
 			for (t = t1; m > 0; m--) {
@@ -802,7 +802,7 @@ char *mac_next_parm(char *s)
 			s++;
 			if (*s == '\0') {
 				asmerr(E_INVOPE);
-				return(NULL);
+				return (NULL);
 			} else
 				*t++ = *s++;
 		} else if (*s == LBRACK) {
@@ -815,7 +815,7 @@ char *mac_next_parm(char *s)
 		} else if (*s == RBRACK) {
 			if (n == 0) {
 				asmerr(E_INVOPE);
-				return(NULL);
+				return (NULL);
 			} else {
 				/* remove top level RBRACK */
 				n--;
@@ -834,10 +834,10 @@ char *mac_next_parm(char *s)
 	}
 	if (n > 0) {
 		asmerr(E_INVOPE);
-		return(NULL);
+		return (NULL);
 	}
 	*t1 = '\0';
-	return(s);
+	return (s);
 }
 
 /*
@@ -864,18 +864,18 @@ int mac_rept_irp(struct expn *e)
 
 	s = e->expn_irp;
 	if (*s == '\0')
-		return(FALSE);
+		return (FALSE);
 	else if (*s++ != ',') {
 		asmerr(E_INVOPE);
-		return(FALSE);
+		return (FALSE);
 	} else {
 		if ((s = mac_next_parm(s)) == NULL)
-			return(FALSE);
+			return (FALSE);
 		e->expn_irp = s;
 		if (e->expn_parms->parm_val != NULL)
 			free(e->expn_parms->parm_val);
 		e->expn_parms->parm_val = strsave(tmp);
-		return(TRUE);
+		return (TRUE);
 	}
 }
 
@@ -902,9 +902,9 @@ int mac_rept_irpc(struct expn *e)
 {
 	if (*e->expn_irp != '\0') {
 		*e->expn_parms->parm_val = *e->expn_irp++;
-		return(TRUE);
+		return (TRUE);
 	} else
-		return(FALSE);
+		return (FALSE);
 }
 
 /*
@@ -945,7 +945,7 @@ void mac_start_rept(struct expn *e)
  */
 int mac_rept_rept(struct expn *e)
 {
-	return(e->expn_iter < e->expn_mac->mac_nrept);
+	return (e->expn_iter < e->expn_mac->mac_nrept);
 }
 
 /*
@@ -961,7 +961,7 @@ WORD op_endm(BYTE dummy1, BYTE dummy2)
 		asmerr(E_NIMEXP);
 	else
 		(void) mac_rept_expn();
-	return(0);
+	return (0);
 }
 
 /*
@@ -977,7 +977,7 @@ WORD op_exitm(BYTE dummy1, BYTE dummy2)
 		asmerr(E_NIMEXP);
 	else
 		mac_end_expn();
-	return(0);
+	return (0);
 }
 
 /*
@@ -993,11 +993,11 @@ WORD op_mcond(BYTE op_code, BYTE dummy)
 	a_mode = A_NONE;
 	if (iflevel == INT_MAX) {
 		asmerr(E_IFNEST);
-		return(0);
+		return (0);
 	}
 	iflevel++;
 	if (!gencode)
-		return(0);
+		return (0);
 	switch (op_code) {
 	case 1:				/* IFB */
 	case 2:				/* IFNB */
@@ -1045,7 +1045,7 @@ WORD op_mcond(BYTE op_code, BYTE dummy)
 	if (t != NULL)
 		free(t);
 	act_iflevel = iflevel;
-	return(0);
+	return (0);
 }
 
 /*
@@ -1111,7 +1111,7 @@ WORD op_irp(BYTE op_code, BYTE dummy)
 	}
 	if (err)
 		mac_delete(m);
-	return(0);
+	return (0);
 }
 
 /*
@@ -1127,7 +1127,7 @@ WORD op_local(BYTE dummy1, BYTE dummy2)
 	a_mode = A_NONE;
 	if (mac_exp_nest == 0) {
 		asmerr(E_NIMEXP);
-		return(0);
+		return (0);
 	}
 	s = operand;
 	while (s != NULL) {
@@ -1142,7 +1142,7 @@ WORD op_local(BYTE dummy1, BYTE dummy2)
 		}
 		s = s1;
 	}
-	return(0);
+	return (0);
 }
 
 /*
@@ -1178,7 +1178,7 @@ WORD op_macro(BYTE dummy1, BYTE dummy2)
 	}
 	mac_curr = m;
 	mac_def_nest++;
-	return(0);
+	return (0);
 }
 
 /*
@@ -1196,5 +1196,5 @@ WORD op_rept(BYTE dummy1, BYTE dummy2)
 	m->mac_nrept = eval(operand);
 	mac_curr = m;
 	mac_def_nest++;
-	return(0);
+	return (0);
 }

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -136,9 +136,9 @@ BYTE search_opr(char *s)
 		else if (cond > 0)
 			low = mid + 1;
 		else
-			return(mid->opr_type);
+			return (mid->opr_type);
 	}
-	return(T_UNDSYM);
+	return (T_UNDSYM);
 }
 
 /*
@@ -160,7 +160,7 @@ int get_token(void)
 	if (*s == '\0') {				/* nothing there? */
 		tok_type = T_EMPTY;
 		scan_pos = s;
-		return(E_OK);
+		return (E_OK);
 	}
 	if (*s == 'X' && *(s + 1) == STRDEL) {		/* X'h' hex constant */
 		s += 2;
@@ -174,9 +174,9 @@ int get_token(void)
 			tok_type = T_VAL;
 			tok_val = n;
 			scan_pos = s + 1;
-			return(E_OK);
+			return (E_OK);
 		} else					/* missing final ' */
-			return(E_MISDEL);
+			return (E_MISDEL);
 	}
 	p1 = p2 = tok_sym;				/* gather symbol */
 	while (IS_SYM(*s))
@@ -210,14 +210,14 @@ int get_token(void)
 						n += m;
 						p1++;
 					} else		/* digit not of base */
-						return(E_INVEXP);
+						return (E_INVEXP);
 				} else			/* not a digit */
-					return(E_INVEXP);
+					return (E_INVEXP);
 			}
 			tok_type = T_VAL;
 			tok_val = n;
 			scan_pos = s;
-			return(E_OK);
+			return (E_OK);
 		}
 		*p2 = '\0';
 		if (*p1 == '$' && *(p1 + 1) == '\0') {	/* location counter */
@@ -233,7 +233,7 @@ int get_token(void)
 				tok_type = search_opr(p1);
 		}
 		scan_pos = s;
-		return(E_OK);
+		return (E_OK);
 	}
 	switch (*s) {
 	case STRDEL:					/* char constant */
@@ -245,20 +245,20 @@ int get_token(void)
 				tok_type = T_VAL;
 				tok_val = n;
 				scan_pos = s;
-				return(E_OK);
+				return (E_OK);
 			}
 			if (m++ == 2)
-				return(E_VALOUT);
+				return (E_VALOUT);
 			n <<= 8;
 			n |= (BYTE) *s;
 		}
-		return(E_MISDEL);
+		return (E_MISDEL);
 	case '!':
 		if (*(s + 1) == '=') {
 			s++;
 			tok_type = T_NE;
 		} else
-			return(E_INVEXP);
+			return (E_INVEXP);
 		break;
 	case '%':
 		tok_type = T_MOD;
@@ -322,10 +322,10 @@ int get_token(void)
 		tok_type = T_NOT;
 		break;
 	default:
-		return(E_INVEXP);
+		return (E_INVEXP);
 	}
 	scan_pos = s + 1;
-	return(E_OK);
+	return (E_OK);
 }
 
 /*
@@ -346,13 +346,13 @@ int factor(WORD *resultp)
 	case T_VAL:
 		value = tok_val;
 		if ((err = get_token()) != E_OK)
-			return(err);
+			return (err);
 		*resultp = value;
-		return(E_OK);
+		return (E_OK);
 	case T_UNDSYM:
 		if ((err = get_token()) != E_OK)
-			return(err);
-		return(E_UNDSYM);
+			return (err);
+		return (E_UNDSYM);
 	case T_NUL:
 		s = scan_pos;
 		while (IS_SPC(*s))
@@ -369,13 +369,13 @@ int factor(WORD *resultp)
 			s++;
 		tok_type = T_EMPTY;
 		scan_pos = s;
-		return(E_OK);
+		return (E_OK);
 	case T_TYPE:
 		if (get_token() != E_OK || factor(&value) != E_OK)
 			*resultp = 0;
 		else
 			*resultp = 0x20; /* local defined absolute */
-		return(E_OK);
+		return (E_OK);
 	case T_ADD:
 	case T_SUB:
 	case T_NOT:
@@ -384,7 +384,7 @@ int factor(WORD *resultp)
 		opr_type = tok_type;
 		if ((err = get_token()) != E_OK
 		    || (err = factor(&value)) != E_OK)
-			return(err);
+			return (err);
 		switch (opr_type) {
 		case T_ADD:
 			*resultp = value;
@@ -404,25 +404,25 @@ int factor(WORD *resultp)
 		default:
 			break;
 		}
-		return(E_OK);
+		return (E_OK);
 	case T_LPAREN:
 		if ((err = get_token()) != E_OK)
-			return(err);
+			return (err);
 		if ((erru = expr(&value)) > E_UNDSYM)
-			return(erru);
+			return (erru);
 		if (tok_type == T_RPAREN)
 			if ((err = get_token()) != E_OK)
-				return(err);
+				return (err);
 			else if (erru != E_OK)
-				return(erru);
+				return (erru);
 			else {
 				*resultp = value;
-				return(E_OK);
+				return (E_OK);
  			}
 		else
-			return(E_MISPAR);
+			return (E_MISPAR);
 	default:
-		return(E_INVEXP);
+		return (E_INVEXP);
 	}
 }
 
@@ -433,14 +433,14 @@ int mul_term(WORD *resultp)
 	WORD value;
 
 	if ((erru = factor(resultp)) > E_UNDSYM)
-		return(erru);
+		return (erru);
 	while (tok_type == T_MUL || tok_type == T_DIV || tok_type == T_MOD
 				 || tok_type == T_SHR || tok_type == T_SHL) {
 		opr_type = tok_type;
 		if ((err = get_token()) != E_OK)
-			return(err);
+			return (err);
 		if ((err = factor(&value)) > E_UNDSYM)
-			return(err);
+			return (err);
 		if (err != E_OK) {
 			erru = err;
 			continue;
@@ -451,12 +451,12 @@ int mul_term(WORD *resultp)
 			break;
 		case T_DIV:
 			if (value == 0)		/* don't crash on div by 0 */
-				return(E_DIVBY0);
+				return (E_DIVBY0);
 			*resultp /= value;
 			break;
 		case T_MOD:
 			if (value == 0)		/* don't crash on mod by 0 */
-				return(E_DIVBY0);
+				return (E_DIVBY0);
 			*resultp %= value;
 			break;
 		case T_SHR:
@@ -469,7 +469,7 @@ int mul_term(WORD *resultp)
 			break;
 		}
 	}
-	return(erru);
+	return (erru);
 }
 
 int add_term(WORD *resultp)
@@ -479,13 +479,13 @@ int add_term(WORD *resultp)
 	WORD value;
 
 	if ((erru = mul_term(resultp)) > E_UNDSYM)
-		return(erru);
+		return (erru);
 	while (tok_type == T_ADD || tok_type == T_SUB) {
 		opr_type = tok_type;
 		if ((err = get_token()) != E_OK)
-			return(err);
+			return (err);
 		if ((err = mul_term(&value)) > E_UNDSYM)
-			return(err);
+			return (err);
 		if (err != E_OK) {
 			erru = err;
 			continue;
@@ -501,7 +501,7 @@ int add_term(WORD *resultp)
 			break;
 		}
 	}
-	return(erru);
+	return (erru);
 }
 
 int cmp_term(WORD *resultp)
@@ -511,15 +511,15 @@ int cmp_term(WORD *resultp)
 	WORD value;
 
 	if ((erru = add_term(resultp)) > E_UNDSYM)
-		return(erru);
+		return (erru);
 	while (tok_type == T_EQ || tok_type == T_NE
 				|| tok_type == T_LT || tok_type == T_LE
 				|| tok_type == T_GT || tok_type == T_GE) {
 		opr_type = tok_type;
 		if ((err = get_token()) != E_OK)
-			return(err);
+			return (err);
 		if ((err = add_term(&value)) > E_UNDSYM)
-			return(err);
+			return (err);
 		if (err != E_OK) {
 			erru = err;
 			continue;
@@ -547,7 +547,7 @@ int cmp_term(WORD *resultp)
 			break;
 		}
 	}
-	return(erru);
+	return (erru);
 }
 
 int expr(WORD *resultp)
@@ -557,13 +557,13 @@ int expr(WORD *resultp)
 	WORD value;
 
 	if ((erru = cmp_term(resultp)) > E_UNDSYM)
-		return(erru);
+		return (erru);
 	while (tok_type == T_AND || tok_type == T_XOR || tok_type == T_OR) {
 		opr_type = tok_type;
 		if ((err = get_token()) != E_OK)
-			return(err);
+			return (err);
 		if ((err = cmp_term(&value)) > E_UNDSYM)
-			return(err);
+			return (err);
 		if (err != E_OK) {
 			erru = err;
 			continue;
@@ -582,7 +582,7 @@ int expr(WORD *resultp)
 			break;
 		}
 	}
-	return(erru);
+	return (erru);
 }
 
 /*
@@ -596,18 +596,18 @@ WORD eval(char *s)
 
 	if (s == NULL || *s == '\0') {
 		asmerr(E_MISOPE);
-		return(0);
+		return (0);
 	}
 	result = 0;
 	scan_pos = s;
 	if ((err = get_token()) != E_OK || (err = expr(&result)) != E_OK) {
 		asmerr(err);
-		return(0);
+		return (0);
 	} else if (tok_type != T_EMPTY) {	/* leftovers, error out */
 		asmerr(E_INVEXP);
-		return(0);
+		return (0);
 	} else
-		return(result);
+		return (result);
 }
 
 /*
@@ -617,10 +617,10 @@ WORD eval(char *s)
 BYTE chk_byte(WORD w)
 {
 	if (w >= (WORD) -256 || w <= 255)
-		return(w);
+		return (w);
 	else {
 		asmerr(E_VALOUT);
-		return(0);
+		return (0);
 	}
 }
 
@@ -631,9 +631,9 @@ BYTE chk_byte(WORD w)
 BYTE chk_sbyte(WORD w)
 {
 	if (w >= (WORD) -128 || w <= 127)
-		return(w);
+		return (w);
 	else {
 		asmerr(E_VALOUT);
-		return(0);
+		return (0);
 	}
 }

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -407,8 +407,8 @@ void instrset(int is)
  */
 int opccmp(const void *p1, const void *p2)
 {
-	return(strcmp((*(const struct opc **) p1)->op_name,
-		      (*(const struct opc **) p2)->op_name));
+	return (strcmp((*(const struct opc **) p1)->op_name,
+		       (*(const struct opc **) p2)->op_name));
 }
 
 /*
@@ -430,11 +430,11 @@ struct opc *search_op(char *op_name)
 		else if (cond > 0)
 			low = mid + 1;
 		else if (!undoc_flag && ((*mid)->op_flags & OP_UNDOC))
-			return(NULL);
+			return (NULL);
 		else
-			return(*mid);
+			return (*mid);
 	}
-	return(NULL);
+	return (NULL);
 }
 
 /*
@@ -449,7 +449,7 @@ BYTE get_reg(char *s)
 	int cond;
 
 	if (s == NULL || *s == '\0')
-		return(NOOPERA);
+		return (NOOPERA);
 	low = opetab;
 	high = opetab + no_operands - 1;
 	while (low <= high) {
@@ -459,9 +459,9 @@ BYTE get_reg(char *s)
 		else if (cond > 0)
 			low = mid + 1;
 		else if (!undoc_flag && (mid->ope_flags & OPE_UNDOC))
-			return(NOREG);
+			return (NOREG);
 		else
-			return(mid->ope_sym);
+			return (mid->ope_sym);
 	}
-	return(NOREG);
+	return (NOREG);
 }

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -383,6 +383,7 @@ void instrset(int is)
 		break;
 	default:
 		fatal(F_INTERN, "invalid instr. set for function instrset");
+		break;
 	}
 	if (opctab == NULL) {
 		i = no_opc_psd;

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -601,7 +601,7 @@ char *btoh(BYTE b, char *p)
 	*p++ = c + (c < 10 ? '0' : '7');
 	c = b & 0xf;
 	*p++ = c + (c < 10 ? '0' : '7');
-	return(p);
+	return (p);
 }
 
 /*
@@ -618,5 +618,5 @@ BYTE chksum(BYTE rec_type)
 	sum += rec_type;
 	for (i = 0; i < hex_cnt; i++)
 		sum += hex_buf[i];
-	return(-sum);
+	return (-sum);
 }

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -57,6 +57,7 @@ WORD op_instrset(BYTE op_code, BYTE dummy)
 		break;
 	default:
 		fatal(F_INTERN, "invalid opcode for function op_instrset");
+		break;
 	}
 	return(0);
 }
@@ -105,6 +106,7 @@ WORD op_org(BYTE op_code, BYTE dummy)
 		break;
 	default:
 		fatal(F_INTERN, "invalid opcode for function op_org");
+		break;
 	}
 	return(0);
 }
@@ -234,6 +236,7 @@ WORD op_db(BYTE op_code, BYTE dummy)
 		break;
 	default:
 		fatal(F_INTERN, "invalid opcode for function op_db");
+		break;
 	}
 	return(i);
 }
@@ -286,7 +289,7 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 	UNUSED(dummy);
 
 	a_mode = A_NONE;
-	switch(op_code) {
+	switch (op_code) {
 	case 1:				/* EJECT and PAGE */
 		if (operand[0] != '\0') {
 			if ((pass == 1 && !page_done) || pass == 2) {
@@ -432,7 +435,7 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 		iflevel++;
 		if (!gencode)
 			return(0);
-		switch(op_code) {
+		switch (op_code) {
 		case 1:			/* IFDEF */
 		case 2:			/* IFNDEF */
 			if (get_sym(operand) == NULL)
@@ -472,7 +475,7 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 			asmerr(E_MISIFF);
 			return(0);
 		}
-		switch(op_code) {
+		switch (op_code) {
 		case 98:		/* ELSE */
 			if (iflevel == act_iflevel) {
 				if (iflevel == act_elselevel)
@@ -506,7 +509,7 @@ WORD op_glob(BYTE op_code, BYTE dummy)
 	UNUSED(dummy);
 
 	a_mode = A_NONE;
-	switch(op_code) {
+	switch (op_code) {
 	case 1:				/* EXTRN, EXTERNAL, EXT */
 		break;
 	case 2:				/* PUBLIC, ENT, ENTRY, GLOBAL */

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -59,7 +59,7 @@ WORD op_instrset(BYTE op_code, BYTE dummy)
 		fatal(F_INTERN, "invalid opcode for function op_instrset");
 		break;
 	}
-	return(0);
+	return (0);
 }
 
 /*
@@ -76,7 +76,7 @@ WORD op_org(BYTE op_code, BYTE dummy)
 	case 1:				/* ORG */
 		if (phs_flag) {
 			asmerr(E_ORGPHS);
-			return(0);
+			return (0);
 		}
 		n = eval(operand);
 		if (pass == 1) {	/* PASS 1 */
@@ -108,7 +108,7 @@ WORD op_org(BYTE op_code, BYTE dummy)
 		fatal(F_INTERN, "invalid opcode for function op_org");
 		break;
 	}
-	return(0);
+	return (0);
 }
 
 /*
@@ -128,7 +128,7 @@ WORD op_radix(BYTE dummy1, BYTE dummy2)
 		asmerr(E_VALOUT);
 	else
 		radix = r;
-	return(0);
+	return (0);
 }
 
 /*
@@ -147,7 +147,7 @@ WORD op_equ(BYTE dummy1, BYTE dummy2)
 		new_sym(label)->sym_val = a_addr;
 	else if (sp->sym_val != a_addr)
 		asmerr(E_MULSYM);
-	return(0);
+	return (0);
 }
 
 /*
@@ -161,7 +161,7 @@ WORD op_dl(BYTE dummy1, BYTE dummy2)
 	a_mode = A_SET;
 	a_addr = eval(operand);
 	put_sym(label, a_addr);
-	return(0);
+	return (0);
 }
 
 /*
@@ -187,7 +187,7 @@ WORD op_ds(BYTE dummy1, BYTE dummy2)
 		} else
 			obj_fill(count);
 	}
-	return(count);
+	return (count);
 }
 
 /*
@@ -209,7 +209,7 @@ WORD op_db(BYTE op_code, BYTE dummy)
 		p1 = next_arg(p, &sf);
 		if (sf < 0) {		/* a non-terminated string */
 			asmerr(E_MISDEL);
-			return(i);
+			return (i);
 		} else if (sf > 0) {	/* a valid string */
 			c = *p++;
 			while (*p != c || *++p == c) /* double delim? */
@@ -238,7 +238,7 @@ WORD op_db(BYTE op_code, BYTE dummy)
 		fatal(F_INTERN, "invalid opcode for function op_db");
 		break;
 	}
-	return(i);
+	return (i);
 }
 
 /*
@@ -268,7 +268,7 @@ WORD op_dw(BYTE dummy1, BYTE dummy2)
 		}
 		p = p1;
 	}
-	return(i);
+	return (i);
 }
 
 /*
@@ -330,7 +330,7 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 				if (*p == '\0') {
 					putchar('\n');
 					asmerr(E_MISDEL);
-					return(0);
+					return (0);
 				}
 				/* check for double delim */
 				if (*p == c && *++p != c)
@@ -413,7 +413,7 @@ WORD op_misc(BYTE op_code, BYTE dummy)
 		fatal(F_INTERN, "invalid opcode for function op_misc");
 		break;
 	}
-	return(0);
+	return (0);
 }
 
 /*
@@ -430,11 +430,11 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 	if (op_code < 90) {
 		if (iflevel == INT_MAX) {
 			asmerr(E_IFNEST);
-			return(0);
+			return (0);
 		}
 		iflevel++;
 		if (!gencode)
-			return(0);
+			return (0);
 		switch (op_code) {
 		case 1:			/* IFDEF */
 		case 2:			/* IFNDEF */
@@ -473,7 +473,7 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 	} else {
 		if (iflevel == 0) {
 			asmerr(E_MISIFF);
-			return(0);
+			return (0);
 		}
 		switch (op_code) {
 		case 98:		/* ELSE */
@@ -498,7 +498,7 @@ WORD op_cond(BYTE op_code, BYTE dummy)
 			break;
 		}
 	}
-	return(0);
+	return (0);
 }
 
 /*
@@ -520,7 +520,7 @@ WORD op_glob(BYTE op_code, BYTE dummy)
 		fatal(F_INTERN, "invalid opcode for function op_glob");
 		break;
 	}
-	return(0);
+	return (0);
 }
 
 /*
@@ -533,5 +533,5 @@ WORD op_end(BYTE dummy1, BYTE dummy2)
 
 	if (pass == 2 && operand[0] != '\0')
 		start_addr = eval(operand);
-	return(0);
+	return (0);
 }

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -99,6 +99,7 @@ WORD op_pupo(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -125,6 +126,7 @@ WORD op_ex(BYTE base_ops, BYTE base_opd)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case REGAF:
@@ -138,6 +140,7 @@ WORD op_ex(BYTE base_ops, BYTE base_opd)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case REGISP:
@@ -157,6 +160,7 @@ WORD op_ex(BYTE base_ops, BYTE base_opd)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case NOOPERA:			/* missing operand */
@@ -164,6 +168,7 @@ WORD op_ex(BYTE base_ops, BYTE base_opd)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -216,6 +221,7 @@ WORD op_ret(BYTE base_op, BYTE base_opc)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -286,6 +292,7 @@ WORD op_jpcall(BYTE base_op, BYTE base_opc)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -328,6 +335,7 @@ WORD op_jr(BYTE base_op, BYTE base_opc)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -390,6 +398,7 @@ WORD op_ld(BYTE base_op, BYTE dummy)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case REGBC:			/* LD BC,? */
@@ -473,6 +482,7 @@ WORD op_ld(BYTE base_op, BYTE dummy)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case REGIIX:			/* LD (IX),r */
@@ -494,6 +504,7 @@ WORD op_ld(BYTE base_op, BYTE dummy)
 			len = ldinn(sec); /* LD (nn),? */
 		else			/* invalid operand */
 			asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -591,6 +602,7 @@ WORD ldreg(BYTE base_op, char *sec)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -628,6 +640,7 @@ WORD ldixhl(BYTE base_op, char *sec)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -665,6 +678,7 @@ WORD ldiyhl(BYTE base_op, char *sec)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -714,6 +728,7 @@ WORD ldsp(char *sec)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -749,6 +764,7 @@ WORD ldihl(BYTE base_op, char *sec)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -800,6 +816,7 @@ WORD ldiixy(BYTE prefix, BYTE base_op, char *sec)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -860,6 +877,7 @@ WORD ldinn(char *sec)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -892,6 +910,7 @@ WORD op_add(BYTE base_op, BYTE base_op16)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case REGIX:			/* ADD IX,? */
@@ -909,6 +928,7 @@ WORD op_add(BYTE base_op, BYTE base_op16)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case REGIY:			/* ADD IY,? */
@@ -926,6 +946,7 @@ WORD op_add(BYTE base_op, BYTE base_op16)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case NOOPERA:			/* missing operand */
@@ -933,6 +954,7 @@ WORD op_add(BYTE base_op, BYTE base_op16)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -966,6 +988,7 @@ WORD op_sbadc(BYTE base_op, BYTE base_op16)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case NOOPERA:			/* missing operand */
@@ -973,6 +996,7 @@ WORD op_sbadc(BYTE base_op, BYTE base_op16)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1044,6 +1068,7 @@ WORD op_decinc(BYTE base_op, BYTE base_op16)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1117,6 +1142,7 @@ WORD aluop(BYTE base_op, char *sec)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1134,7 +1160,7 @@ WORD op_out(BYTE op_base, BYTE op_basec)
 	if (operand[0] == '\0')		/* missing operand */
 		asmerr(E_MISOPE);
 	else if (strcmp(operand, "(C)") == 0) {
-		switch(op = get_reg(sec)) {
+		switch (op = get_reg(sec)) {
 		case REGA:		/* OUT (C),A */
 		case REGB:		/* OUT (C),B */
 		case REGC:		/* OUT (C),C */
@@ -1156,6 +1182,7 @@ WORD op_out(BYTE op_base, BYTE op_basec)
 				ops[1] = op_basec + (REGIHL & OPMASK3);
 			} else		/* invalid operand */
 				asmerr(E_INVOPE);
+			break;
 		}
 	} else if (operand[0] == '(' && operand[strlen(operand) - 1] == ')') {
 		switch (get_reg(sec)) {
@@ -1171,6 +1198,7 @@ WORD op_out(BYTE op_base, BYTE op_basec)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 	} else				/* invalid operand */
 		asmerr(E_INVOPE);
@@ -1213,6 +1241,7 @@ WORD op_in(BYTE op_base, BYTE op_basec)
 				ops[1] = op_basec + (REGIHL & OPMASK3);
 			} else		/* invalid operand */
 				asmerr(E_INVOPE);
+			break;
 		}
 	} else if (*sec == '(' && *(sec + strlen(sec) - 1) == ')') {
 		switch (get_reg(operand)) {
@@ -1228,6 +1257,7 @@ WORD op_in(BYTE op_base, BYTE op_basec)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 	} else				/* invalid operand */
 		asmerr(E_INVOPE);
@@ -1292,6 +1322,7 @@ WORD op_cbgrp(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1346,6 +1377,7 @@ WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 	} else				/* invalid operand */
 		asmerr(E_INVOPE);
@@ -1395,6 +1427,7 @@ WORD op8080_mov(BYTE base_op, BYTE dummy)
 			break;
 		default:		/* invalid operand */
 			asmerr(E_INVOPE);
+			break;
 		}
 		break;
 	case NOOPERA:			/* missing operand */
@@ -1402,6 +1435,7 @@ WORD op8080_mov(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1433,6 +1467,7 @@ WORD op8080_alu(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1464,6 +1499,7 @@ WORD op8080_dcrinr(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1491,6 +1527,7 @@ WORD op8080_reg16(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1516,6 +1553,7 @@ WORD op8080_regbd(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1576,6 +1614,7 @@ WORD op8080_pupo(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1632,6 +1671,7 @@ WORD op8080_mvi(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }
@@ -1667,6 +1707,7 @@ WORD op8080_lxi(BYTE base_op, BYTE dummy)
 		break;
 	default:			/* invalid operand */
 		asmerr(E_INVOPE);
+		break;
 	}
 	return(len);
 }

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -37,7 +37,7 @@ WORD op_1b(BYTE b1, BYTE dummy)
 	UNUSED(dummy);
 
 	ops[0] = b1;
-	return(1);
+	return (1);
 }
 
 /*
@@ -47,7 +47,7 @@ WORD op_2b(BYTE b1, BYTE b2)
 {
 	ops[0] = b1;
 	ops[1] = b2;
-	return(2);
+	return (2);
 }
 
 /*
@@ -67,7 +67,7 @@ WORD op_im(BYTE base_op1, BYTE base_op2)
 		ops[0] = base_op1;
 		ops[1] = base_op2 + (op << 3);
 	}
-	return(2);
+	return (2);
 }
 
 /*
@@ -101,7 +101,7 @@ WORD op_pupo(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -170,7 +170,7 @@ WORD op_ex(BYTE base_ops, BYTE base_opd)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -190,7 +190,7 @@ WORD op_rst(BYTE base_op, BYTE dummy)
 		}
 		ops[0] = base_op + op;
 	}
-	return(1);
+	return (1);
 }
 
 /*
@@ -223,7 +223,7 @@ WORD op_ret(BYTE base_op, BYTE base_opc)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -294,7 +294,7 @@ WORD op_jpcall(BYTE base_op, BYTE base_opc)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -337,7 +337,7 @@ WORD op_jr(BYTE base_op, BYTE base_opc)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -351,7 +351,7 @@ WORD op_djnz(BYTE base_op, BYTE dummy)
 		ops[0] = base_op;
 		ops[1] = chk_sbyte(eval(operand) - pc - 2);
 	}
-	return(2);
+	return (2);
 }
 
 /*
@@ -506,7 +506,7 @@ WORD op_ld(BYTE base_op, BYTE dummy)
 			asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -604,7 +604,7 @@ WORD ldreg(BYTE base_op, char *sec)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -642,7 +642,7 @@ WORD ldixhl(BYTE base_op, char *sec)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -680,7 +680,7 @@ WORD ldiyhl(BYTE base_op, char *sec)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -730,7 +730,7 @@ WORD ldsp(char *sec)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -766,7 +766,7 @@ WORD ldihl(BYTE base_op, char *sec)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -818,7 +818,7 @@ WORD ldiixy(BYTE prefix, BYTE base_op, char *sec)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -879,7 +879,7 @@ WORD ldinn(char *sec)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -956,7 +956,7 @@ WORD op_add(BYTE base_op, BYTE base_op16)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -998,7 +998,7 @@ WORD op_sbadc(BYTE base_op, BYTE base_op16)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1070,7 +1070,7 @@ WORD op_decinc(BYTE base_op, BYTE base_op16)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1080,7 +1080,7 @@ WORD op_alu(BYTE base_op, BYTE dummy)
 {
 	UNUSED(dummy);
 
-	return(aluop(base_op, operand));
+	return (aluop(base_op, operand));
 }
 
 /*
@@ -1144,7 +1144,7 @@ WORD aluop(BYTE base_op, char *sec)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1202,7 +1202,7 @@ WORD op_out(BYTE op_base, BYTE op_basec)
 		}
 	} else				/* invalid operand */
 		asmerr(E_INVOPE);
-	return(len);
+	return (len);
 }
 
 /*
@@ -1261,7 +1261,7 @@ WORD op_in(BYTE op_base, BYTE op_basec)
 		}
 	} else				/* invalid operand */
 		asmerr(E_INVOPE);
-	return(len);
+	return (len);
 }
 
 /*
@@ -1324,7 +1324,7 @@ WORD op_cbgrp(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1381,7 +1381,7 @@ WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 		}
 	} else				/* invalid operand */
 		asmerr(E_INVOPE);
-	return(len);
+	return (len);
 }
 
 /*
@@ -1437,7 +1437,7 @@ WORD op8080_mov(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1469,7 +1469,7 @@ WORD op8080_alu(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1501,7 +1501,7 @@ WORD op8080_dcrinr(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1529,7 +1529,7 @@ WORD op8080_reg16(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1555,7 +1555,7 @@ WORD op8080_regbd(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1569,7 +1569,7 @@ WORD op8080_imm(BYTE base_op, BYTE dummy)
 		ops[0] = base_op;
 		ops[1] = chk_byte(eval(operand));
 	}
-	return(2);
+	return (2);
 }
 
 /*
@@ -1589,7 +1589,7 @@ WORD op8080_rst(BYTE base_op, BYTE dummy)
 		}
 		ops[0] = base_op + (op << 3);
 	}
-	return(1);
+	return (1);
 }
 /*
  *	8080 PUSH and POP
@@ -1616,7 +1616,7 @@ WORD op8080_pupo(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1636,7 +1636,7 @@ WORD op8080_addr(BYTE base_op, BYTE dummy)
 		ops[1] = n & 0xff;
 		ops[2] = n >> 8;
 	}
-	return(3);
+	return (3);
 }
 
 /*
@@ -1673,7 +1673,7 @@ WORD op8080_mvi(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }
 
 /*
@@ -1709,5 +1709,5 @@ WORD op8080_lxi(BYTE base_op, BYTE dummy)
 		asmerr(E_INVOPE);
 		break;
 	}
-	return(len);
+	return (len);
 }

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -44,8 +44,8 @@ struct sym *look_sym(char *sym_name)
 
 	for (sp = symtab[hash(sym_name)]; sp != NULL; sp = sp->sym_next)
 		if (strcmp(sym_name, sp->sym_name) == 0)
-			return(sp);
-	return(NULL);
+			return (sp);
+	return (NULL);
 }
 
 /*
@@ -59,7 +59,7 @@ struct sym *get_sym(char *sym_name)
 
 	if ((sp = look_sym(sym_name)) != NULL)
 		sp->sym_refflg = TRUE;
-	return(sp);
+	return (sp);
 }
 
 /*
@@ -84,7 +84,7 @@ struct sym *new_sym(char *sym_name)
 	if (n > symmax)
 		symmax = n;
 	symcnt++;
-	return(sp);
+	return (sp);
 }
 
 /*
@@ -124,7 +124,7 @@ int hash(char *name)
 
 	for (h = 0; *name != '\0';)
 		h = ((h << 5) | (h >> (sizeof(h) * 8 - 5))) ^ (BYTE) *name++;
-	return(h % HASHSIZE);
+	return (h % HASHSIZE);
 }
 
 /*
@@ -137,7 +137,7 @@ struct sym *first_sym(int sort_mode)
 	register int i;
 
 	if (symcnt == 0)
-		return(NULL);
+		return (NULL);
 	symsort = sort_mode;
 	switch (sort_mode) {
 	case SYM_UNSORT:
@@ -145,7 +145,7 @@ struct sym *first_sym(int sort_mode)
 		while ((symptr = symtab[symidx]) == NULL)
 			if (++symidx == HASHSIZE)
 				break;
-		return(symptr);
+		return (symptr);
 	case SYM_SORTN:
 	case SYM_SORTA:
 		symarray = (struct sym **) malloc(sizeof(struct sym *)
@@ -158,7 +158,7 @@ struct sym *first_sym(int sort_mode)
 		qsort(symarray, symcnt, sizeof(struct sym *),
 		      sort_mode == SYM_SORTN ? namecmp : valcmp);
 		symidx = 0;
-		return(symarray[symidx]);
+		return (symarray[symidx]);
 	default:
 		fatal(F_INTERN, "unknown sort mode in first_sym");
 		break;
@@ -179,10 +179,10 @@ struct sym *next_sym(void)
 					symptr = symtab[symidx];
 			} while (symptr == NULL);
 		}
-		return(symptr);
+		return (symptr);
 	} else if (++symidx < symcnt)
-		return(symarray[symidx]);
-	return(NULL);
+		return (symarray[symidx]);
+	return (NULL);
 }
 
 /*
@@ -190,8 +190,8 @@ struct sym *next_sym(void)
  */
 int namecmp(const void *p1, const void *p2)
 {
-	return(strcmp((*(const struct sym **) p1)->sym_name,
-		      (*(const struct sym **) p2)->sym_name));
+	return (strcmp((*(const struct sym **) p1)->sym_name,
+		       (*(const struct sym **) p2)->sym_name));
 }
 
 /*
@@ -205,9 +205,9 @@ int valcmp(const void *p1, const void *p2)
 	n1 = (*(const struct sym **) p1)->sym_val;
 	n2 = (*(const struct sym **) p2)->sym_val;
 	if (n1 < n2)
-		return(-1);
+		return (-1);
 	else if (n1 > n2)
-		return(1);
+		return (1);
 	else
-		return(namecmp(p1, p2));
+		return (namecmp(p1, p2));
 }

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -139,7 +139,7 @@ struct sym *first_sym(int sort_mode)
 	if (symcnt == 0)
 		return(NULL);
 	symsort = sort_mode;
-	switch(sort_mode) {
+	switch (sort_mode) {
 	case SYM_UNSORT:
 		symidx = 0;
 		while ((symptr = symtab[symidx]) == NULL)
@@ -161,6 +161,7 @@ struct sym *first_sym(int sort_mode)
 		return(symarray[symidx]);
 	default:
 		fatal(F_INTERN, "unknown sort mode in first_sym");
+		break;
 	}
 }
 

--- a/z80core/fpmain.cpp
+++ b/z80core/fpmain.cpp
@@ -11,5 +11,5 @@ extern "C" int sim_main(int, char *[]);
 
 int main(int argc, char *argv[])
 {
-	return sim_main(argc, argv);
+	return (sim_main(argc, argv));
 }

--- a/z80core/sim0.c
+++ b/z80core/sim0.c
@@ -372,10 +372,10 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 
 	if (l_flag) {		/* load core */
 		if (load_core())
-			return(EXIT_FAILURE);
+			return (EXIT_FAILURE);
 	} else if (x_flag) { 	/* OR load memory from file */
 		if (load_file(xfn, 0, 0)) /* don't care where it loads */
-			return(EXIT_FAILURE);
+			return (EXIT_FAILURE);
 	}
 
 	int_on();		/* initialize UNIX interrupts */
@@ -389,7 +389,7 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 	exit_io();		/* stop I/O devices */
 	int_off();		/* stop UNIX interrupts */
 
-	return(EXIT_SUCCESS);
+	return (EXIT_SUCCESS);
 }
 
 /*
@@ -506,7 +506,7 @@ int load_core(void)
 
 	if ((fp = fopen("core.z80", "r")) == NULL) {
 		puts("can't open file core.z80");
-		return(1);
+		return (1);
 	}
 
 	fread(&A, sizeof(A), 1, fp);
@@ -540,8 +540,8 @@ int load_core(void)
 	if (ferror(fp)) {
 		fclose(fp);
 		puts("error reading core.z80");
-		return(1);
+		return (1);
 	}
 	fclose(fp);
-	return(0);
+	return (0);
 }

--- a/z80core/sim1.c
+++ b/z80core/sim1.c
@@ -599,7 +599,7 @@ leave:
 
 static int op_nop(void)			/* NOP */
 {
-	return(4);
+	return (4);
 }
 
 static int op_halt(void)		/* HALT */
@@ -662,14 +662,14 @@ static int op_halt(void)		/* HALT */
 	}
 #endif
 
-	return(4);
+	return (4);
 }
 
 static int op_scf(void)			/* SCF */
 {
 	F |= C_FLAG;
 	F &= ~(N_FLAG | H_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_ccf(void)			/* CCF */
@@ -682,14 +682,14 @@ static int op_ccf(void)			/* CCF */
 		F |= C_FLAG;
 	}
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cpl(void)			/* CPL */
 {
 	A = ~A;
 	F |= H_FLAG | N_FLAG;
-	return(4);
+	return (4);
 }
 
 /*
@@ -727,7 +727,7 @@ static int op_daa(void)			/* DAA */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(4);
+	return (4);
 }
 #endif
 
@@ -768,20 +768,20 @@ static int op_daa(void)			/* DAA */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_ei(void)			/* EI */
 {
 	IFF = 3;
 	int_protection = 1;		/* protect next instruction */
-	return(4);
+	return (4);
 }
 
 static int op_di(void)			/* DI */
 {
 	IFF = 0;
-	return(4);
+	return (4);
 }
 
 static int op_in(void)			/* IN A,(n) */
@@ -791,7 +791,7 @@ static int op_in(void)			/* IN A,(n) */
 
 	addr = memrdr(PC++);
 	A = io_in(addr, A);
-	return(11);
+	return (11);
 }
 
 static int op_out(void)			/* OUT (n),A */
@@ -801,61 +801,61 @@ static int op_out(void)			/* OUT (n),A */
 
 	addr = memrdr(PC++);
 	io_out(addr, A, A);
-	return(11);
+	return (11);
 }
 
 static int op_ldan(void)		/* LD A,n */
 {
 	A = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_ldbn(void)		/* LD B,n */
 {
 	B = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_ldcn(void)		/* LD C,n */
 {
 	C = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_lddn(void)		/* LD D,n */
 {
 	D = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_lden(void)		/* LD E,n */
 {
 	E = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_ldhn(void)		/* LD H,n */
 {
 	H = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_ldln(void)		/* LD L,n */
 {
 	L = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_ldabc(void)		/* LD A,(BC) */
 {
 	A = memrdr((B << 8) + C);
-	return(7);
+	return (7);
 }
 
 static int op_ldade(void)		/* LD A,(DE) */
 {
 	A = memrdr((D << 8) + E);
-	return(7);
+	return (7);
 }
 
 static int op_ldann(void)		/* LD A,(nn) */
@@ -865,19 +865,19 @@ static int op_ldann(void)		/* LD A,(nn) */
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
 	A = memrdr(i);
-	return(13);
+	return (13);
 }
 
 static int op_ldbca(void)		/* LD (BC),A */
 {
 	memwrt((B << 8) + C, A);
-	return(7);
+	return (7);
 }
 
 static int op_lddea(void)		/* LD (DE),A */
 {
 	memwrt((D << 8) + E, A);
-	return(7);
+	return (7);
 }
 
 static int op_ldnna(void)		/* LD (nn),A */
@@ -887,418 +887,418 @@ static int op_ldnna(void)		/* LD (nn),A */
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
 	memwrt(i, A);
-	return(13);
+	return (13);
 }
 
 static int op_ldhla(void)		/* LD (HL),A */
 {
 	memwrt((H << 8) + L, A);
-	return(7);
+	return (7);
 }
 
 static int op_ldhlb(void)		/* LD (HL),B */
 {
 	memwrt((H << 8) + L, B);
-	return(7);
+	return (7);
 }
 
 static int op_ldhlc(void)		/* LD (HL),C */
 {
 	memwrt((H << 8) + L, C);
-	return(7);
+	return (7);
 }
 
 static int op_ldhld(void)		/* LD (HL),D */
 {
 	memwrt((H << 8) + L, D);
-	return(7);
+	return (7);
 }
 
 static int op_ldhle(void)		/* LD (HL),E */
 {
 	memwrt((H << 8) + L, E);
-	return(7);
+	return (7);
 }
 
 static int op_ldhlh(void)		/* LD (HL),H */
 {
 	memwrt((H << 8) + L, H);
-	return(7);
+	return (7);
 }
 
 static int op_ldhll(void)		/* LD (HL),L */
 {
 	memwrt((H << 8) + L, L);
-	return(7);
+	return (7);
 }
 
 static int op_ldhl1(void)		/* LD (HL),n */
 {
 	memwrt((H << 8) + L, memrdr(PC++));
-	return(10);
+	return (10);
 }
 
 static int op_ldaa(void)		/* LD A,A */
 {
-	return(4);
+	return (4);
 }
 
 static int op_ldab(void)		/* LD A,B */
 {
 	A = B;
-	return(4);
+	return (4);
 }
 
 static int op_ldac(void)		/* LD A,C */
 {
 	A = C;
-	return(4);
+	return (4);
 }
 
 static int op_ldad(void)		/* LD A,D */
 {
 	A = D;
-	return(4);
+	return (4);
 }
 
 static int op_ldae(void)		/* LD A,E */
 {
 	A = E;
-	return(4);
+	return (4);
 }
 
 static int op_ldah(void)		/* LD A,H */
 {
 	A = H;
-	return(4);
+	return (4);
 }
 
 static int op_ldal(void)		/* LD A,L */
 {
 	A = L;
-	return(4);
+	return (4);
 }
 
 static int op_ldahl(void)		/* LD A,(HL) */
 {
 	A = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_ldba(void)		/* LD B,A */
 {
 	B = A;
-	return(4);
+	return (4);
 }
 
 static int op_ldbb(void)		/* LD B,B */
 {
-	return(4);
+	return (4);
 }
 
 static int op_ldbc(void)		/* LD B,C */
 {
 	B = C;
-	return(4);
+	return (4);
 }
 
 static int op_ldbd(void)		/* LD B,D */
 {
 	B = D;
-	return(4);
+	return (4);
 }
 
 static int op_ldbe(void)		/* LD B,E */
 {
 	B = E;
-	return(4);
+	return (4);
 }
 
 static int op_ldbh(void)		/* LD B,H */
 {
 	B = H;
-	return(4);
+	return (4);
 }
 
 static int op_ldbl(void)		/* LD B,L */
 {
 	B = L;
-	return(4);
+	return (4);
 }
 
 static int op_ldbhl(void)		/* LD B,(HL) */
 {
 	B = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_ldca(void)		/* LD C,A */
 {
 	C = A;
-	return(4);
+	return (4);
 }
 
 static int op_ldcb(void)		/* LD C,B */
 {
 	C = B;
-	return(4);
+	return (4);
 }
 
 static int op_ldcc(void)		/* LD C,C */
 {
-	return(4);
+	return (4);
 }
 
 static int op_ldcd(void)		/* LD C,D */
 {
 	C = D;
-	return(4);
+	return (4);
 }
 
 static int op_ldce(void)		/* LD C,E */
 {
 	C = E;
-	return(4);
+	return (4);
 }
 
 static int op_ldch(void)		/* LD C,H */
 {
 	C = H;
-	return(4);
+	return (4);
 }
 
 static int op_ldcl(void)		/* LD C,L */
 {
 	C = L;
-	return(4);
+	return (4);
 }
 
 static int op_ldchl(void)		/* LD C,(HL) */
 {
 	C = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_ldda(void)		/* LD D,A */
 {
 	D = A;
-	return(4);
+	return (4);
 }
 
 static int op_lddb(void)		/* LD D,B */
 {
 	D = B;
-	return(4);
+	return (4);
 }
 
 static int op_lddc(void)		/* LD D,C */
 {
 	D = C;
-	return(4);
+	return (4);
 }
 
 static int op_lddd(void)		/* LD D,D */
 {
-	return(4);
+	return (4);
 }
 
 static int op_ldde(void)		/* LD D,E */
 {
 	D = E;
-	return(4);
+	return (4);
 }
 
 static int op_lddh(void)		/* LD D,H */
 {
 	D = H;
-	return(4);
+	return (4);
 }
 
 static int op_lddl(void)		/* LD D,L */
 {
 	D = L;
-	return(4);
+	return (4);
 }
 
 static int op_lddhl(void)		/* LD D,(HL) */
 {
 	D = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_ldea(void)		/* LD E,A */
 {
 	E = A;
-	return(4);
+	return (4);
 }
 
 static int op_ldeb(void)		/* LD E,B */
 {
 	E = B;
-	return(4);
+	return (4);
 }
 
 static int op_ldec(void)		/* LD E,C */
 {
 	E = C;
-	return(4);
+	return (4);
 }
 
 static int op_lded(void)		/* LD E,D */
 {
 	E = D;
-	return(4);
+	return (4);
 }
 
 static int op_ldee(void)		/* LD E,E */
 {
-	return(4);
+	return (4);
 }
 
 static int op_ldeh(void)		/* LD E,H */
 {
 	E = H;
-	return(4);
+	return (4);
 }
 
 static int op_ldel(void)		/* LD E,L */
 {
 	E = L;
-	return(4);
+	return (4);
 }
 
 static int op_ldehl(void)		/* LD E,(HL) */
 {
 	E = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_ldha(void)		/* LD H,A */
 {
 	H = A;
-	return(4);
+	return (4);
 }
 
 static int op_ldhb(void)		/* LD H,B */
 {
 	H = B;
-	return(4);
+	return (4);
 }
 
 static int op_ldhc(void)		/* LD H,C */
 {
 	H = C;
-	return(4);
+	return (4);
 }
 
 static int op_ldhd(void)		/* LD H,D */
 {
 	H = D;
-	return(4);
+	return (4);
 }
 
 static int op_ldhe(void)		/* LD H,E */
 {
 	H = E;
-	return(4);
+	return (4);
 }
 
 static int op_ldhh(void)		/* LD H,H */
 {
-	return(4);
+	return (4);
 }
 
 static int op_ldhl(void)		/* LD H,L */
 {
 	H = L;
-	return(4);
+	return (4);
 }
 
 static int op_ldhhl(void)		/* LD H,(HL) */
 {
 	H = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_ldla(void)		/* LD L,A */
 {
 	L = A;
-	return(4);
+	return (4);
 }
 
 static int op_ldlb(void)		/* LD L,B */
 {
 	L = B;
-	return(4);
+	return (4);
 }
 
 static int op_ldlc(void)		/* LD L,C */
 {
 	L = C;
-	return(4);
+	return (4);
 }
 
 static int op_ldld(void)		/* LD L,D */
 {
 	L = D;
-	return(4);
+	return (4);
 }
 
 static int op_ldle(void)		/* LD L,E */
 {
 	L = E;
-	return(4);
+	return (4);
 }
 
 static int op_ldlh(void)		/* LD L,H */
 {
 	L = H;
-	return(4);
+	return (4);
 }
 
 static int op_ldll(void)		/* LD L,L */
 {
-	return(4);
+	return (4);
 }
 
 static int op_ldlhl(void)		/* LD L,(HL) */
 {
 	L = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_ldbcnn(void)		/* LD BC,nn */
 {
 	C = memrdr(PC++);
 	B = memrdr(PC++);
-	return(10);
+	return (10);
 }
 
 static int op_lddenn(void)		/* LD DE,nn */
 {
 	E = memrdr(PC++);
 	D = memrdr(PC++);
-	return(10);
+	return (10);
 }
 
 static int op_ldhlnn(void)		/* LD HL,nn */
 {
 	L = memrdr(PC++);
 	H = memrdr(PC++);
-	return(10);
+	return (10);
 }
 
 static int op_ldspnn(void)		/* LD SP,nn */
 {
 	SP = memrdr(PC++);
 	SP += memrdr(PC++) << 8;
-	return(10);
+	return (10);
 }
 
 static int op_ldsphl(void)		/* LD SP,HL */
 {
 	SP = (H << 8) + L;
-	return(6);
+	return (6);
 }
 
 static int op_ldhlin(void)		/* LD HL,(nn) */
@@ -1309,7 +1309,7 @@ static int op_ldhlin(void)		/* LD HL,(nn) */
 	i += memrdr(PC++) << 8;
 	L = memrdr(i++);
 	H = memrdr(i);
-	return(16);
+	return (16);
 }
 
 static int op_ldinhl(void)		/* LD (nn),HL */
@@ -1320,7 +1320,7 @@ static int op_ldinhl(void)		/* LD (nn),HL */
 	i += memrdr(PC++) << 8;
 	memwrt(i++, L);
 	memwrt(i, H);
-	return(16);
+	return (16);
 }
 
 static int op_incbc(void)		/* INC BC */
@@ -1328,7 +1328,7 @@ static int op_incbc(void)		/* INC BC */
 	C++;
 	if (!C)
 		B++;
-	return(6);
+	return (6);
 }
 
 static int op_incde(void)		/* INC DE */
@@ -1336,7 +1336,7 @@ static int op_incde(void)		/* INC DE */
 	E++;
 	if (!E)
 		D++;
-	return(6);
+	return (6);
 }
 
 static int op_inchl(void)		/* INC HL */
@@ -1344,13 +1344,13 @@ static int op_inchl(void)		/* INC HL */
 	L++;
 	if (!L)
 		H++;
-	return(6);
+	return (6);
 }
 
 static int op_incsp(void)		/* INC SP */
 {
 	SP++;
-	return(6);
+	return (6);
 }
 
 static int op_decbc(void)		/* DEC BC */
@@ -1358,7 +1358,7 @@ static int op_decbc(void)		/* DEC BC */
 	C--;
 	if (C == 0xff)
 		B--;
-	return(6);
+	return (6);
 }
 
 static int op_decde(void)		/* DEC DE */
@@ -1366,7 +1366,7 @@ static int op_decde(void)		/* DEC DE */
 	E--;
 	if (E == 0xff)
 		D--;
-	return(6);
+	return (6);
 }
 
 static int op_dechl(void)		/* DEC HL */
@@ -1374,13 +1374,13 @@ static int op_dechl(void)		/* DEC HL */
 	L--;
 	if (L == 0xff)
 		H--;
-	return(6);
+	return (6);
 }
 
 static int op_decsp(void)		/* DEC SP */
 {
 	SP--;
-	return(6);
+	return (6);
 }
 
 static int op_adhlbc(void)		/* ADD HL,BC */
@@ -1393,7 +1393,7 @@ static int op_adhlbc(void)		/* ADD HL,BC */
 	(H + B + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H += B + carry;
 	F &= ~N_FLAG;
-	return(11);
+	return (11);
 }
 
 static int op_adhlde(void)		/* ADD HL,DE */
@@ -1406,7 +1406,7 @@ static int op_adhlde(void)		/* ADD HL,DE */
 	(H + D + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H += D + carry;
 	F &= ~N_FLAG;
-	return(11);
+	return (11);
 }
 
 static int op_adhlhl(void)		/* ADD HL,HL */
@@ -1419,7 +1419,7 @@ static int op_adhlhl(void)		/* ADD HL,HL */
 	(H + H + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H += H + carry;
 	F &= ~N_FLAG;
-	return(11);
+	return (11);
 }
 
 static int op_adhlsp(void)		/* ADD HL,SP */
@@ -1436,7 +1436,7 @@ static int op_adhlsp(void)		/* ADD HL,SP */
 	(H + sph + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H += sph + carry;
 	F &= ~N_FLAG;
-	return(11);
+	return (11);
 }
 
 static int op_anda(void)		/* AND A */
@@ -1446,7 +1446,7 @@ static int op_anda(void)		/* AND A */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_andb(void)		/* AND B */
@@ -1457,7 +1457,7 @@ static int op_andb(void)		/* AND B */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_andc(void)		/* AND C */
@@ -1468,7 +1468,7 @@ static int op_andc(void)		/* AND C */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_andd(void)		/* AND D */
@@ -1479,7 +1479,7 @@ static int op_andd(void)		/* AND D */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_ande(void)		/* AND E */
@@ -1490,7 +1490,7 @@ static int op_ande(void)		/* AND E */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_andh(void)		/* AND H */
@@ -1501,7 +1501,7 @@ static int op_andh(void)		/* AND H */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_andl(void)		/* AND L */
@@ -1512,7 +1512,7 @@ static int op_andl(void)		/* AND L */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_andhl(void)		/* AND (HL) */
@@ -1523,7 +1523,7 @@ static int op_andhl(void)		/* AND (HL) */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_andn(void)		/* AND n */
@@ -1534,7 +1534,7 @@ static int op_andn(void)		/* AND n */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_ora(void)			/* OR A */
@@ -1543,7 +1543,7 @@ static int op_ora(void)			/* OR A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orb(void)			/* OR B */
@@ -1553,7 +1553,7 @@ static int op_orb(void)			/* OR B */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orc(void)			/* OR C */
@@ -1563,7 +1563,7 @@ static int op_orc(void)			/* OR C */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_ord(void)			/* OR D */
@@ -1573,7 +1573,7 @@ static int op_ord(void)			/* OR D */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_ore(void)			/* OR E */
@@ -1583,7 +1583,7 @@ static int op_ore(void)			/* OR E */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orh(void)			/* OR H */
@@ -1593,7 +1593,7 @@ static int op_orh(void)			/* OR H */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orl(void)			/* OR L */
@@ -1603,7 +1603,7 @@ static int op_orl(void)			/* OR L */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orhl(void)		/* OR (HL) */
@@ -1613,7 +1613,7 @@ static int op_orhl(void)		/* OR (HL) */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_orn(void)			/* OR n */
@@ -1623,7 +1623,7 @@ static int op_orn(void)			/* OR n */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_xora(void)		/* XOR A */
@@ -1631,7 +1631,7 @@ static int op_xora(void)		/* XOR A */
 	A = 0;
 	F &= ~(S_FLAG | H_FLAG | N_FLAG | C_FLAG);
 	F |= Z_FLAG | P_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_xorb(void)		/* XOR B */
@@ -1641,7 +1641,7 @@ static int op_xorb(void)		/* XOR B */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xorc(void)		/* XOR C */
@@ -1651,7 +1651,7 @@ static int op_xorc(void)		/* XOR C */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xord(void)		/* XOR D */
@@ -1661,7 +1661,7 @@ static int op_xord(void)		/* XOR D */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xore(void)		/* XOR E */
@@ -1671,7 +1671,7 @@ static int op_xore(void)		/* XOR E */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xorh(void)		/* XOR H */
@@ -1681,7 +1681,7 @@ static int op_xorh(void)		/* XOR H */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xorl(void)		/* XOR L */
@@ -1691,7 +1691,7 @@ static int op_xorl(void)		/* XOR L */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xorhl(void)		/* XOR (HL) */
@@ -1701,7 +1701,7 @@ static int op_xorhl(void)		/* XOR (HL) */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_xorn(void)		/* XOR n */
@@ -1711,7 +1711,7 @@ static int op_xorn(void)		/* XOR n */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_adda(void)		/* ADD A,A */
@@ -1725,7 +1725,7 @@ static int op_adda(void)		/* ADD A,A */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_addb(void)		/* ADD A,B */
@@ -1739,7 +1739,7 @@ static int op_addb(void)		/* ADD A,B */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_addc(void)		/* ADD A,C */
@@ -1753,7 +1753,7 @@ static int op_addc(void)		/* ADD A,C */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_addd(void)		/* ADD A,D */
@@ -1767,7 +1767,7 @@ static int op_addd(void)		/* ADD A,D */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_adde(void)		/* ADD A,E */
@@ -1781,7 +1781,7 @@ static int op_adde(void)		/* ADD A,E */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_addh(void)		/* ADD A,H */
@@ -1795,7 +1795,7 @@ static int op_addh(void)		/* ADD A,H */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_addl(void)		/* ADD A,L */
@@ -1809,7 +1809,7 @@ static int op_addl(void)		/* ADD A,L */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_addhl(void)		/* ADD A,(HL) */
@@ -1825,7 +1825,7 @@ static int op_addhl(void)		/* ADD A,(HL) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_addn(void)		/* ADD A,n */
@@ -1841,7 +1841,7 @@ static int op_addn(void)		/* ADD A,n */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_adca(void)		/* ADC A,A */
@@ -1856,7 +1856,7 @@ static int op_adca(void)		/* ADC A,A */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_adcb(void)		/* ADC A,B */
@@ -1871,7 +1871,7 @@ static int op_adcb(void)		/* ADC A,B */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_adcc(void)		/* ADC A,C */
@@ -1886,7 +1886,7 @@ static int op_adcc(void)		/* ADC A,C */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_adcd(void)		/* ADC A,D */
@@ -1901,7 +1901,7 @@ static int op_adcd(void)		/* ADC A,D */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_adce(void)		/* ADC A,E */
@@ -1916,7 +1916,7 @@ static int op_adce(void)		/* ADC A,E */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_adch(void)		/* ADC A,H */
@@ -1931,7 +1931,7 @@ static int op_adch(void)		/* ADC A,H */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_adcl(void)		/* ADC A,L */
@@ -1946,7 +1946,7 @@ static int op_adcl(void)		/* ADC A,L */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_adchl(void)		/* ADC A,(HL) */
@@ -1963,7 +1963,7 @@ static int op_adchl(void)		/* ADC A,(HL) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_adcn(void)		/* ADC A,n */
@@ -1980,7 +1980,7 @@ static int op_adcn(void)		/* ADC A,n */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_suba(void)		/* SUB A,A */
@@ -1988,7 +1988,7 @@ static int op_suba(void)		/* SUB A,A */
 	A = 0;
 	F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
 	F |= Z_FLAG | N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_subb(void)		/* SUB A,B */
@@ -2002,7 +2002,7 @@ static int op_subb(void)		/* SUB A,B */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_subc(void)		/* SUB A,C */
@@ -2016,7 +2016,7 @@ static int op_subc(void)		/* SUB A,C */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_subd(void)		/* SUB A,D */
@@ -2030,7 +2030,7 @@ static int op_subd(void)		/* SUB A,D */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_sube(void)		/* SUB A,E */
@@ -2044,7 +2044,7 @@ static int op_sube(void)		/* SUB A,E */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_subh(void)		/* SUB A,H */
@@ -2058,7 +2058,7 @@ static int op_subh(void)		/* SUB A,H */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_subl(void)		/* SUB A,L */
@@ -2072,7 +2072,7 @@ static int op_subl(void)		/* SUB A,L */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_subhl(void)		/* SUB A,(HL) */
@@ -2088,7 +2088,7 @@ static int op_subhl(void)		/* SUB A,(HL) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_subn(void)		/* SUB A,n */
@@ -2104,7 +2104,7 @@ static int op_subn(void)		/* SUB A,n */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_sbca(void)		/* SBC A,A */
@@ -2118,7 +2118,7 @@ static int op_sbca(void)		/* SBC A,A */
 		F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
 		A = 0;
 	}
-	return(4);
+	return (4);
 }
 
 static int op_sbcb(void)		/* SBC A,B */
@@ -2133,7 +2133,7 @@ static int op_sbcb(void)		/* SBC A,B */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_sbcc(void)		/* SBC A,C */
@@ -2148,7 +2148,7 @@ static int op_sbcc(void)		/* SBC A,C */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_sbcd(void)		/* SBC A,D */
@@ -2163,7 +2163,7 @@ static int op_sbcd(void)		/* SBC A,D */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_sbce(void)		/* SBC A,E */
@@ -2178,7 +2178,7 @@ static int op_sbce(void)		/* SBC A,E */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_sbch(void)		/* SBC A,H */
@@ -2193,7 +2193,7 @@ static int op_sbch(void)		/* SBC A,H */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_sbcl(void)		/* SBC A,L */
@@ -2208,7 +2208,7 @@ static int op_sbcl(void)		/* SBC A,L */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_sbchl(void)		/* SBC A,(HL) */
@@ -2225,7 +2225,7 @@ static int op_sbchl(void)		/* SBC A,(HL) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_sbcn(void)		/* SBC A,n */
@@ -2242,14 +2242,14 @@ static int op_sbcn(void)		/* SBC A,n */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_cpa(void)			/* CP A */
 {
 	F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
 	F |= Z_FLAG | N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cpb(void)			/* CP B */
@@ -2263,7 +2263,7 @@ static int op_cpb(void)			/* CP B */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cpc(void)			/* CP C */
@@ -2277,7 +2277,7 @@ static int op_cpc(void)			/* CP C */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cpd(void)			/* CP D */
@@ -2291,7 +2291,7 @@ static int op_cpd(void)			/* CP D */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cpe(void)			/* CP E */
@@ -2305,7 +2305,7 @@ static int op_cpe(void)			/* CP E */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cph(void)			/* CP H */
@@ -2319,7 +2319,7 @@ static int op_cph(void)			/* CP H */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cplr(void)		/* CP L */
@@ -2333,7 +2333,7 @@ static int op_cplr(void)		/* CP L */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cphl(void)		/* CP (HL) */
@@ -2349,7 +2349,7 @@ static int op_cphl(void)		/* CP (HL) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_cpn(void)			/* CP n */
@@ -2365,7 +2365,7 @@ static int op_cpn(void)			/* CP n */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_inca(void)		/* INC A */
@@ -2376,7 +2376,7 @@ static int op_inca(void)		/* INC A */
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_incb(void)		/* INC B */
@@ -2387,7 +2387,7 @@ static int op_incb(void)		/* INC B */
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_incc(void)		/* INC C */
@@ -2398,7 +2398,7 @@ static int op_incc(void)		/* INC C */
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_incd(void)		/* INC D */
@@ -2409,7 +2409,7 @@ static int op_incd(void)		/* INC D */
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_ince(void)		/* INC E */
@@ -2420,7 +2420,7 @@ static int op_ince(void)		/* INC E */
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_inch(void)		/* INC H */
@@ -2431,7 +2431,7 @@ static int op_inch(void)		/* INC H */
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_incl(void)		/* INC L */
@@ -2442,7 +2442,7 @@ static int op_incl(void)		/* INC L */
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_incihl(void)		/* INC (HL) */
@@ -2459,7 +2459,7 @@ static int op_incihl(void)		/* INC (HL) */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(11);
+	return (11);
 }
 
 static int op_deca(void)		/* DEC A */
@@ -2470,7 +2470,7 @@ static int op_deca(void)		/* DEC A */
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_decb(void)		/* DEC B */
@@ -2481,7 +2481,7 @@ static int op_decb(void)		/* DEC B */
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_decc(void)		/* DEC C */
@@ -2492,7 +2492,7 @@ static int op_decc(void)		/* DEC C */
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_decd(void)		/* DEC D */
@@ -2503,7 +2503,7 @@ static int op_decd(void)		/* DEC D */
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_dece(void)		/* DEC E */
@@ -2514,7 +2514,7 @@ static int op_dece(void)		/* DEC E */
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_dech(void)		/* DEC H */
@@ -2525,7 +2525,7 @@ static int op_dech(void)		/* DEC H */
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_decl(void)		/* DEC L */
@@ -2536,7 +2536,7 @@ static int op_decl(void)		/* DEC L */
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_decihl(void)		/* DEC (HL) */
@@ -2553,7 +2553,7 @@ static int op_decihl(void)		/* DEC (HL) */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(11);
+	return (11);
 }
 
 static int op_rlca(void)		/* RLCA */
@@ -2565,7 +2565,7 @@ static int op_rlca(void)		/* RLCA */
 	F &= ~(H_FLAG | N_FLAG);
 	A <<= 1;
 	A |= i;
-	return(4);
+	return (4);
 }
 
 static int op_rrca(void)		/* RRCA */
@@ -2577,7 +2577,7 @@ static int op_rrca(void)		/* RRCA */
 	F &= ~(H_FLAG | N_FLAG);
 	A >>= 1;
 	if (i) A |= 128;
-	return(4);
+	return (4);
 }
 
 static int op_rla(void)			/* RLA */
@@ -2589,7 +2589,7 @@ static int op_rla(void)			/* RLA */
 	F &= ~(H_FLAG | N_FLAG);
 	A <<= 1;
 	if (old_c_flag) A |= 1;
-	return(4);
+	return (4);
 }
 
 static int op_rra(void)			/* RRA */
@@ -2602,7 +2602,7 @@ static int op_rra(void)			/* RRA */
 	F &= ~(H_FLAG | N_FLAG);
 	A >>= 1;
 	if (old_c_flag) A |= 128;
-	return(4);
+	return (4);
 }
 
 static int op_exdehl(void)		/* EX DE,HL */
@@ -2615,7 +2615,7 @@ static int op_exdehl(void)		/* EX DE,HL */
 	i = E;
 	E = L;
 	L = i;
-	return(4);
+	return (4);
 }
 
 static int op_exafaf(void)		/* EX AF,AF' */
@@ -2628,7 +2628,7 @@ static int op_exafaf(void)		/* EX AF,AF' */
 	i = F;
 	F = F_;
 	F_ = i;
-	return(4);
+	return (4);
 }
 
 static int op_exx(void)			/* EXX */
@@ -2653,7 +2653,7 @@ static int op_exx(void)			/* EXX */
 	i = L;
 	L = L_;
 	L_ = i;
-	return(4);
+	return (4);
 }
 
 static int op_exsphl(void)		/* EX (SP),HL */
@@ -2666,63 +2666,63 @@ static int op_exsphl(void)		/* EX (SP),HL */
 	i = memrdr(SP + 1);
 	memwrt(SP + 1, H);
 	H = i;
-	return(19);
+	return (19);
 }
 
 static int op_pushaf(void)		/* PUSH AF */
 {
 	memwrt(--SP, A);
 	memwrt(--SP, F);
-	return(11);
+	return (11);
 }
 
 static int op_pushbc(void)		/* PUSH BC */
 {
 	memwrt(--SP, B);
 	memwrt(--SP, C);
-	return(11);
+	return (11);
 }
 
 static int op_pushde(void)		/* PUSH DE */
 {
 	memwrt(--SP, D);
 	memwrt(--SP, E);
-	return(11);
+	return (11);
 }
 
 static int op_pushhl(void)		/* PUSH HL */
 {
 	memwrt(--SP, H);
 	memwrt(--SP, L);
-	return(11);
+	return (11);
 }
 
 static int op_popaf(void)		/* POP AF */
 {
 	F = memrdr(SP++);
 	A = memrdr(SP++);
-	return(10);
+	return (10);
 }
 
 static int op_popbc(void)		/* POP BC */
 {
 	C = memrdr(SP++);
 	B = memrdr(SP++);
-	return(10);
+	return (10);
 }
 
 static int op_popde(void)		/* POP DE */
 {
 	E = memrdr(SP++);
 	D = memrdr(SP++);
-	return(10);
+	return (10);
 }
 
 static int op_pophl(void)		/* POP HL */
 {
 	L = memrdr(SP++);
 	H = memrdr(SP++);
-	return(10);
+	return (10);
 }
 
 static int op_jp(void)			/* JP */
@@ -2732,29 +2732,29 @@ static int op_jp(void)			/* JP */
 	i = memrdr(PC++);
 	i += memrdr(PC) << 8;
 	PC = i;
-	return(10);
+	return (10);
 }
 
 static int op_jphl(void)		/* JP (HL) */
 {
 	PC = (H << 8) + L;
-	return(4);
+	return (4);
 }
 
 static int op_jr(void)			/* JR */
 {
 	PC += (signed char) memrdr(PC) + 1;
-	return(12);
+	return (12);
 }
 
 static int op_djnz(void)		/* DJNZ */
 {
 	if (--B) {
 		PC += (signed char) memrdr(PC) + 1;
-		return(13);
+		return (13);
 	} else {
 		PC++;
-		return(8);
+		return (8);
 	}
 }
 
@@ -2767,7 +2767,7 @@ static int op_call(void)		/* CALL */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = i;
-	return(17);
+	return (17);
 }
 
 static int op_ret(void)			/* RET */
@@ -2777,7 +2777,7 @@ static int op_ret(void)			/* RET */
 	i = memrdr(SP++);
 	i += memrdr(SP++) << 8;
 	PC = i;
-	return(10);
+	return (10);
 }
 
 static int op_jpz(void)			/* JP Z,nn */
@@ -2791,7 +2791,7 @@ static int op_jpz(void)			/* JP Z,nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jpnz(void)		/* JP NZ,nn */
@@ -2805,7 +2805,7 @@ static int op_jpnz(void)		/* JP NZ,nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jpc(void)			/* JP C,nn */
@@ -2819,7 +2819,7 @@ static int op_jpc(void)			/* JP C,nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jpnc(void)		/* JP NC,nn */
@@ -2833,7 +2833,7 @@ static int op_jpnc(void)		/* JP NC,nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jppe(void)		/* JP PE,nn */
@@ -2847,7 +2847,7 @@ static int op_jppe(void)		/* JP PE,nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jppo(void)		/* JP PO,nn */
@@ -2861,7 +2861,7 @@ static int op_jppo(void)		/* JP PO,nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jpm(void)			/* JP M,nn */
@@ -2875,7 +2875,7 @@ static int op_jpm(void)			/* JP M,nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jpp(void)			/* JP P,nn */
@@ -2889,7 +2889,7 @@ static int op_jpp(void)			/* JP P,nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_calz(void)		/* CALL Z,nn */
@@ -2902,10 +2902,10 @@ static int op_calz(void)		/* CALL Z,nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(10);
+		return (10);
 	}
 }
 
@@ -2919,10 +2919,10 @@ static int op_calnz(void)		/* CALL NZ,nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(10);
+		return (10);
 	}
 }
 
@@ -2936,10 +2936,10 @@ static int op_calc(void)		/* CALL C,nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(10);
+		return (10);
 	}
 }
 
@@ -2953,10 +2953,10 @@ static int op_calnc(void)		/* CALL NC,nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(10);
+		return (10);
 	}
 }
 
@@ -2970,10 +2970,10 @@ static int op_calpe(void)		/* CALL PE,nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(10);
+		return (10);
 	}
 }
 
@@ -2987,10 +2987,10 @@ static int op_calpo(void)		/* CALL PO,nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(10);
+		return (10);
 	}
 }
 
@@ -3004,10 +3004,10 @@ static int op_calm(void)		/* CALL M,nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(10);
+		return (10);
 	}
 }
 
@@ -3021,10 +3021,10 @@ static int op_calp(void)		/* CALL P,nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(10);
+		return (10);
 	}
 }
 
@@ -3036,9 +3036,9 @@ static int op_retz(void)		/* RET Z */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3050,9 +3050,9 @@ static int op_retnz(void)		/* RET NZ */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3064,9 +3064,9 @@ static int op_retc(void)		/* RET C */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3078,9 +3078,9 @@ static int op_retnc(void)		/* RET NC */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3092,9 +3092,9 @@ static int op_retpe(void)		/* RET PE */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3106,9 +3106,9 @@ static int op_retpo(void)		/* RET PO */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3120,9 +3120,9 @@ static int op_retm(void)		/* RET M */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3134,9 +3134,9 @@ static int op_retp(void)		/* RET P */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3144,10 +3144,10 @@ static int op_jrz(void)			/* JR Z,n */
 {
 	if (F & Z_FLAG) {
 		PC += (signed char) memrdr(PC) + 1;
-		return(12);
+		return (12);
 	} else {
 		PC++;
-		return(7);
+		return (7);
 	}
 }
 
@@ -3155,10 +3155,10 @@ static int op_jrnz(void)		/* JR NZ,n */
 {
 	if (!(F & Z_FLAG)) {
 		PC += (signed char) memrdr(PC) + 1;
-		return(12);
+		return (12);
 	} else {
 		PC++;
-		return(7);
+		return (7);
 	}
 }
 
@@ -3166,10 +3166,10 @@ static int op_jrc(void)			/* JR C,n */
 {
 	if (F & C_FLAG) {
 		PC += (signed char) memrdr(PC) + 1;
-		return(12);
+		return (12);
 	} else {
 		PC++;
-		return(7);
+		return (7);
 	}
 }
 
@@ -3177,10 +3177,10 @@ static int op_jrnc(void)		/* JR NC,n */
 {
 	if (!(F & C_FLAG)) {
 		PC += (signed char) memrdr(PC) + 1;
-		return(12);
+		return (12);
 	} else {
 		PC++;
-		return(7);
+		return (7);
 	}
 }
 
@@ -3189,7 +3189,7 @@ static int op_rst00(void)		/* RST 00 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0;
-	return(11);
+	return (11);
 }
 
 static int op_rst08(void)		/* RST 08 */
@@ -3197,7 +3197,7 @@ static int op_rst08(void)		/* RST 08 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x08;
-	return(11);
+	return (11);
 }
 
 static int op_rst10(void)		/* RST 10 */
@@ -3205,7 +3205,7 @@ static int op_rst10(void)		/* RST 10 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x10;
-	return(11);
+	return (11);
 }
 
 static int op_rst18(void)		/* RST 18 */
@@ -3213,7 +3213,7 @@ static int op_rst18(void)		/* RST 18 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x18;
-	return(11);
+	return (11);
 }
 
 static int op_rst20(void)		/* RST 20 */
@@ -3221,7 +3221,7 @@ static int op_rst20(void)		/* RST 20 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x20;
-	return(11);
+	return (11);
 }
 
 static int op_rst28(void)		/* RST 28 */
@@ -3229,7 +3229,7 @@ static int op_rst28(void)		/* RST 28 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x28;
-	return(11);
+	return (11);
 }
 
 static int op_rst30(void)		/* RST 30 */
@@ -3237,7 +3237,7 @@ static int op_rst30(void)		/* RST 30 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x30;
-	return(11);
+	return (11);
 }
 
 static int op_rst38(void)		/* RST 38 */
@@ -3245,5 +3245,5 @@ static int op_rst38(void)		/* RST 38 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x38;
-	return(11);
+	return (11);
 }

--- a/z80core/sim1a.c
+++ b/z80core/sim1a.c
@@ -577,7 +577,7 @@ leave:
 
 static int op_nop(void)			/* NOP */
 {
-	return(4);
+	return (4);
 }
 
 static int op_undoc_nop(void)		/* Undocumented NOP */
@@ -585,9 +585,9 @@ static int op_undoc_nop(void)		/* Undocumented NOP */
 	if (u_flag) {	/* trap with option -u */
 		cpu_error = OPTRAP1;
 		cpu_state = STOPPED;
-		return(0);
+		return (0);
 	} else {	/* else NOP */
-		return(4);
+		return (4);
 	}
 }
 
@@ -649,13 +649,13 @@ static int op_hlt(void)			/* HLT */
 	}
 #endif
 
-	return(7);
+	return (7);
 }
 
 static int op_stc(void)			/* STC */
 {
 	F |= C_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cmc(void)			/* CMC */
@@ -664,13 +664,13 @@ static int op_cmc(void)			/* CMC */
 		F &= ~C_FLAG;
 	else
 		F |= C_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cma(void)			/* CMA */
 {
 	A = ~A;
-	return(4);
+	return (4);
 }
 
 static int op_daa(void)			/* DAA */
@@ -690,20 +690,20 @@ static int op_daa(void)			/* DAA */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_ei(void)			/* EI */
 {
 	IFF = 3;
 	int_protection = 1;		/* protect next instruction */
-	return(4);
+	return (4);
 }
 
 static int op_di(void)			/* DI */
 {
 	IFF = 0;
-	return(4);
+	return (4);
 }
 
 static int op_in(void)			/* IN n */
@@ -713,7 +713,7 @@ static int op_in(void)			/* IN n */
 
 	addr = memrdr(PC++);
 	A = io_in(addr, addr);
-	return(10);
+	return (10);
 }
 
 static int op_out(void)			/* OUT n */
@@ -723,61 +723,61 @@ static int op_out(void)			/* OUT n */
 
 	addr = memrdr(PC++);
 	io_out(addr, addr, A);
-	return(10);
+	return (10);
 }
 
 static int op_mvian(void)		/* MVI A,n */
 {
 	A = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_mvibn(void)		/* MVI B,n */
 {
 	B = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_mvicn(void)		/* MVI C,n */
 {
 	C = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_mvidn(void)		/* MVI D,n */
 {
 	D = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_mvien(void)		/* MVI E,n */
 {
 	E = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_mvihn(void)		/* MVI H,n */
 {
 	H = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_mviln(void)		/* MVI L,n */
 {
 	L = memrdr(PC++);
-	return(7);
+	return (7);
 }
 
 static int op_ldaxb(void)		/* LDAX B */
 {
 	A = memrdr((B << 8) + C);
-	return(7);
+	return (7);
 }
 
 static int op_ldaxd(void)		/* LDAX D */
 {
 	A = memrdr((D << 8) + E);
-	return(7);
+	return (7);
 }
 
 static int op_ldann(void)		/* LDA nn */
@@ -787,19 +787,19 @@ static int op_ldann(void)		/* LDA nn */
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
 	A = memrdr(i);
-	return(13);
+	return (13);
 }
 
 static int op_staxb(void)		/* STAX B */
 {
 	memwrt((B << 8) + C, A);
-	return(7);
+	return (7);
 }
 
 static int op_staxd(void)		/* STAX D */
 {
 	memwrt((D << 8) + E, A);
-	return(7);
+	return (7);
 }
 
 static int op_stann(void)		/* STA nn */
@@ -809,412 +809,412 @@ static int op_stann(void)		/* STA nn */
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
 	memwrt(i, A);
-	return(13);
+	return (13);
 }
 
 static int op_movma(void)		/* MOV M,A */
 {
 	memwrt((H << 8) + L, A);
-	return(7);
+	return (7);
 }
 
 static int op_movmb(void)		/* MOV M,B */
 {
 	memwrt((H << 8) + L, B);
-	return(7);
+	return (7);
 }
 
 static int op_movmc(void)		/* MOV M,C */
 {
 	memwrt((H << 8) + L, C);
-	return(7);
+	return (7);
 }
 
 static int op_movmd(void)		/* MOV M,D */
 {
 	memwrt((H << 8) + L, D);
-	return(7);
+	return (7);
 }
 
 static int op_movme(void)		/* MOV M,E */
 {
 	memwrt((H << 8) + L, E);
-	return(7);
+	return (7);
 }
 
 static int op_movmh(void)		/* MOV M,H */
 {
 	memwrt((H << 8) + L, H);
-	return(7);
+	return (7);
 }
 
 static int op_movml(void)		/* MOV M,L */
 {
 	memwrt((H << 8) + L, L);
-	return(7);
+	return (7);
 }
 
 static int op_mvimn(void)		/* MVI M,n */
 {
 	memwrt((H << 8) + L, memrdr(PC++));
-	return(10);
+	return (10);
 }
 
 static int op_movaa(void)		/* MOV A,A */
 {
-	return(5);
+	return (5);
 }
 
 static int op_movab(void)		/* MOV A,B */
 {
 	A = B;
-	return(5);
+	return (5);
 }
 
 static int op_movac(void)		/* MOV A,C */
 {
 	A = C;
-	return(5);
+	return (5);
 }
 
 static int op_movad(void)		/* MOV A,D */
 {
 	A = D;
-	return(5);
+	return (5);
 }
 
 static int op_movae(void)		/* MOV A,E */
 {
 	A = E;
-	return(5);
+	return (5);
 }
 
 static int op_movah(void)		/* MOV A,H */
 {
 	A = H;
-	return(5);
+	return (5);
 }
 
 static int op_moval(void)		/* MOV A,L */
 {
 	A = L;
-	return(5);
+	return (5);
 }
 
 static int op_movam(void)		/* MOV A,M */
 {
 	A = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_movba(void)		/* MOV B,A */
 {
 	B = A;
-	return(5);
+	return (5);
 }
 
 static int op_movbb(void)		/* MOV B,B */
 {
-	return(5);
+	return (5);
 }
 
 static int op_movbc(void)		/* MOV B,C */
 {
 	B = C;
-	return(5);
+	return (5);
 }
 
 static int op_movbd(void)		/* MOV B,D */
 {
 	B = D;
-	return(5);
+	return (5);
 }
 
 static int op_movbe(void)		/* MOV B,E */
 {
 	B = E;
-	return(5);
+	return (5);
 }
 
 static int op_movbh(void)		/* MOV B,H */
 {
 	B = H;
-	return(5);
+	return (5);
 }
 
 static int op_movbl(void)		/* MOV B,L */
 {
 	B = L;
-	return(5);
+	return (5);
 }
 
 static int op_movbm(void)		/* MOV B,M */
 {
 	B = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_movca(void)		/* MOV C,A */
 {
 	C = A;
-	return(5);
+	return (5);
 }
 
 static int op_movcb(void)		/* MOV C,B */
 {
 	C = B;
-	return(5);
+	return (5);
 }
 
 static int op_movcc(void)		/* MOV C,C */
 {
-	return(5);
+	return (5);
 }
 
 static int op_movcd(void)		/* MOV C,D */
 {
 	C = D;
-	return(5);
+	return (5);
 }
 
 static int op_movce(void)		/* MOV C,E */
 {
 	C = E;
-	return(5);
+	return (5);
 }
 
 static int op_movch(void)		/* MOV C,H */
 {
 	C = H;
-	return(5);
+	return (5);
 }
 
 static int op_movcl(void)		/* MOV C,L */
 {
 	C = L;
-	return(5);
+	return (5);
 }
 
 static int op_movcm(void)		/* MOV C,M */
 {
 	C = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_movda(void)		/* MOV D,A */
 {
 	D = A;
-	return(5);
+	return (5);
 }
 
 static int op_movdb(void)		/* MOV D,B */
 {
 	D = B;
-	return(5);
+	return (5);
 }
 
 static int op_movdc(void)		/* MOV D,C */
 {
 	D = C;
-	return(5);
+	return (5);
 }
 
 static int op_movdd(void)		/* MOV D,D */
 {
-	return(5);
+	return (5);
 }
 
 static int op_movde(void)		/* MOV D,E */
 {
 	D = E;
-	return(5);
+	return (5);
 }
 
 static int op_movdh(void)		/* MOV D,H */
 {
 	D = H;
-	return(5);
+	return (5);
 }
 
 static int op_movdl(void)		/* MOV D,L */
 {
 	D = L;
-	return(5);
+	return (5);
 }
 
 static int op_movdm(void)		/* MOV D,M */
 {
 	D = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_movea(void)		/* MOV E,A */
 {
 	E = A;
-	return(5);
+	return (5);
 }
 
 static int op_moveb(void)		/* MOV E,B */
 {
 	E = B;
-	return(5);
+	return (5);
 }
 
 static int op_movec(void)		/* MOV E,C */
 {
 	E = C;
-	return(5);
+	return (5);
 }
 
 static int op_moved(void)		/* MOV E,D */
 {
 	E = D;
-	return(5);
+	return (5);
 }
 
 static int op_movee(void)		/* MOV E,E */
 {
-	return(5);
+	return (5);
 }
 
 static int op_moveh(void)		/* MOV E,H */
 {
 	E = H;
-	return(5);
+	return (5);
 }
 
 static int op_movel(void)		/* MOV E,L */
 {
 	E = L;
-	return(5);
+	return (5);
 }
 
 static int op_movem(void)		/* MOV E,M */
 {
 	E = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_movha(void)		/* MOV H,A */
 {
 	H = A;
-	return(5);
+	return (5);
 }
 
 static int op_movhb(void)		/* MOV H,B */
 {
 	H = B;
-	return(5);
+	return (5);
 }
 
 static int op_movhc(void)		/* MOV H,C */
 {
 	H = C;
-	return(5);
+	return (5);
 }
 
 static int op_movhd(void)		/* MOV H,D */
 {
 	H = D;
-	return(5);
+	return (5);
 }
 
 static int op_movhe(void)		/* MOV H,E */
 {
 	H = E;
-	return(5);
+	return (5);
 }
 
 static int op_movhh(void)		/* MOV H,H */
 {
-	return(5);
+	return (5);
 }
 
 static int op_movhl(void)		/* MOV H,L */
 {
 	H = L;
-	return(5);
+	return (5);
 }
 
 static int op_movhm(void)		/* MOV H,M */
 {
 	H = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_movla(void)		/* MOV L,A */
 {
 	L = A;
-	return(5);
+	return (5);
 }
 
 static int op_movlb(void)		/* MOV L,B */
 {
 	L = B;
-	return(5);
+	return (5);
 }
 
 static int op_movlc(void)		/* MOV L,C */
 {
 	L = C;
-	return(5);
+	return (5);
 }
 
 static int op_movld(void)		/* MOV L,D */
 {
 	L = D;
-	return(5);
+	return (5);
 }
 
 static int op_movle(void)		/* MOV L,E */
 {
 	L = E;
-	return(5);
+	return (5);
 }
 
 static int op_movlh(void)		/* MOV L,H */
 {
 	L = H;
-	return(5);
+	return (5);
 }
 
 static int op_movll(void)		/* MOV L,L */
 {
-	return(5);
+	return (5);
 }
 
 static int op_movlm(void)		/* MOV L,M */
 {
 	L = memrdr((H << 8) + L);
-	return(7);
+	return (7);
 }
 
 static int op_lxibnn(void)		/* LXI B,nn */
 {
 	C = memrdr(PC++);
 	B = memrdr(PC++);
-	return(10);
+	return (10);
 }
 
 static int op_lxidnn(void)		/* LXI D,nn */
 {
 	E = memrdr(PC++);
 	D = memrdr(PC++);
-	return(10);
+	return (10);
 }
 
 static int op_lxihnn(void)		/* LXI H,nn */
 {
 	L = memrdr(PC++);
 	H = memrdr(PC++);
-	return(10);
+	return (10);
 }
 
 static int op_lxispnn(void)		/* LXI SP,nn */
 {
 	SP = memrdr(PC++);
 	SP += memrdr(PC++) << 8;
-	return(10);
+	return (10);
 }
 
 static int op_sphl(void)		/* SPHL */
@@ -1223,7 +1223,7 @@ static int op_sphl(void)		/* SPHL */
 	addr_leds(H << 8 | L);
 #endif
 	SP = (H << 8) + L;
-	return(5);
+	return (5);
 }
 
 static int op_lhldnn(void)		/* LHLD nn */
@@ -1234,7 +1234,7 @@ static int op_lhldnn(void)		/* LHLD nn */
 	i += memrdr(PC++) << 8;
 	L = memrdr(i);
 	H = memrdr(i + 1);
-	return(16);
+	return (16);
 }
 
 static int op_shldnn(void)		/* SHLD nn */
@@ -1245,7 +1245,7 @@ static int op_shldnn(void)		/* SHLD nn */
 	i += memrdr(PC++) << 8;
 	memwrt(i, L);
 	memwrt(i + 1, H);
-	return(16);
+	return (16);
 }
 
 static int op_inxb(void)		/* INX B */
@@ -1256,7 +1256,7 @@ static int op_inxb(void)		/* INX B */
 	C++;
 	if (!C)
 		B++;
-	return(5);
+	return (5);
 }
 
 static int op_inxd(void)		/* INX D */
@@ -1267,7 +1267,7 @@ static int op_inxd(void)		/* INX D */
 	E++;
 	if (!E)
 		D++;
-	return(5);
+	return (5);
 }
 
 static int op_inxh(void)		/* INX H */
@@ -1278,7 +1278,7 @@ static int op_inxh(void)		/* INX H */
 	L++;
 	if (!L)
 		H++;
-	return(5);
+	return (5);
 }
 
 static int op_inxsp(void)		/* INX SP */
@@ -1287,7 +1287,7 @@ static int op_inxsp(void)		/* INX SP */
 	addr_leds(SP);
 #endif
 	SP++;
-	return(5);
+	return (5);
 }
 
 static int op_dcxb(void)		/* DCX B */
@@ -1298,7 +1298,7 @@ static int op_dcxb(void)		/* DCX B */
 	C--;
 	if (C == 0xff)
 		B--;
-	return(5);
+	return (5);
 }
 
 static int op_dcxd(void)		/* DCX D */
@@ -1309,7 +1309,7 @@ static int op_dcxd(void)		/* DCX D */
 	E--;
 	if (E == 0xff)
 		D--;
-	return(5);
+	return (5);
 }
 
 static int op_dcxh(void)		/* DCX H */
@@ -1320,7 +1320,7 @@ static int op_dcxh(void)		/* DCX H */
 	L--;
 	if (L == 0xff)
 		H--;
-	return(5);
+	return (5);
 }
 
 static int op_dcxsp(void)		/* DCX SP */
@@ -1329,7 +1329,7 @@ static int op_dcxsp(void)		/* DCX SP */
 	addr_leds(SP);
 #endif
 	SP--;
-	return(5);
+	return (5);
 }
 
 static int op_dadb(void)		/* DAD B */
@@ -1340,7 +1340,7 @@ static int op_dadb(void)		/* DAD B */
 	L += C;
 	(H + B + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H += B + carry;
-	return(10);
+	return (10);
 }
 
 static int op_dadd(void)		/* DAD D */
@@ -1351,7 +1351,7 @@ static int op_dadd(void)		/* DAD D */
 	L += E;
 	(H + D + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H += D + carry;
-	return(10);
+	return (10);
 }
 
 static int op_dadh(void)		/* DAD H */
@@ -1362,7 +1362,7 @@ static int op_dadh(void)		/* DAD H */
 	L <<= 1;
 	(H + H + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H += H + carry;
-	return(10);
+	return (10);
 }
 
 static int op_dadsp(void)		/* DAD SP */
@@ -1376,7 +1376,7 @@ static int op_dadsp(void)		/* DAD SP */
 	L += spl;
 	(H + sph + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H += sph + carry;
-	return(10);
+	return (10);
 }
 
 static int op_anaa(void)		/* ANA A */
@@ -1386,7 +1386,7 @@ static int op_anaa(void)		/* ANA A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~C_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_anab(void)		/* ANA B */
@@ -1397,7 +1397,7 @@ static int op_anab(void)		/* ANA B */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~C_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_anac(void)		/* ANA C */
@@ -1408,7 +1408,7 @@ static int op_anac(void)		/* ANA C */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~C_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_anad(void)		/* ANA D */
@@ -1419,7 +1419,7 @@ static int op_anad(void)		/* ANA D */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~C_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_anae(void)		/* ANA E */
@@ -1430,7 +1430,7 @@ static int op_anae(void)		/* ANA E */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~C_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_anah(void)		/* ANA H */
@@ -1441,7 +1441,7 @@ static int op_anah(void)		/* ANA H */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~C_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_anal(void)		/* ANA L */
@@ -1452,7 +1452,7 @@ static int op_anal(void)		/* ANA L */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~C_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_anam(void)		/* ANA M */
@@ -1466,7 +1466,7 @@ static int op_anam(void)		/* ANA M */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~C_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_anin(void)		/* ANI n */
@@ -1480,7 +1480,7 @@ static int op_anin(void)		/* ANI n */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~C_FLAG;
-	return(7);
+	return (7);
 }
 
 static int op_oraa(void)		/* ORA A */
@@ -1489,7 +1489,7 @@ static int op_oraa(void)		/* ORA A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(C_FLAG | H_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orab(void)		/* ORA B */
@@ -1499,7 +1499,7 @@ static int op_orab(void)		/* ORA B */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(C_FLAG | H_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orac(void)		/* ORA C */
@@ -1509,7 +1509,7 @@ static int op_orac(void)		/* ORA C */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(C_FLAG | H_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orad(void)		/* ORA D */
@@ -1519,7 +1519,7 @@ static int op_orad(void)		/* ORA D */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(C_FLAG | H_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orae(void)		/* ORA E */
@@ -1529,7 +1529,7 @@ static int op_orae(void)		/* ORA E */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(C_FLAG | H_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_orah(void)		/* ORA H */
@@ -1539,7 +1539,7 @@ static int op_orah(void)		/* ORA H */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(C_FLAG | H_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_oral(void)		/* ORA L */
@@ -1549,7 +1549,7 @@ static int op_oral(void)		/* ORA L */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(C_FLAG | H_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_oram(void)		/* ORA M */
@@ -1559,7 +1559,7 @@ static int op_oram(void)		/* ORA M */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(C_FLAG | H_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_orin(void)		/* ORI n */
@@ -1569,7 +1569,7 @@ static int op_orin(void)		/* ORI n */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(C_FLAG | H_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_xraa(void)		/* XRA A */
@@ -1577,7 +1577,7 @@ static int op_xraa(void)		/* XRA A */
 	A = 0;
 	F &= ~(S_FLAG | H_FLAG | C_FLAG);
 	F |= Z_FLAG | P_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_xrab(void)		/* XRA B */
@@ -1587,7 +1587,7 @@ static int op_xrab(void)		/* XRA B */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xrac(void)		/* XRA C */
@@ -1597,7 +1597,7 @@ static int op_xrac(void)		/* XRA C */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xrad(void)		/* XRA D */
@@ -1607,7 +1607,7 @@ static int op_xrad(void)		/* XRA D */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xrae(void)		/* XRA E */
@@ -1617,7 +1617,7 @@ static int op_xrae(void)		/* XRA E */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xrah(void)		/* XRA H */
@@ -1627,7 +1627,7 @@ static int op_xrah(void)		/* XRA H */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xral(void)		/* XRA L */
@@ -1637,7 +1637,7 @@ static int op_xral(void)		/* XRA L */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | C_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_xram(void)		/* XRA M */
@@ -1647,7 +1647,7 @@ static int op_xram(void)		/* XRA M */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | C_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_xrin(void)		/* XRI n */
@@ -1657,7 +1657,7 @@ static int op_xrin(void)		/* XRI n */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | C_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_adda(void)		/* ADD A */
@@ -1668,7 +1668,7 @@ static int op_adda(void)		/* ADD A */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_addb(void)		/* ADD B */
@@ -1679,7 +1679,7 @@ static int op_addb(void)		/* ADD B */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_addc(void)		/* ADD C */
@@ -1690,7 +1690,7 @@ static int op_addc(void)		/* ADD C */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_addd(void)		/* ADD D */
@@ -1701,7 +1701,7 @@ static int op_addd(void)		/* ADD D */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_adde(void)		/* ADD E */
@@ -1712,7 +1712,7 @@ static int op_adde(void)		/* ADD E */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_addh(void)		/* ADD H */
@@ -1723,7 +1723,7 @@ static int op_addh(void)		/* ADD H */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_addl(void)		/* ADD L */
@@ -1734,7 +1734,7 @@ static int op_addl(void)		/* ADD L */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_addm(void)		/* ADD M */
@@ -1748,7 +1748,7 @@ static int op_addm(void)		/* ADD M */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_adin(void)		/* ADI n */
@@ -1762,7 +1762,7 @@ static int op_adin(void)		/* ADI n */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_adca(void)		/* ADC A */
@@ -1776,7 +1776,7 @@ static int op_adca(void)		/* ADC A */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_adcb(void)		/* ADC B */
@@ -1790,7 +1790,7 @@ static int op_adcb(void)		/* ADC B */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_adcc(void)		/* ADC C */
@@ -1804,7 +1804,7 @@ static int op_adcc(void)		/* ADC C */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_adcd(void)		/* ADC D */
@@ -1818,7 +1818,7 @@ static int op_adcd(void)		/* ADC D */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_adce(void)		/* ADC E */
@@ -1832,7 +1832,7 @@ static int op_adce(void)		/* ADC E */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_adch(void)		/* ADC H */
@@ -1846,7 +1846,7 @@ static int op_adch(void)		/* ADC H */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_adcl(void)		/* ADC L */
@@ -1860,7 +1860,7 @@ static int op_adcl(void)		/* ADC L */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_adcm(void)		/* ADC M */
@@ -1876,7 +1876,7 @@ static int op_adcm(void)		/* ADC M */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_acin(void)		/* ACI n */
@@ -1892,7 +1892,7 @@ static int op_acin(void)		/* ACI n */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_suba(void)		/* SUB A */
@@ -1900,7 +1900,7 @@ static int op_suba(void)		/* SUB A */
 	A = 0;
 	F &= ~(S_FLAG | C_FLAG);
 	F |= Z_FLAG | H_FLAG | P_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_subb(void)		/* SUB B */
@@ -1911,7 +1911,7 @@ static int op_subb(void)		/* SUB B */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_subc(void)		/* SUB C */
@@ -1922,7 +1922,7 @@ static int op_subc(void)		/* SUB C */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_subd(void)		/* SUB D */
@@ -1933,7 +1933,7 @@ static int op_subd(void)		/* SUB D */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_sube(void)		/* SUB E */
@@ -1944,7 +1944,7 @@ static int op_sube(void)		/* SUB E */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_subh(void)		/* SUB H */
@@ -1955,7 +1955,7 @@ static int op_subh(void)		/* SUB H */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_subl(void)		/* SUB L */
@@ -1966,7 +1966,7 @@ static int op_subl(void)		/* SUB L */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_subm(void)		/* SUB M */
@@ -1980,7 +1980,7 @@ static int op_subm(void)		/* SUB M */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_suin(void)		/* SUI n */
@@ -1994,7 +1994,7 @@ static int op_suin(void)		/* SUI n */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_sbba(void)		/* SBB A */
@@ -2008,7 +2008,7 @@ static int op_sbba(void)		/* SBB A */
 		F &= ~(S_FLAG | C_FLAG);
 		A = 0;
 	}
-	return(4);
+	return (4);
 }
 
 static int op_sbbb(void)		/* SBB B */
@@ -2022,7 +2022,7 @@ static int op_sbbb(void)		/* SBB B */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_sbbc(void)		/* SBB C */
@@ -2036,7 +2036,7 @@ static int op_sbbc(void)		/* SBB C */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_sbbd(void)		/* SBB D */
@@ -2050,7 +2050,7 @@ static int op_sbbd(void)		/* SBB D */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_sbbe(void)		/* SBB E */
@@ -2064,7 +2064,7 @@ static int op_sbbe(void)		/* SBB E */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_sbbh(void)		/* SBB H */
@@ -2078,7 +2078,7 @@ static int op_sbbh(void)		/* SBB H */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_sbbl(void)		/* SBB L */
@@ -2092,7 +2092,7 @@ static int op_sbbl(void)		/* SBB L */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_sbbm(void)		/* SBB M */
@@ -2108,7 +2108,7 @@ static int op_sbbm(void)		/* SBB M */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_sbin(void)		/* SBI n */
@@ -2124,14 +2124,14 @@ static int op_sbin(void)		/* SBI n */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_cmpa(void)		/* CMP A */
 {
 	F &= ~(S_FLAG | C_FLAG);
 	F |= Z_FLAG | H_FLAG | P_FLAG;
-	return(4);
+	return (4);
 }
 
 static int op_cmpb(void)		/* CMP B */
@@ -2144,7 +2144,7 @@ static int op_cmpb(void)		/* CMP B */
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_cmpc(void)		/* CMP C */
@@ -2157,7 +2157,7 @@ static int op_cmpc(void)		/* CMP C */
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_cmpd(void)		/* CMP D */
@@ -2170,7 +2170,7 @@ static int op_cmpd(void)		/* CMP D */
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_cmpe(void)		/* CMP E */
@@ -2183,7 +2183,7 @@ static int op_cmpe(void)		/* CMP E */
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_cmph(void)		/* CMP H */
@@ -2196,7 +2196,7 @@ static int op_cmph(void)		/* CMP H */
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_cmpl(void)		/* CMP L */
@@ -2209,7 +2209,7 @@ static int op_cmpl(void)		/* CMP L */
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(4);
+	return (4);
 }
 
 static int op_cmpm(void)		/* CMP M */
@@ -2224,7 +2224,7 @@ static int op_cmpm(void)		/* CMP M */
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_cpin(void)		/* CPI n */
@@ -2239,7 +2239,7 @@ static int op_cpin(void)		/* CPI n */
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(7);
+	return (7);
 }
 
 static int op_inra(void)		/* INR A */
@@ -2249,7 +2249,7 @@ static int op_inra(void)		/* INR A */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_inrb(void)		/* INR B */
@@ -2259,7 +2259,7 @@ static int op_inrb(void)		/* INR B */
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_inrc(void)		/* INR C */
@@ -2269,7 +2269,7 @@ static int op_inrc(void)		/* INR C */
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_inrd(void)		/* INR D */
@@ -2279,7 +2279,7 @@ static int op_inrd(void)		/* INR D */
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_inre(void)		/* INR E */
@@ -2289,7 +2289,7 @@ static int op_inre(void)		/* INR E */
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_inrh(void)		/* INR H */
@@ -2299,7 +2299,7 @@ static int op_inrh(void)		/* INR H */
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_inrl(void)		/* INR L */
@@ -2309,7 +2309,7 @@ static int op_inrl(void)		/* INR L */
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_inrm(void)		/* INR M */
@@ -2325,7 +2325,7 @@ static int op_inrm(void)		/* INR M */
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(10);
+	return (10);
 }
 
 static int op_dcra(void)		/* DCR A */
@@ -2335,7 +2335,7 @@ static int op_dcra(void)		/* DCR A */
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_dcrb(void)		/* DCR B */
@@ -2345,7 +2345,7 @@ static int op_dcrb(void)		/* DCR B */
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_dcrc(void)		/* DCR C */
@@ -2355,7 +2355,7 @@ static int op_dcrc(void)		/* DCR C */
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_dcrd(void)		/* DCR D */
@@ -2365,7 +2365,7 @@ static int op_dcrd(void)		/* DCR D */
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_dcre(void)		/* DCR E */
@@ -2375,7 +2375,7 @@ static int op_dcre(void)		/* DCR E */
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_dcrh(void)		/* DCR H */
@@ -2385,7 +2385,7 @@ static int op_dcrh(void)		/* DCR H */
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_dcrl(void)		/* DCR L */
@@ -2395,7 +2395,7 @@ static int op_dcrl(void)		/* DCR L */
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(5);
+	return (5);
 }
 
 static int op_dcrm(void)		/* DCR M */
@@ -2411,7 +2411,7 @@ static int op_dcrm(void)		/* DCR M */
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(10);
+	return (10);
 }
 
 static int op_rlc(void)			/* RLC */
@@ -2422,7 +2422,7 @@ static int op_rlc(void)			/* RLC */
 	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A <<= 1;
 	A |= i;
-	return(4);
+	return (4);
 }
 
 static int op_rrc(void)			/* RRC */
@@ -2433,7 +2433,7 @@ static int op_rrc(void)			/* RRC */
 	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A >>= 1;
 	if (i) A |= 128;
-	return(4);
+	return (4);
 }
 
 static int op_ral(void)			/* RAL */
@@ -2444,7 +2444,7 @@ static int op_ral(void)			/* RAL */
 	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A <<= 1;
 	if (old_c_flag) A |= 1;
-	return(4);
+	return (4);
 }
 
 static int op_rar(void)			/* RAR */
@@ -2456,7 +2456,7 @@ static int op_rar(void)			/* RAR */
 	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A >>= 1;
 	if (old_c_flag) A |= 128;
-	return(4);
+	return (4);
 }
 
 static int op_xchg(void)		/* XCHG */
@@ -2469,7 +2469,7 @@ static int op_xchg(void)		/* XCHG */
 	i = E;
 	E = L;
 	L = i;
-	return(4);
+	return (4);
 }
 
 static int op_xthl(void)		/* XTHL */
@@ -2485,7 +2485,7 @@ static int op_xthl(void)		/* XTHL */
 	i = memrdr(SP + 1);
 	memwrt(SP + 1, H);
 	H = i;
-	return(18);
+	return (18);
 }
 
 static int op_pushpsw(void)		/* PUSH PSW */
@@ -2495,7 +2495,7 @@ static int op_pushpsw(void)		/* PUSH PSW */
 #endif
 	memwrt(--SP, A);
 	memwrt(--SP, F);
-	return(11);
+	return (11);
 }
 
 static int op_pushb(void)		/* PUSH B */
@@ -2505,7 +2505,7 @@ static int op_pushb(void)		/* PUSH B */
 #endif
 	memwrt(--SP, B);
 	memwrt(--SP, C);
-	return(11);
+	return (11);
 }
 
 static int op_pushd(void)		/* PUSH D */
@@ -2515,7 +2515,7 @@ static int op_pushd(void)		/* PUSH D */
 #endif
 	memwrt(--SP, D);
 	memwrt(--SP, E);
-	return(11);
+	return (11);
 }
 
 static int op_pushh(void)		/* PUSH H */
@@ -2525,7 +2525,7 @@ static int op_pushh(void)		/* PUSH H */
 #endif
 	memwrt(--SP, H);
 	memwrt(--SP, L);
-	return(11);
+	return (11);
 }
 
 static int op_poppsw(void)		/* POP PSW */
@@ -2537,7 +2537,7 @@ static int op_poppsw(void)		/* POP PSW */
 	F &= ~(N2_FLAG | N1_FLAG);
 	F |= N_FLAG;
 	A = memrdr(SP++);
-	return(10);
+	return (10);
 }
 
 static int op_popb(void)		/* POP B */
@@ -2547,7 +2547,7 @@ static int op_popb(void)		/* POP B */
 #endif
 	C = memrdr(SP++);
 	B = memrdr(SP++);
-	return(10);
+	return (10);
 }
 
 static int op_popd(void)		/* POP D */
@@ -2557,7 +2557,7 @@ static int op_popd(void)		/* POP D */
 #endif
 	E = memrdr(SP++);
 	D = memrdr(SP++);
-	return(10);
+	return (10);
 }
 
 static int op_poph(void)		/* POP H */
@@ -2567,7 +2567,7 @@ static int op_poph(void)		/* POP H */
 #endif
 	L = memrdr(SP++);
 	H = memrdr(SP++);
-	return(10);
+	return (10);
 }
 
 static int op_jmp(void)			/* JMP */
@@ -2577,7 +2577,7 @@ static int op_jmp(void)			/* JMP */
 	i = memrdr(PC++);
 	i += memrdr(PC) << 8;
 	PC = i;
-	return(10);
+	return (10);
 }
 
 static int op_undoc_jmp(void)		/* Undocumented JMP */
@@ -2585,16 +2585,16 @@ static int op_undoc_jmp(void)		/* Undocumented JMP */
 	if (u_flag) {	/* trap with option -u */
 		cpu_error = OPTRAP1;
 		cpu_state = STOPPED;
-		return(0);
+		return (0);
 	} else {	/* else JMP */
-		return(op_jmp());
+		return (op_jmp());
 	}
 }
 
 static int op_pchl(void)		/* PCHL */
 {
 	PC = (H << 8) + L;
-	return(5);
+	return (5);
 }
 
 static int op_call(void)		/* CALL */
@@ -2609,7 +2609,7 @@ static int op_call(void)		/* CALL */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = i;
-	return(17);
+	return (17);
 }
 
 static int op_undoc_call(void)		/* Undocumented CALL */
@@ -2617,9 +2617,9 @@ static int op_undoc_call(void)		/* Undocumented CALL */
 	if (u_flag) {	/* trap with option -u */
 		cpu_error = OPTRAP1;
 		cpu_state = STOPPED;
-		return(0);
+		return (0);
 	} else {
-		return(op_call());
+		return (op_call());
 	}
 }
 
@@ -2633,7 +2633,7 @@ static int op_ret(void)			/* RET */
 	i = memrdr(SP++);
 	i += memrdr(SP++) << 8;
 	PC = i;
-	return(10);
+	return (10);
 }
 
 static int op_undoc_ret(void)		/* Undocumented RET */
@@ -2641,9 +2641,9 @@ static int op_undoc_ret(void)		/* Undocumented RET */
 	if (u_flag) {	/* trap with option -u */
 		cpu_error = OPTRAP1;
 		cpu_state = STOPPED;
-		return(0);
+		return (0);
 	} else {	/* else RET */
-		return(op_ret());
+		return (op_ret());
 	}
 }
 
@@ -2658,7 +2658,7 @@ static int op_jz(void)			/* JZ nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jnz(void)			/* JNZ nn */
@@ -2672,7 +2672,7 @@ static int op_jnz(void)			/* JNZ nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jc(void)			/* JC nn */
@@ -2686,7 +2686,7 @@ static int op_jc(void)			/* JC nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jnc(void)			/* JNC nn */
@@ -2700,7 +2700,7 @@ static int op_jnc(void)			/* JNC nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jpe(void)			/* JPE nn */
@@ -2714,7 +2714,7 @@ static int op_jpe(void)			/* JPE nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jpo(void)			/* JPO nn */
@@ -2728,7 +2728,7 @@ static int op_jpo(void)			/* JPO nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jm(void)			/* JM nn */
@@ -2742,7 +2742,7 @@ static int op_jm(void)			/* JM nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_jp(void)			/* JP nn */
@@ -2756,7 +2756,7 @@ static int op_jp(void)			/* JP nn */
 	} else {
 		PC += 2;
 	}
-	return(10);
+	return (10);
 }
 
 static int op_cz(void)			/* CZ nn */
@@ -2772,10 +2772,10 @@ static int op_cz(void)			/* CZ nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(11);
+		return (11);
 	}
 }
 
@@ -2792,10 +2792,10 @@ static int op_cnz(void)			/* CNZ nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(11);
+		return (11);
 	}
 }
 
@@ -2812,10 +2812,10 @@ static int op_cc(void)			/* CC nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(11);
+		return (11);
 	}
 }
 
@@ -2832,10 +2832,10 @@ static int op_cnc(void)			/* CNC nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(11);
+		return (11);
 	}
 }
 
@@ -2852,10 +2852,10 @@ static int op_cpe(void)			/* CPE nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(11);
+		return (11);
 	}
 }
 
@@ -2872,10 +2872,10 @@ static int op_cpo(void)			/* CPO nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(11);
+		return (11);
 	}
 }
 
@@ -2892,10 +2892,10 @@ static int op_cm(void)			/* CM nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(11);
+		return (11);
 	}
 }
 
@@ -2912,10 +2912,10 @@ static int op_cp(void)			/* CP nn */
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return(17);
+		return (17);
 	} else {
 		PC += 2;
-		return(11);
+		return (11);
 	}
 }
 
@@ -2930,9 +2930,9 @@ static int op_rz(void)			/* RZ */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -2947,9 +2947,9 @@ static int op_rnz(void)			/* RNZ */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -2964,9 +2964,9 @@ static int op_rc(void)			/* RC */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -2981,9 +2981,9 @@ static int op_rnc(void)			/* RNC */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -2998,9 +2998,9 @@ static int op_rpe(void)			/* RPE */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3015,9 +3015,9 @@ static int op_rpo(void)			/* RPO */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3032,9 +3032,9 @@ static int op_rm(void)			/* RM */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3049,9 +3049,9 @@ static int op_rp(void)			/* RP */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return(11);
+		return (11);
 	} else {
-		return(5);
+		return (5);
 	}
 }
 
@@ -3063,7 +3063,7 @@ static int op_rst0(void)		/* RST 0 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0;
-	return(11);
+	return (11);
 }
 
 static int op_rst1(void)		/* RST 1 */
@@ -3074,7 +3074,7 @@ static int op_rst1(void)		/* RST 1 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x08;
-	return(11);
+	return (11);
 }
 
 static int op_rst2(void)		/* RST 2 */
@@ -3085,7 +3085,7 @@ static int op_rst2(void)		/* RST 2 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x10;
-	return(11);
+	return (11);
 }
 
 static int op_rst3(void)		/* RST 3 */
@@ -3096,7 +3096,7 @@ static int op_rst3(void)		/* RST 3 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x18;
-	return(11);
+	return (11);
 }
 
 static int op_rst4(void)		/* RST 4 */
@@ -3107,7 +3107,7 @@ static int op_rst4(void)		/* RST 4 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x20;
-	return(11);
+	return (11);
 }
 
 static int op_rst5(void)		/* RST 5 */
@@ -3118,7 +3118,7 @@ static int op_rst5(void)		/* RST 5 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x28;
-	return(11);
+	return (11);
 }
 
 static int op_rst6(void)		/* RST 6 */
@@ -3129,7 +3129,7 @@ static int op_rst6(void)		/* RST 6 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x30;
-	return(11);
+	return (11);
 }
 
 static int op_rst7(void)		/* RST 7 */
@@ -3140,5 +3140,5 @@ static int op_rst7(void)		/* RST 7 */
 	memwrt(--SP, PC >> 8);
 	memwrt(--SP, PC);
 	PC = 0x38;
-	return(11);
+	return (11);
 }

--- a/z80core/sim2.c
+++ b/z80core/sim2.c
@@ -380,7 +380,7 @@ int op_cb_handle(void)
 
 	t = (*op_cb[memrdr(PC++)]) ();	/* execute next opcode */
 
-	return(t);
+	return (t);
 }
 
 /*
@@ -391,7 +391,7 @@ static int trap_cb(void)
 {
 	cpu_error = OPTRAP2;
 	cpu_state = STOPPED;
-	return(0);
+	return (0);
 }
 
 static int op_srla(void)		/* SRL A */
@@ -402,7 +402,7 @@ static int op_srla(void)		/* SRL A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srlb(void)		/* SRL B */
@@ -413,7 +413,7 @@ static int op_srlb(void)		/* SRL B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srlc(void)		/* SRL C */
@@ -424,7 +424,7 @@ static int op_srlc(void)		/* SRL C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srld(void)		/* SRL D */
@@ -435,7 +435,7 @@ static int op_srld(void)		/* SRL D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srle(void)		/* SRL E */
@@ -446,7 +446,7 @@ static int op_srle(void)		/* SRL E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) :(F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srlh(void)		/* SRL H */
@@ -457,7 +457,7 @@ static int op_srlh(void)		/* SRL H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srll(void)		/* SRL L */
@@ -468,7 +468,7 @@ static int op_srll(void)		/* SRL L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srlhl(void)		/* SRL (HL) */
@@ -485,7 +485,7 @@ static int op_srlhl(void)		/* SRL (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(15);
+	return (15);
 }
 
 static int op_slaa(void)		/* SLA A */
@@ -496,7 +496,7 @@ static int op_slaa(void)		/* SLA A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_slab(void)		/* SLA B */
@@ -507,7 +507,7 @@ static int op_slab(void)		/* SLA B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_slac(void)		/* SLA C */
@@ -518,7 +518,7 @@ static int op_slac(void)		/* SLA C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_slad(void)		/* SLA D */
@@ -529,7 +529,7 @@ static int op_slad(void)		/* SLA D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_slae(void)		/* SLA E */
@@ -540,7 +540,7 @@ static int op_slae(void)		/* SLA E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_slah(void)		/* SLA H */
@@ -551,7 +551,7 @@ static int op_slah(void)		/* SLA H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_slal(void)		/* SLA L */
@@ -562,7 +562,7 @@ static int op_slal(void)		/* SLA L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_slahl(void)		/* SLA (HL) */
@@ -579,7 +579,7 @@ static int op_slahl(void)		/* SLA (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(15);
+	return (15);
 }
 
 static int op_rlra(void)		/* RL A */
@@ -594,7 +594,7 @@ static int op_rlra(void)		/* RL A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlb(void)			/* RL B */
@@ -609,7 +609,7 @@ static int op_rlb(void)			/* RL B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlc(void)			/* RL C */
@@ -624,7 +624,7 @@ static int op_rlc(void)			/* RL C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rld(void)			/* RL D */
@@ -639,7 +639,7 @@ static int op_rld(void)			/* RL D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rle(void)			/* RL E */
@@ -654,7 +654,7 @@ static int op_rle(void)			/* RL E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlh(void)			/* RL H */
@@ -669,7 +669,7 @@ static int op_rlh(void)			/* RL H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) :(F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rll(void)			/* RL L */
@@ -684,7 +684,7 @@ static int op_rll(void)			/* RL L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlhl(void)		/* RL (HL) */
@@ -704,7 +704,7 @@ static int op_rlhl(void)		/* RL (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(15);
+	return (15);
 }
 
 static int op_rrra(void)		/* RR A */
@@ -719,7 +719,7 @@ static int op_rrra(void)		/* RR A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrb(void)			/* RR B */
@@ -734,7 +734,7 @@ static int op_rrb(void)			/* RR B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrc(void)			/* RR C */
@@ -749,7 +749,7 @@ static int op_rrc(void)			/* RR C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrd(void)			/* RR D */
@@ -764,7 +764,7 @@ static int op_rrd(void)			/* RR D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rre(void)			/* RR E */
@@ -779,7 +779,7 @@ static int op_rre(void)			/* RR E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrh(void)			/* RR H */
@@ -794,7 +794,7 @@ static int op_rrh(void)			/* RR H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrl(void)			/* RR L */
@@ -809,7 +809,7 @@ static int op_rrl(void)			/* RR L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrhl(void)		/* RR (HL) */
@@ -829,7 +829,7 @@ static int op_rrhl(void)		/* RR (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(15);
+	return (15);
 }
 
 static int op_rrcra(void)		/* RRC A */
@@ -844,7 +844,7 @@ static int op_rrcra(void)		/* RRC A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrcb(void)		/* RRC B */
@@ -859,7 +859,7 @@ static int op_rrcb(void)		/* RRC B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrcc(void)		/* RRC C */
@@ -874,7 +874,7 @@ static int op_rrcc(void)		/* RRC C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrcd(void)		/* RRC D */
@@ -889,7 +889,7 @@ static int op_rrcd(void)		/* RRC D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrce(void)		/* RRC E */
@@ -904,7 +904,7 @@ static int op_rrce(void)		/* RRC E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrch(void)		/* RRC H */
@@ -919,7 +919,7 @@ static int op_rrch(void)		/* RRC H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrcl(void)		/* RRC L */
@@ -934,7 +934,7 @@ static int op_rrcl(void)		/* RRC L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rrchl(void)		/* RRC (HL) */
@@ -954,7 +954,7 @@ static int op_rrchl(void)		/* RRC (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(15);
+	return (15);
 }
 
 static int op_rlcra(void)		/* RLC A */
@@ -969,7 +969,7 @@ static int op_rlcra(void)		/* RLC A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlcb(void)		/* RLC B */
@@ -984,7 +984,7 @@ static int op_rlcb(void)		/* RLC B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlcc(void)		/* RLC C */
@@ -999,7 +999,7 @@ static int op_rlcc(void)		/* RLC C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlcd(void)		/* RLC D */
@@ -1014,7 +1014,7 @@ static int op_rlcd(void)		/* RLC D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlce(void)		/* RLC E */
@@ -1029,7 +1029,7 @@ static int op_rlce(void)		/* RLC E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlch(void)		/* RLC H */
@@ -1044,7 +1044,7 @@ static int op_rlch(void)		/* RLC H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlcl(void)		/* RLC L */
@@ -1059,7 +1059,7 @@ static int op_rlcl(void)		/* RLC L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_rlchl(void)		/* RLC (HL) */
@@ -1079,7 +1079,7 @@ static int op_rlchl(void)		/* RLC (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(15);
+	return (15);
 }
 
 static int op_sraa(void)		/* SRA A */
@@ -1094,7 +1094,7 @@ static int op_sraa(void)		/* SRA A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srab(void)		/* SRA B */
@@ -1109,7 +1109,7 @@ static int op_srab(void)		/* SRA B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srac(void)		/* SRA C */
@@ -1124,7 +1124,7 @@ static int op_srac(void)		/* SRA C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srad(void)		/* SRA D */
@@ -1139,7 +1139,7 @@ static int op_srad(void)		/* SRA D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srae(void)		/* SRA E */
@@ -1154,7 +1154,7 @@ static int op_srae(void)		/* SRA E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srah(void)		/* SRA H */
@@ -1169,7 +1169,7 @@ static int op_srah(void)		/* SRA H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_sral(void)		/* SRA L */
@@ -1184,7 +1184,7 @@ static int op_sral(void)		/* SRA L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_srahl(void)		/* SRA (HL) */
@@ -1203,775 +1203,775 @@ static int op_srahl(void)		/* SRA (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(15);
+	return (15);
 }
 
 static int op_sb0a(void)		/* SET 0,A */
 {
 	A |= 1;
-	return(8);
+	return (8);
 }
 
 static int op_sb1a(void)		/* SET 1,A */
 {
 	A |= 2;
-	return(8);
+	return (8);
 }
 
 static int op_sb2a(void)		/* SET 2,A */
 {
 	A |= 4;
-	return(8);
+	return (8);
 }
 
 static int op_sb3a(void)		/* SET 3,A */
 {
 	A |= 8;
-	return(8);
+	return (8);
 }
 
 static int op_sb4a(void)		/* SET 4,A */
 {
 	A |= 16;
-	return(8);
+	return (8);
 }
 
 static int op_sb5a(void)		/* SET 5,A */
 {
 	A |= 32;
-	return(8);
+	return (8);
 }
 
 static int op_sb6a(void)		/* SET 6,A */
 {
 	A |= 64;
-	return(8);
+	return (8);
 }
 
 static int op_sb7a(void)		/* SET 7,A */
 {
 	A |= 128;
-	return(8);
+	return (8);
 }
 
 static int op_sb0b(void)		/* SET 0,B */
 {
 	B |= 1;
-	return(8);
+	return (8);
 }
 
 static int op_sb1b(void)		/* SET 1,B */
 {
 	B |= 2;
-	return(8);
+	return (8);
 }
 
 static int op_sb2b(void)		/* SET 2,B */
 {
 	B |= 4;
-	return(8);
+	return (8);
 }
 
 static int op_sb3b(void)		/* SET 3,B */
 {
 	B |= 8;
-	return(8);
+	return (8);
 }
 
 static int op_sb4b(void)		/* SET 4,B */
 {
 	B |= 16;
-	return(8);
+	return (8);
 }
 
 static int op_sb5b(void)		/* SET 5,B */
 {
 	B |= 32;
-	return(8);
+	return (8);
 }
 
 static int op_sb6b(void)		/* SET 6,B */
 {
 	B |= 64;
-	return(8);
+	return (8);
 }
 
 static int op_sb7b(void)		/* SET 7,B */
 {
 	B |= 128;
-	return(8);
+	return (8);
 }
 
 static int op_sb0c(void)		/* SET 0,C */
 {
 	C |= 1;
-	return(8);
+	return (8);
 }
 
 static int op_sb1c(void)		/* SET 1,C */
 {
 	C |= 2;
-	return(8);
+	return (8);
 }
 
 static int op_sb2c(void)		/* SET 2,C */
 {
 	C |= 4;
-	return(8);
+	return (8);
 }
 
 static int op_sb3c(void)		/* SET 3,C */
 {
 	C |= 8;
-	return(8);
+	return (8);
 }
 
 static int op_sb4c(void)		/* SET 4,C */
 {
 	C |= 16;
-	return(8);
+	return (8);
 }
 
 static int op_sb5c(void)		/* SET 5,C */
 {
 	C |= 32;
-	return(8);
+	return (8);
 }
 
 static int op_sb6c(void)		/* SET 6,C */
 {
 	C |= 64;
-	return(8);
+	return (8);
 }
 
 static int op_sb7c(void)		/* SET 7,C */
 {
 	C |= 128;
-	return(8);
+	return (8);
 }
 
 static int op_sb0d(void)		/* SET 0,D */
 {
 	D |= 1;
-	return(8);
+	return (8);
 }
 
 static int op_sb1d(void)		/* SET 1,D */
 {
 	D |= 2;
-	return(8);
+	return (8);
 }
 
 static int op_sb2d(void)		/* SET 2,D */
 {
 	D |= 4;
-	return(8);
+	return (8);
 }
 
 static int op_sb3d(void)		/* SET 3,D */
 {
 	D |= 8;
-	return(8);
+	return (8);
 }
 
 static int op_sb4d(void)		/* SET 4,D */
 {
 	D |= 16;
-	return(8);
+	return (8);
 }
 
 static int op_sb5d(void)		/* SET 5,D */
 {
 	D |= 32;
-	return(8);
+	return (8);
 }
 
 static int op_sb6d(void)		/* SET 6,D */
 {
 	D |= 64;
-	return(8);
+	return (8);
 }
 
 static int op_sb7d(void)		/* SET 7,D */
 {
 	D |= 128;
-	return(8);
+	return (8);
 }
 
 static int op_sb0e(void)		/* SET 0,E */
 {
 	E |= 1;
-	return(8);
+	return (8);
 }
 
 static int op_sb1e(void)		/* SET 1,E */
 {
 	E |= 2;
-	return(8);
+	return (8);
 }
 
 static int op_sb2e(void)		/* SET 2,E */
 {
 	E |= 4;
-	return(8);
+	return (8);
 }
 
 static int op_sb3e(void)		/* SET 3,E */
 {
 	E |= 8;
-	return(8);
+	return (8);
 }
 
 static int op_sb4e(void)		/* SET 4,E */
 {
 	E |= 16;
-	return(8);
+	return (8);
 }
 
 static int op_sb5e(void)		/* SET 5,E */
 {
 	E |= 32;
-	return(8);
+	return (8);
 }
 
 static int op_sb6e(void)		/* SET 6,E */
 {
 	E |= 64;
-	return(8);
+	return (8);
 }
 
 static int op_sb7e(void)		/* SET 7,E */
 {
 	E |= 128;
-	return(8);
+	return (8);
 }
 
 static int op_sb0h(void)		/* SET 0,H */
 {
 	H |= 1;
-	return(8);
+	return (8);
 }
 
 static int op_sb1h(void)		/* SET 1,H */
 {
 	H |= 2;
-	return(8);
+	return (8);
 }
 
 static int op_sb2h(void)		/* SET 2,H */
 {
 	H |= 4;
-	return(8);
+	return (8);
 }
 
 static int op_sb3h(void)		/* SET 3,H */
 {
 	H |= 8;
-	return(8);
+	return (8);
 }
 
 static int op_sb4h(void)		/* SET 4,H */
 {
 	H |= 16;
-	return(8);
+	return (8);
 }
 
 static int op_sb5h(void)		/* SET 5,H */
 {
 	H |= 32;
-	return(8);
+	return (8);
 }
 
 static int op_sb6h(void)		/* SET 6,H */
 {
 	H |= 64;
-	return(8);
+	return (8);
 }
 
 static int op_sb7h(void)		/* SET 7,H */
 {
 	H |= 128;
-	return(8);
+	return (8);
 }
 
 static int op_sb0l(void)		/* SET 0,L */
 {
 	L |= 1;
-	return(8);
+	return (8);
 }
 
 static int op_sb1l(void)		/* SET 1,L */
 {
 	L |= 2;
-	return(8);
+	return (8);
 }
 
 static int op_sb2l(void)		/* SET 2,L */
 {
 	L |= 4;
-	return(8);
+	return (8);
 }
 
 static int op_sb3l(void)		/* SET 3,L */
 {
 	L |= 8;
-	return(8);
+	return (8);
 }
 
 static int op_sb4l(void)		/* SET 4,L */
 {
 	L |= 16;
-	return(8);
+	return (8);
 }
 
 static int op_sb5l(void)		/* SET 5,L */
 {
 	L |= 32;
-	return(8);
+	return (8);
 }
 
 static int op_sb6l(void)		/* SET 6,L */
 {
 	L |= 64;
-	return(8);
+	return (8);
 }
 
 static int op_sb7l(void)		/* SET 7,L */
 {
 	L |= 128;
-	return(8);
+	return (8);
 }
 
 static int op_sb0hl(void)		/* SET 0,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 1);
-	return(15);
+	return (15);
 }
 
 static int op_sb1hl(void)		/* SET 1,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 2);
-	return(15);
+	return (15);
 }
 
 static int op_sb2hl(void)		/* SET 2,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 4);
-	return(15);
+	return (15);
 }
 
 static int op_sb3hl(void)		/* SET 3,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 8);
-	return(15);
+	return (15);
 }
 
 static int op_sb4hl(void)		/* SET 4,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 16);
-	return(15);
+	return (15);
 }
 
 static int op_sb5hl(void)		/* SET 5,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 32);
-	return(15);
+	return (15);
 }
 
 static int op_sb6hl(void)		/* SET 6,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 64);
-	return(15);
+	return (15);
 }
 
 static int op_sb7hl(void)		/* SET 7,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 128);
-	return(15);
+	return (15);
 }
 
 static int op_rb0a(void)		/* RES 0,A */
 {
 	A &= ~1;
-	return(8);
+	return (8);
 }
 
 static int op_rb1a(void)		/* RES 1,A */
 {
 	A &= ~2;
-	return(8);
+	return (8);
 }
 
 static int op_rb2a(void)		/* RES 2,A */
 {
 	A &= ~4;
-	return(8);
+	return (8);
 }
 
 static int op_rb3a(void)		/* RES 3,A */
 {
 	A &= ~8;
-	return(8);
+	return (8);
 }
 
 static int op_rb4a(void)		/* RES 4,A */
 {
 	A &= ~16;
-	return(8);
+	return (8);
 }
 
 static int op_rb5a(void)		/* RES 5,A */
 {
 	A &= ~32;
-	return(8);
+	return (8);
 }
 
 static int op_rb6a(void)		/* RES 6,A */
 {
 	A &= ~64;
-	return(8);
+	return (8);
 }
 
 static int op_rb7a(void)		/* RES 7,A */
 {
 	A &= ~128;
-	return(8);
+	return (8);
 }
 
 static int op_rb0b(void)		/* RES 0,B */
 {
 	B &= ~1;
-	return(8);
+	return (8);
 }
 
 static int op_rb1b(void)		/* RES 1,B */
 {
 	B &= ~2;
-	return(8);
+	return (8);
 }
 
 static int op_rb2b(void)		/* RES 2,B */
 {
 	B &= ~4;
-	return(8);
+	return (8);
 }
 
 static int op_rb3b(void)		/* RES 3,B */
 {
 	B &= ~8;
-	return(8);
+	return (8);
 }
 
 static int op_rb4b(void)		/* RES 4,B */
 {
 	B &= ~16;
-	return(8);
+	return (8);
 }
 
 static int op_rb5b(void)		/* RES 5,B */
 {
 	B &= ~32;
-	return(8);
+	return (8);
 }
 
 static int op_rb6b(void)		/* RES 6,B */
 {
 	B &= ~64;
-	return(8);
+	return (8);
 }
 
 static int op_rb7b(void)		/* RES 7,B */
 {
 	B &= ~128;
-	return(8);
+	return (8);
 }
 
 static int op_rb0c(void)		/* RES 0,C */
 {
 	C &= ~1;
-	return(8);
+	return (8);
 }
 
 static int op_rb1c(void)		/* RES 1,C */
 {
 	C &= ~2;
-	return(8);
+	return (8);
 }
 
 static int op_rb2c(void)		/* RES 2,C */
 {
 	C &= ~4;
-	return(8);
+	return (8);
 }
 
 static int op_rb3c(void)		/* RES 3,C */
 {
 	C &= ~8;
-	return(8);
+	return (8);
 }
 
 static int op_rb4c(void)		/* RES 4,C */
 {
 	C &= ~16;
-	return(8);
+	return (8);
 }
 
 static int op_rb5c(void)		/* RES 5,C */
 {
 	C &= ~32;
-	return(8);
+	return (8);
 }
 
 static int op_rb6c(void)		/* RES 6,C */
 {
 	C &= ~64;
-	return(8);
+	return (8);
 }
 
 static int op_rb7c(void)		/* RES 7,C */
 {
 	C &= ~128;
-	return(8);
+	return (8);
 }
 
 static int op_rb0d(void)		/* RES 0,D */
 {
 	D &= ~1;
-	return(8);
+	return (8);
 }
 
 static int op_rb1d(void)		/* RES 1,D */
 {
 	D &= ~2;
-	return(8);
+	return (8);
 }
 
 static int op_rb2d(void)		/* RES 2,D */
 {
 	D &= ~4;
-	return(8);
+	return (8);
 }
 
 static int op_rb3d(void)		/* RES 3,D */
 {
 	D &= ~8;
-	return(8);
+	return (8);
 }
 
 static int op_rb4d(void)		/* RES 4,D */
 {
 	D &= ~16;
-	return(8);
+	return (8);
 }
 
 static int op_rb5d(void)		/* RES 5,D */
 {
 	D &= ~32;
-	return(8);
+	return (8);
 }
 
 static int op_rb6d(void)		/* RES 6,D */
 {
 	D &= ~64;
-	return(8);
+	return (8);
 }
 
 static int op_rb7d(void)		/* RES 7,D */
 {
 	D &= ~128;
-	return(8);
+	return (8);
 }
 
 static int op_rb0e(void)		/* RES 0,E */
 {
 	E &= ~1;
-	return(8);
+	return (8);
 }
 
 static int op_rb1e(void)		/* RES 1,E */
 {
 	E &= ~2;
-	return(8);
+	return (8);
 }
 
 static int op_rb2e(void)		/* RES 2,E */
 {
 	E &= ~4;
-	return(8);
+	return (8);
 }
 
 static int op_rb3e(void)		/* RES 3,E */
 {
 	E &= ~8;
-	return(8);
+	return (8);
 }
 
 static int op_rb4e(void)		/* RES 4,E */
 {
 	E &= ~16;
-	return(8);
+	return (8);
 }
 
 static int op_rb5e(void)		/* RES 5,E */
 {
 	E &= ~32;
-	return(8);
+	return (8);
 }
 
 static int op_rb6e(void)		/* RES 6,E */
 {
 	E &= ~64;
-	return(8);
+	return (8);
 }
 
 static int op_rb7e(void)		/* RES 7,E */
 {
 	E &= ~128;
-	return(8);
+	return (8);
 }
 
 static int op_rb0h(void)		/* RES 0,H */
 {
 	H &= ~1;
-	return(8);
+	return (8);
 }
 
 static int op_rb1h(void)		/* RES 1,H */
 {
 	H &= ~2;
-	return(8);
+	return (8);
 }
 
 static int op_rb2h(void)		/* RES 2,H */
 {
 	H &= ~4;
-	return(8);
+	return (8);
 }
 
 static int op_rb3h(void)		/* RES 3,H */
 {
 	H &= ~8;
-	return(8);
+	return (8);
 }
 
 static int op_rb4h(void)		/* RES 4,H */
 {
 	H &= ~16;
-	return(8);
+	return (8);
 }
 
 static int op_rb5h(void)		/* RES 5,H */
 {
 	H &= ~32;
-	return(8);
+	return (8);
 }
 
 static int op_rb6h(void)		/* RES 6,H */
 {
 	H &= ~64;
-	return(8);
+	return (8);
 }
 
 static int op_rb7h(void)		/* RES 7,H */
 {
 	H &= ~128;
-	return(8);
+	return (8);
 }
 
 static int op_rb0l(void)		/* RES 0,L */
 {
 	L &= ~1;
-	return(8);
+	return (8);
 }
 
 static int op_rb1l(void)		/* RES 1,L */
 {
 	L &= ~2;
-	return(8);
+	return (8);
 }
 
 static int op_rb2l(void)		/* RES 2,L */
 {
 	L &= ~4;
-	return(8);
+	return (8);
 }
 
 static int op_rb3l(void)		/* RES 3,L */
 {
 	L &= ~8;
-	return(8);
+	return (8);
 }
 
 static int op_rb4l(void)		/* RES 4,L */
 {
 	L &= ~16;
-	return(8);
+	return (8);
 }
 
 static int op_rb5l(void)		/* RES 5,L */
 {
 	L &= ~32;
-	return(8);
+	return (8);
 }
 
 static int op_rb6l(void)		/* RES 6,L */
 {
 	L &= ~64;
-	return(8);
+	return (8);
 }
 
 static int op_rb7l(void)		/* RES 7,L */
 {
 	L &= ~128;
-	return(8);
+	return (8);
 }
 
 static int op_rb0hl(void)		/* RES 0,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~1);
-	return(15);
+	return (15);
 }
 
 static int op_rb1hl(void)		/* RES 1,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~2);
-	return(15);
+	return (15);
 }
 
 static int op_rb2hl(void)		/* RES 2,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~4);
-	return(15);
+	return (15);
 }
 
 static int op_rb3hl(void)		/* RES 3,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~8);
-	return(15);
+	return (15);
 }
 
 static int op_rb4hl(void)		/* RES 4,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~16);
-	return(15);
+	return (15);
 }
 
 static int op_rb5hl(void)		/* RES 5,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~32);
-	return(15);
+	return (15);
 }
 
 static int op_rb6hl(void)		/* RES 6,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~64);
-	return(15);
+	return (15);
 }
 
 static int op_rb7hl(void)		/* RES 7,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~128);
-	return(15);
+	return (15);
 }
 
 static int op_tb0a(void)		/* BIT 0,A */
@@ -1979,7 +1979,7 @@ static int op_tb0a(void)		/* BIT 0,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb1a(void)		/* BIT 1,A */
@@ -1987,7 +1987,7 @@ static int op_tb1a(void)		/* BIT 1,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb2a(void)		/* BIT 2,A */
@@ -1995,7 +1995,7 @@ static int op_tb2a(void)		/* BIT 2,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb3a(void)		/* BIT 3,A */
@@ -2003,7 +2003,7 @@ static int op_tb3a(void)		/* BIT 3,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb4a(void)		/* BIT 4,A */
@@ -2011,7 +2011,7 @@ static int op_tb4a(void)		/* BIT 4,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb5a(void)		/* BIT 5,A */
@@ -2019,7 +2019,7 @@ static int op_tb5a(void)		/* BIT 5,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb6a(void)		/* BIT 6,A */
@@ -2027,7 +2027,7 @@ static int op_tb6a(void)		/* BIT 6,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb7a(void)		/* BIT 7,A */
@@ -2041,7 +2041,7 @@ static int op_tb7a(void)		/* BIT 7,A */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(8);
+	return (8);
 }
 
 static int op_tb0b(void)		/* BIT 0,B */
@@ -2049,7 +2049,7 @@ static int op_tb0b(void)		/* BIT 0,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb1b(void)		/* BIT 1,B */
@@ -2057,7 +2057,7 @@ static int op_tb1b(void)		/* BIT 1,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb2b(void)		/* BIT 2,B */
@@ -2065,7 +2065,7 @@ static int op_tb2b(void)		/* BIT 2,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb3b(void)		/* BIT 3,B */
@@ -2073,7 +2073,7 @@ static int op_tb3b(void)		/* BIT 3,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb4b(void)		/* BIT 4,B */
@@ -2081,7 +2081,7 @@ static int op_tb4b(void)		/* BIT 4,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb5b(void)		/* BIT 5,B */
@@ -2089,7 +2089,7 @@ static int op_tb5b(void)		/* BIT 5,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb6b(void)		/* BIT 6,B */
@@ -2097,7 +2097,7 @@ static int op_tb6b(void)		/* BIT 6,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb7b(void)		/* BIT 7,B */
@@ -2111,7 +2111,7 @@ static int op_tb7b(void)		/* BIT 7,B */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(8);
+	return (8);
 }
 
 static int op_tb0c(void)		/* BIT 0,C */
@@ -2119,7 +2119,7 @@ static int op_tb0c(void)		/* BIT 0,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb1c(void)		/* BIT 1,C */
@@ -2127,7 +2127,7 @@ static int op_tb1c(void)		/* BIT 1,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb2c(void)		/* BIT 2,C */
@@ -2135,7 +2135,7 @@ static int op_tb2c(void)		/* BIT 2,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb3c(void)		/* BIT 3,C */
@@ -2143,7 +2143,7 @@ static int op_tb3c(void)		/* BIT 3,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb4c(void)		/* BIT 4,C */
@@ -2151,7 +2151,7 @@ static int op_tb4c(void)		/* BIT 4,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb5c(void)		/* BIT 5,C */
@@ -2159,7 +2159,7 @@ static int op_tb5c(void)		/* BIT 5,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb6c(void)		/* BIT 6,C */
@@ -2167,7 +2167,7 @@ static int op_tb6c(void)		/* BIT 6,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb7c(void)		/* BIT 7,C */
@@ -2181,7 +2181,7 @@ static int op_tb7c(void)		/* BIT 7,C */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(8);
+	return (8);
 }
 
 static int op_tb0d(void)		/* BIT 0,D */
@@ -2189,7 +2189,7 @@ static int op_tb0d(void)		/* BIT 0,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb1d(void)		/* BIT 1,D */
@@ -2197,7 +2197,7 @@ static int op_tb1d(void)		/* BIT 1,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb2d(void)		/* BIT 2,D */
@@ -2205,7 +2205,7 @@ static int op_tb2d(void)		/* BIT 2,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb3d(void)		/* BIT 3,D */
@@ -2213,7 +2213,7 @@ static int op_tb3d(void)		/* BIT 3,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb4d(void)		/* BIT 4,D */
@@ -2221,7 +2221,7 @@ static int op_tb4d(void)		/* BIT 4,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb5d(void)		/* BIT 5,D */
@@ -2229,7 +2229,7 @@ static int op_tb5d(void)		/* BIT 5,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb6d(void)		/* BIT 6,D */
@@ -2237,7 +2237,7 @@ static int op_tb6d(void)		/* BIT 6,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb7d(void)		/* BIT 7,D */
@@ -2251,7 +2251,7 @@ static int op_tb7d(void)		/* BIT 7,D */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(8);
+	return (8);
 }
 
 static int op_tb0e(void)		/* BIT 0,E */
@@ -2259,7 +2259,7 @@ static int op_tb0e(void)		/* BIT 0,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb1e(void)		/* BIT 1,E */
@@ -2267,7 +2267,7 @@ static int op_tb1e(void)		/* BIT 1,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb2e(void)		/* BIT 2,E */
@@ -2275,7 +2275,7 @@ static int op_tb2e(void)		/* BIT 2,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb3e(void)		/* BIT 3,E */
@@ -2283,7 +2283,7 @@ static int op_tb3e(void)		/* BIT 3,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb4e(void)		/* BIT 4,E */
@@ -2291,7 +2291,7 @@ static int op_tb4e(void)		/* BIT 4,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb5e(void)		/* BIT 5,E */
@@ -2299,7 +2299,7 @@ static int op_tb5e(void)		/* BIT 5,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb6e(void)		/* BIT 6,E */
@@ -2307,7 +2307,7 @@ static int op_tb6e(void)		/* BIT 6,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb7e(void)		/* BIT 7,E */
@@ -2321,7 +2321,7 @@ static int op_tb7e(void)		/* BIT 7,E */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(8);
+	return (8);
 }
 
 static int op_tb0h(void)		/* BIT 0,H */
@@ -2329,7 +2329,7 @@ static int op_tb0h(void)		/* BIT 0,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb1h(void)		/* BIT 1,H */
@@ -2337,7 +2337,7 @@ static int op_tb1h(void)		/* BIT 1,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb2h(void)		/* BIT 2,H */
@@ -2345,7 +2345,7 @@ static int op_tb2h(void)		/* BIT 2,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb3h(void)		/* BIT 3,H */
@@ -2353,7 +2353,7 @@ static int op_tb3h(void)		/* BIT 3,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb4h(void)		/* BIT 4,H */
@@ -2361,7 +2361,7 @@ static int op_tb4h(void)		/* BIT 4,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb5h(void)		/* BIT 5,H */
@@ -2369,7 +2369,7 @@ static int op_tb5h(void)		/* BIT 5,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb6h(void)		/* BIT 6,H */
@@ -2377,7 +2377,7 @@ static int op_tb6h(void)		/* BIT 6,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb7h(void)		/* BIT 7,H */
@@ -2391,7 +2391,7 @@ static int op_tb7h(void)		/* BIT 7,H */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(8);
+	return (8);
 }
 
 static int op_tb0l(void)		/* BIT 0,L */
@@ -2399,7 +2399,7 @@ static int op_tb0l(void)		/* BIT 0,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb1l(void)		/* BIT 1,L */
@@ -2407,7 +2407,7 @@ static int op_tb1l(void)		/* BIT 1,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb2l(void)		/* BIT 2,L */
@@ -2415,7 +2415,7 @@ static int op_tb2l(void)		/* BIT 2,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb3l(void)		/* BIT 3,L */
@@ -2423,7 +2423,7 @@ static int op_tb3l(void)		/* BIT 3,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb4l(void)		/* BIT 4,L */
@@ -2431,7 +2431,7 @@ static int op_tb4l(void)		/* BIT 4,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb5l(void)		/* BIT 5,L */
@@ -2439,7 +2439,7 @@ static int op_tb5l(void)		/* BIT 5,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb6l(void)		/* BIT 6,L */
@@ -2447,7 +2447,7 @@ static int op_tb6l(void)		/* BIT 6,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
-	return(8);
+	return (8);
 }
 
 static int op_tb7l(void)		/* BIT 7,L */
@@ -2461,7 +2461,7 @@ static int op_tb7l(void)		/* BIT 7,L */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(8);
+	return (8);
 }
 
 static int op_tb0hl(void)		/* BIT 0,(HL) */
@@ -2470,7 +2470,7 @@ static int op_tb0hl(void)		/* BIT 0,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
-	return(12);
+	return (12);
 }
 
 static int op_tb1hl(void)		/* BIT 1,(HL) */
@@ -2479,7 +2479,7 @@ static int op_tb1hl(void)		/* BIT 1,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
-	return(12);
+	return (12);
 }
 
 static int op_tb2hl(void)		/* BIT 2,(HL) */
@@ -2488,7 +2488,7 @@ static int op_tb2hl(void)		/* BIT 2,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
-	return(12);
+	return (12);
 }
 
 static int op_tb3hl(void)		/* BIT 3,(HL) */
@@ -2497,7 +2497,7 @@ static int op_tb3hl(void)		/* BIT 3,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
-	return(12);
+	return (12);
 }
 
 static int op_tb4hl(void)		/* BIT 4,(HL) */
@@ -2506,7 +2506,7 @@ static int op_tb4hl(void)		/* BIT 4,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
-	return(12);
+	return (12);
 }
 
 static int op_tb5hl(void)		/* BIT 5,(HL) */
@@ -2515,7 +2515,7 @@ static int op_tb5hl(void)		/* BIT 5,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
-	return(12);
+	return (12);
 }
 
 static int op_tb6hl(void)		/* BIT 6,(HL) */
@@ -2524,7 +2524,7 @@ static int op_tb6hl(void)		/* BIT 6,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
-	return(12);
+	return (12);
 }
 
 static int op_tb7hl(void)		/* BIT 7,(HL) */
@@ -2538,7 +2538,7 @@ static int op_tb7hl(void)		/* BIT 7,(HL) */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(12);
+	return (12);
 }
 
 /**********************************************************************/
@@ -2560,7 +2560,7 @@ static int op_undoc_slla(void)		/* SLL A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 #ifdef Z80_UNDOC
@@ -2569,7 +2569,7 @@ static int op_undoc_sllb(void)		/* SLL B */
 {
 	if (u_flag) {
 		trap_cb();
-		return(0);
+		return (0);
 	}
 
 	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -2578,14 +2578,14 @@ static int op_undoc_sllb(void)		/* SLL B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_sllc(void)		/* SLL C */
 {
 	if (u_flag) {
 		trap_cb();
-		return(0);
+		return (0);
 	}
 
 	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -2594,14 +2594,14 @@ static int op_undoc_sllc(void)		/* SLL C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_slld(void)		/* SLL D */
 {
 	if (u_flag) {
 		trap_cb();
-		return(0);
+		return (0);
 	}
 
 	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -2610,14 +2610,14 @@ static int op_undoc_slld(void)		/* SLL D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_slle(void)		/* SLL E */
 {
 	if (u_flag) {
 		trap_cb();
-		return(0);
+		return (0);
 	}
 
 	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -2626,14 +2626,14 @@ static int op_undoc_slle(void)		/* SLL E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_sllh(void)		/* SLL H */
 {
 	if (u_flag) {
 		trap_cb();
-		return(0);
+		return (0);
 	}
 
 	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -2642,14 +2642,14 @@ static int op_undoc_sllh(void)		/* SLL H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_slll(void)		/* SLL L */
 {
 	if (u_flag) {
 		trap_cb();
-		return(0);
+		return (0);
 	}
 
 	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
@@ -2658,7 +2658,7 @@ static int op_undoc_slll(void)		/* SLL L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_sllhl(void)		/* SLL (HL) */
@@ -2668,7 +2668,7 @@ static int op_undoc_sllhl(void)		/* SLL (HL) */
 
 	if (u_flag) {
 		trap_cb();
-		return(0);
+		return (0);
 	}
 
 	addr = (H << 8) + L;
@@ -2680,7 +2680,7 @@ static int op_undoc_sllhl(void)		/* SLL (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(15);
+	return (15);
 }
 
 #endif

--- a/z80core/sim3.c
+++ b/z80core/sim3.c
@@ -347,7 +347,7 @@ int op_dd_handle(void)
 
 	t = (*op_dd[memrdr(PC++)]) ();	/* execute next opcode */
 
-	return(t);
+	return (t);
 }
 
 /*
@@ -361,32 +361,32 @@ static int trap_dd(void)
 		/* Treat 0xdd prefix as NOP on non IX-instructions */
 		PC--;
 		R--;
-		return(4);
+		return (4);
 	}
 #endif
 	cpu_error = OPTRAP2;
 	cpu_state = STOPPED;
-	return(0);
+	return (0);
 }
 
 static int op_popix(void)		/* POP IX */
 {
 	IX = memrdr(SP++);
 	IX += memrdr(SP++) << 8;
-	return(14);
+	return (14);
 }
 
 static int op_pusix(void)		/* PUSH IX */
 {
 	memwrt(--SP, IX >> 8);
 	memwrt(--SP, IX);
-	return(15);
+	return (15);
 }
 
 static int op_jpix(void)		/* JP (IX) */
 {
 	PC = IX;
-	return(8);
+	return (8);
 }
 
 static int op_exspx(void)		/* EX (SP),IX */
@@ -397,20 +397,20 @@ static int op_exspx(void)		/* EX (SP),IX */
 	memwrt(SP, IX);
 	memwrt(SP + 1, IX >> 8);
 	IX = i;
-	return(23);
+	return (23);
 }
 
 static int op_ldspx(void)		/* LD SP,IX */
 {
 	SP = IX;
-	return(10);
+	return (10);
 }
 
 static int op_ldixnn(void)		/* LD IX,nn */
 {
 	IX = memrdr(PC++);
 	IX += memrdr(PC++) << 8;
-	return(14);
+	return (14);
 }
 
 static int op_ldixinn(void)		/* LD IX,(nn) */
@@ -421,7 +421,7 @@ static int op_ldixinn(void)		/* LD IX,(nn) */
 	i += memrdr(PC++) << 8;
 	IX = memrdr(i);
 	IX += memrdr(i + 1) << 8;
-	return(20);
+	return (20);
 }
 
 static int op_ldinx(void)		/* LD (nn),IX */
@@ -432,7 +432,7 @@ static int op_ldinx(void)		/* LD (nn),IX */
 	i += memrdr(PC++) << 8;
 	memwrt(i, IX);
 	memwrt(i + 1, IX >> 8);
-	return(20);
+	return (20);
 }
 
 static int op_adaxd(void)		/* ADD A,(IX+d) */
@@ -448,7 +448,7 @@ static int op_adaxd(void)		/* ADD A,(IX+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_acaxd(void)		/* ADC A,(IX+d) */
@@ -465,7 +465,7 @@ static int op_acaxd(void)		/* ADC A,(IX+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_suaxd(void)		/* SUB A,(IX+d) */
@@ -481,7 +481,7 @@ static int op_suaxd(void)		/* SUB A,(IX+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_scaxd(void)		/* SBC A,(IX+d) */
@@ -498,7 +498,7 @@ static int op_scaxd(void)		/* SBC A,(IX+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_andxd(void)		/* AND (IX+d) */
@@ -509,7 +509,7 @@ static int op_andxd(void)		/* AND (IX+d) */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(19);
+	return (19);
 }
 
 static int op_xorxd(void)		/* XOR (IX+d) */
@@ -519,7 +519,7 @@ static int op_xorxd(void)		/* XOR (IX+d) */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(19);
+	return (19);
 }
 
 static int op_orxd(void)		/* OR (IX+d) */
@@ -529,7 +529,7 @@ static int op_orxd(void)		/* OR (IX+d) */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(19);
+	return (19);
 }
 
 static int op_cpxd(void)		/* CP (IX+d) */
@@ -545,7 +545,7 @@ static int op_cpxd(void)		/* CP (IX+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_incxd(void)		/* INC (IX+d) */
@@ -562,7 +562,7 @@ static int op_incxd(void)		/* INC (IX+d) */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(23);
+	return (23);
 }
 
 static int op_decxd(void)		/* DEC (IX+d) */
@@ -579,7 +579,7 @@ static int op_decxd(void)		/* DEC (IX+d) */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(23);
+	return (23);
 }
 
 static int op_addxb(void)		/* ADD IX,BC */
@@ -596,7 +596,7 @@ static int op_addxb(void)		/* ADD IX,BC */
 	ixh += B + carry;
 	IX = (ixh << 8) + ixl;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_addxd(void)		/* ADD IX,DE */
@@ -613,7 +613,7 @@ static int op_addxd(void)		/* ADD IX,DE */
 	ixh += D + carry;
 	IX = (ixh << 8) + ixl;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_addxs(void)		/* ADD IX,SP */
@@ -632,7 +632,7 @@ static int op_addxs(void)		/* ADD IX,SP */
 	ixh += sph + carry;
 	IX = (ixh << 8) + ixl;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_addxx(void)		/* ADD IX,IX */
@@ -649,103 +649,103 @@ static int op_addxx(void)		/* ADD IX,IX */
 	ixh += ixh + carry;
 	IX = (ixh << 8) + ixl;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_incix(void)		/* INC IX */
 {
 	IX++;
-	return(10);
+	return (10);
 }
 
 static int op_decix(void)		/* DEC IX */
 {
 	IX--;
-	return(10);
+	return (10);
 }
 
 static int op_ldaxd(void)		/* LD A,(IX+d) */
 {
 	A = memrdr(IX + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldbxd(void)		/* LD B,(IX+d) */
 {
 	B = memrdr(IX + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldcxd(void)		/* LD C,(IX+d) */
 {
 	C = memrdr(IX + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_lddxd(void)		/* LD D,(IX+d) */
 {
 	D = memrdr(IX + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldexd(void)		/* LD E,(IX+d) */
 {
 	E = memrdr(IX + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldhxd(void)		/* LD H,(IX+d) */
 {
 	H = memrdr(IX + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldlxd(void)		/* LD L,(IX+d) */
 {
 	L = memrdr(IX + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldxda(void)		/* LD (IX+d),A */
 {
 	memwrt(IX + (signed char) memrdr(PC++), A);
-	return(19);
+	return (19);
 }
 
 static int op_ldxdb(void)		/* LD (IX+d),B */
 {
 	memwrt(IX + (signed char) memrdr(PC++), B);
-	return(19);
+	return (19);
 }
 
 static int op_ldxdc(void)		/* LD (IX+d),C */
 {
 	memwrt(IX + (signed char) memrdr(PC++), C);
-	return(19);
+	return (19);
 }
 
 static int op_ldxdd(void)		/* LD (IX+d),D */
 {
 	memwrt(IX + (signed char) memrdr(PC++), D);
-	return(19);
+	return (19);
 }
 
 static int op_ldxde(void)		/* LD (IX+d),E */
 {
 	memwrt(IX + (signed char) memrdr(PC++), E);
-	return(19);
+	return (19);
 }
 
 static int op_ldxdh(void)		/* LD (IX+d),H */
 {
 	memwrt(IX + (signed char) memrdr(PC++), H);
-	return(19);
+	return (19);
 }
 
 static int op_ldxdl(void)		/* LD (IX+d),L */
 {
 	memwrt(IX + (signed char) memrdr(PC++), L);
-	return(19);
+	return (19);
 }
 
 static int op_ldxdn(void)		/* LD (IX+d),n */
@@ -754,7 +754,7 @@ static int op_ldxdn(void)		/* LD (IX+d),n */
 
 	d = memrdr(PC++);
 	memwrt(IX + d, memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 /**********************************************************************/
@@ -769,284 +769,284 @@ static int op_undoc_ldaixl(void)	/* LD A,IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	A = IX & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldaixh(void)	/* LD A,IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	A = IX >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldbixl(void)	/* LD B,IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	B = IX & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldbixh(void)	/* LD B,IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	B = IX >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldcixl(void)	/* LD C,IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	C = IX & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldcixh(void)	/* LD C,IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	C = IX >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_lddixl(void)	/* LD D,IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	D = IX & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_lddixh(void)	/* LD D,IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	D = IX >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldeixl(void)	/* LD E,IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	E = IX & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldeixh(void)	/* LD E,IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	E = IX >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixla(void)	/* LD IXL,A */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0xff00) | A;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixha(void)	/* LD IXH,A */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0x00ff) | (A << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixlb(void)	/* LD IXL,B */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0xff00) | B;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixhb(void)	/* LD IXH,B */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0x00ff) | (B << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixlc(void)	/* LD IXL,C */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0xff00) | C;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixhc(void)	/* LD IXH,C */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0x00ff) | (C << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixld(void)	/* LD IXL,D */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0xff00) | D;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixhd(void)	/* LD IXH,D */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0x00ff) | (D << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixle(void)	/* LD IXL,E */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0xff00) | E;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixhe(void)	/* LD IXH,E */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0x00ff) | (E << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixlixh(void)	/* LD IXL,IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0xff00) | (IX >> 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixhixh(void)	/* LD IXH,IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixlixl(void)	/* LD IXL,IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixhixl(void)	/* LD IXH,IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0x00ff) | (IX << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldixhn(void)	/* LD IXH,n */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0x00ff) | (memrdr(PC++) << 8);
-	return(11);
+	return (11);
 }
 
 static int op_undoc_ldixln(void)	/* LD IXL,n */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	IX = (IX & 0xff00) | memrdr(PC++);
-	return(11);
+	return (11);
 }
 
 static int op_undoc_cpixl(void)		/* CP IXL */
@@ -1056,7 +1056,7 @@ static int op_undoc_cpixl(void)		/* CP IXL */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX & 0xff;
@@ -1067,7 +1067,7 @@ static int op_undoc_cpixl(void)		/* CP IXL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_cpixh(void)		/* CP IXH */
@@ -1077,7 +1077,7 @@ static int op_undoc_cpixh(void)		/* CP IXH */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX >> 8;
@@ -1088,7 +1088,7 @@ static int op_undoc_cpixh(void)		/* CP IXH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_adaixl(void)	/* ADD A,IXL */
@@ -1098,7 +1098,7 @@ static int op_undoc_adaixl(void)	/* ADD A,IXL */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX & 0xff;
@@ -1109,7 +1109,7 @@ static int op_undoc_adaixl(void)	/* ADD A,IXL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_adaixh(void)	/* ADD A,IXH */
@@ -1119,7 +1119,7 @@ static int op_undoc_adaixh(void)	/* ADD A,IXH */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX >> 8;
@@ -1130,7 +1130,7 @@ static int op_undoc_adaixh(void)	/* ADD A,IXH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_acaixl(void)	/* ADC A,IXL */
@@ -1140,7 +1140,7 @@ static int op_undoc_acaixl(void)	/* ADC A,IXL */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
@@ -1152,7 +1152,7 @@ static int op_undoc_acaixl(void)	/* ADC A,IXL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_acaixh(void)	/* ADC A,IXH */
@@ -1162,7 +1162,7 @@ static int op_undoc_acaixh(void)	/* ADC A,IXH */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
@@ -1174,7 +1174,7 @@ static int op_undoc_acaixh(void)	/* ADC A,IXH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_suaixl(void)	/* SUB A,IXL */
@@ -1184,7 +1184,7 @@ static int op_undoc_suaixl(void)	/* SUB A,IXL */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX & 0xff;
@@ -1195,7 +1195,7 @@ static int op_undoc_suaixl(void)	/* SUB A,IXL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_suaixh(void)	/* SUB A,IXH */
@@ -1205,7 +1205,7 @@ static int op_undoc_suaixh(void)	/* SUB A,IXH */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX >> 8;
@@ -1216,7 +1216,7 @@ static int op_undoc_suaixh(void)	/* SUB A,IXH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_scaixl(void)	/* SBC A,IXL */
@@ -1226,7 +1226,7 @@ static int op_undoc_scaixl(void)	/* SBC A,IXL */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
@@ -1238,7 +1238,7 @@ static int op_undoc_scaixl(void)	/* SBC A,IXL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_scaixh(void)	/* SBC A,IXH */
@@ -1248,7 +1248,7 @@ static int op_undoc_scaixh(void)	/* SBC A,IXH */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
@@ -1260,14 +1260,14 @@ static int op_undoc_scaixh(void)	/* SBC A,IXH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_oraixl(void)	/* OR IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	A |= IX & 0xff;
@@ -1275,14 +1275,14 @@ static int op_undoc_oraixl(void)	/* OR IXL */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_oraixh(void)	/* OR IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	A |= IX >> 8;
@@ -1290,14 +1290,14 @@ static int op_undoc_oraixh(void)	/* OR IXH */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_xorixl(void)	/* XOR IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	A ^= IX & 0xff;
@@ -1305,14 +1305,14 @@ static int op_undoc_xorixl(void)	/* XOR IXL */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_xorixh(void)	/* XOR IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	A ^= IX >> 8;
@@ -1320,14 +1320,14 @@ static int op_undoc_xorixh(void)	/* XOR IXH */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_andixl(void)	/* AND IXL */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	A &= IX & 0xff;
@@ -1336,14 +1336,14 @@ static int op_undoc_andixl(void)	/* AND IXL */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_andixh(void)	/* AND IXH */
 {
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	A &= IX >> 8;
@@ -1352,7 +1352,7 @@ static int op_undoc_andixh(void)	/* AND IXH */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_incixl(void)	/* INC IXL */
@@ -1361,7 +1361,7 @@ static int op_undoc_incixl(void)	/* INC IXL */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX & 0xff;
@@ -1372,7 +1372,7 @@ static int op_undoc_incixl(void)	/* INC IXL */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_incixh(void)	/* INC IXH */
@@ -1381,7 +1381,7 @@ static int op_undoc_incixh(void)	/* INC IXH */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX >> 8;
@@ -1392,7 +1392,7 @@ static int op_undoc_incixh(void)	/* INC IXH */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_decixl(void)	/* DEC IXL */
@@ -1401,7 +1401,7 @@ static int op_undoc_decixl(void)	/* DEC IXL */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX & 0xff;
@@ -1412,7 +1412,7 @@ static int op_undoc_decixl(void)	/* DEC IXL */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_decixh(void)	/* DEC IXH */
@@ -1421,7 +1421,7 @@ static int op_undoc_decixh(void)	/* DEC IXH */
 
 	if (u_flag) {
 		trap_dd();
-		return(0);
+		return (0);
 	}
 
 	P = IX >> 8;
@@ -1432,7 +1432,7 @@ static int op_undoc_decixh(void)	/* DEC IXH */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 #endif

--- a/z80core/sim4.c
+++ b/z80core/sim4.c
@@ -333,7 +333,7 @@ int op_ed_handle(void)
 
 	t = (*op_ed[memrdr(PC++)]) ();	/* execute next opcode */
 
-	return(t);
+	return (t);
 }
 
 /*
@@ -344,25 +344,25 @@ static int trap_ed(void)
 {
 	cpu_error = OPTRAP2;
 	cpu_state = STOPPED;
-	return(0);
+	return (0);
 }
 
 static int op_im0(void)			/* IM 0 */
 {
 	int_mode = 0;
-	return(8);
+	return (8);
 }
 
 static int op_im1(void)			/* IM 1 */
 {
 	int_mode = 1;
-	return(8);
+	return (8);
 }
 
 static int op_im2(void)			/* IM 2 */
 {
 	int_mode = 2;
-	return(8);
+	return (8);
 }
 
 static int op_reti(void)		/* RETI */
@@ -372,7 +372,7 @@ static int op_reti(void)		/* RETI */
 	i = memrdr(SP++);
 	i += memrdr(SP++) << 8;
 	PC = i;
-	return(14);
+	return (14);
 }
 
 static int op_retn(void)		/* RETN */
@@ -384,7 +384,7 @@ static int op_retn(void)		/* RETN */
 	PC = i;
 	if (IFF & 2)
 		IFF |= 1;
-	return(14);
+	return (14);
 }
 
 static int op_neg(void)			/* NEG */
@@ -396,7 +396,7 @@ static int op_neg(void)			/* NEG */
 	F |= N_FLAG;
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_inaic(void)		/* IN A,(C) */
@@ -408,7 +408,7 @@ static int op_inaic(void)		/* IN A,(C) */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(12);
+	return (12);
 }
 
 static int op_inbic(void)		/* IN B,(C) */
@@ -420,7 +420,7 @@ static int op_inbic(void)		/* IN B,(C) */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(12);
+	return (12);
 }
 
 static int op_incic(void)		/* IN C,(C) */
@@ -432,7 +432,7 @@ static int op_incic(void)		/* IN C,(C) */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(12);
+	return (12);
 }
 
 static int op_indic(void)		/* IN D,(C) */
@@ -444,7 +444,7 @@ static int op_indic(void)		/* IN D,(C) */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(12);
+	return (12);
 }
 
 static int op_ineic(void)		/* IN E,(C) */
@@ -456,7 +456,7 @@ static int op_ineic(void)		/* IN E,(C) */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(12);
+	return (12);
 }
 
 static int op_inhic(void)		/* IN H,(C) */
@@ -468,7 +468,7 @@ static int op_inhic(void)		/* IN H,(C) */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(12);
+	return (12);
 }
 
 static int op_inlic(void)		/* IN L,(C) */
@@ -480,7 +480,7 @@ static int op_inlic(void)		/* IN L,(C) */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(12);
+	return (12);
 }
 
 static int op_outca(void)		/* OUT (C),A */
@@ -488,7 +488,7 @@ static int op_outca(void)		/* OUT (C),A */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, A);
-	return(12);
+	return (12);
 }
 
 static int op_outcb(void)		/* OUT (C),B */
@@ -496,7 +496,7 @@ static int op_outcb(void)		/* OUT (C),B */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, B);
-	return(12);
+	return (12);
 }
 
 static int op_outcc(void)		/* OUT (C),C */
@@ -504,7 +504,7 @@ static int op_outcc(void)		/* OUT (C),C */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, C);
-	return(12);
+	return (12);
 }
 
 static int op_outcd(void)		/* OUT (C),D */
@@ -512,7 +512,7 @@ static int op_outcd(void)		/* OUT (C),D */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, D);
-	return(12);
+	return (12);
 }
 
 static int op_outce(void)		/* OUT (C),E */
@@ -520,7 +520,7 @@ static int op_outce(void)		/* OUT (C),E */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, E);
-	return(12);
+	return (12);
 }
 
 static int op_outch(void)		/* OUT (C),H */
@@ -528,7 +528,7 @@ static int op_outch(void)		/* OUT (C),H */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, H);
-	return(12);
+	return (12);
 }
 
 static int op_outcl(void)		/* OUT (C),L */
@@ -536,7 +536,7 @@ static int op_outcl(void)		/* OUT (C),L */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, L);
-	return(12);
+	return (12);
 }
 
 static int op_ini(void)			/* INI */
@@ -552,7 +552,7 @@ static int op_ini(void)			/* INI */
 	B--;
 	F |= N_FLAG;
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(16);
+	return (16);
 }
 
 #ifdef WANT_FASTB
@@ -575,7 +575,7 @@ static int op_inir(void)		/* INIR */
 	H = addr >> 8;
 	L = addr;
 	F |= N_FLAG | Z_FLAG;
-	return(t + 16);
+	return (t + 16);
 }
 #else
 static int op_inir(void)		/* INIR */
@@ -588,7 +588,7 @@ static int op_inir(void)		/* INIR */
 		PC -= 2;
 	} else
 		t = 16;
-	return(t);
+	return (t);
 }
 #endif
 
@@ -605,7 +605,7 @@ static int op_ind(void)			/* IND */
 	B--;
 	F |= N_FLAG;
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(16);
+	return (16);
 }
 
 #ifdef WANT_FASTB
@@ -628,7 +628,7 @@ static int op_indr(void)		/* INDR */
 	H = addr >> 8;
 	L = addr;
 	F |= N_FLAG | Z_FLAG;
-	return(t + 16);
+	return (t + 16);
 }
 #else
 static int op_indr(void)		/* INDR */
@@ -641,7 +641,7 @@ static int op_indr(void)		/* INDR */
 		PC -= 2;
 	} else
 		t = 16;
-	return(t);
+	return (t);
 }
 #endif
 
@@ -658,7 +658,7 @@ static int op_outi(void)		/* OUTI */
 		H++;
 	F |= N_FLAG;
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(16);
+	return (16);
 }
 
 #ifdef WANT_FASTB
@@ -681,7 +681,7 @@ static int op_otir(void)		/* OTIR */
 	H = addr >> 8;
 	L = addr;
 	F |= N_FLAG | Z_FLAG;
-	return(t + 16);
+	return (t + 16);
 }
 #else
 static int op_otir(void)		/* OTIR */
@@ -694,7 +694,7 @@ static int op_otir(void)		/* OTIR */
 		PC -= 2;
 	} else
 		t = 16;
-	return(t);
+	return (t);
 }
 #endif
 
@@ -711,7 +711,7 @@ static int op_outd(void)		/* OUTD */
 		H--;
 	F |= N_FLAG;
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	return(16);
+	return (16);
 }
 
 #ifdef WANT_FASTB
@@ -734,7 +734,7 @@ static int op_otdr(void)		/* OTDR */
 	H = addr >> 8;
 	L = addr;
 	F |= N_FLAG | Z_FLAG;
-	return(t + 16);
+	return (t + 16);
 }
 #else
 static int op_otdr(void)		/* OTDR */
@@ -747,7 +747,7 @@ static int op_otdr(void)		/* OTDR */
 		PC -= 2;
 	} else
 		t = 16;
-	return(t);
+	return (t);
 }
 #endif
 
@@ -758,7 +758,7 @@ static int op_ldai(void)		/* LD A,I */
 	(IFF & 2) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	return(9);
+	return (9);
 }
 
 static int op_ldar(void)		/* LD A,R */
@@ -768,19 +768,19 @@ static int op_ldar(void)		/* LD A,R */
 	(IFF & 2) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	return(9);
+	return (9);
 }
 
 static int op_ldia(void)		/* LD I,A */
 {
 	I = A;
-	return(9);
+	return (9);
 }
 
 static int op_ldra(void)		/* LD R,A */
 {
 	R_ = R = A;
-	return(9);
+	return (9);
 }
 
 static int op_ldbcinn(void)		/* LD BC,(nn) */
@@ -791,7 +791,7 @@ static int op_ldbcinn(void)		/* LD BC,(nn) */
 	i += memrdr(PC++) << 8;
 	C = memrdr(i++);
 	B = memrdr(i);
-	return(20);
+	return (20);
 }
 
 static int op_lddeinn(void)		/* LD DE,(nn) */
@@ -802,7 +802,7 @@ static int op_lddeinn(void)		/* LD DE,(nn) */
 	i += memrdr(PC++) << 8;
 	E = memrdr(i++);
 	D = memrdr(i);
-	return(20);
+	return (20);
 }
 
 static int op_ldhlinn(void)		/* LD HL,(nn) */
@@ -813,7 +813,7 @@ static int op_ldhlinn(void)		/* LD HL,(nn) */
 	i += memrdr(PC++) << 8;
 	L = memrdr(i++);
 	H = memrdr(i);
-	return(20);
+	return (20);
 }
 
 static int op_ldspinn(void)		/* LD SP,(nn) */
@@ -824,7 +824,7 @@ static int op_ldspinn(void)		/* LD SP,(nn) */
 	i += memrdr(PC++) << 8;
 	SP = memrdr(i++);
 	SP += memrdr(i) << 8;
-	return(20);
+	return (20);
 }
 
 static int op_ldinbc(void)		/* LD (nn),BC */
@@ -835,7 +835,7 @@ static int op_ldinbc(void)		/* LD (nn),BC */
 	i += memrdr(PC++) << 8;
 	memwrt(i++, C);
 	memwrt(i, B);
-	return(20);
+	return (20);
 }
 
 static int op_ldinde(void)		/* LD (nn),DE */
@@ -846,7 +846,7 @@ static int op_ldinde(void)		/* LD (nn),DE */
 	i += memrdr(PC++) << 8;
 	memwrt(i++, E);
 	memwrt(i, D);
-	return(20);
+	return (20);
 }
 
 static int op_ldinhl(void)		/* LD (nn),HL */
@@ -857,7 +857,7 @@ static int op_ldinhl(void)		/* LD (nn),HL */
 	i += memrdr(PC++) << 8;
 	memwrt(i++, L);
 	memwrt(i, H);
-	return(20);
+	return (20);
 }
 
 static int op_ldinsp(void)		/* LD (nn),SP */
@@ -870,7 +870,7 @@ static int op_ldinsp(void)		/* LD (nn),SP */
 	i = SP;
 	memwrt(addr++, i);
 	memwrt(addr, i >> 8);
-	return(20);
+	return (20);
 }
 
 static int op_adchb(void)		/* ADC HL,BC */
@@ -895,7 +895,7 @@ static int op_adchb(void)		/* ADC HL,BC */
 	H = i >> 8;
 	L = i;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_adchd(void)		/* ADC HL,DE */
@@ -920,7 +920,7 @@ static int op_adchd(void)		/* ADC HL,DE */
 	H = i >> 8;
 	L = i;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_adchh(void)		/* ADC HL,HL */
@@ -943,7 +943,7 @@ static int op_adchh(void)		/* ADC HL,HL */
 	H = i >> 8;
 	L = i;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_adchs(void)		/* ADC HL,SP */
@@ -968,7 +968,7 @@ static int op_adchs(void)		/* ADC HL,SP */
 	H = i >> 8;
 	L = i;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_sbchb(void)		/* SBC HL,BC */
@@ -993,7 +993,7 @@ static int op_sbchb(void)		/* SBC HL,BC */
 	H = i >> 8;
 	L = i;
 	F |= N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_sbchd(void)		/* SBC HL,DE */
@@ -1018,7 +1018,7 @@ static int op_sbchd(void)		/* SBC HL,DE */
 	H = i >> 8;
 	L = i;
 	F |= N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_sbchh(void)		/* SBC HL,HL */
@@ -1041,7 +1041,7 @@ static int op_sbchh(void)		/* SBC HL,HL */
 	H = i >> 8;
 	L = i;
 	F |= N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_sbchs(void)		/* SBC HL,SP */
@@ -1066,7 +1066,7 @@ static int op_sbchs(void)		/* SBC HL,SP */
 	H = i >> 8;
 	L = i;
 	F |= N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_ldi(void)			/* LDI */
@@ -1083,7 +1083,7 @@ static int op_ldi(void)			/* LDI */
 		B--;
 	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	F &= ~(N_FLAG | H_FLAG);
-	return(16);
+	return (16);
 }
 
 #ifdef WANT_FASTB
@@ -1108,7 +1108,7 @@ static int op_ldir(void)		/* LDIR */
 	H = s >> 8;
 	L = s;
 	F &= ~(N_FLAG | P_FLAG | H_FLAG);
-	return(t + 16);
+	return (t + 16);
 }
 #else
 static int op_ldir(void)		/* LDIR */
@@ -1121,7 +1121,7 @@ static int op_ldir(void)		/* LDIR */
 		PC -= 2;
 	} else
 		t = 16;
-	return(t);
+	return (t);
 }
 #endif
 
@@ -1139,7 +1139,7 @@ static int op_ldd(void)			/* LDD */
 		B--;
 	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	F &= ~(N_FLAG | H_FLAG);
-	return(16);
+	return (16);
 }
 
 #ifdef WANT_FASTB
@@ -1164,7 +1164,7 @@ static int op_lddr(void)		/* LDDR */
 	H = s >> 8;
 	L = s;
 	F &= ~(N_FLAG | P_FLAG | H_FLAG);
-	return(t + 16);
+	return (t + 16);
 }
 #else
 static int op_lddr(void)		/* LDDR */
@@ -1177,7 +1177,7 @@ static int op_lddr(void)		/* LDDR */
 		PC -= 2;
 	} else
 		t = 16;
-	return(t);
+	return (t);
 }
 #endif
 
@@ -1198,7 +1198,7 @@ static int op_cpi(void)			/* CPI */
 	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	return(16);
+	return (16);
 }
 
 #ifdef WANT_FASTB
@@ -1228,7 +1228,7 @@ static int op_cpir(void)		/* CPIR */
 	(i) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(d) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(d & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	return(t + 16);
+	return (t + 16);
 }
 #else
 static int op_cpir(void)		/* CPIR */
@@ -1241,7 +1241,7 @@ static int op_cpir(void)		/* CPIR */
 		PC -= 2;
 	} else
 		t = 16;
-	return(t);
+	return (t);
 }
 #endif
 
@@ -1262,7 +1262,7 @@ static int op_cpdop(void)		/* CPD */
 	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	return(16);
+	return (16);
 }
 
 #ifdef WANT_FASTB
@@ -1292,7 +1292,7 @@ static int op_cpdr(void)		/* CPDR */
 	(i) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(d) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(d & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	return(t + 16);
+	return (t + 16);
 }
 #else
 static int op_cpdr(void)		/* CPDR */
@@ -1305,7 +1305,7 @@ static int op_cpdr(void)		/* CPDR */
 		PC -= 2;
 	} else
 		t = 16;
-	return(t);
+	return (t);
 }
 #endif
 
@@ -1322,7 +1322,7 @@ static int op_oprld(void)		/* RLD (HL) */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(18);
+	return (18);
 }
 
 static int op_oprrd(void)		/* RRD (HL) */
@@ -1338,7 +1338,7 @@ static int op_oprrd(void)		/* RRD (HL) */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(18);
+	return (18);
 }
 
 /**********************************************************************/
@@ -1355,11 +1355,11 @@ static int op_undoc_outc0(void)		/* OUT (C),0 */
 
 	if (u_flag) {
 		trap_ed();
-		return(0);
+		return (0);
 	}
 
 	io_out(C, B, 0); /* NMOS, CMOS outputs 0xff */
-	return(12);
+	return (12);
 }
 
 static int op_undoc_infic(void)		/* IN F,(C) */
@@ -1369,7 +1369,7 @@ static int op_undoc_infic(void)		/* IN F,(C) */
 
 	if (u_flag) {
 		trap_ed();
-		return(0);
+		return (0);
 	}
 
 	tmp = io_in(C, B);
@@ -1377,77 +1377,77 @@ static int op_undoc_infic(void)		/* IN F,(C) */
 	(tmp) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(tmp & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[tmp]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(12);
+	return (12);
 }
 
 static int op_undoc_nop(void)		/* NOP */
 {
 	if (u_flag) {
 		trap_ed();
-		return(0);
+		return (0);
 	}
 
-	return(8);
+	return (8);
 }
 
 static int op_undoc_im0(void)		/* IM 0 */
 {
 	if (u_flag) {
 		trap_ed();
-		return(0);
+		return (0);
 	}
 
-	return(op_im0());
+	return (op_im0());
 }
 
 static int op_undoc_im1(void)		/* IM 1 */
 {
 	if (u_flag) {
 		trap_ed();
-		return(0);
+		return (0);
 	}
 
-	return(op_im1());
+	return (op_im1());
 }
 
 static int op_undoc_im2(void)		/* IM 2 */
 {
 	if (u_flag) {
 		trap_ed();
-		return(0);
+		return (0);
 	}
 
-	return(op_im2());
+	return (op_im2());
 }
 
 static int op_undoc_reti(void)		/* RETI */
 {
 	if (u_flag) {
 		trap_ed();
-		return(0);
+		return (0);
 	}
 
-	return(op_reti());
+	return (op_reti());
 }
 
 static int op_undoc_retn(void)		/* RETN */
 {
 	if (u_flag) {
 		trap_ed();
-		return(0);
+		return (0);
 	}
 
-	return(op_retn());
+	return (op_retn());
 }
 
 static int op_undoc_neg(void)		/* NEG */
 {
 	if (u_flag) {
 		trap_ed();
-		return(0);
+		return (0);
 	}
 
-	return(op_neg());
+	return (op_neg());
 }
 
 #endif

--- a/z80core/sim5.c
+++ b/z80core/sim5.c
@@ -347,7 +347,7 @@ int op_fd_handle(void)
 
 	t = (*op_fd[memrdr(PC++)]) ();	/* execute next opcode */
 
-	return(t);
+	return (t);
 }
 
 /*
@@ -361,32 +361,32 @@ static int trap_fd(void)
 		/* Treat 0xfd prefix as NOP on non IY-instructions */
 		PC--;
 		R--;
-		return(4);
+		return (4);
 	}
 #endif
 	cpu_error = OPTRAP2;
 	cpu_state = STOPPED;
-	return(0);
+	return (0);
 }
 
 static int op_popiy(void)		/* POP IY */
 {
 	IY = memrdr(SP++);
 	IY += memrdr(SP++) << 8;
-	return(14);
+	return (14);
 }
 
 static int op_pusiy(void)		/* PUSH IY */
 {
 	memwrt(--SP, IY >> 8);
 	memwrt(--SP, IY);
-	return(15);
+	return (15);
 }
 
 static int op_jpiy(void)		/* JP (IY) */
 {
 	PC = IY;
-	return(8);
+	return (8);
 }
 
 static int op_exspy(void)		/* EX (SP),IY */
@@ -397,20 +397,20 @@ static int op_exspy(void)		/* EX (SP),IY */
 	memwrt(SP, IY);
 	memwrt(SP + 1, IY >> 8);
 	IY = i;
-	return(23);
+	return (23);
 }
 
 static int op_ldspy(void)		/* LD SP,IY */
 {
 	SP = IY;
-	return(10);
+	return (10);
 }
 
 static int op_ldiynn(void)		/* LD IY,nn */
 {
 	IY = memrdr(PC++);
 	IY += memrdr(PC++) << 8;
-	return(14);
+	return (14);
 }
 
 static int op_ldiyinn(void)		/* LD IY,(nn) */
@@ -421,7 +421,7 @@ static int op_ldiyinn(void)		/* LD IY,(nn) */
 	i += memrdr(PC++) << 8;
 	IY = memrdr(i);
 	IY += memrdr(i + 1) << 8;
-	return(20);
+	return (20);
 }
 
 static int op_ldiny(void)		/* LD (nn),IY */
@@ -432,7 +432,7 @@ static int op_ldiny(void)		/* LD (nn),IY */
 	i += memrdr(PC++) << 8;
 	memwrt(i, IY);
 	memwrt(i + 1, IY >> 8);
-	return(20);
+	return (20);
 }
 
 static int op_adayd(void)		/* ADD A,(IY+d) */
@@ -448,7 +448,7 @@ static int op_adayd(void)		/* ADD A,(IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_acayd(void)		/* ADC A,(IY+d) */
@@ -465,7 +465,7 @@ static int op_acayd(void)		/* ADC A,(IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_suayd(void)		/* SUB A,(IY+d) */
@@ -481,7 +481,7 @@ static int op_suayd(void)		/* SUB A,(IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_scayd(void)		/* SBC A,(IY+d) */
@@ -498,7 +498,7 @@ static int op_scayd(void)		/* SBC A,(IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_andyd(void)		/* AND (IY+d) */
@@ -509,7 +509,7 @@ static int op_andyd(void)		/* AND (IY+d) */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(19);
+	return (19);
 }
 
 static int op_xoryd(void)		/* XOR (IY+d) */
@@ -519,7 +519,7 @@ static int op_xoryd(void)		/* XOR (IY+d) */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(19);
+	return (19);
 }
 
 static int op_oryd(void)		/* OR (IY+d) */
@@ -529,7 +529,7 @@ static int op_oryd(void)		/* OR (IY+d) */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(19);
+	return (19);
 }
 
 static int op_cpyd(void)		/* CP (IY+d) */
@@ -545,7 +545,7 @@ static int op_cpyd(void)		/* CP (IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(19);
+	return (19);
 }
 
 static int op_incyd(void)		/* INC (IY+d) */
@@ -562,7 +562,7 @@ static int op_incyd(void)		/* INC (IY+d) */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(23);
+	return (23);
 }
 
 static int op_decyd(void)		/* DEC (IY+d) */
@@ -579,7 +579,7 @@ static int op_decyd(void)		/* DEC (IY+d) */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(23);
+	return (23);
 }
 
 static int op_addyb(void)		/* ADD IY,BC */
@@ -596,7 +596,7 @@ static int op_addyb(void)		/* ADD IY,BC */
 	iyh += B + carry;
 	IY = (iyh << 8) + iyl;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_addyd(void)		/* ADD IY,DE */
@@ -613,7 +613,7 @@ static int op_addyd(void)		/* ADD IY,DE */
 	iyh += D + carry;
 	IY = (iyh << 8) + iyl;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_addys(void)		/* ADD IY,SP */
@@ -632,7 +632,7 @@ static int op_addys(void)		/* ADD IY,SP */
 	iyh += sph + carry;
 	IY = (iyh << 8) + iyl;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_addyy(void)		/* ADD IY,IY */
@@ -649,103 +649,103 @@ static int op_addyy(void)		/* ADD IY,IY */
 	iyh += iyh + carry;
 	IY = (iyh << 8) + iyl;
 	F &= ~N_FLAG;
-	return(15);
+	return (15);
 }
 
 static int op_inciy(void)		/* INC IY */
 {
 	IY++;
-	return(10);
+	return (10);
 }
 
 static int op_deciy(void)		/* DEC IY */
 {
 	IY--;
-	return(10);
+	return (10);
 }
 
 static int op_ldayd(void)		/* LD A,(IY+d) */
 {
 	A = memrdr(IY + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldbyd(void)		/* LD B,(IY+d) */
 {
 	B = memrdr(IY + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldcyd(void)		/* LD C,(IY+d) */
 {
 	C = memrdr(IY + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_lddyd(void)		/* LD D,(IY+d) */
 {
 	D = memrdr(IY + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldeyd(void)		/* LD E,(IY+d) */
 {
 	E = memrdr(IY + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldhyd(void)		/* LD H,(IY+d) */
 {
 	H = memrdr(IY + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldlyd(void)		/* LD L,(IY+d) */
 {
 	L = memrdr(IY + (signed char) memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 static int op_ldyda(void)		/* LD (IY+d),A */
 {
 	memwrt(IY + (signed char) memrdr(PC++), A);
-	return(19);
+	return (19);
 }
 
 static int op_ldydb(void)		/* LD (IY+d),B */
 {
 	memwrt(IY + (signed char) memrdr(PC++), B);
-	return(19);
+	return (19);
 }
 
 static int op_ldydc(void)		/* LD (IY+d),C */
 {
 	memwrt(IY + (signed char) memrdr(PC++), C);
-	return(19);
+	return (19);
 }
 
 static int op_ldydd(void)		/* LD (IY+d),D */
 {
 	memwrt(IY + (signed char) memrdr(PC++), D);
-	return(19);
+	return (19);
 }
 
 static int op_ldyde(void)		/* LD (IY+d),E */
 {
 	memwrt(IY + (signed char) memrdr(PC++), E);
-	return(19);
+	return (19);
 }
 
 static int op_ldydh(void)		/* LD (IY+d),H */
 {
 	memwrt(IY + (signed char) memrdr(PC++), H);
-	return(19);
+	return (19);
 }
 
 static int op_ldydl(void)		/* LD (IY+d),L */
 {
 	memwrt(IY + (signed char) memrdr(PC++), L);
-	return(19);
+	return (19);
 }
 
 static int op_ldydn(void)		/* LD (IY+d),n */
@@ -754,7 +754,7 @@ static int op_ldydn(void)		/* LD (IY+d),n */
 
 	d = memrdr(PC++);
 	memwrt(IY + d, memrdr(PC++));
-	return(19);
+	return (19);
 }
 
 /**********************************************************************/
@@ -769,284 +769,284 @@ static int op_undoc_ldaiyl(void)	/* LD A,IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	A = IY & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldaiyh(void)	/* LD A,IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	A = IY >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldbiyl(void)	/* LD B,IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	B = IY & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldbiyh(void)	/* LD B,IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	B = IY >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldciyl(void)	/* LD C,IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	C = IY & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldciyh(void)	/* LD C,IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	C = IY >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_lddiyl(void)	/* LD D,IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	D = IY & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_lddiyh(void)	/* LD D,IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	D = IY >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldeiyl(void)	/* LD E,IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	E = IY & 0xff;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldeiyh(void)	/* LD E,IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	E = IY >> 8;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyla(void)	/* LD IYL,A */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0xff00) | A;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyha(void)	/* LD IYH,A */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0x00ff) | (A << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiylb(void)	/* LD IYL,B */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0xff00) | B;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyhb(void)	/* LD IYH,B */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0x00ff) | (B << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiylc(void)	/* LD IYL,C */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0xff00) | C;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyhc(void)	/* LD IYH,C */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0x00ff) | (C << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyld(void)	/* LD IYL,D */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0xff00) | D;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyhd(void)	/* LD IYH,D */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0x00ff) | (D << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyle(void)	/* LD IYL,E */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0xff00) | E;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyhe(void)	/* LD IYH,E */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0x00ff) | (E << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyliyh(void)	/* LD IYL,IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0xff00) | (IY >> 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyhiyh(void)	/* LD IYH,IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyliyl(void)	/* LD IYL,IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyhiyl(void)	/* LD IYH,IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0x00ff) | (IY << 8);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_ldiyhn(void)	/* LD IYH,n */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0x00ff) | (memrdr(PC++) << 8);
-	return(11);
+	return (11);
 }
 
 static int op_undoc_ldiyln(void)	/* LD IYL,n */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	IY = (IY & 0xff00) | memrdr(PC++);
-	return(11);
+	return (11);
 }
 
 static int op_undoc_cpiyl(void)		/* CP IYL */
@@ -1056,7 +1056,7 @@ static int op_undoc_cpiyl(void)		/* CP IYL */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY & 0xff;
@@ -1067,7 +1067,7 @@ static int op_undoc_cpiyl(void)		/* CP IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_cpiyh(void)		/* CP IYH */
@@ -1077,7 +1077,7 @@ static int op_undoc_cpiyh(void)		/* CP IYH */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY >> 8;
@@ -1088,7 +1088,7 @@ static int op_undoc_cpiyh(void)		/* CP IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_adaiyl(void)	/* ADD A,IYL */
@@ -1098,7 +1098,7 @@ static int op_undoc_adaiyl(void)	/* ADD A,IYL */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY & 0xff;
@@ -1109,7 +1109,7 @@ static int op_undoc_adaiyl(void)	/* ADD A,IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_adaiyh(void)	/* ADD A,IYH */
@@ -1119,7 +1119,7 @@ static int op_undoc_adaiyh(void)	/* ADD A,IYH */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY >> 8;
@@ -1130,7 +1130,7 @@ static int op_undoc_adaiyh(void)	/* ADD A,IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_acaiyl(void)	/* ADC A,IYL */
@@ -1140,7 +1140,7 @@ static int op_undoc_acaiyl(void)	/* ADC A,IYL */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
@@ -1152,7 +1152,7 @@ static int op_undoc_acaiyl(void)	/* ADC A,IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_acaiyh(void)	/* ADC A,IYH */
@@ -1162,7 +1162,7 @@ static int op_undoc_acaiyh(void)	/* ADC A,IYH */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
@@ -1174,7 +1174,7 @@ static int op_undoc_acaiyh(void)	/* ADC A,IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_suaiyl(void)	/* SUB A,IYL */
@@ -1184,7 +1184,7 @@ static int op_undoc_suaiyl(void)	/* SUB A,IYL */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY & 0xff;
@@ -1195,7 +1195,7 @@ static int op_undoc_suaiyl(void)	/* SUB A,IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_suaiyh(void)	/* SUB A,IYH */
@@ -1205,7 +1205,7 @@ static int op_undoc_suaiyh(void)	/* SUB A,IYH */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY >> 8;
@@ -1216,7 +1216,7 @@ static int op_undoc_suaiyh(void)	/* SUB A,IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_scaiyl(void)	/* SBC A,IYL */
@@ -1226,7 +1226,7 @@ static int op_undoc_scaiyl(void)	/* SBC A,IYL */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
@@ -1238,7 +1238,7 @@ static int op_undoc_scaiyl(void)	/* SBC A,IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_scaiyh(void)	/* SBC A,IYH */
@@ -1248,7 +1248,7 @@ static int op_undoc_scaiyh(void)	/* SBC A,IYH */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
@@ -1260,14 +1260,14 @@ static int op_undoc_scaiyh(void)	/* SBC A,IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_oraiyl(void)	/* OR IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	A |= IY & 0xff;
@@ -1275,14 +1275,14 @@ static int op_undoc_oraiyl(void)	/* OR IYL */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_oraiyh(void)	/* OR IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	A |= IY >> 8;
@@ -1290,14 +1290,14 @@ static int op_undoc_oraiyh(void)	/* OR IYH */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_xoriyl(void)	/* XOR IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	A ^= IY & 0xff;
@@ -1305,14 +1305,14 @@ static int op_undoc_xoriyl(void)	/* XOR IYL */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_xoriyh(void)	/* XOR IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	A ^= IY >> 8;
@@ -1320,14 +1320,14 @@ static int op_undoc_xoriyh(void)	/* XOR IYH */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_andiyl(void)	/* AND IYL */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	A &= IY & 0xff;
@@ -1336,14 +1336,14 @@ static int op_undoc_andiyl(void)	/* AND IYL */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_andiyh(void)	/* AND IYH */
 {
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	A &= IY >> 8;
@@ -1352,7 +1352,7 @@ static int op_undoc_andiyh(void)	/* AND IYH */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
-	return(8);
+	return (8);
 }
 
 static int op_undoc_inciyl(void)	/* INC IYL */
@@ -1361,7 +1361,7 @@ static int op_undoc_inciyl(void)	/* INC IYL */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY & 0xff;
@@ -1372,7 +1372,7 @@ static int op_undoc_inciyl(void)	/* INC IYL */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_inciyh(void)	/* INC IYH */
@@ -1381,7 +1381,7 @@ static int op_undoc_inciyh(void)	/* INC IYH */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY >> 8;
@@ -1392,7 +1392,7 @@ static int op_undoc_inciyh(void)	/* INC IYH */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_deciyl(void)	/* DEC IYL */
@@ -1401,7 +1401,7 @@ static int op_undoc_deciyl(void)	/* DEC IYL */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY & 0xff;
@@ -1412,7 +1412,7 @@ static int op_undoc_deciyl(void)	/* DEC IYL */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 static int op_undoc_deciyh(void)	/* DEC IYH */
@@ -1421,7 +1421,7 @@ static int op_undoc_deciyh(void)	/* DEC IYH */
 
 	if (u_flag) {
 		trap_fd();
-		return(0);
+		return (0);
 	}
 
 	P = IY >> 8;
@@ -1432,7 +1432,7 @@ static int op_undoc_deciyh(void)	/* DEC IYH */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
-	return(8);
+	return (8);
 }
 
 #endif

--- a/z80core/sim6.c
+++ b/z80core/sim6.c
@@ -373,7 +373,7 @@ int op_ddcb_handle(void)
 	d = (signed char) memrdr(PC++);
 	t = (*op_ddcb[memrdr(PC++)]) (d); /* execute next opcode */
 
-	return(t);
+	return (t);
 }
 
 /*
@@ -386,7 +386,7 @@ static int trap_ddcb(int data)
 
 	cpu_error = OPTRAP4;
 	cpu_state = STOPPED;
-	return(0);
+	return (0);
 }
 
 static int op_tb0ixd(int data)		/* BIT 0,(IX+d) */
@@ -395,7 +395,7 @@ static int op_tb0ixd(int data)		/* BIT 0,(IX+d) */
 	F |= H_FLAG;
 	(memrdr(IX + data) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 				: (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb1ixd(int data)		/* BIT 1,(IX+d) */
@@ -404,7 +404,7 @@ static int op_tb1ixd(int data)		/* BIT 1,(IX+d) */
 	F |= H_FLAG;
 	(memrdr(IX + data) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 				: (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb2ixd(int data)		/* BIT 2,(IX+d) */
@@ -413,7 +413,7 @@ static int op_tb2ixd(int data)		/* BIT 2,(IX+d) */
 	F |= H_FLAG;
 	(memrdr(IX + data) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 				: (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb3ixd(int data)		/* BIT 3,(IX+d) */
@@ -422,7 +422,7 @@ static int op_tb3ixd(int data)		/* BIT 3,(IX+d) */
 	F |= H_FLAG;
 	(memrdr(IX + data) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 				: (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb4ixd(int data)		/* BIT 4,(IX+d) */
@@ -431,7 +431,7 @@ static int op_tb4ixd(int data)		/* BIT 4,(IX+d) */
 	F |= H_FLAG;
 	(memrdr(IX + data) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 				 : (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb5ixd(int data)		/* BIT 5,(IX+d) */
@@ -440,7 +440,7 @@ static int op_tb5ixd(int data)		/* BIT 5,(IX+d) */
 	F |= H_FLAG;
 	(memrdr(IX + data) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 				 : (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb6ixd(int data)		/* BIT 6,(IX+d) */
@@ -449,7 +449,7 @@ static int op_tb6ixd(int data)		/* BIT 6,(IX+d) */
 	F |= H_FLAG;
 	(memrdr(IX + data) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 				 : (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb7ixd(int data)		/* BIT 7,(IX+d) */
@@ -463,103 +463,103 @@ static int op_tb7ixd(int data)		/* BIT 7,(IX+d) */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(20);
+	return (20);
 }
 
 static int op_rb0ixd(int data)		/* RES 0,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) & ~1);
-	return(23);
+	return (23);
 }
 
 static int op_rb1ixd(int data)		/* RES 1,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) & ~2);
-	return(23);
+	return (23);
 }
 
 static int op_rb2ixd(int data)		/* RES 2,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) & ~4);
-	return(23);
+	return (23);
 }
 
 static int op_rb3ixd(int data)		/* RES 3,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) & ~8);
-	return(23);
+	return (23);
 }
 
 static int op_rb4ixd(int data)		/* RES 4,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) & ~16);
-	return(23);
+	return (23);
 }
 
 static int op_rb5ixd(int data)		/* RES 5,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) & ~32);
-	return(23);
+	return (23);
 }
 
 static int op_rb6ixd(int data)		/* RES 6,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) & ~64);
-	return(23);
+	return (23);
 }
 
 static int op_rb7ixd(int data)		/* RES 7,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) & ~128);
-	return(23);
+	return (23);
 }
 
 static int op_sb0ixd(int data)		/* SET 0,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) | 1);
-	return(23);
+	return (23);
 }
 
 static int op_sb1ixd(int data)		/* SET 1,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) | 2);
-	return(23);
+	return (23);
 }
 
 static int op_sb2ixd(int data)		/* SET 2,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) | 4);
-	return(23);
+	return (23);
 }
 
 static int op_sb3ixd(int data)		/* SET 3,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) | 8);
-	return(23);
+	return (23);
 }
 
 static int op_sb4ixd(int data)		/* SET 4,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) | 16);
-	return(23);
+	return (23);
 }
 
 static int op_sb5ixd(int data)		/* SET 5,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) | 32);
-	return(23);
+	return (23);
 }
 
 static int op_sb6ixd(int data)		/* SET 6,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) | 64);
-	return(23);
+	return (23);
 }
 
 static int op_sb7ixd(int data)		/* SET 7,(IX+d) */
 {
 	memwrt(IX + data, memrdr(IX + data) | 128);
-	return(23);
+	return (23);
 }
 
 static int op_rlcixd(int data)		/* RLC (IX+d) */
@@ -579,7 +579,7 @@ static int op_rlcixd(int data)		/* RLC (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_rrcixd(int data)		/* RRC (IX+d) */
@@ -599,7 +599,7 @@ static int op_rrcixd(int data)		/* RRC (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_rlixd(int data)		/* RL (IX+d) */
@@ -619,7 +619,7 @@ static int op_rlixd(int data)		/* RL (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_rrixd(int data)		/* RR (IX+d) */
@@ -639,7 +639,7 @@ static int op_rrixd(int data)		/* RR (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_slaixd(int data)		/* SLA (IX+d) */
@@ -656,7 +656,7 @@ static int op_slaixd(int data)		/* SLA (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_sraixd(int data)		/* SRA (IX+d) */
@@ -675,7 +675,7 @@ static int op_sraixd(int data)		/* SRA (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_srlixd(int data)		/* SRL (IX+d) */
@@ -692,7 +692,7 @@ static int op_srlixd(int data)		/* SRL (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 /**********************************************************************/
@@ -707,1424 +707,1424 @@ static int op_undoc_tb0ixd(int data)	/* BIT 0,(IX+d) */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb0ixd(data));
+	return (op_tb0ixd(data));
 }
 
 static int op_undoc_tb1ixd(int data)	/* BIT 1,(IX+d) */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb1ixd(data));
+	return (op_tb1ixd(data));
 }
 
 static int op_undoc_tb2ixd(int data)	/* BIT 2,(IX+d) */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb2ixd(data));
+	return (op_tb2ixd(data));
 }
 
 static int op_undoc_tb3ixd(int data)	/* BIT 3,(IX+d) */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb3ixd(data));
+	return (op_tb3ixd(data));
 }
 
 static int op_undoc_tb4ixd(int data)	/* BIT 4,(IX+d) */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb4ixd(data));
+	return (op_tb4ixd(data));
 }
 
 static int op_undoc_tb5ixd(int data)	/* BIT 5,(IX+d) */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb5ixd(data));
+	return (op_tb5ixd(data));
 }
 
 static int op_undoc_tb6ixd(int data)	/* BIT 6,(IX+d) */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb6ixd(data));
+	return (op_tb6ixd(data));
 }
 
 static int op_undoc_tb7ixd(int data)	/* BIT 7,(IX+d) */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb7ixd(data));
+	return (op_tb7ixd(data));
 }
 
 static int op_undoc_rb0ixda(int data)	/* RES 0,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) & ~1;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1ixda(int data)	/* RES 1,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) & ~2;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2ixda(int data)	/* RES 2,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) & ~4;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3ixda(int data)	/* RES 3,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) & ~8;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4ixda(int data)	/* RES 4,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) & ~16;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5ixda(int data)	/* RES 5,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) & ~32;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6ixda(int data)	/* RES 6,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) & ~64;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7ixda(int data)	/* RES 7,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) & ~128;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0ixdb(int data)	/* RES 0,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) & ~1;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1ixdb(int data)	/* RES 1,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) & ~2;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2ixdb(int data)	/* RES 2,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) & ~4;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3ixdb(int data)	/* RES 3,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) & ~8;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4ixdb(int data)	/* RES 4,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) & ~16;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5ixdb(int data)	/* RES 5,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) & ~32;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6ixdb(int data)	/* RES 6,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) & ~64;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7ixdb(int data)	/* RES 7,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) & ~128;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0ixdc(int data)	/* RES 0,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) & ~1;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1ixdc(int data)	/* RES 1,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) & ~2;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2ixdc(int data)	/* RES 2,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) & ~4;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3ixdc(int data)	/* RES 3,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) & ~8;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4ixdc(int data)	/* RES 4,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) & ~16;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5ixdc(int data)	/* RES 5,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) & ~32;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6ixdc(int data)	/* RES 6,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) & ~64;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7ixdc(int data)	/* RES 7,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) & ~128;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0ixdd(int data)	/* RES 0,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) & ~1;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1ixdd(int data)	/* RES 1,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) & ~2;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2ixdd(int data)	/* RES 2,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) & ~4;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3ixdd(int data)	/* RES 3,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) & ~8;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4ixdd(int data)	/* RES 4,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) & ~16;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5ixdd(int data)	/* RES 5,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) & ~32;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6ixdd(int data)	/* RES 6,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) & ~64;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7ixdd(int data)	/* RES 7,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) & ~128;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0ixde(int data)	/* RES 0,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) & ~1;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1ixde(int data)	/* RES 1,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) & ~2;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2ixde(int data)	/* RES 2,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) & ~4;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3ixde(int data)	/* RES 3,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) & ~8;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4ixde(int data)	/* RES 4,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) & ~16;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5ixde(int data)	/* RES 5,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) & ~32;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6ixde(int data)	/* RES 6,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) & ~64;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7ixde(int data)	/* RES 7,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) & ~128;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0ixdh(int data)	/* RES 0,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) & ~1;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1ixdh(int data)	/* RES 1,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) & ~2;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2ixdh(int data)	/* RES 2,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) & ~4;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3ixdh(int data)	/* RES 3,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) & ~8;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4ixdh(int data)	/* RES 4,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) & ~16;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5ixdh(int data)	/* RES 5,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) & ~32;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6ixdh(int data)	/* RES 6,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) & ~64;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7ixdh(int data)	/* RES 7,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) & ~128;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0ixdl(int data)	/* RES 0,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) & ~1;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1ixdl(int data)	/* RES 1,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) & ~2;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2ixdl(int data)	/* RES 2,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) & ~4;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3ixdl(int data)	/* RES 3,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) & ~8;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4ixdl(int data)	/* RES 4,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) & ~16;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5ixdl(int data)	/* RES 5,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) & ~32;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6ixdl(int data)	/* RES 6,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) & ~64;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7ixdl(int data)	/* RES 7,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) & ~128;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0ixda(int data)	/* SET 0,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) | 1;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1ixda(int data)	/* SET 1,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) | 2;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2ixda(int data)	/* SET 2,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) | 4;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3ixda(int data)	/* SET 3,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) | 8;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4ixda(int data)	/* SET 4,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) | 16;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5ixda(int data)	/* SET 5,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) | 32;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6ixda(int data)	/* SET 6,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) | 64;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7ixda(int data)	/* SET 7,(IX+d),A */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IX + data) | 128;
 	memwrt(IX + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0ixdb(int data)	/* SET 0,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) | 1;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1ixdb(int data)	/* SET 1,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) | 2;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2ixdb(int data)	/* SET 2,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) | 4;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3ixdb(int data)	/* SET 3,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) | 8;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4ixdb(int data)	/* SET 4,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) | 16;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5ixdb(int data)	/* SET 5,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) | 32;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6ixdb(int data)	/* SET 6,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) | 64;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7ixdb(int data)	/* SET 7,(IX+d),B */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IX + data) | 128;
 	memwrt(IX + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0ixdc(int data)	/* SET 0,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) | 1;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1ixdc(int data)	/* SET 1,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) | 2;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2ixdc(int data)	/* SET 2,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) | 4;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3ixdc(int data)	/* SET 3,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) | 8;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4ixdc(int data)	/* SET 4,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) | 16;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5ixdc(int data)	/* SET 5,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) | 32;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6ixdc(int data)	/* SET 6,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) | 64;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7ixdc(int data)	/* SET 7,(IX+d),C */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IX + data) | 128;
 	memwrt(IX + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0ixdd(int data)	/* SET 0,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) | 1;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1ixdd(int data)	/* SET 1,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) | 2;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2ixdd(int data)	/* SET 2,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) | 4;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3ixdd(int data)	/* SET 3,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) | 8;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4ixdd(int data)	/* SET 4,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) | 16;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5ixdd(int data)	/* SET 5,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) | 32;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6ixdd(int data)	/* SET 6,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) | 64;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7ixdd(int data)	/* SET 7,(IX+d),D */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IX + data) | 128;
 	memwrt(IX + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0ixde(int data)	/* SET 0,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) | 1;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1ixde(int data)	/* SET 1,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) | 2;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2ixde(int data)	/* SET 2,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) | 4;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3ixde(int data)	/* SET 3,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) | 8;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4ixde(int data)	/* SET 4,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) | 16;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5ixde(int data)	/* SET 5,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) | 32;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6ixde(int data)	/* SET 6,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) | 64;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7ixde(int data)	/* SET 7,(IX+d),E */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IX + data) | 128;
 	memwrt(IX + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0ixdh(int data)	/* SET 0,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) | 1;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1ixdh(int data)	/* SET 1,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) | 2;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2ixdh(int data)	/* SET 2,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) | 4;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3ixdh(int data)	/* SET 3,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) | 8;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4ixdh(int data)	/* SET 4,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) | 16;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5ixdh(int data)	/* SET 5,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) | 32;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6ixdh(int data)	/* SET 6,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) | 64;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7ixdh(int data)	/* SET 7,(IX+d),H */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IX + data) | 128;
 	memwrt(IX + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0ixdl(int data)	/* SET 0,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) | 1;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1ixdl(int data)	/* SET 1,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) | 2;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2ixdl(int data)	/* SET 2,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) | 4;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3ixdl(int data)	/* SET 3,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) | 8;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4ixdl(int data)	/* SET 4,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) | 16;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5ixdl(int data)	/* SET 5,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) | 32;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6ixdl(int data)	/* SET 6,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) | 64;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7ixdl(int data)	/* SET 7,(IX+d),L */
 {
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IX + data) | 128;
 	memwrt(IX + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlcixda(int data)	/* RLC (IX+d),A */
@@ -2134,7 +2134,7 @@ static int op_undoc_rlcixda(int data)	/* RLC (IX+d),A */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2148,7 +2148,7 @@ static int op_undoc_rlcixda(int data)	/* RLC (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlcixdb(int data)	/* RLC (IX+d),B */
@@ -2158,7 +2158,7 @@ static int op_undoc_rlcixdb(int data)	/* RLC (IX+d),B */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2172,7 +2172,7 @@ static int op_undoc_rlcixdb(int data)	/* RLC (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlcixdc(int data)	/* RLC (IX+d),C */
@@ -2182,7 +2182,7 @@ static int op_undoc_rlcixdc(int data)	/* RLC (IX+d),C */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2196,7 +2196,7 @@ static int op_undoc_rlcixdc(int data)	/* RLC (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlcixdd(int data)	/* RLC (IX+d),D */
@@ -2206,7 +2206,7 @@ static int op_undoc_rlcixdd(int data)	/* RLC (IX+d),D */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2220,7 +2220,7 @@ static int op_undoc_rlcixdd(int data)	/* RLC (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlcixde(int data)	/* RLC (IX+d),E */
@@ -2230,7 +2230,7 @@ static int op_undoc_rlcixde(int data)	/* RLC (IX+d),E */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2244,7 +2244,7 @@ static int op_undoc_rlcixde(int data)	/* RLC (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlcixdh(int data)	/* RLC (IX+d),H */
@@ -2254,7 +2254,7 @@ static int op_undoc_rlcixdh(int data)	/* RLC (IX+d),H */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2268,7 +2268,7 @@ static int op_undoc_rlcixdh(int data)	/* RLC (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlcixdl(int data)	/* RLC (IX+d),L */
@@ -2278,7 +2278,7 @@ static int op_undoc_rlcixdl(int data)	/* RLC (IX+d),L */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2292,7 +2292,7 @@ static int op_undoc_rlcixdl(int data)	/* RLC (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrcixda(int data)	/* RRC (IX+d),A */
@@ -2302,7 +2302,7 @@ static int op_undoc_rrcixda(int data)	/* RRC (IX+d),A */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2316,7 +2316,7 @@ static int op_undoc_rrcixda(int data)	/* RRC (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrcixdb(int data)	/* RRC (IX+d),B */
@@ -2326,7 +2326,7 @@ static int op_undoc_rrcixdb(int data)	/* RRC (IX+d),B */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2340,7 +2340,7 @@ static int op_undoc_rrcixdb(int data)	/* RRC (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrcixdc(int data)	/* RRC (IX+d),C */
@@ -2350,7 +2350,7 @@ static int op_undoc_rrcixdc(int data)	/* RRC (IX+d),C */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2364,7 +2364,7 @@ static int op_undoc_rrcixdc(int data)	/* RRC (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrcixdd(int data)	/* RRC (IX+d),D */
@@ -2374,7 +2374,7 @@ static int op_undoc_rrcixdd(int data)	/* RRC (IX+d),D */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2388,7 +2388,7 @@ static int op_undoc_rrcixdd(int data)	/* RRC (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrcixde(int data)	/* RRC (IX+d),E */
@@ -2398,7 +2398,7 @@ static int op_undoc_rrcixde(int data)	/* RRC (IX+d),E */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2412,7 +2412,7 @@ static int op_undoc_rrcixde(int data)	/* RRC (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrcixdh(int data)	/* RRC (IX+d),H */
@@ -2422,7 +2422,7 @@ static int op_undoc_rrcixdh(int data)	/* RRC (IX+d),H */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2436,7 +2436,7 @@ static int op_undoc_rrcixdh(int data)	/* RRC (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrcixdl(int data)	/* RRC (IX+d),L */
@@ -2446,7 +2446,7 @@ static int op_undoc_rrcixdl(int data)	/* RRC (IX+d),L */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2460,7 +2460,7 @@ static int op_undoc_rrcixdl(int data)	/* RRC (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlixda(int data)	/* RL (IX+d),A */
@@ -2470,7 +2470,7 @@ static int op_undoc_rlixda(int data)	/* RL (IX+d),A */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2484,7 +2484,7 @@ static int op_undoc_rlixda(int data)	/* RL (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlixdb(int data)	/* RL (IX+d),B */
@@ -2494,7 +2494,7 @@ static int op_undoc_rlixdb(int data)	/* RL (IX+d),B */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2508,7 +2508,7 @@ static int op_undoc_rlixdb(int data)	/* RL (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlixdc(int data)	/* RL (IX+d),C */
@@ -2518,7 +2518,7 @@ static int op_undoc_rlixdc(int data)	/* RL (IX+d),C */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2532,7 +2532,7 @@ static int op_undoc_rlixdc(int data)	/* RL (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlixdd(int data)	/* RL (IX+d),D */
@@ -2542,7 +2542,7 @@ static int op_undoc_rlixdd(int data)	/* RL (IX+d),D */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2556,7 +2556,7 @@ static int op_undoc_rlixdd(int data)	/* RL (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlixde(int data)	/* RL (IX+d),E */
@@ -2566,7 +2566,7 @@ static int op_undoc_rlixde(int data)	/* RL (IX+d),E */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2580,7 +2580,7 @@ static int op_undoc_rlixde(int data)	/* RL (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlixdh(int data)	/* RL (IX+d),H */
@@ -2590,7 +2590,7 @@ static int op_undoc_rlixdh(int data)	/* RL (IX+d),H */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2604,7 +2604,7 @@ static int op_undoc_rlixdh(int data)	/* RL (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlixdl(int data)	/* RL (IX+d),L */
@@ -2614,7 +2614,7 @@ static int op_undoc_rlixdl(int data)	/* RL (IX+d),L */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2628,7 +2628,7 @@ static int op_undoc_rlixdl(int data)	/* RL (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrixda(int data)	/* RR (IX+d),A */
@@ -2638,7 +2638,7 @@ static int op_undoc_rrixda(int data)	/* RR (IX+d),A */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2652,7 +2652,7 @@ static int op_undoc_rrixda(int data)	/* RR (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrixdb(int data)	/* RR (IX+d),B */
@@ -2662,7 +2662,7 @@ static int op_undoc_rrixdb(int data)	/* RR (IX+d),B */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2676,7 +2676,7 @@ static int op_undoc_rrixdb(int data)	/* RR (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrixdc(int data)	/* RR (IX+d),C */
@@ -2686,7 +2686,7 @@ static int op_undoc_rrixdc(int data)	/* RR (IX+d),C */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2700,7 +2700,7 @@ static int op_undoc_rrixdc(int data)	/* RR (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrixdd(int data)	/* RR (IX+d),D */
@@ -2710,7 +2710,7 @@ static int op_undoc_rrixdd(int data)	/* RR (IX+d),D */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2724,7 +2724,7 @@ static int op_undoc_rrixdd(int data)	/* RR (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrixde(int data)	/* RR (IX+d),E */
@@ -2734,7 +2734,7 @@ static int op_undoc_rrixde(int data)	/* RR (IX+d),E */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2748,7 +2748,7 @@ static int op_undoc_rrixde(int data)	/* RR (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrixdh(int data)	/* RR (IX+d),H */
@@ -2758,7 +2758,7 @@ static int op_undoc_rrixdh(int data)	/* RR (IX+d),H */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2772,7 +2772,7 @@ static int op_undoc_rrixdh(int data)	/* RR (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrixdl(int data)	/* RR (IX+d),L */
@@ -2782,7 +2782,7 @@ static int op_undoc_rrixdl(int data)	/* RR (IX+d),L */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2796,7 +2796,7 @@ static int op_undoc_rrixdl(int data)	/* RR (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaixda(int data)	/* SLA (IX+d),A */
@@ -2805,7 +2805,7 @@ static int op_undoc_slaixda(int data)	/* SLA (IX+d),A */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2817,7 +2817,7 @@ static int op_undoc_slaixda(int data)	/* SLA (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaixdb(int data)	/* SLA (IX+d),B */
@@ -2826,7 +2826,7 @@ static int op_undoc_slaixdb(int data)	/* SLA (IX+d),B */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2838,7 +2838,7 @@ static int op_undoc_slaixdb(int data)	/* SLA (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaixdc(int data)	/* SLA (IX+d),C */
@@ -2847,7 +2847,7 @@ static int op_undoc_slaixdc(int data)	/* SLA (IX+d),C */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2859,7 +2859,7 @@ static int op_undoc_slaixdc(int data)	/* SLA (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaixdd(int data)	/* SLA (IX+d),D */
@@ -2868,7 +2868,7 @@ static int op_undoc_slaixdd(int data)	/* SLA (IX+d),D */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2880,7 +2880,7 @@ static int op_undoc_slaixdd(int data)	/* SLA (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaixde(int data)	/* SLA (IX+d),E */
@@ -2889,7 +2889,7 @@ static int op_undoc_slaixde(int data)	/* SLA (IX+d),E */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2901,7 +2901,7 @@ static int op_undoc_slaixde(int data)	/* SLA (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaixdh(int data)	/* SLA (IX+d),H */
@@ -2910,7 +2910,7 @@ static int op_undoc_slaixdh(int data)	/* SLA (IX+d),H */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2922,7 +2922,7 @@ static int op_undoc_slaixdh(int data)	/* SLA (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaixdl(int data)	/* SLA (IX+d),L */
@@ -2931,7 +2931,7 @@ static int op_undoc_slaixdl(int data)	/* SLA (IX+d),L */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2943,7 +2943,7 @@ static int op_undoc_slaixdl(int data)	/* SLA (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraixda(int data)	/* SRA (IX+d),A */
@@ -2953,7 +2953,7 @@ static int op_undoc_sraixda(int data)	/* SRA (IX+d),A */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2966,7 +2966,7 @@ static int op_undoc_sraixda(int data)	/* SRA (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraixdb(int data)	/* SRA (IX+d),B */
@@ -2976,7 +2976,7 @@ static int op_undoc_sraixdb(int data)	/* SRA (IX+d),B */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -2989,7 +2989,7 @@ static int op_undoc_sraixdb(int data)	/* SRA (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraixdc(int data)	/* SRA (IX+d),C */
@@ -2999,7 +2999,7 @@ static int op_undoc_sraixdc(int data)	/* SRA (IX+d),C */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3012,7 +3012,7 @@ static int op_undoc_sraixdc(int data)	/* SRA (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraixdd(int data)	/* SRA (IX+d),D */
@@ -3022,7 +3022,7 @@ static int op_undoc_sraixdd(int data)	/* SRA (IX+d),D */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3035,7 +3035,7 @@ static int op_undoc_sraixdd(int data)	/* SRA (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraixde(int data)	/* SRA (IX+d),E */
@@ -3045,7 +3045,7 @@ static int op_undoc_sraixde(int data)	/* SRA (IX+d),E */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3058,7 +3058,7 @@ static int op_undoc_sraixde(int data)	/* SRA (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraixdh(int data)	/* SRA (IX+d),H */
@@ -3068,7 +3068,7 @@ static int op_undoc_sraixdh(int data)	/* SRA (IX+d),H */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3081,7 +3081,7 @@ static int op_undoc_sraixdh(int data)	/* SRA (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraixdl(int data)	/* SRA (IX+d),L */
@@ -3091,7 +3091,7 @@ static int op_undoc_sraixdl(int data)	/* SRA (IX+d),L */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3104,7 +3104,7 @@ static int op_undoc_sraixdl(int data)	/* SRA (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sllixda(int data)	/* SLL (IX+d),A */
@@ -3113,7 +3113,7 @@ static int op_undoc_sllixda(int data)	/* SLL (IX+d),A */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3125,7 +3125,7 @@ static int op_undoc_sllixda(int data)	/* SLL (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sllixdb(int data)	/* SLL (IX+d),B */
@@ -3134,7 +3134,7 @@ static int op_undoc_sllixdb(int data)	/* SLL (IX+d),B */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3146,7 +3146,7 @@ static int op_undoc_sllixdb(int data)	/* SLL (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sllixdc(int data)	/* SLL (IX+d),C */
@@ -3155,7 +3155,7 @@ static int op_undoc_sllixdc(int data)	/* SLL (IX+d),C */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3167,7 +3167,7 @@ static int op_undoc_sllixdc(int data)	/* SLL (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sllixdd(int data)	/* SLL (IX+d),D */
@@ -3176,7 +3176,7 @@ static int op_undoc_sllixdd(int data)	/* SLL (IX+d),D */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3188,7 +3188,7 @@ static int op_undoc_sllixdd(int data)	/* SLL (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sllixde(int data)	/* SLL (IX+d),E */
@@ -3197,7 +3197,7 @@ static int op_undoc_sllixde(int data)	/* SLL (IX+d),E */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3209,7 +3209,7 @@ static int op_undoc_sllixde(int data)	/* SLL (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sllixdh(int data)	/* SLL (IX+d),H */
@@ -3218,7 +3218,7 @@ static int op_undoc_sllixdh(int data)	/* SLL (IX+d),H */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3230,7 +3230,7 @@ static int op_undoc_sllixdh(int data)	/* SLL (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sllixdl(int data)	/* SLL (IX+d),L */
@@ -3239,7 +3239,7 @@ static int op_undoc_sllixdl(int data)	/* SLL (IX+d),L */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3251,7 +3251,7 @@ static int op_undoc_sllixdl(int data)	/* SLL (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sllixd(int data)	/* SLL (IX+d) */
@@ -3261,7 +3261,7 @@ static int op_undoc_sllixd(int data)	/* SLL (IX+d) */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3273,7 +3273,7 @@ static int op_undoc_sllixd(int data)	/* SLL (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srlixda(int data)	/* SRL (IX+d),A */
@@ -3282,7 +3282,7 @@ static int op_undoc_srlixda(int data)	/* SRL (IX+d),A */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3294,7 +3294,7 @@ static int op_undoc_srlixda(int data)	/* SRL (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srlixdb(int data)	/* SRL (IX+d),B */
@@ -3303,7 +3303,7 @@ static int op_undoc_srlixdb(int data)	/* SRL (IX+d),B */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3315,7 +3315,7 @@ static int op_undoc_srlixdb(int data)	/* SRL (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srlixdc(int data)	/* SRL (IX+d),C */
@@ -3324,7 +3324,7 @@ static int op_undoc_srlixdc(int data)	/* SRL (IX+d),C */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3336,7 +3336,7 @@ static int op_undoc_srlixdc(int data)	/* SRL (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srlixdd(int data)	/* SRL (IX+d),D */
@@ -3345,7 +3345,7 @@ static int op_undoc_srlixdd(int data)	/* SRL (IX+d),D */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3357,7 +3357,7 @@ static int op_undoc_srlixdd(int data)	/* SRL (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srlixde(int data)	/* SRL (IX+d),E */
@@ -3366,7 +3366,7 @@ static int op_undoc_srlixde(int data)	/* SRL (IX+d),E */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3378,7 +3378,7 @@ static int op_undoc_srlixde(int data)	/* SRL (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srlixdh(int data)	/* SRL (IX+d),H */
@@ -3387,7 +3387,7 @@ static int op_undoc_srlixdh(int data)	/* SRL (IX+d),H */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3399,7 +3399,7 @@ static int op_undoc_srlixdh(int data)	/* SRL (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srlixdl(int data)	/* SRL (IX+d),L */
@@ -3408,7 +3408,7 @@ static int op_undoc_srlixdl(int data)	/* SRL (IX+d),L */
 
 	if (u_flag) {
 		trap_ddcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IX + data;
@@ -3420,7 +3420,7 @@ static int op_undoc_srlixdl(int data)	/* SRL (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 #endif

--- a/z80core/sim7.c
+++ b/z80core/sim7.c
@@ -373,7 +373,7 @@ int op_fdcb_handle(void)
 	d = (signed char) memrdr(PC++);
 	t = (*op_fdcb[memrdr(PC++)]) (d); /* execute next opcode */
 
-	return(t);
+	return (t);
 }
 
 /*
@@ -386,7 +386,7 @@ static int trap_fdcb(int data)
 
 	cpu_error = OPTRAP4;
 	cpu_state = STOPPED;
-	return(0);
+	return (0);
 }
 
 static int op_tb0iyd(int data)		/* BIT 0,(IY+d) */
@@ -395,7 +395,7 @@ static int op_tb0iyd(int data)		/* BIT 0,(IY+d) */
 	F |= H_FLAG;
 	(memrdr(IY + data) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 				: (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb1iyd(int data)		/* BIT 1,(IY+d) */
@@ -404,7 +404,7 @@ static int op_tb1iyd(int data)		/* BIT 1,(IY+d) */
 	F |= H_FLAG;
 	(memrdr(IY + data) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 				: (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb2iyd(int data)		/* BIT 2,(IY+d) */
@@ -413,7 +413,7 @@ static int op_tb2iyd(int data)		/* BIT 2,(IY+d) */
 	F |= H_FLAG;
 	(memrdr(IY + data) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 				: (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb3iyd(int data)		/* BIT 3,(IY+d) */
@@ -422,7 +422,7 @@ static int op_tb3iyd(int data)		/* BIT 3,(IY+d) */
 	F |= H_FLAG;
 	(memrdr(IY + data) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 				: (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb4iyd(int data)		/* BIT 4,(IY+d) */
@@ -431,7 +431,7 @@ static int op_tb4iyd(int data)		/* BIT 4,(IY+d) */
 	F |= H_FLAG;
 	(memrdr(IY + data) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 				 : (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb5iyd(int data)		/* BIT 5,(IY+d) */
@@ -440,7 +440,7 @@ static int op_tb5iyd(int data)		/* BIT 5,(IY+d) */
 	F |= H_FLAG;
 	(memrdr(IY + data) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 				 : (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb6iyd(int data)		/* BIT 6,(IY+d) */
@@ -449,7 +449,7 @@ static int op_tb6iyd(int data)		/* BIT 6,(IY+d) */
 	F |= H_FLAG;
 	(memrdr(IY + data) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 				 : (F |= (Z_FLAG | P_FLAG));
-	return(20);
+	return (20);
 }
 
 static int op_tb7iyd(int data)		/* BIT 7,(IY+d) */
@@ -463,103 +463,103 @@ static int op_tb7iyd(int data)		/* BIT 7,(IY+d) */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
-	return(20);
+	return (20);
 }
 
 static int op_rb0iyd(int data)		/* RES 0,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) & ~1);
-	return(23);
+	return (23);
 }
 
 static int op_rb1iyd(int data)		/* RES 1,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) & ~2);
-	return(23);
+	return (23);
 }
 
 static int op_rb2iyd(int data)		/* RES 2,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) & ~4);
-	return(23);
+	return (23);
 }
 
 static int op_rb3iyd(int data)		/* RES 3,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) & ~8);
-	return(23);
+	return (23);
 }
 
 static int op_rb4iyd(int data)		/* RES 4,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) & ~16);
-	return(23);
+	return (23);
 }
 
 static int op_rb5iyd(int data)		/* RES 5,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) & ~32);
-	return(23);
+	return (23);
 }
 
 static int op_rb6iyd(int data)		/* RES 6,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) & ~64);
-	return(23);
+	return (23);
 }
 
 static int op_rb7iyd(int data)		/* RES 7,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) & ~128);
-	return(23);
+	return (23);
 }
 
 static int op_sb0iyd(int data)		/* SET 0,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) | 1);
-	return(23);
+	return (23);
 }
 
 static int op_sb1iyd(int data)		/* SET 1,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) | 2);
-	return(23);
+	return (23);
 }
 
 static int op_sb2iyd(int data)		/* SET 2,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) | 4);
-	return(23);
+	return (23);
 }
 
 static int op_sb3iyd(int data)		/* SET 3,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) | 8);
-	return(23);
+	return (23);
 }
 
 static int op_sb4iyd(int data)		/* SET 4,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) | 16);
-	return(23);
+	return (23);
 }
 
 static int op_sb5iyd(int data)		/* SET 5,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) | 32);
-	return(23);
+	return (23);
 }
 
 static int op_sb6iyd(int data)		/* SET 6,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) | 64);
-	return(23);
+	return (23);
 }
 
 static int op_sb7iyd(int data)		/* SET 7,(IY+d) */
 {
 	memwrt(IY + data, memrdr(IY + data) | 128);
-	return(23);
+	return (23);
 }
 
 static int op_rlciyd(int data)		/* RLC (IY+d) */
@@ -579,7 +579,7 @@ static int op_rlciyd(int data)		/* RLC (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_rrciyd(int data)		/* RRC (IY+d) */
@@ -599,7 +599,7 @@ static int op_rrciyd(int data)		/* RRC (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_rliyd(int data)		/* RL (IY+d) */
@@ -619,7 +619,7 @@ static int op_rliyd(int data)		/* RL (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_rriyd(int data)		/* RR (IY+d) */
@@ -639,7 +639,7 @@ static int op_rriyd(int data)		/* RR (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_slaiyd(int data)		/* SLA (IY+d) */
@@ -656,7 +656,7 @@ static int op_slaiyd(int data)		/* SLA (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_sraiyd(int data)		/* SRA (IY+d) */
@@ -675,7 +675,7 @@ static int op_sraiyd(int data)		/* SRA (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_srliyd(int data)		/* SRL (IY+d) */
@@ -692,7 +692,7 @@ static int op_srliyd(int data)		/* SRL (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 /**********************************************************************/
@@ -707,1424 +707,1424 @@ static int op_undoc_tb0iyd(int data)	/* BIT 0,(IY+d) */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb0iyd(data));
+	return (op_tb0iyd(data));
 }
 
 static int op_undoc_tb1iyd(int data)	/* BIT 1,(IY+d) */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb1iyd(data));
+	return (op_tb1iyd(data));
 }
 
 static int op_undoc_tb2iyd(int data)	/* BIT 2,(IY+d) */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb2iyd(data));
+	return (op_tb2iyd(data));
 }
 
 static int op_undoc_tb3iyd(int data)	/* BIT 3,(IY+d) */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb3iyd(data));
+	return (op_tb3iyd(data));
 }
 
 static int op_undoc_tb4iyd(int data)	/* BIT 4,(IY+d) */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb4iyd(data));
+	return (op_tb4iyd(data));
 }
 
 static int op_undoc_tb5iyd(int data)	/* BIT 5,(IY+d) */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb5iyd(data));
+	return (op_tb5iyd(data));
 }
 
 static int op_undoc_tb6iyd(int data)	/* BIT 6,(IY+d) */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb6iyd(data));
+	return (op_tb6iyd(data));
 }
 
 static int op_undoc_tb7iyd(int data)	/* BIT 7,(IY+d) */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
-	return(op_tb7iyd(data));
+	return (op_tb7iyd(data));
 }
 
 static int op_undoc_rb0iyda(int data)	/* RES 0,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) & ~1;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1iyda(int data)	/* RES 1,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) & ~2;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2iyda(int data)	/* RES 2,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) & ~4;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3iyda(int data)	/* RES 3,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) & ~8;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4iyda(int data)	/* RES 4,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) & ~16;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5iyda(int data)	/* RES 5,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) & ~32;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6iyda(int data)	/* RES 6,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) & ~64;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7iyda(int data)	/* RES 7,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) & ~128;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0iydb(int data)	/* RES 0,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) & ~1;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1iydb(int data)	/* RES 1,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) & ~2;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2iydb(int data)	/* RES 2,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) & ~4;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3iydb(int data)	/* RES 3,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) & ~8;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4iydb(int data)	/* RES 4,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) & ~16;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5iydb(int data)	/* RES 5,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) & ~32;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6iydb(int data)	/* RES 6,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) & ~64;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7iydb(int data)	/* RES 7,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) & ~128;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0iydc(int data)	/* RES 0,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) & ~1;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1iydc(int data)	/* RES 1,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) & ~2;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2iydc(int data)	/* RES 2,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) & ~4;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3iydc(int data)	/* RES 3,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) & ~8;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4iydc(int data)	/* RES 4,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) & ~16;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5iydc(int data)	/* RES 5,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) & ~32;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6iydc(int data)	/* RES 6,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) & ~64;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7iydc(int data)	/* RES 7,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) & ~128;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0iydd(int data)	/* RES 0,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) & ~1;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1iydd(int data)	/* RES 1,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) & ~2;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2iydd(int data)	/* RES 2,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) & ~4;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3iydd(int data)	/* RES 3,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) & ~8;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4iydd(int data)	/* RES 4,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) & ~16;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5iydd(int data)	/* RES 5,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) & ~32;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6iydd(int data)	/* RES 6,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) & ~64;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7iydd(int data)	/* RES 7,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) & ~128;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0iyde(int data)	/* RES 0,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) & ~1;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1iyde(int data)	/* RES 1,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) & ~2;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2iyde(int data)	/* RES 2,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) & ~4;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3iyde(int data)	/* RES 3,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) & ~8;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4iyde(int data)	/* RES 4,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) & ~16;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5iyde(int data)	/* RES 5,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) & ~32;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6iyde(int data)	/* RES 6,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) & ~64;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7iyde(int data)	/* RES 7,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) & ~128;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0iydh(int data)	/* RES 0,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) & ~1;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1iydh(int data)	/* RES 1,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) & ~2;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2iydh(int data)	/* RES 2,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) & ~4;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3iydh(int data)	/* RES 3,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) & ~8;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4iydh(int data)	/* RES 4,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) & ~16;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5iydh(int data)	/* RES 5,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) & ~32;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6iydh(int data)	/* RES 6,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) & ~64;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7iydh(int data)	/* RES 7,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) & ~128;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb0iydl(int data)	/* RES 0,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) & ~1;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb1iydl(int data)	/* RES 1,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) & ~2;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb2iydl(int data)	/* RES 2,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) & ~4;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb3iydl(int data)	/* RES 3,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) & ~8;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb4iydl(int data)	/* RES 4,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) & ~16;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb5iydl(int data)	/* RES 5,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) & ~32;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb6iydl(int data)	/* RES 6,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) & ~64;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rb7iydl(int data)	/* RES 7,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) & ~128;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0iyda(int data)	/* SET 0,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) | 1;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1iyda(int data)	/* SET 1,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) | 2;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2iyda(int data)	/* SET 2,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) | 4;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3iyda(int data)	/* SET 3,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) | 8;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4iyda(int data)	/* SET 4,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) | 16;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5iyda(int data)	/* SET 5,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) | 32;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6iyda(int data)	/* SET 6,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) | 64;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7iyda(int data)	/* SET 7,(IY+d),A */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	A = memrdr(IY + data) | 128;
 	memwrt(IY + data, A);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0iydb(int data)	/* SET 0,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) | 1;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1iydb(int data)	/* SET 1,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) | 2;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2iydb(int data)	/* SET 2,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) | 4;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3iydb(int data)	/* SET 3,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) | 8;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4iydb(int data)	/* SET 4,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) | 16;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5iydb(int data)	/* SET 5,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) | 32;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6iydb(int data)	/* SET 6,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) | 64;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7iydb(int data)	/* SET 7,(IY+d),B */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	B = memrdr(IY + data) | 128;
 	memwrt(IY + data, B);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0iydc(int data)	/* SET 0,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) | 1;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1iydc(int data)	/* SET 1,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) | 2;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2iydc(int data)	/* SET 2,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) | 4;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3iydc(int data)	/* SET 3,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) | 8;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4iydc(int data)	/* SET 4,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) | 16;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5iydc(int data)	/* SET 5,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) | 32;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6iydc(int data)	/* SET 6,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) | 64;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7iydc(int data)	/* SET 7,(IY+d),C */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	C = memrdr(IY + data) | 128;
 	memwrt(IY + data, C);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0iydd(int data)	/* SET 0,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) | 1;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1iydd(int data)	/* SET 1,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) | 2;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2iydd(int data)	/* SET 2,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) | 4;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3iydd(int data)	/* SET 3,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) | 8;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4iydd(int data)	/* SET 4,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) | 16;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5iydd(int data)	/* SET 5,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) | 32;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6iydd(int data)	/* SET 6,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) | 64;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7iydd(int data)	/* SET 7,(IY+d),D */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	D = memrdr(IY + data) | 128;
 	memwrt(IY + data, D);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0iyde(int data)	/* SET 0,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) | 1;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1iyde(int data)	/* SET 1,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) | 2;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2iyde(int data)	/* SET 2,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) | 4;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3iyde(int data)	/* SET 3,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) | 8;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4iyde(int data)	/* SET 4,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) | 16;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5iyde(int data)	/* SET 5,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) | 32;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6iyde(int data)	/* SET 6,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) | 64;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7iyde(int data)	/* SET 7,(IY+d),E */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	E = memrdr(IY + data) | 128;
 	memwrt(IY + data, E);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0iydh(int data)	/* SET 0,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) | 1;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1iydh(int data)	/* SET 1,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) | 2;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2iydh(int data)	/* SET 2,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) | 4;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3iydh(int data)	/* SET 3,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) | 8;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4iydh(int data)	/* SET 4,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) | 16;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5iydh(int data)	/* SET 5,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) | 32;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6iydh(int data)	/* SET 6,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) | 64;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7iydh(int data)	/* SET 7,(IY+d),H */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	H = memrdr(IY + data) | 128;
 	memwrt(IY + data, H);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb0iydl(int data)	/* SET 0,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) | 1;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb1iydl(int data)	/* SET 1,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) | 2;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb2iydl(int data)	/* SET 2,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) | 4;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb3iydl(int data)	/* SET 3,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) | 8;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb4iydl(int data)	/* SET 4,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) | 16;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb5iydl(int data)	/* SET 5,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) | 32;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb6iydl(int data)	/* SET 6,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) | 64;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sb7iydl(int data)	/* SET 7,(IY+d),L */
 {
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	L = memrdr(IY + data) | 128;
 	memwrt(IY + data, L);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlciyda(int data)	/* RLC (IY+d),A */
@@ -2134,7 +2134,7 @@ static int op_undoc_rlciyda(int data)	/* RLC (IY+d),A */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2148,7 +2148,7 @@ static int op_undoc_rlciyda(int data)	/* RLC (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlciydb(int data)	/* RLC (IY+d),B */
@@ -2158,7 +2158,7 @@ static int op_undoc_rlciydb(int data)	/* RLC (IY+d),B */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2172,7 +2172,7 @@ static int op_undoc_rlciydb(int data)	/* RLC (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlciydc(int data)	/* RLC (IY+d),C */
@@ -2182,7 +2182,7 @@ static int op_undoc_rlciydc(int data)	/* RLC (IY+d),C */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2196,7 +2196,7 @@ static int op_undoc_rlciydc(int data)	/* RLC (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlciydd(int data)	/* RLC (IY+d),D */
@@ -2206,7 +2206,7 @@ static int op_undoc_rlciydd(int data)	/* RLC (IY+d),D */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2220,7 +2220,7 @@ static int op_undoc_rlciydd(int data)	/* RLC (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlciyde(int data)	/* RLC (IY+d),E */
@@ -2230,7 +2230,7 @@ static int op_undoc_rlciyde(int data)	/* RLC (IY+d),E */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2244,7 +2244,7 @@ static int op_undoc_rlciyde(int data)	/* RLC (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlciydh(int data)	/* RLC (IY+d),H */
@@ -2254,7 +2254,7 @@ static int op_undoc_rlciydh(int data)	/* RLC (IY+d),H */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2268,7 +2268,7 @@ static int op_undoc_rlciydh(int data)	/* RLC (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rlciydl(int data)	/* RLC (IY+d),L */
@@ -2278,7 +2278,7 @@ static int op_undoc_rlciydl(int data)	/* RLC (IY+d),L */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2292,7 +2292,7 @@ static int op_undoc_rlciydl(int data)	/* RLC (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrciyda(int data)	/* RRC (IY+d),A */
@@ -2302,7 +2302,7 @@ static int op_undoc_rrciyda(int data)	/* RRC (IY+d),A */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2316,7 +2316,7 @@ static int op_undoc_rrciyda(int data)	/* RRC (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrciydb(int data)	/* RRC (IY+d),B */
@@ -2326,7 +2326,7 @@ static int op_undoc_rrciydb(int data)	/* RRC (IY+d),B */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2340,7 +2340,7 @@ static int op_undoc_rrciydb(int data)	/* RRC (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrciydc(int data)	/* RRC (IY+d),C */
@@ -2350,7 +2350,7 @@ static int op_undoc_rrciydc(int data)	/* RRC (IY+d),C */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2364,7 +2364,7 @@ static int op_undoc_rrciydc(int data)	/* RRC (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrciydd(int data)	/* RRC (IY+d),D */
@@ -2374,7 +2374,7 @@ static int op_undoc_rrciydd(int data)	/* RRC (IY+d),D */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2388,7 +2388,7 @@ static int op_undoc_rrciydd(int data)	/* RRC (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrciyde(int data)	/* RRC (IY+d),E */
@@ -2398,7 +2398,7 @@ static int op_undoc_rrciyde(int data)	/* RRC (IY+d),E */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2412,7 +2412,7 @@ static int op_undoc_rrciyde(int data)	/* RRC (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrciydh(int data)	/* RRC (IY+d),H */
@@ -2422,7 +2422,7 @@ static int op_undoc_rrciydh(int data)	/* RRC (IY+d),H */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2436,7 +2436,7 @@ static int op_undoc_rrciydh(int data)	/* RRC (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rrciydl(int data)	/* RRC (IY+d),L */
@@ -2446,7 +2446,7 @@ static int op_undoc_rrciydl(int data)	/* RRC (IY+d),L */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2460,7 +2460,7 @@ static int op_undoc_rrciydl(int data)	/* RRC (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rliyda(int data)	/* RL (IY+d),A */
@@ -2470,7 +2470,7 @@ static int op_undoc_rliyda(int data)	/* RL (IY+d),A */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2484,7 +2484,7 @@ static int op_undoc_rliyda(int data)	/* RL (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rliydb(int data)	/* RL (IY+d),B */
@@ -2494,7 +2494,7 @@ static int op_undoc_rliydb(int data)	/* RL (IY+d),B */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2508,7 +2508,7 @@ static int op_undoc_rliydb(int data)	/* RL (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rliydc(int data)	/* RL (IY+d),C */
@@ -2518,7 +2518,7 @@ static int op_undoc_rliydc(int data)	/* RL (IY+d),C */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2532,7 +2532,7 @@ static int op_undoc_rliydc(int data)	/* RL (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rliydd(int data)	/* RL (IY+d),D */
@@ -2542,7 +2542,7 @@ static int op_undoc_rliydd(int data)	/* RL (IY+d),D */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2556,7 +2556,7 @@ static int op_undoc_rliydd(int data)	/* RL (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rliyde(int data)	/* RL (IY+d),E */
@@ -2566,7 +2566,7 @@ static int op_undoc_rliyde(int data)	/* RL (IY+d),E */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2580,7 +2580,7 @@ static int op_undoc_rliyde(int data)	/* RL (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rliydh(int data)	/* RL (IY+d),H */
@@ -2590,7 +2590,7 @@ static int op_undoc_rliydh(int data)	/* RL (IY+d),H */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2604,7 +2604,7 @@ static int op_undoc_rliydh(int data)	/* RL (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rliydl(int data)	/* RL (IY+d),L */
@@ -2614,7 +2614,7 @@ static int op_undoc_rliydl(int data)	/* RL (IY+d),L */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2628,7 +2628,7 @@ static int op_undoc_rliydl(int data)	/* RL (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rriyda(int data)	/* RR (IY+d),A */
@@ -2638,7 +2638,7 @@ static int op_undoc_rriyda(int data)	/* RR (IY+d),A */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2652,7 +2652,7 @@ static int op_undoc_rriyda(int data)	/* RR (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rriydb(int data)	/* RR (IY+d),B */
@@ -2662,7 +2662,7 @@ static int op_undoc_rriydb(int data)	/* RR (IY+d),B */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2676,7 +2676,7 @@ static int op_undoc_rriydb(int data)	/* RR (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rriydc(int data)	/* RR (IY+d),C */
@@ -2686,7 +2686,7 @@ static int op_undoc_rriydc(int data)	/* RR (IY+d),C */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2700,7 +2700,7 @@ static int op_undoc_rriydc(int data)	/* RR (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rriydd(int data)	/* RR (IY+d),D */
@@ -2710,7 +2710,7 @@ static int op_undoc_rriydd(int data)	/* RR (IY+d),D */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2724,7 +2724,7 @@ static int op_undoc_rriydd(int data)	/* RR (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rriyde(int data)	/* RR (IY+d),E */
@@ -2734,7 +2734,7 @@ static int op_undoc_rriyde(int data)	/* RR (IY+d),E */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2748,7 +2748,7 @@ static int op_undoc_rriyde(int data)	/* RR (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rriydh(int data)	/* RR (IY+d),H */
@@ -2758,7 +2758,7 @@ static int op_undoc_rriydh(int data)	/* RR (IY+d),H */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2772,7 +2772,7 @@ static int op_undoc_rriydh(int data)	/* RR (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_rriydl(int data)	/* RR (IY+d),L */
@@ -2782,7 +2782,7 @@ static int op_undoc_rriydl(int data)	/* RR (IY+d),L */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2796,7 +2796,7 @@ static int op_undoc_rriydl(int data)	/* RR (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaiyda(int data)	/* SLA (IY+d),A */
@@ -2805,7 +2805,7 @@ static int op_undoc_slaiyda(int data)	/* SLA (IY+d),A */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2817,7 +2817,7 @@ static int op_undoc_slaiyda(int data)	/* SLA (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaiydb(int data)	/* SLA (IY+d),B */
@@ -2826,7 +2826,7 @@ static int op_undoc_slaiydb(int data)	/* SLA (IY+d),B */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2838,7 +2838,7 @@ static int op_undoc_slaiydb(int data)	/* SLA (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaiydc(int data)	/* SLA (IY+d),C */
@@ -2847,7 +2847,7 @@ static int op_undoc_slaiydc(int data)	/* SLA (IY+d),C */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2859,7 +2859,7 @@ static int op_undoc_slaiydc(int data)	/* SLA (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaiydd(int data)	/* SLA (IY+d),D */
@@ -2868,7 +2868,7 @@ static int op_undoc_slaiydd(int data)	/* SLA (IY+d),D */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2880,7 +2880,7 @@ static int op_undoc_slaiydd(int data)	/* SLA (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaiyde(int data)	/* SLA (IY+d),E */
@@ -2889,7 +2889,7 @@ static int op_undoc_slaiyde(int data)	/* SLA (IY+d),E */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2901,7 +2901,7 @@ static int op_undoc_slaiyde(int data)	/* SLA (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaiydh(int data)	/* SLA (IY+d),H */
@@ -2910,7 +2910,7 @@ static int op_undoc_slaiydh(int data)	/* SLA (IY+d),H */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2922,7 +2922,7 @@ static int op_undoc_slaiydh(int data)	/* SLA (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slaiydl(int data)	/* SLA (IY+d),L */
@@ -2931,7 +2931,7 @@ static int op_undoc_slaiydl(int data)	/* SLA (IY+d),L */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2943,7 +2943,7 @@ static int op_undoc_slaiydl(int data)	/* SLA (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraiyda(int data)	/* SRA (IY+d),A */
@@ -2953,7 +2953,7 @@ static int op_undoc_sraiyda(int data)	/* SRA (IY+d),A */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2966,7 +2966,7 @@ static int op_undoc_sraiyda(int data)	/* SRA (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraiydb(int data)	/* SRA (IY+d),B */
@@ -2976,7 +2976,7 @@ static int op_undoc_sraiydb(int data)	/* SRA (IY+d),B */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -2989,7 +2989,7 @@ static int op_undoc_sraiydb(int data)	/* SRA (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraiydc(int data)	/* SRA (IY+d),C */
@@ -2999,7 +2999,7 @@ static int op_undoc_sraiydc(int data)	/* SRA (IY+d),C */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3012,7 +3012,7 @@ static int op_undoc_sraiydc(int data)	/* SRA (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraiydd(int data)	/* SRA (IY+d),D */
@@ -3022,7 +3022,7 @@ static int op_undoc_sraiydd(int data)	/* SRA (IY+d),D */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3035,7 +3035,7 @@ static int op_undoc_sraiydd(int data)	/* SRA (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraiyde(int data)	/* SRA (IY+d),E */
@@ -3045,7 +3045,7 @@ static int op_undoc_sraiyde(int data)	/* SRA (IY+d),E */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3058,7 +3058,7 @@ static int op_undoc_sraiyde(int data)	/* SRA (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraiydh(int data)	/* SRA (IY+d),H */
@@ -3068,7 +3068,7 @@ static int op_undoc_sraiydh(int data)	/* SRA (IY+d),H */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3081,7 +3081,7 @@ static int op_undoc_sraiydh(int data)	/* SRA (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_sraiydl(int data)	/* SRA (IY+d),L */
@@ -3091,7 +3091,7 @@ static int op_undoc_sraiydl(int data)	/* SRA (IY+d),L */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3104,7 +3104,7 @@ static int op_undoc_sraiydl(int data)	/* SRA (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slliyda(int data)	/* SLL (IY+d),A */
@@ -3113,7 +3113,7 @@ static int op_undoc_slliyda(int data)	/* SLL (IY+d),A */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3125,7 +3125,7 @@ static int op_undoc_slliyda(int data)	/* SLL (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slliydb(int data)	/* SLL (IY+d),B */
@@ -3134,7 +3134,7 @@ static int op_undoc_slliydb(int data)	/* SLL (IY+d),B */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3146,7 +3146,7 @@ static int op_undoc_slliydb(int data)	/* SLL (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slliydc(int data)	/* SLL (IY+d),C */
@@ -3155,7 +3155,7 @@ static int op_undoc_slliydc(int data)	/* SLL (IY+d),C */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3167,7 +3167,7 @@ static int op_undoc_slliydc(int data)	/* SLL (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slliydd(int data)	/* SLL (IY+d),D */
@@ -3176,7 +3176,7 @@ static int op_undoc_slliydd(int data)	/* SLL (IY+d),D */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3188,7 +3188,7 @@ static int op_undoc_slliydd(int data)	/* SLL (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slliyde(int data)	/* SLL (IY+d),E */
@@ -3197,7 +3197,7 @@ static int op_undoc_slliyde(int data)	/* SLL (IY+d),E */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3209,7 +3209,7 @@ static int op_undoc_slliyde(int data)	/* SLL (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slliydh(int data)	/* SLL (IY+d),H */
@@ -3218,7 +3218,7 @@ static int op_undoc_slliydh(int data)	/* SLL (IY+d),H */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3230,7 +3230,7 @@ static int op_undoc_slliydh(int data)	/* SLL (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slliydl(int data)	/* SLL (IY+d),L */
@@ -3239,7 +3239,7 @@ static int op_undoc_slliydl(int data)	/* SLL (IY+d),L */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3251,7 +3251,7 @@ static int op_undoc_slliydl(int data)	/* SLL (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_slliyd(int data)	/* SLL (IY+d) */
@@ -3261,7 +3261,7 @@ static int op_undoc_slliyd(int data)	/* SLL (IY+d) */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3273,7 +3273,7 @@ static int op_undoc_slliyd(int data)	/* SLL (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srliyda(int data)	/* SRL (IY+d),A */
@@ -3282,7 +3282,7 @@ static int op_undoc_srliyda(int data)	/* SRL (IY+d),A */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3294,7 +3294,7 @@ static int op_undoc_srliyda(int data)	/* SRL (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srliydb(int data)	/* SRL (IY+d),B */
@@ -3303,7 +3303,7 @@ static int op_undoc_srliydb(int data)	/* SRL (IY+d),B */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3315,7 +3315,7 @@ static int op_undoc_srliydb(int data)	/* SRL (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srliydc(int data)	/* SRL (IY+d),C */
@@ -3324,7 +3324,7 @@ static int op_undoc_srliydc(int data)	/* SRL (IY+d),C */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3336,7 +3336,7 @@ static int op_undoc_srliydc(int data)	/* SRL (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srliydd(int data)	/* SRL (IY+d),D */
@@ -3345,7 +3345,7 @@ static int op_undoc_srliydd(int data)	/* SRL (IY+d),D */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3357,7 +3357,7 @@ static int op_undoc_srliydd(int data)	/* SRL (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srliyde(int data)	/* SRL (IY+d),E */
@@ -3366,7 +3366,7 @@ static int op_undoc_srliyde(int data)	/* SRL (IY+d),E */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3378,7 +3378,7 @@ static int op_undoc_srliyde(int data)	/* SRL (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srliydh(int data)	/* SRL (IY+d),H */
@@ -3387,7 +3387,7 @@ static int op_undoc_srliydh(int data)	/* SRL (IY+d),H */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3399,7 +3399,7 @@ static int op_undoc_srliydh(int data)	/* SRL (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 static int op_undoc_srliydl(int data)	/* SRL (IY+d),L */
@@ -3408,7 +3408,7 @@ static int op_undoc_srliydl(int data)	/* SRL (IY+d),L */
 
 	if (u_flag) {
 		trap_fdcb(0);
-		return(0);
+		return (0);
 	}
 
 	addr = IY + data;
@@ -3420,7 +3420,7 @@ static int op_undoc_srliydl(int data)	/* SRL (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	return(23);
+	return (23);
 }
 
 #endif

--- a/z80core/simdis.c
+++ b/z80core/simdis.c
@@ -453,6 +453,7 @@ static void get_opcodes(WORD addr, int len)
 		break;
 	default:
 		sprintf(Opcode_Str, "xx OW OW xx");
+		break;
 	}
 }
 

--- a/z80core/simdis.c
+++ b/z80core/simdis.c
@@ -536,7 +536,7 @@ static int opout(const char *s, WORD a)
 	UNUSED(a);
 
 	strcpy(Disass_Str, s);
-	return(1);
+	return (1);
 }
 
 /*
@@ -545,7 +545,7 @@ static int opout(const char *s, WORD a)
 static int nout(const char *s, WORD a)
 {
 	sprintf(Disass_Str, "%s%02X", s, getmem(a + 1));
-	return(2);
+	return (2);
 }
 
 /*
@@ -554,7 +554,7 @@ static int nout(const char *s, WORD a)
 static int iout(const char *s, WORD a)
 {
 	sprintf(Disass_Str, s, getmem(a + 1));
-	return(2);
+	return (2);
 }
 
 /*
@@ -563,7 +563,7 @@ static int iout(const char *s, WORD a)
 static int rout(const char *s, WORD a)
 {
 	sprintf(Disass_Str, "%s%04X", s, a + (signed char) getmem(a + 1) + 2);
-	return(2);
+	return (2);
 }
 
 /*
@@ -575,7 +575,7 @@ static int nnout(const char *s, WORD a)
 
 	i = getmem(a + 1) + (getmem(a + 2) << 8);
 	sprintf(Disass_Str, "%s%04X", s, i);
-	return(3);
+	return (3);
 }
 
 /*
@@ -587,7 +587,7 @@ static int inout(const char *s, WORD a)
 
 	i = getmem(a + 1) + (getmem(a + 2) << 8);
 	sprintf(Disass_Str, s, i);
-	return(3);
+	return (3);
 }
 
 /*
@@ -606,7 +606,7 @@ static int cbop(const char *s, WORD a)
 	else
 		sprintf(Disass_Str, "%s\t%c,%s",
 			bitins[b2 >> 6], ((b2 >> 3) & 7) + '0', reg[b2 & 7]);
-	return(2);
+	return (2);
 }
 
 /*
@@ -632,7 +632,7 @@ static int edop(const char *s, WORD a)
 		len = (*optabed_5[b2].fun)(optabed_5[b2].text, a + 1);
 	} else						/* undocumented */
 		strcpy(Disass_Str, "NOP*");
-	return(len + 1);
+	return (len + 1);
 }
 
 /*
@@ -664,65 +664,65 @@ static int ddfd(const char *s, WORD a)
 		switch (b2) {
 		case 0x09:
 			sprintf(Disass_Str, "ADD\t%s,BC", ireg[6]);
-			return(2);
+			return (2);
 		case 0x19:
 			sprintf(Disass_Str, "ADD\t%s,DE", ireg[6]);
-			return(2);
+			return (2);
 		case 0x21:
 			sprintf(Disass_Str, "LD\t%s,%04X", ireg[6],
 				getmem(a + 2) + (getmem(a + 3) << 8));
-			return(4);
+			return (4);
 		case 0x22:
 			sprintf(Disass_Str, "LD\t(%04X),%s",
 				getmem(a + 2) + (getmem(a + 3) << 8), ireg[6]);
-			return(4);
+			return (4);
 		case 0x23:
 			sprintf(Disass_Str, "INC\t%s", ireg[6]);
-			return(2);
+			return (2);
 		case 0x24:				/* undocumented */
 			sprintf(Disass_Str, "INC*\t%sH", ireg[6]);
-			return(2);
+			return (2);
 		case 0x25:				/* undocumented */
 			sprintf(Disass_Str, "DEC*\t%sH", ireg[6]);
-			return(2);
+			return (2);
 		case 0x26:				/* undocumented */
 			sprintf(Disass_Str, "LD*\t%sH,%02X", ireg[6],
 				getmem(a + 2));
-			return(3);
+			return (3);
 		case 0x29:
 			sprintf(Disass_Str, "ADD\t%s,%s", ireg[6], ireg[6]);
-			return(2);
+			return (2);
 		case 0x2a:
 			sprintf(Disass_Str, "LD\t%s,(%04X)", ireg[6],
 				getmem(a + 2) + (getmem(a + 3) << 8));
-			return(4);
+			return (4);
 		case 0x2b:
 			sprintf(Disass_Str, "DEC\t%s", ireg[6]);
-			return(2);
+			return (2);
 		case 0x2c:				/* undocumented */
 			sprintf(Disass_Str, "INC*\t%sL", ireg[6]);
-			return(2);
+			return (2);
 		case 0x2d:				/* undocumented */
 			sprintf(Disass_Str, "DEC*\t%sL", ireg[6]);
-			return(2);
+			return (2);
 		case 0x2e:				/* undocumented */
 			sprintf(Disass_Str, "LD*\t%sL,%02X", ireg[6],
 				getmem(a + 2));
-			return(3);
+			return (3);
 		case 0x34:
 			if (off == 0)
 				sprintf(Disass_Str, "INC\t(%s)", ireg[6]);
 			else
 				sprintf(Disass_Str, "INC\t(%s%c%02X)",
 					ireg[6], sign, off);
-			return(3);
+			return (3);
 		case 0x35:
 			if (off == 0)
 				sprintf(Disass_Str, "DEC\t(%s)", ireg[6]);
 			else
 				sprintf(Disass_Str, "DEC\t(%s%c%02X)",
 					ireg[6], sign, off);
-			return(3);
+			return (3);
 		case 0x36:
 			if (off == 0)
 				sprintf(Disass_Str, "LD\t(%s),%02X",
@@ -730,19 +730,19 @@ static int ddfd(const char *s, WORD a)
 			else
 				sprintf(Disass_Str, "LD\t(%s%c%02X),%02X",
 					ireg[6], sign, off, getmem(a + 3));
-			return(4);
+			return (4);
 		case 0x39:
 			sprintf(Disass_Str, "ADD\t%s,SP", ireg[6]);
-			return(2);
+			return (2);
 		default:				/* undocumented */
 			strcpy(Disass_Str, "NOP*");
-			return(1);
+			return (1);
 		}
 	} else if (b2 < 0x80) {
 		if (((r1 < 4 || r1 > 6) && (r2 < 4 || r2 > 6))
 		    || (r1 == 6 && r2 == 6)) {		/* undocumented */
 			strcpy(Disass_Str, "NOP*");
-			return(1);
+			return (1);
 		} else if (r1 == 6) {
 			if (off == 0)
 				sprintf(Disass_Str, "LD\t(%s),%s",
@@ -750,7 +750,7 @@ static int ddfd(const char *s, WORD a)
 			else
 				sprintf(Disass_Str, "LD\t(%s%c%02X),%s",
 					ireg[r1], sign, off, reg[r2]);
-			return(3);
+			return (3);
 		} else if (r2 == 6) {
 			if (off == 0)
 				sprintf(Disass_Str, "LD\t%s,(%s)",
@@ -758,15 +758,15 @@ static int ddfd(const char *s, WORD a)
 			else
 				sprintf(Disass_Str, "LD\t%s,(%s%c%02X)",
 					reg[r1], ireg[r2], sign, off);
-			return(3);
+			return (3);
 		} else {				/* undocumented */
 			sprintf(Disass_Str, "LD*\t%s,%s", ireg[r1], ireg[r2]);
-			return(2);
+			return (2);
 		}
 	} else if (b2 < 0xc0) {
 		if (r2 < 4 || r2 > 6) {			/* undocumented */
 			strcpy(Disass_Str, "NOP*");
-			return(1);
+			return (1);
 		} else if (r2 == 6) {
 			if (off == 0)
 				sprintf(Disass_Str, "%s(%s)", aluins[r1],
@@ -774,10 +774,10 @@ static int ddfd(const char *s, WORD a)
 			else
 				sprintf(Disass_Str, "%s(%s%c%02X)", aluins[r1],
 					ireg[r2], sign, off);
-			return(3);
+			return (3);
 		} else {				/* undocumented */
 			sprintf(Disass_Str, "%s%s", aluinsu[r1], ireg[r2]);
-			return(2);
+			return (2);
 		}
 	} else {
 		switch (b2) {
@@ -847,25 +847,25 @@ static int ddfd(const char *s, WORD a)
 						ireg[6], sign, off,
 						reg[b4 & 7]);
 			}
-			return(4);
+			return (4);
 		case 0xe1:
 			sprintf(Disass_Str, "POP\t%s", ireg[6]);
-			return(2);
+			return (2);
 		case 0xe3:
 			sprintf(Disass_Str, "EX\t(SP),%s", ireg[6]);
-			return(2);
+			return (2);
 		case 0xe5:
 			sprintf(Disass_Str, "PUSH\t%s", ireg[6]);
-			return(2);
+			return (2);
 		case 0xe9:
 			sprintf(Disass_Str, "JP\t(%s)", ireg[6]);
-			return(2);
+			return (2);
 		case 0xf9:
 			sprintf(Disass_Str, "LD\tSP,%s", ireg[6]);
-			return(2);
+			return (2);
 		default:				/* undocumented */
 			strcpy(Disass_Str, "NOP*");
-			return(1);
+			return (1);
 		}
 	}
 }

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -47,7 +47,7 @@ int exatoi(char *str)
 			num += toupper((unsigned char) *str) - '7';
 		str++;
 	}
-	return(num);
+	return (num);
 }
 
 /*
@@ -65,7 +65,7 @@ int getkey(void)
 	tcsetattr(0, TCSADRAIN, &new_term);
 	c = getchar();
 	tcsetattr(0, TCSADRAIN, &old_term);
-	return(c);
+	return (c);
 }
 
 /*
@@ -117,9 +117,9 @@ int time_diff(struct timeval *t1, struct timeval *t2)
 		usec += 1000000L;
 	}
 	if (sec != 0L)
-		return(-1); /* result is to large */
+		return (-1); /* result is to large */
 	else
-		return((int) usec);
+		return ((int) usec);
 }
 
 /*
@@ -141,19 +141,19 @@ int load_file(char *fn, WORD start, int size)
 
 	if (strlen(fn) == 0) {
 		LOGE(TAG, "no input file given");
-		return(1);
+		return (1);
 	}
 
 	if ((fd = open(fn, O_RDONLY)) == -1) {
 		LOGE(TAG, "can't open file %s", fn);
-		return(1);
+		return (1);
 	}
 
 	n = read(fd, (char *) &d, 1);	/* read first byte of file */
 	close(fd);
 	if (n != 1) {
 		LOGE(TAG, "invalid file %s", fn);
-		return(1);
+		return (1);
 	}
 
 	if (size > 0)
@@ -161,9 +161,9 @@ int load_file(char *fn, WORD start, int size)
 		     start, start + size - 1);
 
 	if (d == 0xff) {		/* Mostek header ? */
-		return(load_mos(fn, start, size));
+		return (load_mos(fn, start, size));
 	} else {
-		return(load_hex(fn, start, size));
+		return (load_hex(fn, start, size));
 	}
 }
 
@@ -185,7 +185,7 @@ static int load_mos(char *fn, WORD start, int size)
 
 	if ((fp = fopen(fn, "r")) == NULL) {
 		LOGE(TAG, "can't open file %s", fn);
-		return(1);
+		return (1);
 	}
 
 	/* read load address */
@@ -193,7 +193,7 @@ static int load_mos(char *fn, WORD start, int size)
 	    || (c = getc(fp)) == EOF || (c2 = getc(fp)) == EOF) {
 		LOGE(TAG, "invalid Mostek file %s", fn);
 		fclose(fp);
-		return(1);
+		return (1);
 	}
 	laddr = (c2 << 8) | c;
 
@@ -203,7 +203,7 @@ static int load_mos(char *fn, WORD start, int size)
 		LOGW(TAG, "tried to load Mostek file outside "
 		     "expected address range. Address: %04X", laddr);
 		fclose(fp);
-		return(1);
+		return (1);
 	}
 
 	count = 0;
@@ -214,7 +214,7 @@ static int load_mos(char *fn, WORD start, int size)
 				     "expected address range. "
 				     "Address: %04X", i);
 				fclose(fp);
-				return(1);
+				return (1);
 			}
 			count++;
 			putmem(i, (BYTE) c);
@@ -233,7 +233,7 @@ static int load_mos(char *fn, WORD start, int size)
 	LOG(TAG, "PC    : %04XH\r\n", PC);
 	LOG(TAG, "LOADED: %04XH (%d)\r\n\r\n", count, count);
 
-	return(0);
+	return (0);
 }
 
 /*
@@ -256,7 +256,7 @@ static int load_hex(char *fn, WORD start, int size)
 
 	if ((fp = fopen(fn, "r")) == NULL) {
 		LOGE(TAG, "can't open file %s", fn);
-		return(1);
+		return (1);
 	}
 
 	while (fgets(inbuf, BUFSIZE, fp) != NULL) {
@@ -276,7 +276,7 @@ static int load_hex(char *fn, WORD start, int size)
 				LOGE(TAG, "invalid character in "
 				     "HEX record %s", s0);
 				fclose(fp);
-				return(1);
+				return (1);
 			}
 			*p = (*s <= '9' ? *s - '0' : *s - 'A' + 10) << 4;
 			s++;
@@ -284,14 +284,14 @@ static int load_hex(char *fn, WORD start, int size)
 				LOGE(TAG, "odd number of characters in "
 				     "HEX record %s", s0);
 				fclose(fp);
-				return(1);
+				return (1);
 			}
 			else if (!(*s >= '0' && *s <= '9')
 				 && !(*s >= 'A' && *s <= 'F')) {
 				LOGE(TAG, "invalid character in "
 				     "HEX record %s", s0);
 				fclose(fp);
-				return(1);
+				return (1);
 			}
 			*p |= (*s <= '9' ? *s - '0' : *s - 'A' + 10);
 			s++;
@@ -301,12 +301,12 @@ static int load_hex(char *fn, WORD start, int size)
 		if (n < 5) {
 			LOGE(TAG, "invalid HEX record %s", s0);
 			fclose(fp);
-			return(1);
+			return (1);
 		}
 		if ((chksum & 255) != 0) {
 			LOGE(TAG, "invalid checksum in HEX record %s", s0);
 			fclose(fp);
-			return(1);
+			return (1);
 		}
 
 		p = outbuf;
@@ -314,7 +314,7 @@ static int load_hex(char *fn, WORD start, int size)
 		if (count + 5 != n) {
 			LOGE(TAG, "invalid count in HEX record %s", s0);
 			fclose(fp);
-			return(1);
+			return (1);
 		}
 		addr = *p++;
 		addr = (addr << 8) | *p++;
@@ -329,7 +329,7 @@ static int load_hex(char *fn, WORD start, int size)
 				     "Address: %04X-%04X",
 				     addr, addr + count - 1);
 				fclose(fp);
-				return(1);
+				return (1);
 			}
 		}
 
@@ -354,7 +354,7 @@ static int load_hex(char *fn, WORD start, int size)
 	LOG(TAG, "PC    : %04XH\r\n", PC);
 	LOG(TAG, "LOADED: %04XH (%d)\r\n\r\n", count & 0xffff, count & 0xffff);
 
-	return(0);
+	return (0);
 }
 
 /*

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -182,7 +182,7 @@ static void do_step(void)
 
 	cpu_state = SINGLE_STEP;
 	cpu_error = NONE;
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;
@@ -218,7 +218,7 @@ static void do_trace(char *s)
 	print_head();
 	print_reg();
 	for (i = 0; i < count; i++) {
-		switch(cpu) {
+		switch (cpu) {
 		case Z80:
 			cpu_z80();
 			break;
@@ -254,7 +254,7 @@ static void do_go(char *s)
 cont:
 	cpu_state = CONTIN_RUN;
 	cpu_error = NONE;
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;
@@ -301,7 +301,7 @@ was_softbreak:
 	PC--;				/* substitute HALT opcode by */
 	putmem(PC, soft[i].sb_oldopc);	/* original opcode */
 	cpu_state = SINGLE_STEP;	/* and execute it */
-	switch(cpu) {
+	switch (cpu) {
 	case Z80:
 		cpu_z80();
 		break;
@@ -867,7 +867,7 @@ static void do_clock(void)
 	tim.it_interval.tv_sec = 0;
 	tim.it_interval.tv_usec = 0;
 	setitimer(ITIMER_REAL, &tim, NULL);
-	switch(cpu) {			/* start CPU */
+	switch (cpu) {			/* start CPU */
 	case Z80:
 		cpu_z80();
 		s = "JP";

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -289,7 +289,7 @@ static int handle_break(void)
 	for (i = 0; i < SBSIZE; i++)	/* search for breakpoint */
 		if (soft[i].sb_addr == PC - 1)
 			goto was_softbreak;
-	return(0);
+	return (0);
 was_softbreak:
 #ifdef HISIZE
 	h_next--;			/* correct history */
@@ -312,12 +312,12 @@ was_softbreak:
 	putmem(soft[i].sb_addr, 0x76);	/* restore HALT opcode again */
 	soft[i].sb_passcount++;		/* increment passcounter */
 	if (soft[i].sb_passcount != soft[i].sb_pass)
-		return(1);		/* pass not reached, continue */
+		return (1);		/* pass not reached, continue */
 	printf("Software breakpoint %d reached at %04x\n", i, break_address);
 	soft[i].sb_passcount = 0;	/* reset passcounter */
-	return(0);			/* pass reached, stop */
+	return (0);			/* pass reached, stop */
 #else
-	return(0);
+	return (0);
 #endif
 }
 

--- a/z80sim/srcsim/iosim.c
+++ b/z80sim/srcsim/iosim.c
@@ -94,7 +94,7 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 
 	io_port = addrl;
 	io_data = (*port_in[addrl]) ();
-	return(io_data);
+	return (io_data);
 }
 
 /*
@@ -123,7 +123,7 @@ static BYTE io_trap_in(void)
 		cpu_error = IOTRAPIN;
 		cpu_state = STOPPED;
 	}
-	return((BYTE) 0xff);
+	return ((BYTE) 0xff);
 }
 
 /*
@@ -164,7 +164,7 @@ static BYTE p000_in(void)
 		cpu_error = IOERROR;
 		cpu_state = STOPPED;
 	}
-	return(tty_stat);
+	return (tty_stat);
 }
 
 /*
@@ -173,7 +173,7 @@ static BYTE p000_in(void)
  */
 static BYTE p001_in(void)
 {
-	return((BYTE) getchar());
+	return ((BYTE) getchar());
 }
 
 /*

--- a/z80sim/srcsim/memory.h
+++ b/z80sim/srcsim/memory.h
@@ -25,7 +25,7 @@ static inline void memwrt(WORD addr, BYTE data)
 
 static inline BYTE memrdr(WORD addr)
 {
-	return(memory[addr]);
+	return (memory[addr]);
 }
 
 /*
@@ -38,7 +38,7 @@ static inline void dma_write(WORD addr, BYTE data)
 
 static inline BYTE dma_read(WORD addr)
 {
-	return(memory[addr]);
+	return (memory[addr]);
 }
 
 /*
@@ -51,5 +51,5 @@ static inline void putmem(WORD addr, BYTE data)
 
 static inline BYTE getmem(WORD addr)
 {
-	return(memory[addr]);
+	return (memory[addr]);
 }


### PR DESCRIPTION
These changes may be controversial, but allow the use of formatting tools like "clang-format" or "astyle" to clean-up the code to follow a common coding style. I haven't found a way to tell these tools to have a space after statements like "if", "for", "switch" etc., and not after "return".