### PR TITLE
Move SLEEP_MS() to sim.h and time_diff() to simcore.c

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -48,6 +48,9 @@
 #define NUMNSOC 0	/* number of TCP/IP sockets for SIO connections */
 #define NUMUSOC 2	/* number of UNIX sockets for SIO connections */
 
+extern void do_sleep_ms(int);
+#define SLEEP_MS(t)	do_sleep_ms(t)
+
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -38,6 +38,9 @@
 #undef TCPASYNC		/* SIGIO on BSD sockets not working */
 #endif
 
+extern void do_sleep_ms(int);
+#define SLEEP_MS(t)	do_sleep_ms(t)
+
 /*
  *	Structure for the disk images
  */

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -67,6 +67,9 @@
 #undef TCPASYNC
 #endif
 
+extern void do_sleep_ms(int);
+#define SLEEP_MS(t)	do_sleep_ms(t)
+
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -61,6 +61,9 @@
 #define NUMNSOC 0	/* number of TCP/IP sockets for SIO connections */
 #define NUMUSOC 1	/* number of UNIX sockets for SIO connections */
 
+extern void do_sleep_ms(int);
+#define SLEEP_MS(t)	do_sleep_ms(t)
+
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -29,6 +29,9 @@
 /*#define HAS_DISKS*/	/* not using standard disk define */
 /*#define HAS_CONFIG*/  /* not using standard config define */
 
+extern void do_sleep_ms(int);
+#define SLEEP_MS(t)	do_sleep_ms(t)
+
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/picosim/picosim.c
+++ b/picosim/picosim.c
@@ -19,32 +19,6 @@ extern void init_cpu(void);
 extern void run_cpu(void);
 extern void report_cpu_error(void);
 
-/*
- *	Compute difference between two timeval in microseconds
- *
- *	Note: yes there are timersub() and friends, but not
- *	defined in POSIX.1 and implemented wrong on some
- *	systems. Some systems define tv_usec as unsigned int,
- *	here we assume that a long is longer than unsigned.
- *	If that is not the case cast to (long long).
- */
-int time_diff(struct timeval *t1, struct timeval *t2)
-{
-	long sec, usec;
-
-	sec = (long) t2->tv_sec - (long) t1->tv_sec;
-	usec = (long) t2->tv_usec - (long) t1->tv_usec;
-	/* normalize result */
-	if (usec < 0L) {
-		sec--;
-		usec += 1000000L;
-	}
-	if (sec != 0L)
-		return (-1); /* result is to large */
-	else
-		return ((int) usec);
-}
-
 int main(void)
 {
 	stdio_init_all();	/* initialize Pico stdio */

--- a/picosim/sim.h
+++ b/picosim/sim.h
@@ -12,6 +12,7 @@
 /*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
 #define EXCLUDE_I8080	/* don't include 8080 emulation support */
 
+extern void sleep_ms(unsigned);
 #define SLEEP_MS(t)	sleep_ms(t)
 
 #include "simcore.h"

--- a/picosim/sim.h
+++ b/picosim/sim.h
@@ -12,4 +12,6 @@
 /*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
 #define EXCLUDE_I8080	/* don't include 8080 emulation support */
 
+#define SLEEP_MS(t)	sleep_ms(t)
+
 #include "simcore.h"

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -236,3 +236,29 @@ void end_bus_request(void)
 	dma_bus_master = NULL;
 	bus_request = 0;
 }
+
+/*
+ *	Compute difference between two timeval in microseconds
+ *
+ *	Note: yes there are timersub() and friends, but not
+ *	defined in POSIX.1 and implemented wrong on some
+ *	systems. Some systems define tv_usec as unsigned int,
+ *	here we assume that a long is longer than unsigned.
+ *	If that is not the case cast to (long long).
+ */
+int time_diff(struct timeval *t1, struct timeval *t2)
+{
+	long sec, usec;
+
+	sec = (long) t2->tv_sec - (long) t1->tv_sec;
+	usec = (long) t2->tv_usec - (long) t1->tv_usec;
+	/* normalize result */
+	if (usec < 0L) {
+		sec--;
+		usec += 1000000L;
+	}
+	if (sec != 0L)
+		return (-1); /* result is to large */
+	else
+		return ((int) usec);
+}

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -81,9 +81,6 @@ struct softbreak {		/* structure of a breakpoint */
 };
 #endif
 
-extern void do_sleep_ms(int);
-#define SLEEP_MS(t)	do_sleep_ms(t)
-
 /*
  *	macro for declaring unused function parameters
  */

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -97,32 +97,6 @@ again:
 }
 
 /*
- *	Compute difference between two timeval in microseconds
- *
- *	Note: yes there are timersub() and friends, but not
- *	defined in POSIX.1 and implemented wrong on some
- *	systems. Some systems define tv_usec as unsigned int,
- *	here we assume that a long is longer than unsigned.
- *	If that is not the case cast to (long long).
- */
-int time_diff(struct timeval *t1, struct timeval *t2)
-{
-	long sec, usec;
-
-	sec = (long) t2->tv_sec - (long) t1->tv_sec;
-	usec = (long) t2->tv_usec - (long) t1->tv_usec;
-	/* normalize result */
-	if (usec < 0L) {
-		sec--;
-		usec += 1000000L;
-	}
-	if (sec != 0L)
-		return (-1); /* result is to large */
-	else
-		return ((int) usec);
-}
-
-/*
  *	Read a file into the memory of the emulated CPU.
  *	The following file formats are supported:
  *

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -23,6 +23,9 @@
 /*#define HAS_DISKS*/	/* has no disk drives */
 /*#define HAS_CONFIG*/	/* has no configuration files */
 
+extern void do_sleep_ms(int);
+#define SLEEP_MS(t)	do_sleep_ms(t)
+
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -24,6 +24,9 @@
 /*#define HAS_DISKS*/	/* has no disk drives */
 /*#define HAS_CONFIG*/	/* has no configuration files */
 
+extern void do_sleep_ms(int);
+#define SLEEP_MS(t)	do_sleep_ms(t)
+
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,


### PR DESCRIPTION
The *nix systems use do_sleep_ms() from sim_fun.c for SLEEP_MS(). The Pico uses its native sleep_ms() SDK function.

time_diff() is used by the core simulator code.