### PR TITLE
Tidy-up undocumented instruction support, add full EXCLUDE_* support

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -31,7 +31,7 @@
  */
 #define DEF_CPU I8080	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 2	/* default CPU speed */
-#define Z80_UNDOC	/* compile undocumented Z80 instructions */
+#define UNDOC_INST	/* compile undocumented instructions */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 

--- a/cpmsim/srcsim/memory.h
+++ b/cpmsim/srcsim/memory.h
@@ -44,8 +44,10 @@ static inline void memwrt(WORD addr, BYTE data)
 {
 	if ((addr >= segsize) && (wp_common != 0)) {
 		wp_common |= 0x80;
+#ifndef EXCLUDE_Z80
 		if (wp_common & 0x40)
 			int_nmi = 1;
+#endif
 		return;
 	}
 

--- a/cpmsim/srcsim/memory.h
+++ b/cpmsim/srcsim/memory.h
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2019 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  *
  * This module implements banked memory management for cpmsim
  *

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -10,7 +10,7 @@
  */
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
-#define Z80_UNDOC	/* compile undocumented Z80 instructions */
+#define UNDOC_INST	/* compile undocumented instructions */
 #define WANT_FASTB	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -32,7 +32,7 @@
  */
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 4	/* default CPU speed */
-#define Z80_UNDOC	/* compile undocumented Z80 instructions */
+#define UNDOC_INST	/* compile undocumented instructions */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -31,7 +31,7 @@
  */
 #define DEF_CPU I8080	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 2	/* default CPU speed */
-#define Z80_UNDOC	/* compile undocumented Z80 instructions */
+#define UNDOC_INST	/* compile undocumented instructions */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -19,7 +19,7 @@
  */
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
-#define Z80_UNDOC	/* compile undocumented Z80 instructions */
+#define UNDOC_INST	/* compile undocumented instructions */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 #define EXCLUDE_I8080	/* this was a Z80 machine */

--- a/picosim/sim.h
+++ b/picosim/sim.h
@@ -8,9 +8,9 @@
 
 #define PICO_W		/* board we use, comment for Pico */
 
-#define DEF_CPU Z80     /* default CPU (Z80 or I8080) */
-#define CPU_SPEED 0     /* default CPU speed 0=unlimited */
-#define Z80_UNDOC       /* compile undocumented Z80 instructions */
+#define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
+#define CPU_SPEED 0	/* default CPU speed 0=unlimited */
+#define UNDOC_INST	/* compile undocumented instructions */
 /*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
 #define EXCLUDE_I8080	/* don't include 8080 emulation support */
 

--- a/z80asm/COPYING
+++ b/z80asm/COPYING
@@ -1,6 +1,5 @@
-Copyright (c) 1987-2022 Udo Munk
-Copyright (c) 2016-2017 Didier Derny
-Copyright (c) 2022 Thomas Eberhardt
+Copyright (c) 1987-2024 Udo Munk
+Copyright (c) 2022-2024 Thomas Eberhardt
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -261,7 +261,7 @@ struct sym {
 /*
  *	attribute for declaring that a function doesn't return
  */
-#if __GNUC__ > 2 || __clang__
+#if __GNUC__ > 2 || defined(__clang__)
 #define NORETURN	__attribute__ ((noreturn))
 #else
 #define NORETURN

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -15,6 +15,12 @@
 #endif
 #include "memory.h"
 
+#ifdef UNDOC_INST
+#define UNDOC(f) f
+#else
+#define UNDOC(f) trap_undoc
+#endif
+
 #ifdef WANT_GUI
 extern void check_gui_break(void);
 #endif
@@ -89,8 +95,11 @@ static int op_rz(void), op_rnz(void), op_rc(void), op_rnc(void);
 static int op_rpe(void), op_rpo(void), op_rm(void), op_rp(void);
 static int op_rst0(void), op_rst1(void), op_rst2(void), op_rst3(void);
 static int op_rst4(void), op_rst5(void), op_rst6(void), op_rst7(void);
+
+#ifdef UNDOC_INST
 static int op_undoc_nop(void), op_undoc_jmp(void);
 static int op_undoc_ret(void), op_undoc_call(void);
+#endif
 
 /*
  * Function to update address bus LED's during execution of
@@ -127,7 +136,7 @@ void cpu_8080(void)
 		op_dcrb,			/* 0x05 */
 		op_mvibn,			/* 0x06 */
 		op_rlc,				/* 0x07 */
-		op_undoc_nop,			/* 0x08 */
+		UNDOC(op_undoc_nop),		/* 0x08 */
 		op_dadb,			/* 0x09 */
 		op_ldaxb,			/* 0x0a */
 		op_dcxb,			/* 0x0b */
@@ -135,7 +144,7 @@ void cpu_8080(void)
 		op_dcrc,			/* 0x0d */
 		op_mvicn,			/* 0x0e */
 		op_rrc,				/* 0x0f */
-		op_undoc_nop,			/* 0x10 */
+		UNDOC(op_undoc_nop),		/* 0x10 */
 		op_lxidnn,			/* 0x11 */
 		op_staxd,			/* 0x12 */
 		op_inxd,			/* 0x13 */
@@ -143,7 +152,7 @@ void cpu_8080(void)
 		op_dcrd,			/* 0x15 */
 		op_mvidn,			/* 0x16 */
 		op_ral,				/* 0x17 */
-		op_undoc_nop,			/* 0x18 */
+		UNDOC(op_undoc_nop),		/* 0x18 */
 		op_dadd,			/* 0x19 */
 		op_ldaxd,			/* 0x1a */
 		op_dcxd,			/* 0x1b */
@@ -151,7 +160,7 @@ void cpu_8080(void)
 		op_dcre,			/* 0x1d */
 		op_mvien,			/* 0x1e */
 		op_rar,				/* 0x1f */
-		op_undoc_nop,			/* 0x20 */
+		UNDOC(op_undoc_nop),		/* 0x20 */
 		op_lxihnn,			/* 0x21 */
 		op_shldnn,			/* 0x22 */
 		op_inxh,			/* 0x23 */
@@ -159,7 +168,7 @@ void cpu_8080(void)
 		op_dcrh,			/* 0x25 */
 		op_mvihn,			/* 0x26 */
 		op_daa,				/* 0x27 */
-		op_undoc_nop,			/* 0x28 */
+		UNDOC(op_undoc_nop),		/* 0x28 */
 		op_dadh,			/* 0x29 */
 		op_lhldnn,			/* 0x2a */
 		op_dcxh,			/* 0x2b */
@@ -167,7 +176,7 @@ void cpu_8080(void)
 		op_dcrl,			/* 0x2d */
 		op_mviln,			/* 0x2e */
 		op_cma,				/* 0x2f */
-		op_undoc_nop,			/* 0x30 */
+		UNDOC(op_undoc_nop),		/* 0x30 */
 		op_lxispnn,			/* 0x31 */
 		op_stann,			/* 0x32 */
 		op_inxsp,			/* 0x33 */
@@ -175,7 +184,7 @@ void cpu_8080(void)
 		op_dcrm,			/* 0x35 */
 		op_mvimn,			/* 0x36 */
 		op_stc,				/* 0x37 */
-		op_undoc_nop,			/* 0x38 */
+		UNDOC(op_undoc_nop),		/* 0x38 */
 		op_dadsp,			/* 0x39 */
 		op_ldann,			/* 0x3a */
 		op_dcxsp,			/* 0x3b */
@@ -322,7 +331,7 @@ void cpu_8080(void)
 		op_rz,				/* 0xc8 */
 		op_ret,				/* 0xc9 */
 		op_jz,				/* 0xca */
-		op_undoc_jmp,			/* 0xcb */
+		UNDOC(op_undoc_jmp),		/* 0xcb */
 		op_cz,				/* 0xcc */
 		op_call,			/* 0xcd */
 		op_acin,			/* 0xce */
@@ -336,11 +345,11 @@ void cpu_8080(void)
 		op_suin,			/* 0xd6 */
 		op_rst2,			/* 0xd7 */
 		op_rc,				/* 0xd8 */
-		op_undoc_ret,			/* 0xd9 */
+		UNDOC(op_undoc_ret),		/* 0xd9 */
 		op_jc,				/* 0xda */
 		op_in,				/* 0xdb */
 		op_cc,				/* 0xdc */
-		op_undoc_call,			/* 0xdd */
+		UNDOC(op_undoc_call),		/* 0xdd */
 		op_sbin,			/* 0xde */
 		op_rst3,			/* 0xdf */
 		op_rpo,				/* 0xe0 */
@@ -356,7 +365,7 @@ void cpu_8080(void)
 		op_jpe,				/* 0xea */
 		op_xchg,			/* 0xeb */
 		op_cpe,				/* 0xec */
-		op_undoc_call,			/* 0xed */
+		UNDOC(op_undoc_call),		/* 0xed */
 		op_xrin,			/* 0xee */
 		op_rst5,			/* 0xef */
 		op_rp,				/* 0xf0 */
@@ -372,7 +381,7 @@ void cpu_8080(void)
 		op_jm,				/* 0xfa */
 		op_ei,				/* 0xfb */
 		op_cm,				/* 0xfc */
-		op_undoc_call,			/* 0xfd */
+		UNDOC(op_undoc_call),		/* 0xfd */
 		op_cpin,			/* 0xfe */
 		op_rst7				/* 0xff */
 	};
@@ -581,20 +590,19 @@ leave:
 #endif
 }
 
+/*
+ *	This function traps undocumented opcodes.
+ */
+static int trap_undoc(void)
+{
+	cpu_error = OPTRAP1;
+	cpu_state = STOPPED;
+	return (0);
+}
+
 static int op_nop(void)			/* NOP */
 {
 	return (4);
-}
-
-static int op_undoc_nop(void)		/* Undocumented NOP */
-{
-	if (u_flag) {	/* trap with option -u */
-		cpu_error = OPTRAP1;
-		cpu_state = STOPPED;
-		return (0);
-	} else {	/* else NOP */
-		return (4);
-	}
 }
 
 static int op_hlt(void)			/* HLT */
@@ -2586,17 +2594,6 @@ static int op_jmp(void)			/* JMP */
 	return (10);
 }
 
-static int op_undoc_jmp(void)		/* Undocumented JMP */
-{
-	if (u_flag) {	/* trap with option -u */
-		cpu_error = OPTRAP1;
-		cpu_state = STOPPED;
-		return (0);
-	} else {	/* else JMP */
-		return (op_jmp());
-	}
-}
-
 static int op_pchl(void)		/* PCHL */
 {
 	PC = (H << 8) + L;
@@ -2618,17 +2615,6 @@ static int op_call(void)		/* CALL */
 	return (17);
 }
 
-static int op_undoc_call(void)		/* Undocumented CALL */
-{
-	if (u_flag) {	/* trap with option -u */
-		cpu_error = OPTRAP1;
-		cpu_state = STOPPED;
-		return (0);
-	} else {
-		return (op_call());
-	}
-}
-
 static int op_ret(void)			/* RET */
 {
 	register WORD i;
@@ -2640,17 +2626,6 @@ static int op_ret(void)			/* RET */
 	i += memrdr(SP++) << 8;
 	PC = i;
 	return (10);
-}
-
-static int op_undoc_ret(void)		/* Undocumented RET */
-{
-	if (u_flag) {	/* trap with option -u */
-		cpu_error = OPTRAP1;
-		cpu_state = STOPPED;
-		return (0);
-	} else {	/* else RET */
-		return (op_ret());
-	}
 }
 
 static int op_jz(void)			/* JZ nn */
@@ -3148,3 +3123,53 @@ static int op_rst7(void)		/* RST 7 */
 	PC = 0x38;
 	return (11);
 }
+
+/**********************************************************************/
+/**********************************************************************/
+/*********       UNDOCUMENTED 8080 INSTRUCTIONS, BEWARE!      *********/
+/**********************************************************************/
+/**********************************************************************/
+
+#ifdef UNDOC_INST
+
+static int op_undoc_nop(void)		/* NOP */
+{
+	if (u_flag) {
+		trap_undoc();
+		return (0);
+	}
+
+	return (4);
+}
+
+static int op_undoc_jmp(void)		/* JMP */
+{
+	if (u_flag) {
+		trap_undoc();
+		return (0);
+	}
+
+	return (op_jmp());
+}
+
+static int op_undoc_call(void)		/* CALL */
+{
+	if (u_flag) {
+		trap_undoc();
+		return (0);
+	}
+
+	return (op_call());
+}
+
+static int op_undoc_ret(void)		/* RET */
+{
+	if (u_flag) {
+		trap_undoc();
+		return (0);
+	}
+
+	return (op_ret());
+}
+
+#endif

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -15,6 +15,8 @@
 #endif
 #include "memory.h"
 
+#ifndef EXCLUDE_I8080
+
 #ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
@@ -3171,5 +3173,7 @@ static int op_undoc_ret(void)		/* RET */
 
 	return (op_ret());
 }
+
+#endif
 
 #endif

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2024 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  */
 
 #include <unistd.h>

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -42,10 +42,9 @@ void init_cpu(void)
 	L = rand() % 256;
 	F = rand() % 256;
 
-	if (cpu == I8080) {	/* i8080 specific */
-		F &= ~(N2_FLAG | N1_FLAG);
-		F |= N_FLAG;
-	} else {		/* Z80 specific */
+	switch (cpu) {
+#ifndef EXCLUDE_Z80
+	case Z80:
 		I = 0;
 		A_ = rand() % 256;
 		B_ = rand() % 256;
@@ -57,6 +56,16 @@ void init_cpu(void)
 		F_ = rand() % 256;
 		IX = rand() % 65536;
 		IY = rand() % 65536;
+		break;
+#endif
+#ifndef EXCLUDE_I8080
+	case I8080:
+		F &= ~(N2_FLAG | N1_FLAG);
+		F |= N_FLAG;
+		break;
+#endif
+	default:
+		break;
 	}
 }
 
@@ -65,14 +74,25 @@ void init_cpu(void)
  */
 void reset_cpu(void)
 {
-	IFF = int_int = int_nmi = int_protection = int_mode = 0;
+	IFF = int_int = int_protection = 0;
 	int_data = -1;
 
 	PC = 0;
 
-	if (cpu == Z80) {
+	switch (cpu) {
+#ifndef EXCLUDE_Z80
+	case Z80:
 		I = 0;
 		R_ = R = 0L;
+		int_nmi = int_mode = 0;
+		break;
+#endif
+#ifndef EXCLUDE_I8080
+	case I8080:
+		break;
+#endif
+	default:
+		break;
 	}
 }
 
@@ -84,15 +104,17 @@ void run_cpu(void)
 	cpu_state = CONTIN_RUN;
 	cpu_error = NONE;
 	switch (cpu) {
-	case Z80:
 #ifndef EXCLUDE_Z80
+	case Z80:
 		cpu_z80();
-#endif
 		break;
-	case I8080:
-#ifndef EXCLUDE_I8080
-		cpu_8080();
 #endif
+#ifndef EXCLUDE_I8080
+	case I8080:
+		cpu_8080();
+		break;
+#endif
+	default:
 		break;
 	}
 }
@@ -105,15 +127,17 @@ void step_cpu(void)
 	cpu_state = SINGLE_STEP;
 	cpu_error = NONE;
 	switch (cpu) {
-	case Z80:
 #ifndef EXCLUDE_Z80
+	case Z80:
 		cpu_z80();
-#endif
 		break;
-	case I8080:
-#ifndef EXCLUDE_I8080
-		cpu_8080();
 #endif
+#ifndef EXCLUDE_I8080
+	case I8080:
+		cpu_8080();
+		break;
+#endif
+	default:
 		break;
 	}
 	cpu_state = STOPPED;

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -13,13 +13,23 @@
 #define Z80		1	/* simulated CPUs */
 #define I8080		2
 
+#if defined(EXCLUDE_I8080) && defined(EXCLUDE_Z80)
+#error "Only one of EXCLUDE_I8080 or EXCLUDE_Z80 can be used"
+#endif
+#if defined(EXCLUDE_I8080) && DEF_CPU == I8080
+#error "DEF_CPU=I8080 and no 8080 simulation included"
+#endif
+#if defined(EXCLUDE_Z80) && DEF_CPU == Z80
+#error "DEF_CPU=Z80 and no Z80 simulation included"
+#endif
+
 #define S_FLAG		128	/* bit definitions of CPU flags */
 #define Z_FLAG		64
 #define N2_FLAG		32
 #define H_FLAG		16
 #define N1_FLAG		8
 #define P_FLAG		4
-#define N_FLAG		2
+#define N_FLAG		2	/* not used by the 8080 */
 #define C_FLAG		1
 
 #define CPU_MEMR	128	/* bit definitions for CPU bus status */
@@ -66,8 +76,10 @@ struct history {		/* structure of a history entry */
 	WORD	h_bc;		/* register BC */
 	WORD	h_de;		/* register DE */
 	WORD	h_hl;		/* register HL */
+#ifndef EXCLUDE_Z80
 	WORD	h_ix;		/* register IX */
 	WORD	h_iy;		/* register IY */
+#endif
 	WORD	h_sp;		/* register SP */
 };
 #endif

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2024 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  */
 
 #define COPYR	"Copyright (C) 1987-2024 by Udo Munk and others"

--- a/z80core/simdis.c
+++ b/z80core/simdis.c
@@ -4,7 +4,7 @@
  * Copyright (C) 1989-2021 by Udo Munk
  * Parts Copyright (C) 2008 by Justin Clancy
  * 8080 disassembler Copyright (C) 2018 by Christophe Staiesse
- * Copyright (c) 2022 by Thomas Eberhardt
+ * Copyright (c) 2022-2024 by Thomas Eberhardt
  */
 
 /*

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -26,18 +26,20 @@ int cpu = DEF_CPU;
  */
 BYTE A, B, C, D, E, H, L;	/* primary registers */
 int  F;				/* normally 8-Bit, but int is faster */
+#ifndef EXCLUDE_Z80
 WORD IX, IY;			/* Z80 index registers */
 BYTE A_, B_, C_, D_, E_, H_, L_; /* Z80 alternate registers */
+BYTE I;				/* Z80 interrupt register */
 int  F_;
+BYTE R_;			/* BYTE copy of R for keeping the 7th bit */
+#endif
 WORD PC;			/* programm counter */
 WORD SP;			/* stackpointer */
-BYTE I;				/* Z80 interrupt register */
 BYTE IFF;			/* interrupt flags */
 long R;				/* Z80 refresh register */
 				/* is normally a 8 bit register */
 				/* the larger bits are used to measure the */
 				/* clock frequency */
-BYTE R_;			/* BYTE copy of R for keeping the 7th bit */
 Tstates_t T;			/* CPU clock */
 
 #ifdef BUS_8080
@@ -51,8 +53,10 @@ int busy_loop_cnt[MAXCHAN];	/* counters for I/O busy loop detection */
 
 BYTE cpu_state;			/* state of CPU emulation */
 int cpu_error;			/* error status of CPU emulation */
+#ifndef EXCLUDE_Z80
 int int_mode;			/* CPU interrupt mode (IM 0, IM 1, IM 2) */
 int int_nmi;			/* non maskable interrupt request */
+#endif
 int int_int;			/* interrupt request */
 int int_data = -1;		/* data from interrupting device on data bus */
 int int_protection;		/* to delay interrupts after EI */

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 1987-2021 Udo Munk
  * Copyright (C) 2021 David McNaughton
- * Copyright (C) 2022 Thomas Eberhardt
+ * Copyright (C) 2022-2024 Thomas Eberhardt
  */
 
 /*

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 1987-2021 Udo Munk
  * Copyright (C) 2021 David McNaughton
- * Copyright (C) 2022 Thomas Eberhardt
+ * Copyright (C) 2022-2024 Thomas Eberhardt
  */
 
 /*

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -19,9 +19,15 @@ void end_bus_request(void);
 
 extern int	cpu;
 
-extern BYTE	A, B, C, D, E, H, L, A_, B_, C_, D_, E_, H_, L_, I, IFF, R_;
-extern WORD	PC, SP, IX, IY;
-extern int	F, F_;
+extern BYTE	A, B, C, D, E, H, L;
+extern int	F;
+#ifndef EXCLUDE_Z80
+extern WORD	IX, IY;
+extern BYTE	A_, B_, C_, D_, E_, H_, L_, I, R_;
+extern int	F_;
+#endif
+extern WORD	PC, SP;
+extern BYTE	IFF;
 extern long	R;
 extern Tstates_t T;
 extern BYTE	io_port, io_data;
@@ -38,8 +44,10 @@ extern int	int_data;
 
 extern int	s_flag, l_flag, m_flag, x_flag, break_flag, i_flag, f_flag,
 		u_flag, r_flag, c_flag, M_flag, R_flag,
-		cpu_error, int_nmi, int_int, int_mode, parity[], sb_next,
-		int_protection;
+		cpu_error, int_int, parity[], sb_next, int_protection;
+#ifndef EXCLUDE_Z80
+extern int	int_nmi, int_mode;
+#endif
 
 extern int	tmax, cpu_needed;
 extern int	busy_loop_cnt[];

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2022 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  */
 
 /*

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -874,7 +874,7 @@ static void do_show(void)
 	i = 0;
 #endif
 	printf("No. of software breakpoints: %d\n", i);
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 	i = u_flag;
 #else
 	i = 1;

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 1987-2024 Udo Munk
  * Copyright (C) 2021 David McNaughton
- * Copyright (C) 2022 Thomas Eberhardt
+ * Copyright (C) 2022-2024 Thomas Eberhardt
  */
 
 /*

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -324,23 +324,14 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 	else
 		printf("CPU speed is unlimited");
 
-	if (cpu == Z80) {
-#ifndef Z80_UNDOC
-		printf(", CPU doesn't execute undocumented instructions\n");
+#ifndef UNDOC_INST
+	printf(", CPU doesn't execute undocumented instructions\n");
 #else
-		if (u_flag)
-			printf(", CPU doesn't execute undocumented "
-			       "instructions\n");
-		else
-			printf(", CPU executes undocumented instructions\n");
+	if (u_flag)
+		printf(", CPU doesn't execute undocumented instructions\n");
+	else
+		printf(", CPU executes undocumented instructions\n");
 #endif
-	} else {
-		if (u_flag)
-			printf(", CPU doesn't execute undocumented "
-			       "instructions\n");
-		else
-			printf(", CPU executes undocumented instructions\n");
-	}
 
 	fflush(stdout);
 

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -2,7 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
- * Copyright (C) 2022 by Thomas Eberhardt
+ * Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -18,7 +18,7 @@
 #endif
 #include "memory.h"
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
 #define UNDOC(f) trap_cb
@@ -96,7 +96,7 @@ static int op_tb0hl(void), op_tb1hl(void), op_tb2hl(void), op_tb3hl(void);
 static int op_tb4hl(void), op_tb5hl(void), op_tb6hl(void), op_tb7hl(void);
 
 static int op_undoc_slla(void);
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 static int op_undoc_sllb(void), op_undoc_sllc(void), op_undoc_slld(void);
 static int op_undoc_slle(void), op_undoc_sllh(void), op_undoc_slll(void);
 static int op_undoc_sllhl(void);
@@ -2563,7 +2563,7 @@ static int op_undoc_slla(void)		/* SLL A */
 	return (8);
 }
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 
 static int op_undoc_sllb(void)		/* SLL B */
 {

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -18,6 +18,8 @@
 #endif
 #include "memory.h"
 
+#ifndef EXCLUDE_Z80
+
 #ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
@@ -2682,5 +2684,7 @@ static int op_undoc_sllhl(void)		/* SLL (HL) */
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	return (15);
 }
+
+#endif
 
 #endif

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -18,6 +18,8 @@
 #endif
 #include "memory.h"
 
+#ifndef EXCLUDE_Z80
+
 #ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
@@ -1434,5 +1436,7 @@ static int op_undoc_decixh(void)	/* DEC IXH */
 	F |= N_FLAG;
 	return (8);
 }
+
+#endif
 
 #endif

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -18,7 +18,7 @@
 #endif
 #include "memory.h"
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
 #define UNDOC(f) trap_dd
@@ -43,7 +43,7 @@ static int op_ldxdd(void), op_ldxde(void);
 static int op_ldxdh(void), op_ldxdl(void), op_ldxdn(void);
 extern int op_ddcb_handle(void);
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 static int op_undoc_ldaixl(void), op_undoc_ldaixh(void);
 static int op_undoc_ldbixl(void), op_undoc_ldbixh(void);
 static int op_undoc_ldcixl(void), op_undoc_ldcixh(void);
@@ -356,7 +356,7 @@ int op_dd_handle(void)
  */
 static int trap_dd(void)
 {
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 	if (!u_flag) {
 		/* Treat 0xdd prefix as NOP on non IX-instructions */
 		PC--;
@@ -763,7 +763,7 @@ static int op_ldxdn(void)		/* LD (IX+d),n */
 /**********************************************************************/
 /**********************************************************************/
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 
 static int op_undoc_ldaixl(void)	/* LD A,IXL */
 {

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -2,7 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
- * Copyright (C) 2022 by Thomas Eberhardt
+ * Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*

--- a/z80core/simz80-ddcb.c
+++ b/z80core/simz80-ddcb.c
@@ -18,6 +18,8 @@
 #endif
 #include "memory.h"
 
+#ifndef EXCLUDE_Z80
+
 #ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
@@ -3422,5 +3424,7 @@ static int op_undoc_srlixdl(int data)	/* SRL (IX+d),L */
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	return (23);
 }
+
+#endif
 
 #endif

--- a/z80core/simz80-ddcb.c
+++ b/z80core/simz80-ddcb.c
@@ -2,7 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
- * Copyright (C) 2022 by Thomas Eberhardt
+ * Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*

--- a/z80core/simz80-ddcb.c
+++ b/z80core/simz80-ddcb.c
@@ -18,7 +18,7 @@
 #endif
 #include "memory.h"
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
 #define UNDOC(f) trap_ddcb
@@ -34,7 +34,7 @@ static int op_sb4ixd(int), op_sb5ixd(int), op_sb6ixd(int), op_sb7ixd(int);
 static int op_rlcixd(int), op_rrcixd(int), op_rlixd(int), op_rrixd(int);
 static int op_slaixd(int), op_sraixd(int), op_srlixd(int);
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 static int op_undoc_tb0ixd(int), op_undoc_tb1ixd(int), op_undoc_tb2ixd(int);
 static int op_undoc_tb3ixd(int), op_undoc_tb4ixd(int), op_undoc_tb5ixd(int);
 static int op_undoc_tb6ixd(int), op_undoc_tb7ixd(int);
@@ -701,7 +701,7 @@ static int op_srlixd(int data)		/* SRL (IX+d) */
 /**********************************************************************/
 /**********************************************************************/
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 
 static int op_undoc_tb0ixd(int data)	/* BIT 0,(IX+d) */
 {

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -2,7 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
- * Copyright (C) 2022 by Thomas Eberhardt
+ * Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -19,6 +19,8 @@
 #endif
 #include "memory.h"
 
+#ifndef EXCLUDE_Z80
+
 #ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
@@ -1449,5 +1451,7 @@ static int op_undoc_neg(void)		/* NEG */
 
 	return (op_neg());
 }
+
+#endif
 
 #endif

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -19,7 +19,7 @@
 #endif
 #include "memory.h"
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
 #define UNDOC(f) trap_ed
@@ -47,7 +47,7 @@ static int op_ldi(void), op_ldir(void), op_ldd(void), op_lddr(void);
 static int op_cpi(void), op_cpir(void), op_cpdop(void), op_cpdr(void);
 static int op_oprld(void), op_oprrd(void);
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 static int op_undoc_outc0(void), op_undoc_infic(void);
 static int op_undoc_nop(void);
 static int op_undoc_im0(void), op_undoc_im1(void), op_undoc_im2(void);
@@ -1347,7 +1347,7 @@ static int op_oprrd(void)		/* RRD (HL) */
 /**********************************************************************/
 /**********************************************************************/
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 
 static int op_undoc_outc0(void)		/* OUT (C),0 */
 {

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -18,7 +18,7 @@
 #endif
 #include "memory.h"
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
 #define UNDOC(f) trap_fd
@@ -43,7 +43,7 @@ static int op_ldydd(void), op_ldyde(void);
 static int op_ldydh(void), op_ldydl(void), op_ldydn(void);
 extern int op_fdcb_handle(void);
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 static int op_undoc_ldaiyl(void), op_undoc_ldaiyh(void);
 static int op_undoc_ldbiyl(void), op_undoc_ldbiyh(void);
 static int op_undoc_ldciyl(void), op_undoc_ldciyh(void);
@@ -356,7 +356,7 @@ int op_fd_handle(void)
  */
 static int trap_fd(void)
 {
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 	if (!u_flag) {
 		/* Treat 0xfd prefix as NOP on non IY-instructions */
 		PC--;
@@ -763,7 +763,7 @@ static int op_ldydn(void)		/* LD (IY+d),n */
 /**********************************************************************/
 /**********************************************************************/
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 
 static int op_undoc_ldaiyl(void)	/* LD A,IYL */
 {

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -2,7 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
- * Copyright (C) 2022 by Thomas Eberhardt
+ * Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -18,6 +18,8 @@
 #endif
 #include "memory.h"
 
+#ifndef EXCLUDE_Z80
+
 #ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
@@ -1434,5 +1436,7 @@ static int op_undoc_deciyh(void)	/* DEC IYH */
 	F |= N_FLAG;
 	return (8);
 }
+
+#endif
 
 #endif

--- a/z80core/simz80-fdcb.c
+++ b/z80core/simz80-fdcb.c
@@ -2,7 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2021 by Udo Munk
- * Copyright (C) 2022 by Thomas Eberhardt
+ * Copyright (C) 2022-2024 by Thomas Eberhardt
  */
 
 /*

--- a/z80core/simz80-fdcb.c
+++ b/z80core/simz80-fdcb.c
@@ -18,6 +18,8 @@
 #endif
 #include "memory.h"
 
+#ifndef EXCLUDE_Z80
+
 #ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
@@ -3422,5 +3424,7 @@ static int op_undoc_srliydl(int data)	/* SRL (IY+d),L */
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	return (23);
 }
+
+#endif
 
 #endif

--- a/z80core/simz80-fdcb.c
+++ b/z80core/simz80-fdcb.c
@@ -18,7 +18,7 @@
 #endif
 #include "memory.h"
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
 #define UNDOC(f) trap_fdcb
@@ -34,7 +34,7 @@ static int op_sb4iyd(int), op_sb5iyd(int), op_sb6iyd(int), op_sb7iyd(int);
 static int op_rlciyd(int), op_rrciyd(int), op_rliyd(int), op_rriyd(int);
 static int op_slaiyd(int), op_sraiyd(int), op_srliyd(int);
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 static int op_undoc_tb0iyd(int), op_undoc_tb1iyd(int), op_undoc_tb2iyd(int);
 static int op_undoc_tb3iyd(int), op_undoc_tb4iyd(int), op_undoc_tb5iyd(int);
 static int op_undoc_tb6iyd(int), op_undoc_tb7iyd(int);
@@ -701,7 +701,7 @@ static int op_srliyd(int data)		/* SRL (IY+d) */
 /**********************************************************************/
 /**********************************************************************/
 
-#ifdef Z80_UNDOC
+#ifdef UNDOC_INST
 
 static int op_undoc_tb0iyd(int data)	/* BIT 0,(IY+d) */
 {

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -16,6 +16,8 @@
 #endif
 #include "memory.h"
 
+#ifndef EXCLUDE_Z80
+
 #ifdef WANT_GUI
 extern void check_gui_break(void);
 #endif
@@ -3266,3 +3268,5 @@ static int op_rst38(void)		/* RST 38 */
 	PC = 0x38;
 	return (11);
 }
+
+#endif

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -2,6 +2,7 @@
  * Z80SIM  -  a Z80-CPU simulator
  *
  * Copyright (C) 1987-2024 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  */
 
 #include <unistd.h>

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -12,7 +12,7 @@
  */
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
-#define Z80_UNDOC	/* compile undocumented Z80 instructions */
+#define UNDOC_INST	/* compile undocumented instructions */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 /*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
 

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -13,7 +13,7 @@
  */
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
-#define Z80_UNDOC	/* compile undocumented Z80 instructions */
+#define UNDOC_INST	/* compile undocumented instructions */
 #define WANT_FASTB	/* much faster but not accurate Z80 block instr. */
 /*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
 


### PR DESCRIPTION
Rename Z80_UNDOC to UNDOC_INST. Change sim8080.c to handle undocumented instructions like simz80*.c

Make EXCLUDE_(I8080|Z80) a fully implemented feature.
Now EXCLUDE_I8080 or EXCLUDE_Z80 will completely remove support for the excluded CPU type.
Make save_core()/load_core() save/load core.z80 or core.8080 depending on the CPU type.
Fix ICE "x" command, which accepted "a'" and "f'" for the 8080.

z80asm: fix "#if"

Removed Didier Derny from z80asm/COPYING since z80anum.c was essentially a total rewrite. The only function that looks like the old code is init_ctype().
Right or wrong, what do you think?
