### PR TITLE
Small clean-ups and reassemble to get new version number into list files

### DIFF
--- a/altairsim/basic8k78.lis
+++ b/altairsim/basic8k78.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:46:11 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/dzmation.lis
+++ b/altairsim/dzmation.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:46:14 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; HAND DISASSEMBLY OF THE DAZZLEMATION MEMORY IMAGE PROVIDED IN THE

--- a/altairsim/fdct1.lis
+++ b/altairsim/fdct1.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:47:41 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/killbits.lis
+++ b/altairsim/killbits.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:47:56 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/killbits2.lis
+++ b/altairsim/killbits2.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:48:14 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/kscope.lis
+++ b/altairsim/kscope.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:48:37 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/life.lis
+++ b/altairsim/life.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:48:57 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; LIFE .... VERSION 2.0

--- a/altairsim/microchess.lis
+++ b/altairsim/microchess.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:49:33 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '8080 MICROCHESS'

--- a/altairsim/roms/als8-rom.lis
+++ b/altairsim/roms/als8-rom.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:50:33 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/roms/apple.lis
+++ b/altairsim/roms/apple.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:51:01 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '<APPLE MONITOR, *ECT ROM* V1.0  JAN 07, 1979>'

--- a/altairsim/roms/bootromt-old.lis
+++ b/altairsim/roms/bootromt-old.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 18:07:58 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;******************************************************************

--- a/altairsim/roms/bootromt.lis
+++ b/altairsim/roms/bootromt.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 19:30:32 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;******************************************************************

--- a/altairsim/roms/cuter-mits.lis
+++ b/altairsim/roms/cuter-mits.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:51:45 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>

--- a/altairsim/roms/dbl.lis
+++ b/altairsim/roms/dbl.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:52:07 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;***************************************************************

--- a/altairsim/roms/mbl.lis
+++ b/altairsim/roms/mbl.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:52:21 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; MBL - MULTI BOOT LOADER FOR THE ALTAIR 8800

--- a/altairsim/roms/miniboot.lis
+++ b/altairsim/roms/miniboot.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:52:39 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/roms/tinybasic-1.0.lis
+++ b/altairsim/roms/tinybasic-1.0.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:52:55 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/altairsim/roms/tinybasic-2.0.lis
+++ b/altairsim/roms/tinybasic-2.0.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:53:15 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/altairsim/roms/turnmon.lis
+++ b/altairsim/roms/turnmon.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:53:37 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; **************************************************************

--- a/altairsim/roms/umzapex.lis
+++ b/altairsim/roms/umzapex.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 18:02:09 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 	TITLE	<Zapple Monitor Extension for MITS ALTAIR>

--- a/altairsim/roms/zapple.lis
+++ b/altairsim/roms/zapple.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 18:02:25 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;	<< ZAPPLE 2-K MONITOR SYSTEM >>

--- a/cromemcosim/dzmation.lis
+++ b/cromemcosim/dzmation.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:54:22 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; HAND DISASSEMBLY OF THE DAZZLEMATION MEMORY IMAGE PROVIDED IN THE

--- a/cromemcosim/kscope.lis
+++ b/cromemcosim/kscope.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:54:36 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/cromemcosim/life.lis
+++ b/cromemcosim/life.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:55:15 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; LIFE .... VERSION 2.0

--- a/cromemcosim/microchess.lis
+++ b/cromemcosim/microchess.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:55:40 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '8080 MICROCHESS'

--- a/cromemcosim/roms/rdos1.lis
+++ b/cromemcosim/roms/rdos1.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 18:03:14 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; COPYRIGHT (C) 1977, CROMEMCO, INC.

--- a/cromemcosim/roms/rdos252.lis
+++ b/cromemcosim/roms/rdos252.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 18:03:39 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/cromemcosim/roms/z1mon-1.0.lis
+++ b/cromemcosim/roms/z1mon-1.0.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:56:07 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/cromemcosim/roms/z1mon-1.4.lis
+++ b/cromemcosim/roms/z1mon-1.4.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 18:27:25 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/imsaisim/dzmation.lis
+++ b/imsaisim/dzmation.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:57:33 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; HAND DISASSEMBLY OF THE DAZZLEMATION MEMORY IMAGE PROVIDED IN THE

--- a/imsaisim/kscope.lis
+++ b/imsaisim/kscope.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:57:59 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/imsaisim/life.lis
+++ b/imsaisim/life.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:58:26 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; LIFE .... VERSION 2.0

--- a/imsaisim/microchess.lis
+++ b/imsaisim/microchess.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:58:39 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '8080 MICROCHESS'

--- a/imsaisim/roms/basic4k.lis
+++ b/imsaisim/roms/basic4k.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 18:05:31 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 *HEADING IMSAI 8080 4K BASIC

--- a/imsaisim/roms/basic8k.lis
+++ b/imsaisim/roms/basic8k.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:59:09 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;EDITS:

--- a/imsaisim/roms/memon80.lis
+++ b/imsaisim/roms/memon80.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Thu Nov  3 22:57:19 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;==============================================================

--- a/imsaisim/roms/viofm1.lis
+++ b/imsaisim/roms/viofm1.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:59:28 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/imsaisim/scs1.lis
+++ b/imsaisim/scs1.lis
@@ -1,4 +1,4 @@
-Z80-Macro-Assembler  Release 1.11-dev	Wed Nov  2 17:59:44 2022
+Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE           'IMSAI SCS-1 REV. 2 06 OCT. 1976'

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -78,12 +78,13 @@ void reset_cpu(void)
 	int_data = -1;
 
 	PC = 0;
+	R = 0L;
 
 	switch (cpu) {
 #ifndef EXCLUDE_Z80
 	case Z80:
 		I = 0;
-		R_ = R = 0L;
+		R_ = 0;
 		int_nmi = int_mode = 0;
 		break;
 #endif

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -30,7 +30,7 @@
 #define H_FLAG		16
 #define N1_FLAG		8
 #define P_FLAG		4
-#define N_FLAG		2	/* not used by the 8080 */
+#define N_FLAG		2
 #define C_FLAG		1
 
 #define CPU_MEMR	128	/* bit definitions for CPU bus status */

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -389,7 +389,7 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 
 	config();		/* read system configuration */
 	init_cpu();		/* initialize CPU */
-	init_memory();	/* initialize memory configuration */
+	init_memory();		/* initialize memory configuration */
 
 	if (l_flag) {		/* load core */
 		if (load_core())
@@ -549,9 +549,8 @@ static int load_core(void)
 	if (cpu == Z80) {
 		fread(&R, sizeof(R), 1, fp);
 		fread(&R_, sizeof(R_), 1, fp);
-	} else
+	}
 #endif
-		R = 0L;
 	fread(&PC, sizeof(PC), 1, fp);
 	fread(&SP, sizeof(SP), 1, fp);
 #ifndef EXCLUDE_Z80


### PR DESCRIPTION
Clear R unconditionally in reset_cpu(), since it is also incremented in cpu_8080().
Don't need to zero R in load_core() for 8080, since it is already 0. Looked ugly.
Remove comment I added, don't know why I added it...
Reassemble files to get the new version number into the list files.