### PR TITLE
improve error handling in tools

### DIFF
--- a/cpmsim/srccpm2/Makefile
+++ b/cpmsim/srccpm2/Makefile
@@ -9,10 +9,10 @@ putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
 
 bios.bin: bios.asm
-	z80asm -vl -sn -fm -x bios.asm
+	z80asm -vl -sn -fb -x bios.asm
 
 boot.bin: boot.asm
-	z80asm -vl -sn -fm boot.asm
+	z80asm -vl -sn -fb boot.asm
 
 clean:
 	rm -f *.lis bios.bin boot.bin putsys putsys.exe

--- a/cpmsim/srccpm2/putsys.c
+++ b/cpmsim/srccpm2/putsys.c
@@ -2,6 +2,7 @@
  * Write the CP/M system files to system tracks of drive A
  *
  * Copyright (C) 1988-2016 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  *
  * History:
  * 29-APR-88 Development on TARGON/35 with AT&T Unix System V.3
@@ -9,6 +10,7 @@
  * 02-OCT-06 modified to compile on modern POSIX OS's
  * 10-JAN-14 lseek POSIX conformance
  * 03-APR-16 disk drive name drivea.dsk
+ * 27-APR-24 improve error handling, use simple binary format
  */
 
 #include <unistd.h>
@@ -16,93 +18,111 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <string.h>
+#include <errno.h>
+
+#define DISK "../disks/drivea.dsk"
 
 /*
  *	This program writes the CP/M 2.2 OS from the following files
- *	onto the system tracks of the boot disk (drivea.dsk):
+ *	onto the system tracks of the boot disk (DISK):
  *
- *	boot loader	boot.bin	(Mostek binary format)
- *	CCP		cpm.bin		(binary format)
- *	BDOS		cpm.bin		(binary format)
- *	BIOS		bios.bin	(Mostek binary format)
+ *	boot loader	boot.bin
+ *	CCP		cpm.bin
+ *	BDOS		cpm.bin
+ *	BIOS		bios.bin
  */
 int main(void)
 {
-	unsigned char header[3];
 	unsigned char sector[128];
 	register int i;
-	int fd, drivea, readn;
+	int fd, drivea;
+	ssize_t n;
+	off_t o;
 
 	/* open drive A for writing */
-	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
-		perror("file ../disks/drivea.dsk");
+	if ((drivea = open(DISK, O_WRONLY)) == -1) {
+		perror(DISK);
 		exit(EXIT_FAILURE);
 	}
+
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
-		perror("file boot.bin");
+		perror("boot.bin");
 		exit(EXIT_FAILURE);
-	}
-	/* read and check 3 byte header */
-	if (read(fd, (char *) header, 3) != 3) {
-		perror("file boot.bin");
-		exit(EXIT_FAILURE);
-	}
-	if (header[0] != 0xff || header[1] != 0 || header[2] != 0) {
-		puts("start address of boot.bin <> 0");
-		exit(EXIT_SUCCESS);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
-	read(fd, (char *) sector, 128);
-	close(fd);
+	if (read(fd, (char *) sector, 128) == -1) {
+		perror("boot.bin");
+		exit(EXIT_FAILURE);
+	}
 	/* and write it to disk in drive A */
-	write(drivea, (char *) sector, 128);
+	if ((n = write(drivea, (char *) sector, 128)) != 128) {
+		fprintf(stderr, DISK ": %s\n",
+			n == -1 ? strerror(errno) : "short write");
+		exit(EXIT_FAILURE);
+	}
+	close(fd);
+
 	/* open CP/M system file (cpm.bin) for reading */
 	if ((fd = open("cpm.bin", O_RDONLY)) == -1) {
-		perror("file cpm.bin");
+		perror("cpm.bin");
 		exit(EXIT_FAILURE);
 	}
-	/* position to CCP in cpm.bin, needed if created with SAVE or similar */
-	lseek(fd, (long) 17 * 128, SEEK_SET);
+	/* position to CCP in cpm.bin, needed if created with e.g. SAVE */
+	if ((o = lseek(fd, 17 * 128L, SEEK_SET)) != 17 * 128L) {
+		fprintf(stderr, "cpm.bin: %s\n",
+			o == -1 ? strerror(errno) : "short file");
+		exit(EXIT_FAILURE);
+	}
 	/* read CCP and BDOS from cpm.bin and write them to disk in drive A */
 	for (i = 0; i < 44; i++) {
-		if (read(fd, (char *) sector, 128) != 128) {
-			perror("file cpm.bin");
+		if ((n = read(fd, (char *) sector, 128)) != 128) {
+			fprintf(stderr, "cpm.bin: %s\n",
+				n == -1 ? strerror(errno) : "short read");
 			exit(EXIT_FAILURE);
 		}
-		write(drivea, (char *) sector, 128);
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
 	}
 	close(fd);
+
 	/* open BIOS (bios.bin) for reading */
 	if ((fd = open("bios.bin", O_RDONLY)) == -1) {
-		perror("file bios.bin");
+		perror("bios.bin");
 		exit(EXIT_FAILURE);
-	}
-	/* read and check 3 byte header */
-	if (read(fd, (char *) header, 3) != 3) {
-		perror("file bios.bin");
-		exit(EXIT_FAILURE);
-	}
-	if (header[0] != 0xff) {
-		puts("unknown format of bios.bin");
-		exit(EXIT_SUCCESS);
 	}
 	/* read BIOS from bios.bin and write it to disk in drive A */
 	i = 0;
-	while ((readn = read(fd, (char *) sector, 128)) == 128) {
-		write(drivea, (char *) sector, 128);
+	while ((n = read(fd, (char *) sector, 128)) == 128) {
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
 		i++;
 		if (i == 6) {
-			puts("6 sectors written, can't write any more!");
-			goto stop;
+			fputs(DISK ": out of space (6 sectors written)",
+			      stderr);
+			exit(EXIT_FAILURE);
 		}
 	}
-	if (readn > 0) {
-		write(drivea, (char *) sector, 128);
+	if (n == -1) {
+		perror("bios.bin");
+		exit(EXIT_FAILURE);
+	} else if (n > 0) {
+		memset((char *) &sector[n], 0, 128 - n);
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
 	}
-stop:
 	close(fd);
+
 	close(drivea);
 	return (EXIT_SUCCESS);
 }

--- a/cpmsim/srccpm3/putsys.c
+++ b/cpmsim/srccpm3/putsys.c
@@ -2,6 +2,7 @@
  * Write the CP/M 3 system files to system tracks of drive A
  *
  * Copyright (C) 1988-2016 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  *
  * History:
  * 29-APR-88 Development on TARGON/35 with AT&T Unix System V.3
@@ -10,6 +11,7 @@
  * 15-SEP-07 also write ccp to system tracks
  * 10-JAN-14 lseek POSIX conformance
  * 03-APR-16 disk drive name drivea.dsk
+ * 27-APR-24 improve error handling
  */
 
 #include <unistd.h>
@@ -17,10 +19,13 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <string.h>
+#include <errno.h>
+
+#define DISK "../disks/drivea.dsk"
 
 /*
  *	This program writes the CP/M 3 OS from the following files
- *	onto the system tracks of the boot disk (drivea.dsk):
+ *	onto the system tracks of the boot disk (DISK):
  *
  *	boot loader	boot.bin
  *	cpmldr		cpmldr.bin
@@ -30,45 +35,91 @@ int main(void)
 {
 	unsigned char sector[128];
 	int fd, drivea;
+	ssize_t n;
+	off_t o;
 
 	/* open drive A for writing */
-	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
-		perror("file ../disks/drivea.dsk");
+	if ((drivea = open(DISK, O_WRONLY)) == -1) {
+		perror(DISK);
 		exit(EXIT_FAILURE);
 	}
+
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
-		perror("file boot.bin");
+		perror("boot.bin");
 		exit(EXIT_FAILURE);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
-	read(fd, (char *) sector, 128);
-	close(fd);
+	if (read(fd, (char *) sector, 128) == -1) {
+		perror("boot.bin");
+		exit(EXIT_FAILURE);
+	}
 	/* and write it to disk in drive A */
-	write(drivea, (char *) sector, 128);
+	if ((n = write(drivea, (char *) sector, 128)) != 128) {
+		fprintf(stderr, DISK ": %s\n",
+			n == -1 ? strerror(errno) : "short write");
+		exit(EXIT_FAILURE);
+	}
+	close(fd);
+
 	/* open CP/M 3 cpmldr file (cpmldr.bin) for reading */
 	if ((fd = open("cpmldr.bin", O_RDONLY)) == -1) {
-		perror("file cpmldr.bin");
+		perror("cpmldr.bin");
 		exit(EXIT_FAILURE);
 	}
 	/* read from cpmldr.bin and write to disk in drive A */
-	while (read(fd, (char *) sector, 128) == 128)
-		write(drivea, (char *) sector, 128);
-	write(drivea, (char *) sector, 128);
+	while ((n = read(fd, (char *) sector, 128)) == 128)
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
+	if (n == -1) {
+		perror("cpmldr.bin");
+		exit(EXIT_FAILURE);
+	} else if (n > 0) {
+		memset((char *) &sector[n], 0, 128 - n);
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
+	}
 	close(fd);
+
 	/* seek to track 1, sector 1 of disk */
-	lseek(drivea, 128 * 26, SEEK_SET);
+	if ((o = lseek(drivea, 26 * 128L, SEEK_SET)) != 26 * 128L) {
+		fprintf(stderr, DISK ": %s\n",
+			o == -1 ? strerror(errno) : "short file");
+		exit(EXIT_FAILURE);
+	}
+
 	/* open CP/M 3 ccp file (ccp.bin) for reading */
 	if ((fd = open("ccp.bin", O_RDONLY)) == -1) {
-		perror("file ccp.bin");
+		perror("ccp.bin");
 		exit(EXIT_FAILURE);
 	}
 	/* read from ccp.bin and write to disk in drive A */
-	while (read(fd, (char *) sector, 128) == 128)
-		write(drivea, (char *) sector, 128);
-	write(drivea, (char *) sector, 128);
+	while ((n = read(fd, (char *) sector, 128)) == 128)
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
+	if (n == -1) {
+		perror("ccp.bin");
+		exit(EXIT_FAILURE);
+	} else if (n > 0) {
+		memset((char *) &sector[n], 0, 128 - n);
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
+	}
 	close(fd);
+
 	close(drivea);
 	return (EXIT_SUCCESS);
 }

--- a/cpmsim/srcmpm/putsys.c
+++ b/cpmsim/srcmpm/putsys.c
@@ -2,10 +2,12 @@
  * Write the MP/M 2 system files to system tracks of drive A
  *
  * Copyright (C) 2006-2016 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  *
  * History:
  * 08-DEC-06 cloned from the version for CP/M 3
  * 03-APR-16 disk drive name drivea.dsk
+ * 27-APR-24 improve error handling
  */
 
 #include <unistd.h>
@@ -13,10 +15,12 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <string.h>
+#include <errno.h>
 
+#define DISK "../disks/drivea.dsk"
 /*
  *	This program writes the MP/M 2 OS from the following files
- *	onto the system tracks of the boot disk (drivea.dsk):
+ *	onto the system tracks of the boot disk (DISK):
  *
  *	boot loader	boot.bin
  *	mpmldr		mpmldr.bin
@@ -25,33 +29,58 @@ int main(void)
 {
 	unsigned char sector[128];
 	int fd, drivea;
+	ssize_t n;
 
 	/* open drive A for writing */
-	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
-		perror("file ../disks/drivea.dsk");
+	if ((drivea = open(DISK, O_WRONLY)) == -1) {
+		perror(DISK);
 		exit(EXIT_FAILURE);
 	}
+
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
-		perror("file boot.bin");
+		perror("boot.bin");
 		exit(EXIT_FAILURE);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
-	read(fd, (char *) sector, 128);
-	close(fd);
+	if (read(fd, (char *) sector, 128) == -1) {
+		perror("boot.bin");
+		exit(EXIT_FAILURE);
+	}
 	/* and write it to disk in drive A */
-	write(drivea, (char *) sector, 128);
+	if ((n = write(drivea, (char *) sector, 128)) != 128) {
+		fprintf(stderr, DISK ": %s\n",
+			n == -1 ? strerror(errno) : "short write");
+		exit(EXIT_FAILURE);
+	}
+	close(fd);
+
 	/* open MP/M 2 mpmldr file (mpmldr.bin) for reading */
 	if ((fd = open("mpmldr.bin", O_RDONLY)) == -1) {
-		perror("file mpmldr.bin");
+		perror("mpmldr.bin");
 		exit(EXIT_FAILURE);
 	}
 	/* read from mpmldr.bin and write to disk in drive A */
-	while (read(fd, (char *) sector, 128) == 128)
-		write(drivea, (char *) sector, 128);
-	write(drivea, (char *) sector, 128);
+	while ((n = read(fd, (char *) sector, 128)) == 128)
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
+	if (n == -1) {
+		perror("mpmldr.bin");
+		exit(EXIT_FAILURE);
+	} else if (n > 0) {
+		memset((char *) &sector[n], 0, 128 - n);
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
+	}
 	close(fd);
+
 	close(drivea);
 	return (EXIT_SUCCESS);
 }

--- a/cpmsim/srctools/cpmrecv.c
+++ b/cpmsim/srctools/cpmrecv.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
 			}
 		}
 	}
-	if (n == -1) {
+	if (!signal_catched && n == -1) {
 		perror("auxout pipe");
 		exit(EXIT_FAILURE);
 	}

--- a/cpmsim/srctools/cpmrecv.c
+++ b/cpmsim/srctools/cpmrecv.c
@@ -12,6 +12,7 @@
  * 11-MAY-2016 delayed create outfile so that it is created if used
  * 20-MAR-2017 renamed pipe
  * 19-APR-2024 don't use exit() in signal handler and switch to sigaction()
+ * 27-APR-2024 improve error handling
  */
 
 #include <unistd.h>
@@ -19,6 +20,8 @@
 #include <stdio.h>
 #include <signal.h>
 #include <fcntl.h>
+#include <string.h>
+#include <errno.h>
 
 #define UNUSED(x) (void) (x)
 
@@ -28,6 +31,7 @@ int main(int argc, char *argv[])
 {
 	char c;
 	int fdin, fdout;
+	ssize_t n;
 	static struct sigaction newact;
 	void int_handler(int);
 
@@ -38,7 +42,7 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 	if ((fdin = open("/tmp/.z80pack/cpmsim.auxout", O_RDONLY)) == -1) {
-		perror("pipe auxout");
+		perror("auxout pipe");
 		exit(EXIT_FAILURE);
 	}
 
@@ -50,7 +54,7 @@ int main(int argc, char *argv[])
 	newact.sa_handler = int_handler;
 	sigaction(SIGHUP, &newact, NULL);
 
-	while (!signal_catched && read(fdin, &c, 1) == 1) {
+	while (!signal_catched && (n = read(fdin, &c, 1)) == 1) {
 		if (c != '\r') {
 			if (fdout == 0) {
 				if ((fdout = creat(argv[1], 0644)) == -1) {
@@ -58,8 +62,17 @@ int main(int argc, char *argv[])
 					exit(EXIT_FAILURE);
 				}
 			}
-			write(fdout, &c, 1);
+			if ((n = write(fdout, &c, 1)) != 1) {
+				fprintf(stderr, "%s: %s\n", argv[1],
+					n == -1 ? strerror(errno)
+						: "short write");
+				exit(EXIT_FAILURE);
+			}
 		}
+	}
+	if (n == -1) {
+		perror("auxout pipe");
+		exit(EXIT_FAILURE);
 	}
 
 	close(fdin);

--- a/cpmsim/srctools/cpmsend.c
+++ b/cpmsim/srctools/cpmsend.c
@@ -2,6 +2,7 @@
  * Sends a file through named pipe "auxin" to the CP/M simulation
  *
  * Copyright (C) 1988-2017 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  *
  * History:
  * 05-OCT-1988 Development on TARGON/35 with AT&T Unix System V.3
@@ -9,14 +10,17 @@
  * 01-OCT-2006 modified to compile on modern POSIX OS's
  * 09-MAR-2016 moved pipes to /tmp/.z80pack
  * 20-MAR-2017 renamed pipe
+ * 27-APR-2024 improve error handling
  */
 
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <fcntl.h>
+#include <string.h>
+#include <errno.h>
 
-void sendbuf(int);
+void sendbuf(ssize_t);
 
 char buf[BUFSIZ];
 char cr = '\r';
@@ -24,7 +28,7 @@ int fdout, fdin;
 
 int main(int argc, char *argv[])
 {
-	register int readn;
+	ssize_t n;
 
 	if (argc != 2) {
 		puts("usage: cpmsend filename &");
@@ -35,25 +39,38 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 	if ((fdout = open("/tmp/.z80pack/cpmsim.auxin", O_WRONLY)) == -1) {
-		perror("pipe auxin");
+		perror("auxin pipe");
 		exit(EXIT_FAILURE);
 	}
-	while ((readn = read(fdin, buf, BUFSIZ)) == BUFSIZ)
+	while ((n = read(fdin, buf, BUFSIZ)) == BUFSIZ)
 		sendbuf(BUFSIZ);
-	if (readn)
-		sendbuf(readn);
+	if (n == -1) {
+		perror(argv[1]);
+		exit(EXIT_FAILURE);
+	} else if (n > 0)
+		sendbuf(n);
 	close(fdin);
 	close(fdout);
 	return (EXIT_SUCCESS);
 }
 
-void sendbuf(int size)
+void sendbuf(ssize_t size)
 {
 	register char *s = buf;
+	ssize_t n;
 
 	while (s - buf < size) {
 		if (*s == '\n')
-			write(fdout, (char *) &cr, 1);
-		write(fdout, s++, 1);
+			if ((n = write(fdout, (char *) &cr, 1)) != 1) {
+				fprintf(stderr, "auxin pipe: %s\n",
+					n == -1 ? strerror(errno)
+						: "short write");
+				exit(EXIT_FAILURE);
+			}
+		if ((n = write(fdout, s++, 1)) != 1) {
+			fprintf(stderr, "auxin pipe: %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
 	}
 }

--- a/cpmsim/srctools/ptp2bin.c
+++ b/cpmsim/srctools/ptp2bin.c
@@ -3,9 +3,11 @@
  * the leading 0's
  *
  * Copyright (C) 2015 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  *
  * History:
  * 04-APR-15 first version
+ * 27-APR-24 improve error handling
  */
 
 #include <unistd.h>
@@ -13,37 +15,48 @@
 #include <stdio.h>
 #include <libgen.h>
 #include <fcntl.h>
+#include <string.h>
+#include <errno.h>
 
 int main(int argc, char *argv[])
 {
 	int fdin, fdout;
 	int flag = 0;
+	ssize_t n;
 	char c;
 	char *pn = basename(argv[0]);
 
 	if (argc != 3) {
 		printf("usage: %s infile outfile\n", pn);
-		return (EXIT_FAILURE);
+		exit(EXIT_FAILURE);
 	}
 
 	if ((fdin = open(argv[1], O_RDONLY)) == -1) {
 		perror(argv[1]);
-		return (EXIT_FAILURE);
+		exit(EXIT_FAILURE);
 	}
 
 	if ((fdout = open(argv[2], O_WRONLY | O_CREAT, 0644)) == -1) {
 		perror(argv[2]);
-		return (EXIT_FAILURE);
+		exit(EXIT_FAILURE);
 	}
 
-	while (read(fdin, &c, 1) == 1) {
+	while ((n = read(fdin, &c, 1)) == 1) {
 		if (flag == 0) {
 			if (c == 0)
 				continue;
 			else
 				flag++;
 		}
-		write(fdout, &c, 1);
+		if ((n = write(fdout, &c, 1)) != 1) {
+			fprintf(stderr, "%s: %s\n", argv[2],
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
+	}
+	if (n == -1) {
+		perror(argv[1]);
+		exit(EXIT_FAILURE);
 	}
 
 	close(fdin);

--- a/cpmsim/srcucsd-iv/putsys.c
+++ b/cpmsim/srcucsd-iv/putsys.c
@@ -2,10 +2,12 @@
  * Write the UCSD pSystem IV boot and BIOS code to system tracks of drive A
  *
  * Copyright (C) 2008-2016 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  *
  * History:
  * 12-AUG-08 initial version
  * 03-APR-16 disk drive name drivea.dsk
+ * 27-APR-24 improve error handling
  */
 
 #include <unistd.h>
@@ -13,58 +15,90 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <string.h>
+#include <errno.h>
+
+#define DISK "../disks/drivea.dsk"
 
 /*
  *	This program writes the UCSD boot code from the following files
- *	onto the system tracks of the boot disk (drivea.dsk):
+ *	onto the system tracks of the boot disk (DISK):
  *
- *	boot loader	boot.bin	(binary format)
- *	BIOS		bios.bin	(binary format)
+ *	boot loader	boot.bin
+ *	BIOS		bios.bin
  */
 int main(void)
 {
 	unsigned char sector[128];
 	register int i;
-	int fd, drivea, readn;
+	int fd, drivea;
+	ssize_t n;
+	off_t o;
 
 	/* open drive A for writing */
-	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
-		perror("file ../disks/drivea.dsk");
+	if ((drivea = open(DISK, O_WRONLY)) == -1) {
+		perror(DISK);
 		exit(EXIT_FAILURE);
 	}
+
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
-		perror("file boot.bin");
+		perror("boot.bin");
 		exit(EXIT_FAILURE);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
-	read(fd, (char *) sector, 128);
-	close(fd);
+	if (read(fd, (char *) sector, 128) == -1) {
+		perror("boot.bin");
+		exit(EXIT_FAILURE);
+	}
 	/* and write it to disk in drive A */
-	write(drivea, (char *) sector, 128);
+	if ((n = write(drivea, (char *) sector, 128)) != 128) {
+		fprintf(stderr, DISK ": %s\n",
+			n == -1 ? strerror(errno) : "short write");
+		exit(EXIT_FAILURE);
+	}
+	close(fd);
+
 	/* seek to sector 19 on drive A */
-	lseek(drivea, (long) 18 * 128, 0);
+	if ((o = lseek(drivea, 18 * 128L, SEEK_SET)) != 18 * 128L) {
+		fprintf(stderr, DISK ": %s\n",
+			o == -1 ? strerror(errno) : "short file");
+		exit(EXIT_FAILURE);
+	}
+
 	/* open BIOS (bios.bin) for reading */
 	if ((fd = open("bios.bin", O_RDONLY)) == -1) {
-		perror("file bios.bin");
+		perror("bios.bin");
 		exit(EXIT_FAILURE);
 	}
 	/* read BIOS from bios.bin and write it to disk in drive A */
 	i = 0;
-	while ((readn = read(fd, (char *) sector, 128)) == 128) {
-		write(drivea, (char *) sector, 128);
+	while ((n = read(fd, (char *) sector, 128)) == 128) {
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
 		i++;
 		if (i == 8) {
-			puts("8 sectors written, can't write any more!");
-			goto stop;
+			fputs(DISK ": out of space (8 sectors written)",
+			      stderr);
+			exit(EXIT_FAILURE);
 		}
 	}
-	if (readn > 0) {
-		write(drivea, (char *) sector, 128);
+	if (n == -1) {
+		perror("bios.bin");
+		exit(EXIT_FAILURE);
+	} else if (n > 0) {
+		memset((char *) &sector[n], 0, 128 - n);
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
 	}
-stop:
 	close(fd);
+
 	close(drivea);
 	return (EXIT_SUCCESS);
 }

--- a/imsaisim/srcucsd-iv/putsys.c
+++ b/imsaisim/srcucsd-iv/putsys.c
@@ -2,10 +2,12 @@
  * Write the UCSD pSystem IV boot and BIOS code to system tracks of drive A
  *
  * Copyright (C) 2008-2016 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
  *
  * History:
  * 12-AUG-08 initial version
  * 03-APR-16 disk drive name drivea.dsk
+ * 27-APR-24 improve error handling
  */
 
 #include <unistd.h>
@@ -13,58 +15,90 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <string.h>
+#include <errno.h>
+
+#define DISK "../disks/drivea.dsk"
 
 /*
  *	This program writes the UCSD boot code from the following files
- *	onto the system tracks of the boot disk (drivea.dsk):
+ *	onto the system tracks of the boot disk (DISK):
  *
- *	boot loader	boot.bin	(binary format)
- *	BIOS		bios.bin	(binary format)
+ *	boot loader	boot.bin
+ *	BIOS		bios.bin
  */
 int main(void)
 {
 	unsigned char sector[128];
 	register int i;
-	int fd, drivea, readn;
+	int fd, drivea;
+	ssize_t n;
+	off_t o;
 
 	/* open drive A for writing */
-	if ((drivea = open("../disks/drivea.dsk", O_WRONLY)) == -1) {
-		perror("file ../disks/drivea.dsk");
+	if ((drivea = open(DISK, O_WRONLY)) == -1) {
+		perror(DISK);
 		exit(EXIT_FAILURE);
 	}
+
 	/* open boot loader (boot.bin) for reading */
 	if ((fd = open("boot.bin", O_RDONLY)) == -1) {
-		perror("file boot.bin");
+		perror("boot.bin");
 		exit(EXIT_FAILURE);
 	}
 	/* read boot loader */
 	memset((char *) sector, 0, 128);
-	read(fd, (char *) sector, 128);
-	close(fd);
+	if (read(fd, (char *) sector, 128) == -1) {
+		perror("boot.bin");
+		exit(EXIT_FAILURE);
+	}
 	/* and write it to disk in drive A */
-	write(drivea, (char *) sector, 128);
+	if ((n = write(drivea, (char *) sector, 128)) != 128) {
+		fprintf(stderr, DISK ": %s\n",
+			n == -1 ? strerror(errno) : "short write");
+		exit(EXIT_FAILURE);
+	}
+	close(fd);
+
 	/* seek to sector 19 on drive A */
-	lseek(drivea, (long) 18 * 128, 0);
+	if ((o = lseek(drivea, 18 * 128L, SEEK_SET)) != 18 * 128L) {
+		fprintf(stderr, DISK ": %s\n",
+			o == -1 ? strerror(errno) : "short file");
+		exit(EXIT_FAILURE);
+	}
+
 	/* open BIOS (bios.bin) for reading */
 	if ((fd = open("bios.bin", O_RDONLY)) == -1) {
-		perror("file bios.bin");
+		perror("bios.bin");
 		exit(EXIT_FAILURE);
 	}
 	/* read BIOS from bios.bin and write it to disk in drive A */
 	i = 0;
-	while ((readn = read(fd, (char *) sector, 128)) == 128) {
-		write(drivea, (char *) sector, 128);
+	while ((n = read(fd, (char *) sector, 128)) == 128) {
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
 		i++;
 		if (i == 8) {
-			puts("8 sectors written, can't write any more!");
-			goto stop;
+			fputs(DISK ": out of space (8 sectors written)",
+			      stderr);
+			exit(EXIT_FAILURE);
 		}
 	}
-	if (readn > 0) {
-		write(drivea, (char *) sector, 128);
+	if (n == -1) {
+		perror("bios.bin");
+		exit(EXIT_FAILURE);
+	} else if (n > 0) {
+		memset((char *) &sector[n], 0, 128 - n);
+		if ((n = write(drivea, (char *) sector, 128)) != 128) {
+			fprintf(stderr, DISK ": %s\n",
+				n == -1 ? strerror(errno) : "short write");
+			exit(EXIT_FAILURE);
+		}
 	}
-stop:
 	close(fd);
+
 	close(drivea);
 	return (EXIT_SUCCESS);
 }


### PR DESCRIPTION
Ubuntu 24.04 gcc was complaining about unchecked return values from read() and write().

Change srccpm2 putsys.c to not use Mostek binary files as input, like the srccpm3, srcmpm, and srcucsd-iv putsys.c.
Adjust srccpm2 Makefile accordingly.

It just occurred to me: Aren't cpmrecv and cpmsend superseded by "r.com" and "w.com" from Mike Douglas?
Should they perhaps be removed?