### PR TITLE
fix unchecked strtok() return values in config file parsing

### DIFF
--- a/altairsim/srcsim/config.c
+++ b/altairsim/srcsim/config.c
@@ -94,8 +94,14 @@ void config(void)
 		while (fgets(s, BUFSIZE, fp) != NULL) {
 			if ((*s == '\n') || (*s == '\r') || (*s == '#'))
 				continue;
-			t1 = strtok(s, " \t");
-			t2 = strtok(NULL, " \t,");
+			if ((t1 = strtok(s, " \t")) == NULL) {
+				LOGW(TAG, "missing command");
+				continue;
+			}
+			if ((t2 = strtok(NULL, " \t,")) == NULL) {
+				LOGW(TAG, "missing parameter for %s", t1);
+				continue;
+			}
 			if (!strcmp(t1, "sio0_upper_case")) {
 				switch (*t2) {
 				case '0':
@@ -105,7 +111,7 @@ void config(void)
 					sio0_upper_case = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio1_upper_case")) {
@@ -117,7 +123,7 @@ void config(void)
 					sio1_upper_case = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio2_upper_case")) {
@@ -129,7 +135,7 @@ void config(void)
 					sio2_upper_case = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio0_strip_parity")) {
@@ -141,7 +147,7 @@ void config(void)
 					sio0_strip_parity = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio1_strip_parity")) {
@@ -153,7 +159,7 @@ void config(void)
 					sio1_strip_parity = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio2_strip_parity")) {
@@ -165,7 +171,7 @@ void config(void)
 					sio2_strip_parity = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio0_drop_nulls")) {
@@ -177,7 +183,7 @@ void config(void)
 					sio0_drop_nulls = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio1_drop_nulls")) {
@@ -189,7 +195,7 @@ void config(void)
 					sio1_drop_nulls = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio2_drop_nulls")) {
@@ -201,7 +207,7 @@ void config(void)
 					sio2_drop_nulls = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio0_revision")) {
@@ -213,7 +219,7 @@ void config(void)
 					sio0_revision = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio0_baud_rate")) {
@@ -229,14 +235,10 @@ void config(void)
 			} else if (!strcmp(t1, "fp_fps")) {
 #ifdef FRONTPANEL
 				fp_fps = (float) atoi(t2);
-#else
-				;
 #endif
 			} else if (!strcmp(t1, "fp_size")) {
 #ifdef FRONTPANEL
 				fp_size = atoi(t2);
-#else
-				;
 #endif
 			} else if (!strcmp(t1, "vdm_bg")) {
 				strncpy(&bg_color[1], t2, 6);
@@ -248,18 +250,21 @@ void config(void)
 			} else if (!strcmp(t1, "ram")) {
 				if (num_segs >= MAXMEMMAP) {
 					LOGW(TAG, "too many rom/ram statements");
-					goto next;
+					continue;
 				}
-				t3 = strtok(NULL, " \t,");
+				if ((t3 = strtok(NULL, " \t,")) == NULL) {
+					LOGW(TAG, "missing ram size");
+					continue;
+				}
 				v1 = strtol(t2, NULL, 0);
 				if (v1 < 0 || v1 > 255) {
 					LOGW(TAG, "invalid ram start address %d", v1);
-					goto next;
+					continue;
 				}
 				v2 = strtol(t3, NULL, 0);
 				if (v2 < 1 || v1 + v2 > 256) {
 					LOGW(TAG, "invalid ram size %d", v2);
-					goto next;
+					continue;
 				}
 				memconf[section][num_segs].type = MEM_RW;
 				memconf[section][num_segs].spage = v1;
@@ -270,19 +275,22 @@ void config(void)
 			} else if (!strcmp(t1, "rom")) {
 				if (num_segs >= MAXMEMMAP) {
 					LOGW(TAG, "too many rom/ram statements");
-					goto next;
+					continue;
 				}
-				t3 = strtok(NULL, " \t,");
-				t4 = strtok(NULL, " \t\n");
+				if ((t3 = strtok(NULL, " \t,")) == NULL) {
+					LOGW(TAG, "missing rom size");
+					continue;
+				}
+				t4 = strtok(NULL, " \t\r\n");
 				v1 = strtol(t2, NULL, 0);
 				if (v1 < 0 || v1 > 255) {
 					LOGW(TAG, "invalid rom start address %d", v1);
-					goto next;
+					continue;
 				}
 				v2 = strtol(t3, NULL, 0);
 				if (v2 < 1 || v1 + v2 > 256) {
 					LOGW(TAG, "invalid rom size %d", v2);
-					goto next;
+					continue;
 				}
 				memconf[section][num_segs].type = MEM_RO;
 				memconf[section][num_segs].spage = v1;
@@ -303,18 +311,14 @@ void config(void)
 				v1 = strtol(t2, &t3, 10);
 				if (t3[0] != ']' || v1 < 1 || v1 > MAXMEMSECT) {
 					LOGW(TAG, "invalid MEMORY section number %d", v1);
-					goto next;
+					continue;
 				}
 				LOGD(TAG, "MEMORY CONFIGURATION %d", v1);
 				section = v1 - 1;
 				num_segs = 0;
 			} else {
-				LOGW(TAG, "system.conf unknown command: %s", s);
+				LOGW(TAG, "unknown command: %s", t1);
 			}
-
-next:
-			;
-
 		}
 		fclose(fp);
 	}

--- a/cromemcosim/srcsim/config.c
+++ b/cromemcosim/srcsim/config.c
@@ -59,37 +59,42 @@ void config(void)
 		while (fgets(s, BUFSIZE, fp) != NULL) {
 			if ((*s == '\n') || (*s == '\r') || (*s == '#'))
 				continue;
-			t1 = strtok(s, " \t");
-			t2 = strtok(NULL, " \t,");
+			if ((t1 = strtok(s, " \t")) == NULL) {
+				LOGW(TAG, "missing command");
+				continue;
+			}
+			if ((t2 = strtok(NULL, " \t,")) == NULL) {
+				LOGW(TAG, "missing parameter for %s", t1);
+				continue;
+			}
 			if (!strcmp(t1, "fp_port")) {
 				fp_port = (BYTE) exatoi(t2);
 			} else if (!strcmp(t1, "fp_fps")) {
 #ifdef FRONTPANEL
 				fp_fps = (float) atoi(t2);
-#else
-				;
 #endif
 			} else if (!strcmp(t1, "fp_size")) {
 #ifdef FRONTPANEL
 				fp_size = atoi(t2);
-#else
-				;
 #endif
 			} else if (!strcmp(t1, "ram")) {
 				if (num_segs >= MAXMEMMAP) {
 					LOGW(TAG, "too many rom/ram statements");
-					goto next;
+					continue;
 				}
-				t3 = strtok(NULL, " \t,");
+				if ((t3 = strtok(NULL, " \t,")) == NULL) {
+					LOGW(TAG, "missing ram size");
+					continue;
+				}
 				v1 = strtol(t2, NULL, 0);
 				if (v1 < 0 || v1 > 255) {
 					LOGW(TAG, "invalid ram start address %d", v1);
-					goto next;
+					continue;
 				}
 				v2 = strtol(t3, NULL, 0);
 				if (v2 < 1 || v1 + v2 > 256) {
 					LOGW(TAG, "invalid ram size %d", v2);
-					goto next;
+					continue;
 				}
 				memconf[section][num_segs].type = MEM_RW;
 				memconf[section][num_segs].spage = v1;
@@ -100,19 +105,22 @@ void config(void)
 			} else if (!strcmp(t1, "rom")) {
 				if (num_segs >= MAXMEMMAP) {
 					LOGW(TAG, "too many rom/ram statements");
-					goto next;
+					continue;
 				}
-				t3 = strtok(NULL, " \t,");
+				if ((t3 = strtok(NULL, " \t,")) == NULL) {
+					LOGW(TAG, "missing rom size");
+					continue;
+				}
 				t4 = strtok(NULL, " \t\r\n");
 				v1 = strtol(t2, NULL, 0);
 				if (v1 < 0 || v1 > 255) {
 					LOGW(TAG, "invalid rom start address %d", v1);
-					goto next;
+					continue;
 				}
 				v2 = strtol(t3, NULL, 0);
 				if (v2 < 1 || v1 + v2 > 256) {
 					LOGW(TAG, "invalid rom size %d", v2);
-					goto next;
+					continue;
 				}
 				memconf[section][num_segs].type = MEM_RO;
 				memconf[section][num_segs].spage = v1;
@@ -133,18 +141,14 @@ void config(void)
 				v1 = strtol(t2, &t3, 10);
 				if (t3[0] != ']' || v1 < 1 || v1 > MAXMEMSECT) {
 					LOGW(TAG, "invalid MEMORY section number %d", v1);
-					goto next;
+					continue;
 				}
 				LOGD(TAG, "MEMORY CONFIGURATION %d", v1);
 				section = v1 - 1;
 				num_segs = 0;
 			} else {
-				LOGW(TAG, "system.conf unknown command: %s", s);
+				LOGW(TAG, "unknown command: %s", t1);
 			}
-
-next:
-			;
-
 		}
 		fclose(fp);
 	}

--- a/imsaisim/srcsim/config.c
+++ b/imsaisim/srcsim/config.c
@@ -102,8 +102,14 @@ void config(void)
 		while (fgets(s, BUFSIZE, fp) != NULL) {
 			if ((*s == '\n') || (*s == '\r') || (*s == '#'))
 				continue;
-			t1 = strtok(s, " \t");
-			t2 = strtok(NULL, " \t,");
+			if ((t1 = strtok(s, " \t")) == NULL) {
+				LOGW(TAG, "missing command");
+				continue;
+			}
+			if ((t2 = strtok(NULL, " \t,")) == NULL) {
+				LOGW(TAG, "missing parameter for %s", t1);
+				continue;
+			}
 			if (!strcmp(t1, "sio1a_upper_case")) {
 				switch (*t2) {
 				case '0':
@@ -113,7 +119,7 @@ void config(void)
 					sio1a_upper_case = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio1b_upper_case")) {
@@ -125,7 +131,7 @@ void config(void)
 					sio1b_upper_case = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio2a_upper_case")) {
@@ -137,7 +143,7 @@ void config(void)
 					sio2a_upper_case = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio2b_upper_case")) {
@@ -149,7 +155,7 @@ void config(void)
 					sio2b_upper_case = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio1a_strip_parity")) {
@@ -161,7 +167,7 @@ void config(void)
 					sio1a_strip_parity = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio1b_strip_parity")) {
@@ -173,7 +179,7 @@ void config(void)
 					sio1b_strip_parity = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio2a_strip_parity")) {
@@ -185,7 +191,7 @@ void config(void)
 					sio2a_strip_parity = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio2b_strip_parity")) {
@@ -197,7 +203,7 @@ void config(void)
 					sio2b_strip_parity = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio1a_drop_nulls")) {
@@ -209,7 +215,7 @@ void config(void)
 					sio1a_drop_nulls = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio1b_drop_nulls")) {
@@ -221,7 +227,7 @@ void config(void)
 					sio1b_drop_nulls = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio2a_drop_nulls")) {
@@ -233,7 +239,7 @@ void config(void)
 					sio2a_drop_nulls = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio2b_drop_nulls")) {
@@ -245,7 +251,7 @@ void config(void)
 					sio2b_drop_nulls = 1;
 					break;
 				default:
-					LOGW(TAG, "system.conf: invalid value for %s: %s", t1, t2);
+					LOGW(TAG, "invalid value for %s: %s", t1, t2);
 					break;
 				}
 			} else if (!strcmp(t1, "sio1a_baud_rate")) {
@@ -261,14 +267,10 @@ void config(void)
 			} else if (!strcmp(t1, "fp_fps")) {
 #ifdef FRONTPANEL
 				fp_fps = (float) atoi(t2);
-#else
-				;
 #endif
 			} else if (!strcmp(t1, "fp_size")) {
 #ifdef FRONTPANEL
 				fp_size = atoi(t2);
-#else
-				;
 #endif
 			} else if (!strcmp(t1, "vio_bg")) {
 				strncpy(&bg_color[1], t2, 6);
@@ -280,18 +282,21 @@ void config(void)
 			} else if (!strcmp(t1, "ram")) {
 				if (num_segs >= MAXMEMMAP) {
 					LOGW(TAG, "too many rom/ram statements");
-					goto next;
+					continue;
 				}
-				t3 = strtok(NULL, " \t,");
+				if ((t3 = strtok(NULL, " \t,")) == NULL) {
+					LOGW(TAG, "missing ram size");
+					continue;
+				}
 				v1 = strtol(t2, NULL, 0);
 				if (v1 < 0 || v1 > 255) {
 					LOGW(TAG, "invalid ram start address %d", v1);
-					goto next;
+					continue;
 				}
 				v2 = strtol(t3, NULL, 0);
 				if (v2 < 1 || v1 + v2 > 256) {
 					LOGW(TAG, "invalid ram size %d", v2);
-					goto next;
+					continue;
 				}
 				memconf[section][num_segs].type = MEM_RW;
 				memconf[section][num_segs].spage = v1;
@@ -302,19 +307,22 @@ void config(void)
 			} else if (!strcmp(t1, "rom")) {
 				if (num_segs >= MAXMEMMAP) {
 					LOGW(TAG, "too many rom/ram statements");
-					goto next;
+					continue;
 				}
-				t3 = strtok(NULL, " \t,");
-				t4 = strtok(NULL, " \t\n");
+				if ((t3 = strtok(NULL, " \t,")) == NULL) {
+					LOGW(TAG, "missing rom size");
+					continue;
+				}
+				t4 = strtok(NULL, " \t\r\n");
 				v1 = strtol(t2, NULL, 0);
 				if (v1 < 0 || v1 > 255) {
 					LOGW(TAG, "invalid rom start address %d", v1);
-					goto next;
+					continue;
 				}
 				v2 = strtol(t3, NULL, 0);
 				if (v2 < 1 || v1 + v2 > 256) {
 					LOGW(TAG, "invalid rom size %d", v2);
-					goto next;
+					continue;
 				}
 				memconf[section][num_segs].type = MEM_RO;
 				memconf[section][num_segs].spage = v1;
@@ -335,17 +343,14 @@ void config(void)
 				v1 = strtol(t2, &t3, 10);
 				if (t3[0] != ']' || v1 < 1 || v1 > MAXMEMSECT) {
 					LOGW(TAG, "invalid MEMORY section number %d", v1);
-					goto next;
+					continue;
 				}
 				LOGD(TAG, "MEMORY CONFIGURATION %d", v1);
 				section = v1 - 1;
 				num_segs = 0;
 			} else {
-				LOGW(TAG, "system.conf unknown command: %s", s);
+				LOGW(TAG, "unknown command: %s", t1);
 			}
-
-next:
-			;
 		}
 		fclose(fp);
 	}

--- a/iodevices/mostek-fdc.c
+++ b/iodevices/mostek-fdc.c
@@ -101,10 +101,18 @@ void get_disk_filename(void)
 			if ((inbuf[0] == '\n') || (inbuf[0] == '\r') ||
 			    (inbuf[0] == '#'))
 				continue;
-			left = strtok(inbuf, "= \t\r\n");
+			if ((left = strtok(inbuf, "= \t\r\n")) == NULL) {
+				LOGW(TAG, "missing command");
+				continue;
+			}
 			if (0 == strncmp(left, "drive", 5)) {
 				if (left[5] == (char) disk + '0') { /* match drive? */
 					right = strtok(NULL, "= \t\r\n");
+					if (right == NULL) {
+						LOGW(TAG, "missing path for %s",
+						     left);
+						continue;
+					}
 					strcpy(fn, right);
 					break;
 				}

--- a/mosteksim/srcsim/config.c
+++ b/mosteksim/srcsim/config.c
@@ -35,8 +35,14 @@ void config(void)
 		while (fgets(s, BUFSIZE, fp) != NULL) {
 			if ((*s == '\n') || (*s == '\r') || (*s == '#'))
 				continue;
-			t1 = strtok(s, "= \t\r\n");
-			t2 = strtok(NULL, "= \t\r\n");
+			if ((t1 = strtok(s, "= \t\r\n")) == NULL) {
+				LOGW(TAG, "missing command");
+				continue;
+			}
+			if ((t2 = strtok(NULL, "= \t\r\n")) == NULL) {
+				LOGW(TAG, "missing parameter for %s", t1);
+				continue;
+			}
 
 			if (0 == strcmp(t1, "bootrom")) {
 				LOG(TAG, "\r\nBoot ROM: %s\r\n\r\n", t2);
@@ -51,7 +57,7 @@ void config(void)
 			} else if (0 == strcmp(t1, "drive3")) {
 				LOG(TAG, "Drive 3: %s\r\n", t2);
 			} else {
-				LOGW(TAG, "unknown command: %s", s);
+				LOGW(TAG, "unknown command: %s", t1);
 			}
 		}
 		fclose(fp);


### PR DESCRIPTION
gcc 14 static analyzer on Ubuntu 24.04 complained about possible NULL return values from strtok().

Removed unnecessary "goto"s and empty statements.

Removed "system.conf:" from LOG because the output already contains the tag "config:",
also it wasn't present in all LOG statements.
