### PR TITLE
Clean-up ignored return values and some other small stuff

### DIFF
--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -527,9 +527,7 @@ void power_clicked(int state, int val)
 		fp_led_address = PC;
 		fp_led_data = fp_read(PC);
 		fp_led_wait = 1;
-		if (isatty(1))
-			system("tput clear");
-		else
+		if (!isatty(fileno(stdout)) || (system("tput clear") == -1))
 			puts("\r\n\r\n\r\n");
 		break;
 	case FP_SW_UP:

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -1593,7 +1593,8 @@ static BYTE cond_in(void)
 	char c;
 
 	busy_loop_cnt[0] = 0;
-	read(0, &c, 1);
+	if (read(fileno(stdin), &c, 1) != 1)
+		LOGE(TAG, "can't read console 0");
 	return ((BYTE) c);
 }
 
@@ -1619,7 +1620,8 @@ static BYTE cond1_in(void)
 		}
 	}
 	if (ss_telnet[0] && (c == '\r'))
-		read(ssc[0], &x, 1);
+		if (read(ssc[0], &x, 1) != 1)
+			LOGE(TAG, "can't read console 1");
 #ifdef SNETDEBUG
 	if (sdirection != 1) {
 		printf("\n<- ");
@@ -1655,7 +1657,8 @@ static BYTE cond2_in(void)
 		}
 	}
 	if (ss_telnet[1] && (c == '\r'))
-		read(ssc[1], &x, 1);
+		if (read(ssc[1], &x, 1) != 1)
+			LOGE(TAG, "can't read console 2");
 #ifdef SNETDEBUG
 	if (sdirection != 1) {
 		printf("\n<- ");
@@ -1691,7 +1694,8 @@ static BYTE cond3_in(void)
 		}
 	}
 	if (ss_telnet[2] && (c == '\r'))
-		read(ssc[2], &x, 1);
+		if (read(ssc[2], &x, 1) != 1)
+			LOGE(TAG, "can't read console 3");
 #ifdef SNETDEBUG
 	if (sdirection != 1) {
 		printf("\n<- ");
@@ -1727,7 +1731,8 @@ static BYTE cond4_in(void)
 		}
 	}
 	if (ss_telnet[3] && (c == '\r'))
-		read(ssc[3], &x, 1);
+		if (read(ssc[3], &x, 1) != 1)
+			LOGE(TAG, "can't read console 4");
 #ifdef SNETDEBUG
 	if (sdirection != 1) {
 		printf("\n<- ");
@@ -2060,7 +2065,8 @@ static void auxd_out(BYTE data)
 		return;
 
 	if (data != '\r')
-		write(auxout, (char *) &data, 1);
+		if (write(auxout, (char *) &data, 1) != 1)
+			LOGE(TAG, "can't write to auxout pipe");
 #else
 	if (data == 0)
 		return;
@@ -2081,7 +2087,8 @@ static void auxd_out(BYTE data)
 	}
 
 	if (data != '\r')
-		write(aux_out, (char *) &data, 1);
+		if (write(aux_out, (char *) &data, 1) != 1)
+			LOGE(TAG, "can't write to auxiliaryout.txt");
 #endif
 }
 
@@ -2609,8 +2616,10 @@ void telnet_negotiation(int fd)
 	BYTE c[3];
 
 	/* send the telnet options we need */
-	write(fd, &char_mode, 3);
-	write(fd, &will_echo, 3);
+	if (write(fd, &char_mode, 3) != 3)
+		LOGE(TAG, "can't send char_mode telnet option");
+	if (write(fd, &will_echo, 3) != 3)
+		LOGE(TAG, "can't send will_echo telnet option");
 
 	/* and reject all others offered */
 	p[0].fd = fd;
@@ -2625,7 +2634,8 @@ void telnet_negotiation(int fd)
 			break;
 
 		/* else read the option */
-		read(fd, &c, 3);
+		if (read(fd, &c, 3) != 3)
+			LOGE(TAG, "can't read telnet option");
 		LOGD(TAG, "telnet: %d %d %d", c[0], c[1], c[2]);
 		if (c[2] == 1 || c[2] == 3)
 			continue;	/* ignore answers to our requests */
@@ -2633,7 +2643,8 @@ void telnet_negotiation(int fd)
 			c[1] = 254;
 		else if (c[1] == 253)
 			c[1] = 252;
-		write(fd, &c, 3);
+		if (write(fd, &c, 3) != 3)
+			LOGE(TAG, "can't write telnet option");
 	}
 }
 #endif

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -460,9 +460,7 @@ void power_clicked(int state, int val)
 		fp_led_speed = (f_flag == 0 || f_flag >= 4) ? 1 : 0;
 		fp_led_wait = 1;
 		fp_led_output = 0;
-		if (isatty(1))
-			system("tput clear");
-		else
+		if (!isatty(fileno(stdout)) || (system("tput clear") == -1))
 			puts("\r\n\r\n\r\n");
 		break;
 	case FP_SW_DOWN:

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -457,9 +457,7 @@ void power_clicked(int state, int val)
 		fp_led_wait = 1;
 		fp_led_output = 0;
 #ifdef UNIX_TERMINAL
-		if (isatty(1))
-			system("tput clear");
-		else
+		if (!isatty(fileno(stdout)) || (system("tput clear") == -1))
 			puts("\r\n\r\n\r\n");
 #endif
 		break;

--- a/iodevices/altair-88-2sio.c
+++ b/iodevices/altair-88-2sio.c
@@ -128,7 +128,8 @@ again:
 
 	if (read(fileno(stdin), &data, 1) == 0) {
 		/* try to reopen tty, input redirection exhausted */
-		freopen("/dev/tty", "r", stdin);
+		if (freopen("/dev/tty", "r", stdin) == NULL)
+			LOGE(TAG, "can't reopen /dev/tty");
 		set_unix_terminal();
 		goto again;
 	}

--- a/iodevices/altair-88-dcdd.c
+++ b/iodevices/altair-88-dcdd.c
@@ -421,8 +421,13 @@ void altair_dsk_data_out(BYTE data)
 		/* write sector */
 		fd = open(fn, O_RDWR);
 		pos = (track[disk] * SPT + rwsec) * SEC_SZ;
-		lseek(fd, pos, SEEK_SET);
-		write(fd, &buf[0], SEC_SZ);
+		if (lseek(fd, pos, SEEK_SET) != pos) {
+			LOGE(TAG, "can't seek to sector %d track %d",
+			     rwsec, track[disk]);
+		} else if (write(fd, &buf[0], SEC_SZ) != SEC_SZ) {
+			LOGE(TAG, "can't write sector %d track %d",
+			     rwsec, track[disk]);
+		}
 		close(fd);
 		LOGD(TAG, "write sector %d track %d", rwsec, track[disk]);
 	}
@@ -446,8 +451,13 @@ BYTE altair_dsk_data_in(void)
 			/* read sector */
 			fd = open(fn, O_RDONLY);
 			pos = (track[disk] * SPT + rwsec) * SEC_SZ;
-			lseek(fd, pos, SEEK_SET);
-			read(fd, &buf[0], SEC_SZ);
+			if (lseek(fd, pos, SEEK_SET) != pos) {
+				LOGE(TAG, "can't seek to sector %d track %d",
+				     rwsec, track[disk]);
+			} else if (read(fd, &buf[0], SEC_SZ) != SEC_SZ) {
+				LOGE(TAG, "can't read sector %d track %d",
+				     rwsec, track[disk]);
+			}
 			close(fd);
 			LOGD(TAG, "read sector %d track %d", rwsec, track[disk]);
 		}

--- a/iodevices/altair-88-sio.c
+++ b/iodevices/altair-88-sio.c
@@ -140,7 +140,8 @@ again:
 
 	if (read(fileno(stdin), &data, 1) == 0) {
 		/* try to reopen tty, input redirection exhausted */
-		freopen("/dev/tty", "r", stdin);
+		if (freopen("/dev/tty", "r", stdin) == NULL)
+			LOGE(TAG, "can't reopen /dev/tty");
 		set_unix_terminal();
 		goto again;
 	}

--- a/iodevices/cromemco-hal.c
+++ b/iodevices/cromemco-hal.c
@@ -130,7 +130,8 @@ again:
 
     if (read(fileno(stdin), &data, 1) == 0) {
         /* try to reopen tty, input redirection exhausted */
-        freopen("/dev/tty", "r", stdin);
+        if (freopen("/dev/tty", "r", stdin) == NULL)
+            LOGE(TAG, "can't reopen /dev/tty");
         set_unix_terminal();
         goto again;
     }
@@ -215,7 +216,9 @@ int scktsrv_in(int dev) {
 		/* process read data */
 		/* telnet client sends \r\n or \r\0, drop second character */
 		if (ncons[dev].telnet && (data == '\r'))
-			read(ncons[dev].ssc, &dummy, 1);
+			if (read(ncons[dev].ssc, &dummy, 1) != 1)
+				LOGE(TAG, "can't read tcpsocket %d data", dev);
+
 
     return data;
 }

--- a/iodevices/generic-at-modem.c
+++ b/iodevices/generic-at-modem.c
@@ -184,7 +184,8 @@ static void telnet_hdlr(telnet_t *telnet, telnet_event_t *ev, void *user_data) {
             }
             LOGD(TAG, "Telnet OUT: %s[%lld]", buf, (long long) ev->data.size);
 		}
-		write(*active_sfd, ev->data.buffer, ev->data.size);
+		if (write(*active_sfd, ev->data.buffer, ev->data.size) != (ssize_t) ev->data.size)
+			LOGE(TAG, "Telnet OUT: can't send data");
 		break;
     case TELNET_EV_WILL:
         if (ev->neg.telopt == TELNET_TELOPT_SGA) {
@@ -1252,7 +1253,8 @@ void modem_device_send(int i, char data) {
                 if (telnet != NULL) {
                     telnet_send(telnet, at_buf, strlen(at_buf));
                 } else {
-                    write(*active_sfd, at_buf, strlen(at_buf));
+                    if (write(*active_sfd, at_buf, strlen(at_buf)) != (ssize_t) strlen(at_buf))
+                        LOGE(TAG, "can't send at_buf to active_sfd");
                 }
 
                 at_state = dat;
@@ -1276,7 +1278,8 @@ void modem_device_send(int i, char data) {
             if (telnet != NULL) {
                 telnet_send(telnet, (char *) &data, 1);
             } else {
-                write(*active_sfd, (char *) &data, 1);
+                if (write(*active_sfd, (char *) &data, 1) != 1)
+                    LOGE(TAG, "can't send data to active_sfd");
             }
             break;
 	/***

--- a/iodevices/imsai-hal.c
+++ b/iodevices/imsai-hal.c
@@ -172,7 +172,8 @@ again:
 
     if (read(fileno(stdin), &data, 1) == 0) {
         /* try to reopen tty, input redirection exhausted */
-        freopen("/dev/tty", "r", stdin);
+        if (freopen("/dev/tty", "r", stdin) == NULL)
+            LOGE(TAG, "can't reopen /dev/tty");
         set_unix_terminal();
         goto again;
     }

--- a/iodevices/mostek-cpu.c
+++ b/iodevices/mostek-cpu.c
@@ -21,7 +21,10 @@
 #include <sys/socket.h>
 #include "sim.h"
 #include "simglb.h"
+#include "log.h"
 #include "unix_terminal.h"
+
+static const char *TAG = "console";
 
 /*
  * read status register
@@ -74,7 +77,8 @@ again:
 
 	if (read(fileno(stdin), &data, 1) == 0) {
 		/* try to reopen tty, input redirection exhausted */
-		freopen("/dev/tty", "r", stdin);
+		if (freopen("/dev/tty", "r", stdin) == NULL)
+			LOGE(TAG, "can't reopen /dev/tty");
 		set_unix_terminal();
 		goto again;
 	}

--- a/iodevices/unix_network.c
+++ b/iodevices/unix_network.c
@@ -194,8 +194,10 @@ void telnet_negotiation(int fd)
 	BYTE c[3];
 
 	/* send the telnet options we need */
-	write(fd, &char_mode, 3);
-	write(fd, &will_echo, 3);
+	if (write(fd, &char_mode, 3) != 3)
+		LOGE(TAG, "can't send char_mode telnet option");
+	if (write(fd, &will_echo, 3) != 3)
+		LOGE(TAG, "can't send will_echo telnet option");
 
 	/* and reject all others offered */
 	p[0].fd = fd;
@@ -210,7 +212,8 @@ void telnet_negotiation(int fd)
 			break;
 
 		/* else read the option */
-		read(fd, &c, 3);
+		if (read(fd, &c, 3) != 3)
+			LOGE(TAG, "can't read telnet option");
 		LOGD(TAG, "telnet: %d %d %d", c[0], c[1], c[2]);
 		if (c[2] == 1 || c[2] == 3)
 			continue;	/* ignore answers to our requests */
@@ -218,6 +221,7 @@ void telnet_negotiation(int fd)
 			c[1] = 254;
 		else if (c[1] == 253)
 			c[1] = 252;
-		write(fd, &c, 3);
+		if (write(fd, &c, 3) != 3)
+			LOGE(TAG, "can't write telnet option");
 	}
 }

--- a/iodevices/unix_terminal.c
+++ b/iodevices/unix_terminal.c
@@ -16,6 +16,7 @@
  * 24-FEB-2017 set line discipline only if fd 0 is a tty
  */
 
+#include <stdio.h>
 #include <unistd.h>
 #include <termios.h>
 
@@ -25,10 +26,10 @@ static int init_flag;
 
 void set_unix_terminal(void)
 {
-	if (init_flag || !isatty(0))
+	if (init_flag || !isatty(fileno(stdin)))
 		return;
 
-	tcgetattr(0, &old_term);
+	tcgetattr(fileno(stdin), &old_term);
 	new_term = old_term;
 
 	new_term.c_lflag &= ~(ICANON | ECHO);
@@ -52,17 +53,17 @@ void set_unix_terminal(void)
 	new_term.c_cc[VLNEXT] = 0;
 #endif
 
-	tcsetattr(0, TCSADRAIN, &new_term);
+	tcsetattr(fileno(stdin), TCSADRAIN, &new_term);
 
 	init_flag++;
 }
 
 void reset_unix_terminal(void)
 {
-	if (!init_flag || !isatty(0))
+	if (!init_flag || !isatty(fileno(stdin)))
 		return;
 
-	tcsetattr(0, TCSAFLUSH, &old_term);
+	tcsetattr(fileno(stdin), TCSAFLUSH, &old_term);
 
 	init_flag--;
 }

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -57,16 +57,16 @@ int getkey(void)
 	register int c;
 	struct termios old_term, new_term;
 
-	tcgetattr(0, &old_term);
+	tcgetattr(fileno(stdin), &old_term);
 	new_term = old_term;
 	new_term.c_lflag &= ~(ICANON | ECHO);
 	new_term.c_iflag &= ~(IXON | IXANY | IXOFF);
 	new_term.c_iflag &= ~(IGNCR | ICRNL | INLCR);
 	new_term.c_oflag &= ~(ONLCR | OCRNL);
 	new_term.c_cc[VMIN] = 1;
-	tcsetattr(0, TCSADRAIN, &new_term);
+	tcsetattr(fileno(stdin), TCSADRAIN, &new_term);
 	c = getchar();
-	tcsetattr(0, TCSADRAIN, &old_term);
+	tcsetattr(fileno(stdin), TCSADRAIN, &old_term);
 	return (c);
 }
 

--- a/z80core/simint.c
+++ b/z80core/simint.c
@@ -25,7 +25,7 @@
 
 static void user_int(int), quit_int(int), term_int(int);
 extern void exit_io(void);
-extern struct termios old_term;
+extern void reset_unix_terminal(void);
 
 void int_on(void)
 {
@@ -77,7 +77,7 @@ static void term_int(int sig)
 
 	exit_io();
 	int_off();
-	tcsetattr(0, TCSADRAIN, &old_term);
+	reset_unix_terminal();
 	puts("\nKilled by user");
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
simmain.c: Don't ignore fread/fwrite results in load_core/save_core.

simint.c: Call reset_unix_terminal since old_term only exists there.

Don't read/write disk file when lseek fails in altair-88-dcdd.c

In the other cases I just added LOGE calls so we at least will know that something went wrong.

Always use fileno(stdin) or fileno(stdout) instead of 0 or 1, since you never know if they weren't freopen()'d.
