### PR TITLE
POSIXfy

### DIFF
--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -866,7 +866,7 @@ void init_io(void)
 		exit(EXIT_FAILURE);
 		break;
 	}
-	if ((auxin = open("/tmp/.z80pack/cpmsim.auxin", O_RDONLY | O_NDELAY)) == -1) {
+	if ((auxin = open("/tmp/.z80pack/cpmsim.auxin", O_RDONLY | O_NONBLOCK)) == -1) {
 		LOGE(TAG, "can't open pipe auxin");
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
cpmsim/srcsim/iosim.c: use POSIX O_NONBLOCK
frontpanel/lp_utils.cpp: don't use obsolete timezone argument. use nanosleep

The code now compiles with -D_XOPEN_SOURCE=700L on Linux, FreeBSD, and macOS when disabling TCPASYNC in sim.h.