### PR TITLE
attempt to fix CPU speed reporting by cpmsim

### DIFF
--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -142,6 +142,7 @@
 
 extern int boot(int);
 extern void reset_cpu(void);
+extern unsigned long long get_millis(void);
 
 static const char *TAG = "IO";
 
@@ -1132,7 +1133,7 @@ void io_out(BYTE addrl, BYTE addrh, BYTE data)
 	io_port = addrl;
 	io_data = data;
 
-	busy_loop_cnt[0] = 0;
+	busy_loop_cnt = 0;
 
 	(*port_out[addrl])(data);
 }
@@ -1169,11 +1170,14 @@ static void io_trap_out(BYTE data)
  */
 static BYTE cons_in(void)
 {
+	unsigned long long t;
 	struct pollfd p[1];
 
-	if (++busy_loop_cnt[0] >= MAX_BUSY_COUNT) {
+	if (++busy_loop_cnt >= MAX_BUSY_COUNT) {
+		t = get_millis();
 		SLEEP_MS(1);
-		busy_loop_cnt[0] = 0;
+		busy_loop_cnt = 0;
+		cpu_start += (get_millis() - t);
 	}
 
 	p[0].fd = fileno(stdin);
@@ -1608,10 +1612,13 @@ static void nets1_out(BYTE data)
 static BYTE cond_in(void)
 {
 	char c;
+	unsigned long long t;
 
-	busy_loop_cnt[0] = 0;
+	busy_loop_cnt = 0;
+	t = get_millis();
 	if (read(fileno(stdin), &c, 1) != 1)
 		LOGE(TAG, "can't read console 0");
+	cpu_start += (get_millis() - t);
 	return ((BYTE) c);
 }
 

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -634,7 +634,7 @@ static int op_hlt(void)			/* HLT */
 		cpu_bus = CPU_INTA | CPU_WO | CPU_HLTA | CPU_M1;
 #endif
 
-	busy_loop_cnt[0] = 0;
+	busy_loop_cnt = 0;
 
 #else
 

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -14,8 +14,6 @@
 #include "sim.h"
 #include "simglb.h"
 
-#define MAXCHAN	5	/* max number of channels for I/O busy detect */
-
 /*
  *	Type of CPU, either Z80 or 8080
  */
@@ -47,7 +45,7 @@ int m1_step;			/* flag for waiting at M1 in single step */
 
 BYTE io_port;			/* I/O port used */
 BYTE io_data;			/* data on I/O port */
-int busy_loop_cnt[MAXCHAN];	/* counters for I/O busy loop detection */
+int busy_loop_cnt;		/* counter for I/O busy loop detection */
 
 BYTE cpu_state;			/* state of CPU emulation */
 int cpu_error;			/* error status of CPU emulation */

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -42,7 +42,7 @@ extern int	m1_step;
 #endif
 
 extern BYTE	io_port, io_data;
-extern int	busy_loop_cnt[];
+extern int	busy_loop_cnt;
 
 extern BYTE	cpu_state;
 extern int	cpu_error;

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -650,7 +650,7 @@ static int op_halt(void)		/* HALT */
 		cpu_bus = CPU_INTA | CPU_WO | CPU_HLTA | CPU_M1;
 #endif
 
-	busy_loop_cnt[0] = 0;
+	busy_loop_cnt = 0;
 
 #else
 


### PR DESCRIPTION
Make busy_loop_cnt an int. Isn't used by anything else. Add time waiting on console input to cpu_start.