### PR TITLE
modernize time code (2nd attempt)

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -48,8 +48,8 @@
 #define NUMNSOC 0	/* number of TCP/IP sockets for SIO connections */
 #define NUMUSOC 2	/* number of UNIX sockets for SIO connections */
 
-extern void do_sleep_ms(int);
-#define SLEEP_MS(t)	do_sleep_ms(t)
+extern void sleep_ms(int);
+#define SLEEP_MS(t)	sleep_ms(t)
 
 /*
  *	The following defines may be modified and activated by

--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -51,7 +51,7 @@
 extern void reset_cpu(void), reset_io(void);
 extern void run_cpu(void), step_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
-extern unsigned long long get_millis(void);
+extern unsigned long long get_clock_us(void);
 
 static const char *TAG = "system";
 
@@ -164,9 +164,9 @@ void mon(void)
 		switch (cpu_switch) {
 		case 1:
 			if (!reset) {
-				cpu_start = get_millis();
+				cpu_start = get_clock_us();
 				run_cpu();
-				cpu_stop = get_millis();
+				cpu_stop = get_clock_us();
 			}
 			break;
 		case 2:
@@ -195,9 +195,9 @@ void mon(void)
 	ice_cmd_loop(0);
 #else
 	/* run the CPU */
-	cpu_start = get_millis();
+	cpu_start = get_clock_us();
 	run_cpu();
-	cpu_stop = get_millis();
+	cpu_stop = get_clock_us();
 #endif
 #endif
 

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -142,7 +142,7 @@
 
 extern int boot(int);
 extern void reset_cpu(void);
-extern unsigned long long get_millis(void);
+extern unsigned long long get_clock_us(void);
 
 static const char *TAG = "IO";
 
@@ -1174,10 +1174,10 @@ static BYTE cons_in(void)
 	struct pollfd p[1];
 
 	if (++busy_loop_cnt >= MAX_BUSY_COUNT) {
-		t = get_millis();
+		t = get_clock_us();
 		SLEEP_MS(1);
 		busy_loop_cnt = 0;
-		cpu_start += (get_millis() - t);
+		cpu_start += (get_clock_us() - t);
 	}
 
 	p[0].fd = fileno(stdin);
@@ -1615,10 +1615,10 @@ static BYTE cond_in(void)
 	unsigned long long t;
 
 	busy_loop_cnt = 0;
-	t = get_millis();
+	t = get_clock_us();
 	if (read(fileno(stdin), &c, 1) != 1)
 		LOGE(TAG, "can't read console 0");
-	cpu_start += (get_millis() - t);
+	cpu_start += (get_clock_us() - t);
 	return ((BYTE) c);
 }
 

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -29,8 +29,8 @@
 /*#define CNETDEBUG*/	/* client network protocol debugger */
 /*#define SNETDEBUG*/	/* server network protocol debugger */
 
-extern void do_sleep_ms(int);
-#define SLEEP_MS(t)	do_sleep_ms(t)
+extern void sleep_ms(int);
+#define SLEEP_MS(t)	sleep_ms(t)
 
 /*
  *	Structure for the disk images

--- a/cpmsim/srcsim/simctl.c
+++ b/cpmsim/srcsim/simctl.c
@@ -17,7 +17,7 @@
 #include "log.h"
 
 extern void run_cpu(void);
-extern unsigned long long get_millis(void);
+extern unsigned long long get_clock_us(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
 
 int boot(int);
@@ -53,9 +53,9 @@ void mon(void)
 	atexit(reset_unix_terminal);
 
 	/* start CPU emulation */
-	cpu_start = get_millis();
+	cpu_start = get_clock_us();
 	run_cpu();
-	cpu_stop = get_millis();
+	cpu_stop = get_clock_us();
 
 	/* reset terminal */
 	reset_unix_terminal();

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -60,8 +60,8 @@
 #define SERVERPORT 4010	/* first TCP/IP server port used */
 #define NUMUSOC 0	/* number of UNIX sockets */
 
-extern void do_sleep_ms(int);
-#define SLEEP_MS(t)	do_sleep_ms(t)
+extern void sleep_ms(int);
+#define SLEEP_MS(t)	sleep_ms(t)
 
 /*
  *	The following defines may be modified and activated by

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -46,7 +46,7 @@
 extern void reset_cpu(void), reset_io(void);
 extern void run_cpu(void), step_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
-extern unsigned long long get_millis(void);
+extern unsigned long long get_clock_us(void);
 
 static const char *TAG = "system";
 
@@ -165,9 +165,9 @@ void mon(void)
 		switch (cpu_switch) {
 		case 1:
 			if (!reset) {
-				cpu_start = get_millis();
+				cpu_start = get_clock_us();
 				run_cpu();
-				cpu_stop = get_millis();
+				cpu_stop = get_clock_us();
 			}
 			break;
 		case 2:
@@ -197,9 +197,9 @@ void mon(void)
 	ice_cmd_loop(0);
 #else
 	/* run the CPU */
-	cpu_start = get_millis();
+	cpu_start = get_clock_us();
 	run_cpu();
-	cpu_stop = get_millis();
+	cpu_stop = get_clock_us();
 #endif
 #endif
 

--- a/frontpanel/lp_utils.cpp
+++ b/frontpanel/lp_utils.cpp
@@ -27,7 +27,6 @@
 #include <ctype.h>
 #include <GL/gl.h>
 #include <GL/glu.h>
-#include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
 #include <errno.h>
@@ -617,7 +616,7 @@ int n = glGetError();
 */
 
 typedef struct {
-    struct timeval              bsdtime;
+    struct timespec             ts;
     float                       dt;
     int                         stopped;
 } watch_t;
@@ -636,28 +635,28 @@ static watch_t syswatch;
 
 double frate_gettime(void)
 {
-   struct timeval      tp;
-    int                 sec;
-    int                 usec;
+   struct timespec     tp;
+    time_t              sec;
+    long                nsec;
     watch_t             *t;
 
-    double	secf, usecf, dt;
+    double	secf, nsecf, dt;
 
     t = &syswatch;
 
-    gettimeofday(&tp, NULL);
-    sec = tp.tv_sec - t->bsdtime.tv_sec;
-    usec = tp.tv_usec - t->bsdtime.tv_usec;
-    if (usec < 0) 
+    clock_gettime(CLOCK_REALTIME, &tp);
+    sec = tp.tv_sec - t->ts.tv_sec;
+    nsec = tp.tv_nsec - t->ts.tv_nsec;
+    if (nsec < 0)
      {
         sec--;
-        usec += 1000000;
+        nsec += 1000000000L;
      }
 
     secf = (double) sec;
-    usecf = (double) usec;
-    usecf = usecf / 1000000.0; 
-    dt = secf + usecf; 
+    nsecf = (double) nsec;
+    nsecf = nsecf / 1.0e9;
+    dt = secf + nsecf;
     return (dt);
 }
 
@@ -690,7 +689,7 @@ void framerate_wait(void)
 
  if( delta > 0.0 )
   {
-    delta = delta * 10e8;
+    delta = delta * 1.0e9;
     ts.tv_sec = 0;
     ts.tv_nsec = (long) delta;
 

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -61,8 +61,8 @@
 #define NUMNSOC 0	/* number of TCP/IP sockets for SIO connections */
 #define NUMUSOC 1	/* number of UNIX sockets for SIO connections */
 
-extern void do_sleep_ms(int);
-#define SLEEP_MS(t)	do_sleep_ms(t)
+extern void sleep_ms(int);
+#define SLEEP_MS(t)	sleep_ms(t)
 
 /*
  *	The following defines may be modified and activated by

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -50,7 +50,7 @@
 extern void reset_cpu(void), reset_io(void);
 extern void run_cpu(void), step_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
-extern unsigned long long get_millis(void);
+extern unsigned long long get_clock_us(void);
 
 static const char *TAG = "system";
 
@@ -163,9 +163,9 @@ void mon(void)
 		switch (cpu_switch) {
 		case 1:
 			if (!reset) {
-				cpu_start = get_millis();
+				cpu_start = get_clock_us();
 				run_cpu();
-				cpu_stop = get_millis();
+				cpu_stop = get_clock_us();
 			}
 			break;
 		case 2:
@@ -194,9 +194,9 @@ void mon(void)
 	ice_cmd_loop(0);
 #else
 	/* run the CPU */
-	cpu_start = get_millis();
+	cpu_start = get_clock_us();
 	run_cpu();
-	cpu_stop = get_millis();
+	cpu_stop = get_clock_us();
 #endif
 #endif
 

--- a/iodevices/cromemco-88ccc.c
+++ b/iodevices/cromemco-88ccc.c
@@ -15,7 +15,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
-#include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
 
@@ -45,9 +44,9 @@ static pthread_t thread = 0;
 /* thread for requesting, receiving & storing the camera image using DMA */
 static void *store_image(void *arg)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
+	extern unsigned long long get_clock_us(void);
 
-	struct timeval t1, t2;
+	unsigned long long t1, t2;
 	int tdiff;
 	int i, j, len;
 	BYTE buffer[FIELDSIZE];
@@ -62,7 +61,7 @@ static void *store_image(void *arg)
 	UNUSED(arg);
 
 	memset(&msg, 0, sizeof(msg));
-	gettimeofday(&t1, NULL);
+	t1 = get_clock_us();
 
 	while (state) {	/* do until total frame is received */
 		if (net_device_alive(DEV_88ACC)) {
@@ -100,8 +99,8 @@ static void *store_image(void *arg)
 		/* SLEEP_MS(j); */
 
 		/* sleep rest of total frame time */
-		gettimeofday(&t2, NULL);
-		tdiff = time_diff(&t1, &t2);
+		t2 = get_clock_us();
+		tdiff = t2 - t1;
 		if (tdiff < (j*1000)) 
 			SLEEP_MS(j - tdiff/1000);
 

--- a/iodevices/cromemco-dazzler.c
+++ b/iodevices/cromemco-dazzler.c
@@ -32,7 +32,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <signal.h>
-#include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
@@ -720,14 +719,14 @@ static void ws_refresh(void)
 /* thread for updating the display */
 static void *update_display(void *arg)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
+	extern unsigned long long get_clock_us(void);
 
-	struct timeval t1, t2;
+	unsigned long long t1, t2;
 	int tdiff;
 
 	UNUSED(arg);
 
-	gettimeofday(&t1, NULL);
+	t1 = get_clock_us();
 
 	while (1) {	/* do forever or until canceled */
 
@@ -765,12 +764,12 @@ static void *update_display(void *arg)
 		flags = 64;
 
 		/* sleep rest to 33ms so that we get 30 fps */
-		gettimeofday(&t2, NULL);
-		tdiff = time_diff(&t1, &t2);
+		t2 = get_clock_us();
+		tdiff = t2 - t1;
 		if ((tdiff > 0) && (tdiff < 33000))
 			SLEEP_MS(33 - (tdiff / 1000));
 
-		gettimeofday(&t1, NULL);
+		t1 = get_clock_us();
 	}
 
 	/* just in case it ever gets here */

--- a/iodevices/imsai-sio2.c
+++ b/iodevices/imsai-sio2.c
@@ -37,7 +37,6 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
-#include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
 #include "imsai-hal.h"
@@ -56,7 +55,7 @@ int sio1a_strip_parity;
 int sio1a_drop_nulls;
 int sio1a_baud_rate = 115200;
 
-static struct timeval sio1a_t1, sio1a_t2;
+static unsigned long long sio1a_t1, sio1a_t2;
 static BYTE sio1a_stat = 0;
 
 int sio1b_upper_case;
@@ -64,7 +63,7 @@ int sio1b_strip_parity;
 int sio1b_drop_nulls;
 int sio1b_baud_rate = 110;
 
-static struct timeval sio1b_t1, sio1b_t2;
+static unsigned long long sio1b_t1, sio1b_t2;
 static BYTE sio1b_stat = 0;
 
 int sio2a_upper_case;
@@ -72,7 +71,7 @@ int sio2a_strip_parity;
 int sio2a_drop_nulls;
 int sio2a_baud_rate = 115200;
 
-static struct timeval sio2a_t1, sio2a_t2;
+static unsigned long long sio2a_t1, sio2a_t2;
 static BYTE sio2a_stat = 0;
 
 int sio2b_upper_case;
@@ -80,8 +79,10 @@ int sio2b_strip_parity;
 int sio2b_drop_nulls;
 int sio2b_baud_rate = 2400;
 
-static struct timeval sio2b_t1, sio2b_t2;
+static unsigned long long sio2b_t1, sio2b_t2;
 static BYTE sio2b_stat = 0;
+
+extern unsigned long long get_clock_us(void);
 
 /*
  * the IMSAI SIO-2 occupies 16 I/O ports, from which only
@@ -114,18 +115,17 @@ void imsai_sio_nofun_out(BYTE data)
  */
 BYTE imsai_sio1a_status_in(void)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
 	int tdiff;
 
-	gettimeofday(&sio1a_t2, NULL);
-	tdiff = time_diff(&sio1a_t1, &sio1a_t2);
+	sio1a_t2 = get_clock_us();
+	tdiff = sio1a_t2 - sio1a_t1;
 	if (sio1a_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME / sio1a_baud_rate))
 			return (sio1a_stat);
 
 	hal_status_in(SIO1A, &sio1a_stat);
 
-	gettimeofday(&sio1a_t1, NULL);
+	sio1a_t1 = get_clock_us();
 
 	return (sio1a_stat);
 }
@@ -155,7 +155,7 @@ BYTE imsai_sio1a_data_in(void)
 		return last;
 	}
 
-	gettimeofday(&sio1a_t1, NULL);
+	sio1a_t1 = get_clock_us();
 	sio1a_stat &= 0b11111101;
 
 	/* process read data */
@@ -182,7 +182,7 @@ void imsai_sio1a_data_out(BYTE data)
 
 	hal_data_out(SIO1A, data);
 
-	gettimeofday(&sio1a_t1, NULL);
+	sio1a_t1 = get_clock_us();
 	sio1a_stat &= 0b11111110;
 }
 
@@ -193,18 +193,17 @@ void imsai_sio1a_data_out(BYTE data)
  */
 BYTE imsai_sio1b_status_in(void)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
 	int tdiff;
 
-	gettimeofday(&sio1b_t2, NULL);
-	tdiff = time_diff(&sio1b_t1, &sio1b_t2);
+	sio1b_t2 = get_clock_us();
+	tdiff = sio1b_t2 - sio1b_t1;
 	if (sio1b_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME / sio1b_baud_rate))
 			return (sio1b_stat);
 
 	hal_status_in(SIO1B, &sio1b_stat);
 
-	gettimeofday(&sio1b_t1, NULL);
+	sio1b_t1 = get_clock_us();
 
 	return (sio1b_stat);
 }
@@ -231,7 +230,7 @@ BYTE imsai_sio1b_data_in(void)
 		return last;
 	}
 
-	gettimeofday(&sio1b_t1, NULL);
+	sio1b_t1 = get_clock_us();
 	sio1b_stat &= 0b11111101;
 
 	/* process read data */
@@ -255,7 +254,7 @@ void imsai_sio1b_data_out(BYTE data)
 
 	hal_data_out(SIO1B, data);
 
-	gettimeofday(&sio1b_t1, NULL);
+	sio1b_t1 = get_clock_us();
 	sio1b_stat &= 0b11111110;
 }
 
@@ -269,18 +268,17 @@ void imsai_sio1b_data_out(BYTE data)
  */
 BYTE imsai_sio2a_status_in(void)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
 	int tdiff;
 
-	gettimeofday(&sio2a_t2, NULL);
-	tdiff = time_diff(&sio2a_t1, &sio2a_t2);
+	sio2a_t2 = get_clock_us();
+	tdiff = sio2a_t2 - sio2a_t1;
 	if (sio2a_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME / sio2a_baud_rate))
 			return (sio2a_stat);
 
 	hal_status_in(SIO2A, &sio2a_stat);
 
-	gettimeofday(&sio2a_t1, NULL);
+	sio2a_t1 = get_clock_us();
 
 	return (sio2a_stat);
 }
@@ -310,7 +308,7 @@ BYTE imsai_sio2a_data_in(void)
 		return last;
 	}
 
-	gettimeofday(&sio2a_t1, NULL);
+	sio2a_t1 = get_clock_us();
 	sio2a_stat &= 0b11111101;
 
 	/* process read data */
@@ -337,7 +335,7 @@ void imsai_sio2a_data_out(BYTE data)
 
 	hal_data_out(SIO2A, data);
 
-	gettimeofday(&sio2a_t1, NULL);
+	sio2a_t1 = get_clock_us();
 	sio2a_stat &= 0b11111110;
 }
 
@@ -351,18 +349,17 @@ void imsai_sio2a_data_out(BYTE data)
  */
 BYTE imsai_sio2b_status_in(void)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
 	int tdiff;
 
-	gettimeofday(&sio2b_t2, NULL);
-	tdiff = time_diff(&sio2b_t1, &sio2b_t2);
+	sio2b_t2 = get_clock_us();
+	tdiff = sio2b_t2 - sio2b_t1;
 	if (sio2b_baud_rate > 0)
 		if ((tdiff >= 0) && (tdiff < BAUDTIME / sio2b_baud_rate))
 			return (sio2b_stat);
 
 	hal_status_in(SIO2B, &sio2b_stat);
 
-	gettimeofday(&sio2b_t1, NULL);
+	sio2b_t1 = get_clock_us();
 
 	return (sio2b_stat);
 }
@@ -392,7 +389,7 @@ BYTE imsai_sio2b_data_in(void)
 		return last;
 	}
 
-	gettimeofday(&sio2b_t1, NULL);
+	sio2b_t1 = get_clock_us();
 	sio2b_stat &= 0b11111101;
 
 	/* process read data */
@@ -419,7 +416,7 @@ void imsai_sio2b_data_out(BYTE data)
 
 	hal_data_out(SIO2B, data);
 
-	gettimeofday(&sio2b_t1, NULL);
+	sio2b_t1 = get_clock_us();
 	sio2b_stat &= 0b11111110;
 }
 

--- a/iodevices/imsai-vio.c
+++ b/iodevices/imsai-vio.c
@@ -27,7 +27,6 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
 #include "../../frontpanel/frontpanel.h"
@@ -458,14 +457,14 @@ static void ws_refresh(void)
 /* thread for updating the display */
 static void *update_display(void *arg)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
+	extern unsigned long long get_clock_us(void);
 
-	struct timeval t1, t2;
+	unsigned long long t1, t2;
 	int tdiff;
 
 	UNUSED(arg);
 
-	gettimeofday(&t1, NULL);
+	t1 = get_clock_us();
 
 	while (state) {
 #ifndef HAS_NETSERVER
@@ -488,12 +487,12 @@ static void *update_display(void *arg)
 #endif
 
 		/* sleep rest to 33ms so that we get 30 fps */
-		gettimeofday(&t2, NULL);
-		tdiff = time_diff(&t1, &t2);
+		t2 = get_clock_us();
+		tdiff = t2 - t1;
 		if ((tdiff > 0) && (tdiff < 33000))
 			SLEEP_MS(33 - (tdiff / 1000));
 
-		gettimeofday(&t1, NULL);
+		t1 = get_clock_us();
 	}
 
 	pthread_exit(NULL);

--- a/iodevices/proctec-vdm.c
+++ b/iodevices/proctec-vdm.c
@@ -21,7 +21,6 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
 #include "../../frontpanel/frontpanel.h"
@@ -211,14 +210,14 @@ static void refresh(void)
 /* thread for updating the display */
 static void *update_display(void *arg)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
+	extern unsigned long long get_clock_us(void);
 
-	struct timeval t1, t2;
+	unsigned long long t1, t2;
 	int tdiff;
 
 	UNUSED(arg);
 
-	gettimeofday(&t1, NULL);
+	t1 = get_clock_us();
 
 	while (state) {
 
@@ -237,12 +236,12 @@ static void *update_display(void *arg)
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
 		/* sleep rest to 33ms so that we get 30 fps */
-		gettimeofday(&t2, NULL);
-		tdiff = time_diff(&t1, &t2);
+		t2 = get_clock_us();
+		tdiff = t2 - t1;
 		if ((tdiff > 0) && (tdiff < 33000))
 			SLEEP_MS(33 - (tdiff / 1000));
 
-		gettimeofday(&t1, NULL);
+		t1 = get_clock_us();
 	}
 
 	pthread_exit(NULL);

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -31,8 +31,8 @@
 /*#define HAS_DISKS*/	/* not using standard disk define */
 /*#define HAS_CONFIG*/  /* not using standard config define */
 
-extern void do_sleep_ms(int);
-#define SLEEP_MS(t)	do_sleep_ms(t)
+extern void sleep_ms(int);
+#define SLEEP_MS(t)	sleep_ms(t)
 
 /*
  *	The following defines may be modified and activated by

--- a/picosim/picosim.c
+++ b/picosim/picosim.c
@@ -32,6 +32,8 @@ extern void report_cpu_error(void), report_cpu_stats(void);
 
 int main(void)
 {
+	extern unsigned long long get_clock_us(void);
+
 	stdio_init_all();	/* initialize Pico stdio */
 
 #if PICO == 1			/* initialize Pico W hardware */
@@ -69,9 +71,9 @@ int main(void)
 	init_cpu();		/* initialize CPU */
 	init_memory();		/* initialize memory configuration */
 
-	cpu_start = to_ms_since_boot(get_absolute_time());
+	cpu_start = get_clock_us();
 	run_cpu();		/* run the CPU with whatever is in memory */
-	cpu_stop = to_ms_since_boot(get_absolute_time());
+	cpu_stop = get_clock_us();
 
 	/* switch builtin LED on */
 #if PICO == 1
@@ -85,4 +87,9 @@ int main(void)
 	report_cpu_stats();	/* print some execution statistics */
 	putchar('\n');
 	stdio_flush();
+}
+
+unsigned long long get_clock_us(void)
+{
+	return to_us_since_boot(get_absolute_time());
 }

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -7,7 +7,6 @@
 
 #include <unistd.h>
 #include <stdio.h>
-#include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
@@ -128,7 +127,7 @@ static inline void addr_leds(WORD data)
  */
 void cpu_8080(void)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
+	extern unsigned long long get_clock_us(void);
 
 	static int (*op_sim[256])(void) = {
 		op_nop,				/* 0x00 */
@@ -391,10 +390,10 @@ void cpu_8080(void)
 
 	register int t = 0;
 	register int states;
-	struct timeval t1, t2;
+	unsigned long long t1, t2;
 	int tdiff;
 
-	gettimeofday(&t1, NULL);
+	t1 = get_clock_us();
 
 	do {
 
@@ -552,12 +551,12 @@ leave:
 
 		if (f_flag) {		/* adjust CPU speed */
 			if (t >= tmax && !cpu_needed) {
-				gettimeofday(&t2, NULL);
-				tdiff = time_diff(&t1, &t2);
+				t2 = get_clock_us();
+				tdiff = t2 - t1;
 				if ((tdiff > 0) && (tdiff < 10000))
 					SLEEP_MS(10 - (tdiff / 1000));
 				t = 0;
-				gettimeofday(&t1, NULL);
+				t1 = get_clock_us();
 			}
 		}
 

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -259,10 +259,10 @@ void report_cpu_stats(void)
 {
 	if (cpu_stop > cpu_start)
 	{
-		printf("CPU ran %lld ms ", cpu_stop - cpu_start);
+		printf("CPU ran %lld ms ", (cpu_stop - cpu_start) / 1000);
 		printf("and executed %lld t-states\n", T);
 		printf("Clock frequency %4.2f MHz\n",
-			(float) (T) / (float) (cpu_stop - cpu_start) / 1000.0);
+		       (float) (T) / (float) (cpu_stop - cpu_start));
 	}
 }
 
@@ -286,30 +286,4 @@ void end_bus_request(void)
 	bus_mode = BUS_DMA_NONE;
 	dma_bus_master = NULL;
 	bus_request = 0;
-}
-
-/*
- *	Compute difference between two timeval in microseconds
- *
- *	Note: yes there are timersub() and friends, but not
- *	defined in POSIX.1 and implemented wrong on some
- *	systems. Some systems define tv_usec as unsigned int,
- *	here we assume that a long is longer than unsigned.
- *	If that is not the case cast to (long long).
- */
-int time_diff(struct timeval *t1, struct timeval *t2)
-{
-	long sec, usec;
-
-	sec = (long) t2->tv_sec - (long) t1->tv_sec;
-	usec = (long) t2->tv_usec - (long) t1->tv_usec;
-	/* normalize result */
-	if (usec < 0L) {
-		sec--;
-		usec += 1000000L;
-	}
-	if (sec != 0L)
-		return (-1); /* result is to large */
-	else
-		return ((int) usec);
 }

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -77,7 +77,7 @@ int getkey(void)
 /*
  *	Sleep for time milliseconds, 999 max
  */
-void do_sleep_ms(int time)
+void sleep_ms(int time)
 {
 	struct timespec timer, rem;
 	int err;
@@ -95,7 +95,7 @@ again:
 			}
 		} else {
 			/* some error */
-			LOGD(TAG, "do_sleep_ms(%d) %s", time, strerror(err));
+			LOGD(TAG, "sleep_ms(%d) %s", time, strerror(err));
 			// cpu_error = IOERROR;
 			// cpu_state = STOPPED;
 		}
@@ -103,15 +103,15 @@ again:
 }
 
 /*
- *	returns time in milliseconds
+ *	returns time in microseconds
  */
-unsigned long long get_millis(void)
+unsigned long long get_clock_us(void)
 {
-	struct timeval tv;
+	struct timespec ts;
 
-	gettimeofday(&tv, NULL);
-	return ((unsigned long long) (tv.tv_sec) * 1000 +
-		(unsigned long long) (tv.tv_usec) / 1000);
+	clock_gettime(CLOCK_REALTIME, &ts);
+	return ((unsigned long long) (ts.tv_sec) * 1000000ULL +
+		(unsigned long long) (ts.tv_nsec / 1000L));
 }
 
 /*

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -25,7 +25,6 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
@@ -41,6 +40,7 @@ extern int load_file(char *, WORD, int);
 extern void int_on(void), int_off(void), mon(void);
 extern void init_io(void), exit_io(void);
 extern int exatoi(char *);
+extern unsigned long long get_clock_us(void);
 
 #ifdef FRONTPANEL
 int sim_main(int argc, char *argv[])
@@ -50,7 +50,6 @@ int main(int argc, char *argv[])
 {
 	register char *s, *p;
 	char *pn = basename(argv[0]);
-	struct timeval tv;
 #ifdef HAS_CONFIG
 	struct stat sbuf;
 	const char *rom = "-r rompath ";
@@ -387,8 +386,7 @@ puts(" #####    ###     #####    ###            #####    ###   #     #");
 #endif
 
 	/* seed random generator */
-	gettimeofday(&tv, NULL);
-	srand(tv.tv_sec);
+	srand(get_clock_us());
 
 	config();		/* read system configuration */
 	init_cpu();		/* initialize CPU */

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -8,7 +8,6 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
@@ -116,7 +115,7 @@ extern int op_ed_handle(void), op_fd_handle(void);
  */
 void cpu_z80(void)
 {
-	extern int time_diff(struct timeval *, struct timeval *);
+	extern unsigned long long get_clock_us(void);
 
 	static int (*op_sim[256])(void) = {
 		op_nop,				/* 0x00 */
@@ -379,11 +378,11 @@ void cpu_z80(void)
 
 	register int t = 0;
 	register int states;
-	struct timeval t1, t2;
+	unsigned long long t1, t2;
 	int tdiff;
 	WORD p;
 
-	gettimeofday(&t1, NULL);
+	t1 = get_clock_us();
 
 	do {
 
@@ -576,12 +575,12 @@ leave:
 
 		if (f_flag) {		/* adjust CPU speed */
 			if (t >= tmax && !cpu_needed) {
-				gettimeofday(&t2, NULL);
-				tdiff = time_diff(&t1, &t2);
+				t2 = get_clock_us();
+				tdiff = t2 - t1;
 				if ((tdiff > 0) && (tdiff < 10000))
 					SLEEP_MS(10 - (tdiff / 1000));
 				t = 0;
-				gettimeofday(&t1, NULL);
+				t1 = get_clock_us();
 			}
 		}
 

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -23,8 +23,8 @@
 /*#define HAS_DISKS*/	/* has no disk drives */
 /*#define HAS_CONFIG*/	/* has no configuration files */
 
-extern void do_sleep_ms(int);
-#define SLEEP_MS(t)	do_sleep_ms(t)
+extern void sleep_ms(int);
+#define SLEEP_MS(t)	sleep_ms(t)
 
 /*
  *	The following defines may be modified and activated by

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -24,8 +24,8 @@
 /*#define HAS_DISKS*/	/* has no disk drives */
 /*#define HAS_CONFIG*/	/* has no configuration files */
 
-extern void do_sleep_ms(int);
-#define SLEEP_MS(t)	do_sleep_ms(t)
+extern void sleep_ms(int);
+#define SLEEP_MS(t)	sleep_ms(t)
 
 /*
  *	The following defines may be modified and activated by


### PR DESCRIPTION
Use clock_gettime instead of gettimeofday.

Convert get_millis in simfun.c to get_clock_us and use it everywhere.

Add get_clock_us implementation to picosim.

Rename do_sleep_ms back to sleep_ms.

Remove now unneeded time_diff* functions.