### PR TITLE
implement runtime switchable CPU type

### DIFF
--- a/altairsim/srcsim/iosim.c
+++ b/altairsim/srcsim/iosim.c
@@ -816,10 +816,16 @@ static BYTE hwctl_in(void)
  *
  *	bit 0 = 1	start interrupt timer
  *	bit 0 = 0	stop interrupt timer
+ *	bit 4 = 1	switch CPU model to 8080
+ *	bit 5 = 1	switch CPU model to Z80
  *	bit 7 = 1       halt emulation via I/O
  */
 static void hwctl_out(BYTE data)
 {
+#if !defined (EXCLUDE_I8080) && !defined(EXCLUDE_Z80)
+	extern void switch_cpu(int);
+#endif
+
 	static struct itimerval tim;
 	static struct sigaction newact;
 
@@ -839,6 +845,18 @@ static void hwctl_out(BYTE data)
 		cpu_error = IOHALT;
 		cpu_state = STOPPED;
 	}
+
+#if !defined (EXCLUDE_I8080) && !defined(EXCLUDE_Z80)
+	if (data & 32) {	/* switch cpu model to Z80 */
+		switch_cpu(Z80);
+		return;
+	}
+
+	if (data & 16) {	/* switch cpu model to 8080 */
+		switch_cpu(I8080);
+		return;
+	}
+#endif
 
 	if (data & 1) {
 		newact.sa_handler = int_timer;

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -2492,11 +2492,18 @@ static BYTE delay_in(void)
  *	Port is locked until magic number 0xaa is received!
  *
  *	I/O handler for write hardware control after unlocking:
+ *
+ *	bit 4 = 1	switch CPU model to 8080
+ *	bit 5 = 1	switch CPU model to Z80
  *	bit 6 = 1	reset CPU, MMU and reboot
  *	bit 7 = 1	halt emulation via I/O
  */
 static void hwctl_out(BYTE data)
 {
+#if !defined (EXCLUDE_I8080) && !defined(EXCLUDE_Z80)
+	extern void switch_cpu(int);
+#endif
+
 	/* if port is locked do nothing */
 	if (hwctl_lock && (data != 0xaa))
 		return;
@@ -2519,6 +2526,18 @@ static void hwctl_out(BYTE data)
 		reset_system();
 		return;
 	}
+
+#if !defined (EXCLUDE_I8080) && !defined(EXCLUDE_Z80)
+	if (data & 32) {	/* switch cpu model to Z80 */
+		switch_cpu(Z80);
+		return;
+	}
+
+	if (data & 16) {	/* switch cpu model to 8080 */
+		switch_cpu(I8080);
+		return;
+	}
+#endif
 }
 
 /*

--- a/cromemcosim/srcsim/iosim.c
+++ b/cromemcosim/srcsim/iosim.c
@@ -858,10 +858,16 @@ static BYTE hwctl_in(void)
  *	Virtual hardware control output.
  *	Doesn't exist in the real machine, used to shutdown
  *
+ *	bit 4 = 1	switch CPU model to 8080
+ *	bit 5 = 1	switch CPU model to Z80
  *	bit 7 = 1       halt emulation via I/O
  */
 static void hwctl_out(BYTE data)
 {
+#if !defined (EXCLUDE_I8080) && !defined(EXCLUDE_Z80)
+	extern void switch_cpu(int);
+#endif
+
 	/* if port is locked do nothing */
 	if (hwctl_lock && (data != 0xaa))
 		return;
@@ -878,6 +884,18 @@ static void hwctl_out(BYTE data)
 		cpu_error = IOHALT;
 		cpu_state = STOPPED;
 	}
+
+#if !defined (EXCLUDE_I8080) && !defined(EXCLUDE_Z80)
+	if (data & 32) {	/* switch cpu model to Z80 */
+		switch_cpu(Z80);
+		return;
+	}
+
+	if (data & 16) {	/* switch cpu model to 8080 */
+		switch_cpu(I8080);
+		return;
+	}
+#endif
 }
 
 /*

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -909,10 +909,16 @@ static BYTE hwctl_in(void)
  *
  *	bit 0 = 1	start interrupt timer
  *	bit 0 = 0	stop interrupt timer
+ *	bit 4 = 1	switch CPU model to 8080
+ *	bit 5 = 1	switch CPU model to Z80
  *	bit 7 = 1	halt emulation via I/O
  */
 static void hwctl_out(BYTE data)
 {
+#if !defined (EXCLUDE_I8080) && !defined(EXCLUDE_Z80)
+	extern void switch_cpu(int);
+#endif
+
 	static struct itimerval tim;
 	static struct sigaction newact;
 
@@ -932,6 +938,18 @@ static void hwctl_out(BYTE data)
 		cpu_error = IOHALT;
 		cpu_state = STOPPED;
 	}
+
+#if !defined (EXCLUDE_I8080) && !defined(EXCLUDE_Z80)
+	if (data & 32) {	/* switch cpu model to Z80 */
+		switch_cpu(Z80);
+		return;
+	}
+
+	if (data & 16) {	/* switch cpu model to 8080 */
+		switch_cpu(I8080);
+		return;
+	}
+#endif
 
 	if (data & 1) {
 		newact.sa_handler = int_timer;

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -399,6 +399,7 @@ void cpu_8080(void)
 
 #ifdef HISIZE
 		/* write history */
+		his[h_next].h_cpu = I8080;
 		his[h_next].h_addr = PC;
 		his[h_next].h_af = (A << 8) + F;
 		his[h_next].h_bc = (B << 8) + C;

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -11,16 +11,21 @@
 #define MAX_LFN		4096	/* maximum long file name length */
 #define LENCMD		80	/* length of command buffers etc */
 
-#define Z80		1	/* simulated CPUs */
+				/* simulated CPUs */
+#ifndef EXCLUDE_Z80
+#define Z80		1
+#endif
+#ifndef EXCLUDE_I8080
 #define I8080		2
+#endif
 
 #if defined(EXCLUDE_I8080) && defined(EXCLUDE_Z80)
 #error "Only one of EXCLUDE_I8080 or EXCLUDE_Z80 can be used"
 #endif
-#if defined(EXCLUDE_I8080) && DEF_CPU == I8080
+#if defined(EXCLUDE_I8080) && DEF_CPU != Z80
 #error "DEF_CPU=I8080 and no 8080 simulation included"
 #endif
-#if defined(EXCLUDE_Z80) && DEF_CPU == Z80
+#if defined(EXCLUDE_Z80) && DEF_CPU != I8080
 #error "DEF_CPU=Z80 and no Z80 simulation included"
 #endif
 
@@ -51,6 +56,7 @@
 #define CONTIN_RUN	1	/* continual run */
 #define SINGLE_STEP	2	/* single step */
 #define RESET		4	/* reset */
+#define MODEL_SWITCH	8	/* model switched */
 
 				/* error codes */
 #define NONE		0	/* no error */
@@ -72,6 +78,7 @@ typedef unsigned char  BYTE;	/* 8 bit unsigned */
 
 #ifdef HISIZE
 struct history {		/* structure of a history entry */
+	int	h_cpu;		/* CPU type */
 	WORD	h_addr;		/* address of execution */
 	WORD	h_af;		/* register AF */
 	WORD	h_bc;		/* register BC */

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -773,7 +773,7 @@ static void do_hist(char *s)
 				else
 					sa = -1;
 			}
-			switch (cpu) {
+			switch (his[i].h_cpu) {
 #ifndef EXCLUDE_Z80
 			case Z80:
 				printf("%04x AF=%04x BC=%04x DE=%04x HL=%04x "
@@ -857,6 +857,7 @@ static void do_clock(void)
 	Tstates_t T0;
 	static struct sigaction newact;
 	static struct itimerval tim;
+	const char *s = NULL;
 
 	save[0] = getmem(0x0000);	/* save memory locations */
 	save[1] = getmem(0x0001);	/* 0000H - 0002H */
@@ -881,9 +882,23 @@ static void do_clock(void)
 	putmem(0x0000, save[0]);	/* restore memory locations */
 	putmem(0x0001, save[1]);	/* 0000H - 0002H */
 	putmem(0x0002, save[2]);
+	switch (cpu) {
+#ifndef EXCLUDE_Z80
+	case Z80:
+		s = "JP";
+		break;
+#endif
+#ifndef EXCLUDE_I8080
+	case I8080:
+		s = "JMP";
+		break;
+#endif
+	default:
+		break;
+	}
 	if (cpu_error == NONE) {
 		printf("CPU executed %lld %s instructions in 3 seconds\n",
-		       (T - T0) / 10, cpu == Z80 ? "JP" : "JMP");
+		       (T - T0) / 10, s);
 		printf("clock frequency = %5.2f MHz\n",
 		       ((float) (T - T0)) / 3000000.0);
 	} else

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -483,8 +483,10 @@ static void save_core(void)
 		cnt += fwrite(&IY, sizeof(IY), 1, fp);
 	}
 #endif
-	if (cpu != Z80)
+#ifndef EXCLUDE_I8080
+	if (cpu == I8080)
 		cnt += 13;	/* pretend we wrote the Z80 registers */
+#endif
 
 	for (i = 0; i < 65536; i++)
 		if (putc(getmem(i), fp) == -1)
@@ -562,8 +564,10 @@ static int load_core(void)
 		cnt += fread(&IY, sizeof(IY), 1, fp);
 	}
 #endif
-	if (cpu != Z80)
+#ifndef EXCLUDE_I8080
+	if (cpu == I8080)
 		cnt += 13;	/* pretend we read the Z80 registers */
+#endif
 
 	for (i = 0; i < 65536; i++)
 		if ((c = getc(fp)) == -1)

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -388,6 +388,7 @@ void cpu_z80(void)
 
 #ifdef HISIZE
 		/* write history */
+		his[h_next].h_cpu = Z80;
 		his[h_next].h_addr = PC;
 		his[h_next].h_af = (A << 8) + F;
 		his[h_next].h_bc = (B << 8) + C;


### PR DESCRIPTION
uses bit 4 (8080) and bit 5 (Z80) of the hardware control port

init_cpu(): initialize registers independent of current CPU type

reset_cpu(): reset state independent of current CPU type

switch_cpu(): new function to switch CPU type and set cpu_state to new state MODEL_SWITCH

run_cpu(): keep running when cpu_state is MODEL_SWITCH

added h_cpu to history buffer to record CPU type

EXCLUDE_* defines: even more hardcore (don't define Z80 or I8080) fixed a few cases where a CPU type value was used that isn't available

Appended are the changes I made to ex.mac to test this.
But the thing is ex.mac completely fails in 8080 mode... (i.e. when assembled with "exkind = 0").
It also doesn't work with z80pack 1.37.
```
 ; Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 ; modifications by Peter Schorn, (C) 2008
+; modifications for z80pack by Thomas Eberhardt, (C) 2024
 
 	aseg
 	org	100h
@@ -61,9 +62,10 @@
 conout	equ	2
 bdosO	equ	5
 wboot	equ	0
-simh	equ	0feh
-set8080	equ	20
-setz80	equ	19
+hwctl	equ	0a0h
+hwunlk	equ	0aah
+set8080	equ	16
+setz80	equ	32
 
 	jp	start
 
@@ -131,7 +133,14 @@
 	jp	dosw
 swz80:	ld	a,setz80
 	ld	de,sz80
-dosw:	out	(simh),a
+dosw:	ld	c,a		; save cpu type
+	in	a,(hwctl)	; check if hardware control port is unlocked
+	or	a
+	jp	z,dosw1
+	ld	a,hwunlk	; unlock hardware control port
+	out	(hwctl),a
+dosw1:	ld	a,c		; switch cpu type
+	out	(hwctl),a
 	ld	(nsw),a
 	ld	c,printst
 	jp	bdos
```