### PR TITLE
z80core: add I/O block instructions S,H,P,N,C flags back for ex.com

### DIFF
--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -545,6 +545,10 @@ static int op_ini(void)			/* INI */
 {
 	extern BYTE io_in(BYTE, BYTE);
 	BYTE data;
+#ifndef Z80BLKIOF_DOC
+	BYTE B0 = B;
+	WORD k;
+#endif
 
 	data = io_in(C, B);
 	memwrt((H << 8) + L, data);
@@ -552,7 +556,16 @@ static int op_ini(void)			/* INI */
 	if (!L)
 		H++;
 	B--;
-	F |= N_FLAG;
+#ifdef Z80BLKIOF_DOC
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	k = (WORD) ((C + 1) & 0xff) + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B0]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#endif
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	return (16);
 }
@@ -563,6 +576,10 @@ static int op_inir(void)		/* INIR */
 	extern BYTE io_in(BYTE, BYTE);
 	WORD addr;
 	BYTE data;
+#ifndef Z80BLKIOF_DOC
+	BYTE B0 = B;
+	WORD k;
+#endif
 	register int t = -21;
 
 	addr = (H << 8) + L;
@@ -576,7 +593,17 @@ static int op_inir(void)		/* INIR */
 	} while (B);
 	H = addr >> 8;
 	L = addr;
-	F |= N_FLAG | Z_FLAG;
+#ifdef Z80BLKIOF_DOC
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	k = (WORD) ((C + 1) & 0xff) + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B0]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	F &= ~S_FLAG;
+#endif
+	F |= Z_FLAG;
 	return (t + 16);
 }
 #else
@@ -598,6 +625,10 @@ static int op_ind(void)			/* IND */
 {
 	extern BYTE io_in(BYTE, BYTE);
 	BYTE data;
+#ifndef Z80BLKIOF_DOC
+	BYTE B0 = B;
+	WORD k;
+#endif
 
 	data = io_in(C, B);
 	memwrt((H << 8) + L, data);
@@ -605,7 +636,16 @@ static int op_ind(void)			/* IND */
 	if (L == 0xff)
 		H--;
 	B--;
-	F |= N_FLAG;
+#ifdef Z80BLKIOF_DOC
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	k = (WORD) ((C - 1) & 0xff) + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B0]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#endif
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	return (16);
 }
@@ -616,6 +656,10 @@ static int op_indr(void)		/* INDR */
 	extern BYTE io_in(BYTE, BYTE);
 	WORD addr;
 	BYTE data;
+#ifndef Z80BLKIOF_DOC
+	BYTE B0 = B;
+	WORD k;
+#endif
 	register int t = -21;
 
 	addr = (H << 8) + L;
@@ -629,7 +673,17 @@ static int op_indr(void)		/* INDR */
 	} while (B);
 	H = addr >> 8;
 	L = addr;
-	F |= N_FLAG | Z_FLAG;
+#ifdef Z80BLKIOF_DOC
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	k = (WORD) ((C - 1) & 0xff) + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B0]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	F &= ~S_FLAG;
+#endif
+	F |= Z_FLAG;
 	return (t + 16);
 }
 #else
@@ -651,6 +705,10 @@ static int op_outi(void)		/* OUTI */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 	BYTE data;
+#ifndef Z80BLKIOF_DOC
+	BYTE B0 = B;
+	WORD k;
+#endif
 
 	B--;
 	data = memrdr((H << 8) + L);
@@ -658,7 +716,16 @@ static int op_outi(void)		/* OUTI */
 	L++;
 	if (!L)
 		H++;
-	F |= N_FLAG;
+#ifdef Z80BLKIOF_DOC
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	k = (WORD) L + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B0]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#endif
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	return (16);
 }
@@ -669,6 +736,10 @@ static int op_otir(void)		/* OTIR */
 	extern void io_out(BYTE, BYTE, BYTE);
 	WORD addr;
 	BYTE data;
+#ifndef Z80BLKIOF_DOC
+	BYTE B0 = B;
+	WORD k;
+#endif
 	register int t = -21;
 
 	addr = (H << 8) + L;
@@ -682,7 +753,17 @@ static int op_otir(void)		/* OTIR */
 	} while (B);
 	H = addr >> 8;
 	L = addr;
-	F |= N_FLAG | Z_FLAG;
+#ifdef Z80BLKIOF_DOC
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	k = (WORD) L + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B0]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	F &= ~S_FLAG;
+#endif
+	F |= Z_FLAG;
 	return (t + 16);
 }
 #else
@@ -704,6 +785,10 @@ static int op_outd(void)		/* OUTD */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 	BYTE data;
+#ifndef Z80BLKIOF_DOC
+	BYTE B0 = B;
+	WORD k;
+#endif
 
 	B--;
 	data = memrdr((H << 8) + L);
@@ -711,7 +796,16 @@ static int op_outd(void)		/* OUTD */
 	L--;
 	if (L == 0xff)
 		H--;
-	F |= N_FLAG;
+#ifdef Z80BLKIOF_DOC
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	k = (WORD) L + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B0]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#endif
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	return (16);
 }
@@ -722,6 +816,10 @@ static int op_otdr(void)		/* OTDR */
 	extern void io_out(BYTE, BYTE, BYTE);
 	WORD addr;
 	BYTE data;
+#ifndef Z80BLKIOF_DOC
+	BYTE B0 = B;
+	WORD k;
+#endif
 	register int t = -21;
 
 	addr = (H << 8) + L;
@@ -735,7 +833,17 @@ static int op_otdr(void)		/* OTDR */
 	} while (B);
 	H = addr >> 8;
 	L = addr;
-	F |= N_FLAG | Z_FLAG;
+#ifdef Z80BLKIOF_DOC
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	k = (WORD) L + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B0]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	F &= ~S_FLAG;
+#endif
+	F |= Z_FLAG;
 	return (t + 16);
 }
 #else


### PR DESCRIPTION
I think users are not expecting that ex.com as supplied on z80tests.dsk fails. This makes it pass.

This is slightly different than ae6346b6901dc53c46689ff0744a2ae8d1bf85d4. The start instead of the final value of B is used for the parity flag calculation.