### PR TITLE
make z80core behave like a Zilog/Mostek NMOS Z80 as far as I can do

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -32,6 +32,7 @@
 #define DEF_CPU I8080	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 2	/* default CPU speed */
 #define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_FLAGS	/* compile undocumented flags */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -11,6 +11,7 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_FLAGS	/* compile undocumented flags */
 #define WANT_FASTB	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -33,6 +33,7 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 4	/* default CPU speed */
 #define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_FLAGS	/* compile undocumented flags */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -32,6 +32,7 @@
 #define DEF_CPU I8080	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 2	/* default CPU speed */
 #define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_FLAGS	/* compile undocumented flags */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -20,6 +20,7 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_FLAGS	/* compile undocumented flags */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 #define CORE_LOG	/* use LOG() logging in core simulator */
 #define EXCLUDE_I8080	/* this was a Z80 machine */

--- a/picosim/sim.h
+++ b/picosim/sim.h
@@ -11,6 +11,8 @@
 #define DEF_CPU Z80	/* CPU (Z80 or I8080) */
 #define CPU_SPEED 4	/* CPU speed 0=unlimited */
 #define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_FLAGS	/* compile undocumented flags */
+/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 /*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
 #define EXCLUDE_I8080	/* don't include 8080 emulation support */
 

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -2663,13 +2663,10 @@ static int op_jz(void)			/* JZ nn */
 {
 	register WORD i;
 
-	if (F & Z_FLAG) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & Z_FLAG)
 		PC = i;
-	} else {
-		PC += 2;
-	}
 	return (10);
 }
 
@@ -2677,13 +2674,10 @@ static int op_jnz(void)			/* JNZ nn */
 {
 	register WORD i;
 
-	if (!(F & Z_FLAG)) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & Z_FLAG))
 		PC = i;
-	} else {
-		PC += 2;
-	}
 	return (10);
 }
 
@@ -2691,13 +2685,10 @@ static int op_jc(void)			/* JC nn */
 {
 	register WORD i;
 
-	if (F & C_FLAG) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & C_FLAG)
 		PC = i;
-	} else {
-		PC += 2;
-	}
 	return (10);
 }
 
@@ -2705,13 +2696,10 @@ static int op_jnc(void)			/* JNC nn */
 {
 	register WORD i;
 
-	if (!(F & C_FLAG)) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & C_FLAG))
 		PC = i;
-	} else {
-		PC += 2;
-	}
 	return (10);
 }
 
@@ -2719,13 +2707,10 @@ static int op_jpe(void)			/* JPE nn */
 {
 	register WORD i;
 
-	if (F & P_FLAG) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & P_FLAG)
 		PC = i;
-	} else {
-		PC += 2;
-	}
 	return (10);
 }
 
@@ -2733,13 +2718,10 @@ static int op_jpo(void)			/* JPO nn */
 {
 	register WORD i;
 
-	if (!(F & P_FLAG)) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & P_FLAG))
 		PC = i;
-	} else {
-		PC += 2;
-	}
 	return (10);
 }
 
@@ -2747,13 +2729,10 @@ static int op_jm(void)			/* JM nn */
 {
 	register WORD i;
 
-	if (F & S_FLAG) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & S_FLAG)
 		PC = i;
-	} else {
-		PC += 2;
-	}
 	return (10);
 }
 
@@ -2761,179 +2740,169 @@ static int op_jp(void)			/* JP nn */
 {
 	register WORD i;
 
-	if (!(F & S_FLAG)) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & S_FLAG))
 		PC = i;
-	} else {
-		PC += 2;
-	}
 	return (10);
 }
 
 static int op_cz(void)			/* CZ nn */
 {
 	register WORD i;
+	register int t = 11;
 
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
 	if (F & Z_FLAG) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return (17);
-	} else {
-		PC += 2;
-		return (11);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_cnz(void)			/* CNZ nn */
 {
 	register WORD i;
+	register int t = 11;
 
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
 	if (!(F & Z_FLAG)) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return (17);
-	} else {
-		PC += 2;
-		return (11);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_cc(void)			/* CC nn */
 {
 	register WORD i;
+	register int t = 11;
 
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
 	if (F & C_FLAG) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return (17);
-	} else {
-		PC += 2;
-		return (11);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_cnc(void)			/* CNC nn */
 {
 	register WORD i;
+	register int t = 11;
 
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
 	if (!(F & C_FLAG)) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return (17);
-	} else {
-		PC += 2;
-		return (11);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_cpe(void)			/* CPE nn */
 {
 	register WORD i;
+	register int t = 11;
 
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
 	if (F & P_FLAG) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return (17);
-	} else {
-		PC += 2;
-		return (11);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_cpo(void)			/* CPO nn */
 {
 	register WORD i;
+	register int t = 11;
 
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
 	if (!(F & P_FLAG)) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return (17);
-	} else {
-		PC += 2;
-		return (11);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_cm(void)			/* CM nn */
 {
 	register WORD i;
+	register int t = 11;
 
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
 	if (F & S_FLAG) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return (17);
-	} else {
-		PC += 2;
-		return (11);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_cp(void)			/* CP nn */
 {
 	register WORD i;
+	register int t = 11;
 
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
 	if (!(F & S_FLAG)) {
-		i = memrdr(PC++);
-		i += memrdr(PC++) << 8;
 #ifdef BUS_8080
 		cpu_bus = CPU_STACK;
 #endif
 		memwrt(--SP, PC >> 8);
 		memwrt(--SP, PC);
 		PC = i;
-		return (17);
-	} else {
-		PC += 2;
-		return (11);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_rz(void)			/* RZ */
 {
 	register WORD i;
+	register int t = 5;
 
 	if (F & Z_FLAG) {
 #ifdef BUS_8080
@@ -2942,15 +2911,15 @@ static int op_rz(void)			/* RZ */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return (11);
-	} else {
-		return (5);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_rnz(void)			/* RNZ */
 {
 	register WORD i;
+	register int t = 5;
 
 	if (!(F & Z_FLAG)) {
 #ifdef BUS_8080
@@ -2959,15 +2928,15 @@ static int op_rnz(void)			/* RNZ */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return (11);
-	} else {
-		return (5);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_rc(void)			/* RC */
 {
 	register WORD i;
+	register int t = 5;
 
 	if (F & C_FLAG) {
 #ifdef BUS_8080
@@ -2976,15 +2945,15 @@ static int op_rc(void)			/* RC */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return (11);
-	} else {
-		return (5);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_rnc(void)			/* RNC */
 {
 	register WORD i;
+	register int t = 5;
 
 	if (!(F & C_FLAG)) {
 #ifdef BUS_8080
@@ -2993,15 +2962,15 @@ static int op_rnc(void)			/* RNC */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return (11);
-	} else {
-		return (5);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_rpe(void)			/* RPE */
 {
 	register WORD i;
+	register int t = 5;
 
 	if (F & P_FLAG) {
 #ifdef BUS_8080
@@ -3010,15 +2979,15 @@ static int op_rpe(void)			/* RPE */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return (11);
-	} else {
-		return (5);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_rpo(void)			/* RPO */
 {
 	register WORD i;
+	register int t = 5;
 
 	if (!(F & P_FLAG)) {
 #ifdef BUS_8080
@@ -3027,15 +2996,15 @@ static int op_rpo(void)			/* RPO */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return (11);
-	} else {
-		return (5);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_rm(void)			/* RM */
 {
 	register WORD i;
+	register int t = 5;
 
 	if (F & S_FLAG) {
 #ifdef BUS_8080
@@ -3044,15 +3013,15 @@ static int op_rm(void)			/* RM */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return (11);
-	} else {
-		return (5);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_rp(void)			/* RP */
 {
 	register WORD i;
+	register int t = 5;
 
 	if (!(F & S_FLAG)) {
 #ifdef BUS_8080
@@ -3061,10 +3030,9 @@ static int op_rp(void)			/* RP */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
-		return (11);
-	} else {
-		return (5);
+		t += 6;
 	}
+	return (t);
 }
 
 static int op_rst0(void)		/* RST 0 */

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -54,6 +54,9 @@ void init_cpu(void)
 	F_ = rand() % 256;
 	IX = rand() % 65536;
 	IY = rand() % 65536;
+#ifdef UNDOC_FLAGS
+	WZ = rand() % 65536;
+#endif
 #endif
 
 #ifndef EXCLUDE_I8080

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -26,6 +26,10 @@ BYTE A, B, C, D, E, H, L;	/* primary registers */
 int  F;				/* normally 8-Bit, but int is faster */
 #ifndef EXCLUDE_Z80
 WORD IX, IY;			/* Z80 index registers */
+#ifdef UNDOC_FLAGS
+WORD WZ;			/* Z80 internal register */
+int  modF, pmodF;		/* current/previous instr manipulated F */
+#endif
 BYTE A_, B_, C_, D_, E_, H_, L_; /* Z80 alternate registers */
 BYTE I;				/* Z80 interrupt register */
 BYTE R;				/* Z80 refresh register (7-bit counter) */

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -31,6 +31,10 @@ extern BYTE	A, B, C, D, E, H, L;
 extern int	F;
 #ifndef EXCLUDE_Z80
 extern WORD	IX, IY;
+#ifdef UNDOC_FLAGS
+extern WORD	WZ;
+extern int	modF, pmodF;
+#endif
 extern BYTE	A_, B_, C_, D_, E_, H_, L_, I, R, R_;
 extern int	F_;
 #endif

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -404,6 +404,11 @@ static int op_srla(void)		/* SRL A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -415,6 +420,11 @@ static int op_srlb(void)		/* SRL B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -426,6 +436,11 @@ static int op_srlc(void)		/* SRL C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -437,6 +452,11 @@ static int op_srld(void)		/* SRL D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -448,6 +468,11 @@ static int op_srle(void)		/* SRL E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -459,6 +484,11 @@ static int op_srlh(void)		/* SRL H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -470,6 +500,11 @@ static int op_srll(void)		/* SRL L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -487,6 +522,11 @@ static int op_srlhl(void)		/* SRL (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -498,6 +538,11 @@ static int op_slaa(void)		/* SLA A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -509,6 +554,11 @@ static int op_slab(void)		/* SLA B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -520,6 +570,11 @@ static int op_slac(void)		/* SLA C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -531,6 +586,11 @@ static int op_slad(void)		/* SLA D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -542,6 +602,11 @@ static int op_slae(void)		/* SLA E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -553,6 +618,11 @@ static int op_slah(void)		/* SLA H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -564,6 +634,11 @@ static int op_slal(void)		/* SLA L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -581,6 +656,11 @@ static int op_slahl(void)		/* SLA (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -596,6 +676,11 @@ static int op_rlra(void)		/* RL A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -611,6 +696,11 @@ static int op_rlb(void)			/* RL B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -626,6 +716,11 @@ static int op_rlc(void)			/* RL C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -641,6 +736,11 @@ static int op_rld(void)			/* RL D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -656,6 +756,11 @@ static int op_rle(void)			/* RL E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -671,6 +776,11 @@ static int op_rlh(void)			/* RL H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -686,6 +796,11 @@ static int op_rll(void)			/* RL L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -706,6 +821,11 @@ static int op_rlhl(void)		/* RL (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -721,6 +841,11 @@ static int op_rrra(void)		/* RR A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -736,6 +861,11 @@ static int op_rrb(void)			/* RR B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -751,6 +881,11 @@ static int op_rrc(void)			/* RR C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -766,6 +901,11 @@ static int op_rrd(void)			/* RR D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -781,6 +921,11 @@ static int op_rre(void)			/* RR E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -796,6 +941,11 @@ static int op_rrh(void)			/* RR H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -811,6 +961,11 @@ static int op_rrl(void)			/* RR L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -831,6 +986,11 @@ static int op_rrhl(void)		/* RR (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -846,6 +1006,11 @@ static int op_rrcra(void)		/* RRC A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -861,6 +1026,11 @@ static int op_rrcb(void)		/* RRC B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -876,6 +1046,11 @@ static int op_rrcc(void)		/* RRC C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -891,6 +1066,11 @@ static int op_rrcd(void)		/* RRC D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -906,6 +1086,11 @@ static int op_rrce(void)		/* RRC E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -921,6 +1106,11 @@ static int op_rrch(void)		/* RRC H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -936,6 +1126,11 @@ static int op_rrcl(void)		/* RRC L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -956,6 +1151,11 @@ static int op_rrchl(void)		/* RRC (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -971,6 +1171,11 @@ static int op_rlcra(void)		/* RLC A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -986,6 +1191,11 @@ static int op_rlcb(void)		/* RLC B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1001,6 +1211,11 @@ static int op_rlcc(void)		/* RLC C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1016,6 +1231,11 @@ static int op_rlcd(void)		/* RLC D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1031,6 +1251,11 @@ static int op_rlce(void)		/* RLC E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1046,6 +1271,11 @@ static int op_rlch(void)		/* RLC H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1061,6 +1291,11 @@ static int op_rlcl(void)		/* RLC L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1081,6 +1316,11 @@ static int op_rlchl(void)		/* RLC (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -1096,6 +1336,11 @@ static int op_sraa(void)		/* SRA A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1111,6 +1356,11 @@ static int op_srab(void)		/* SRA B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1126,6 +1376,11 @@ static int op_srac(void)		/* SRA C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1141,6 +1396,11 @@ static int op_srad(void)		/* SRA D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1156,6 +1416,11 @@ static int op_srae(void)		/* SRA E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1171,6 +1436,11 @@ static int op_srah(void)		/* SRA H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1186,6 +1456,11 @@ static int op_sral(void)		/* SRA L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1205,6 +1480,11 @@ static int op_srahl(void)		/* SRA (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -1981,6 +2261,11 @@ static int op_tb0a(void)		/* BIT 0,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1989,6 +2274,11 @@ static int op_tb1a(void)		/* BIT 1,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1997,6 +2287,11 @@ static int op_tb2a(void)		/* BIT 2,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2005,6 +2300,11 @@ static int op_tb3a(void)		/* BIT 3,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2013,6 +2313,11 @@ static int op_tb4a(void)		/* BIT 4,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2021,6 +2326,11 @@ static int op_tb5a(void)		/* BIT 5,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2029,6 +2339,11 @@ static int op_tb6a(void)		/* BIT 6,A */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(A & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2043,6 +2358,11 @@ static int op_tb7a(void)		/* BIT 7,A */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2051,6 +2371,11 @@ static int op_tb0b(void)		/* BIT 0,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2059,6 +2384,11 @@ static int op_tb1b(void)		/* BIT 1,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2067,6 +2397,11 @@ static int op_tb2b(void)		/* BIT 2,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2075,6 +2410,11 @@ static int op_tb3b(void)		/* BIT 3,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2083,6 +2423,11 @@ static int op_tb4b(void)		/* BIT 4,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2091,6 +2436,11 @@ static int op_tb5b(void)		/* BIT 5,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2099,6 +2449,11 @@ static int op_tb6b(void)		/* BIT 6,B */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(B & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2113,6 +2468,11 @@ static int op_tb7b(void)		/* BIT 7,B */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2121,6 +2481,11 @@ static int op_tb0c(void)		/* BIT 0,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2129,6 +2494,11 @@ static int op_tb1c(void)		/* BIT 1,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2137,6 +2507,11 @@ static int op_tb2c(void)		/* BIT 2,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2145,6 +2520,11 @@ static int op_tb3c(void)		/* BIT 3,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2153,6 +2533,11 @@ static int op_tb4c(void)		/* BIT 4,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2161,6 +2546,11 @@ static int op_tb5c(void)		/* BIT 5,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2169,6 +2559,11 @@ static int op_tb6c(void)		/* BIT 6,C */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(C & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2183,6 +2578,11 @@ static int op_tb7c(void)		/* BIT 7,C */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2191,6 +2591,11 @@ static int op_tb0d(void)		/* BIT 0,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2199,6 +2604,11 @@ static int op_tb1d(void)		/* BIT 1,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2207,6 +2617,11 @@ static int op_tb2d(void)		/* BIT 2,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2215,6 +2630,11 @@ static int op_tb3d(void)		/* BIT 3,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2223,6 +2643,11 @@ static int op_tb4d(void)		/* BIT 4,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2231,6 +2656,11 @@ static int op_tb5d(void)		/* BIT 5,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2239,6 +2669,11 @@ static int op_tb6d(void)		/* BIT 6,D */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(D & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2253,6 +2688,11 @@ static int op_tb7d(void)		/* BIT 7,D */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2261,6 +2701,11 @@ static int op_tb0e(void)		/* BIT 0,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2269,6 +2714,11 @@ static int op_tb1e(void)		/* BIT 1,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2277,6 +2727,11 @@ static int op_tb2e(void)		/* BIT 2,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2285,6 +2740,11 @@ static int op_tb3e(void)		/* BIT 3,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2293,6 +2753,11 @@ static int op_tb4e(void)		/* BIT 4,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2301,6 +2766,11 @@ static int op_tb5e(void)		/* BIT 5,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2309,6 +2779,11 @@ static int op_tb6e(void)		/* BIT 6,E */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(E & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2323,6 +2798,11 @@ static int op_tb7e(void)		/* BIT 7,E */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2331,6 +2811,11 @@ static int op_tb0h(void)		/* BIT 0,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2339,6 +2824,11 @@ static int op_tb1h(void)		/* BIT 1,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2347,6 +2837,11 @@ static int op_tb2h(void)		/* BIT 2,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2355,6 +2850,11 @@ static int op_tb3h(void)		/* BIT 3,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2363,6 +2863,11 @@ static int op_tb4h(void)		/* BIT 4,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2371,6 +2876,11 @@ static int op_tb5h(void)		/* BIT 5,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2379,6 +2889,11 @@ static int op_tb6h(void)		/* BIT 6,H */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(H & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2393,6 +2908,11 @@ static int op_tb7h(void)		/* BIT 7,H */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2401,6 +2921,11 @@ static int op_tb0l(void)		/* BIT 0,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 1) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2409,6 +2934,11 @@ static int op_tb1l(void)		/* BIT 1,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 2) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2417,6 +2947,11 @@ static int op_tb2l(void)		/* BIT 2,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 4) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2425,6 +2960,11 @@ static int op_tb3l(void)		/* BIT 3,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 8) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2433,6 +2973,11 @@ static int op_tb4l(void)		/* BIT 4,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 16) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2441,6 +2986,11 @@ static int op_tb5l(void)		/* BIT 5,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 32) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2449,6 +2999,11 @@ static int op_tb6l(void)		/* BIT 6,L */
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
 	(L & 64) ? (F &= ~(Z_FLAG | P_FLAG)) : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2463,6 +3018,11 @@ static int op_tb7l(void)		/* BIT 7,L */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2472,6 +3032,11 @@ static int op_tb0hl(void)		/* BIT 0,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	((WZ >> 8) & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	((WZ >> 8) & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -2481,6 +3046,11 @@ static int op_tb1hl(void)		/* BIT 1,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	((WZ >> 8) & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	((WZ >> 8) & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -2490,6 +3060,11 @@ static int op_tb2hl(void)		/* BIT 2,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	((WZ >> 8) & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	((WZ >> 8) & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -2499,6 +3074,11 @@ static int op_tb3hl(void)		/* BIT 3,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	((WZ >> 8) & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	((WZ >> 8) & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -2508,6 +3088,11 @@ static int op_tb4hl(void)		/* BIT 4,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	((WZ >> 8) & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	((WZ >> 8) & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -2517,6 +3102,11 @@ static int op_tb5hl(void)		/* BIT 5,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	((WZ >> 8) & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	((WZ >> 8) & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -2526,6 +3116,11 @@ static int op_tb6hl(void)		/* BIT 6,(HL) */
 	F |= H_FLAG;
 	(memrdr((H << 8) + L) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	((WZ >> 8) & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	((WZ >> 8) & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -2540,6 +3135,11 @@ static int op_tb7hl(void)		/* BIT 7,(HL) */
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	((WZ >> 8) & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	((WZ >> 8) & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -2562,6 +3162,11 @@ static int op_undoc_slla(void)		/* SLL A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2578,6 +3183,11 @@ static int op_undoc_sllb(void)		/* SLL B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2592,6 +3202,11 @@ static int op_undoc_sllc(void)		/* SLL C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2606,6 +3221,11 @@ static int op_undoc_slld(void)		/* SLL D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2620,6 +3240,11 @@ static int op_undoc_slle(void)		/* SLL E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2634,6 +3259,11 @@ static int op_undoc_sllh(void)		/* SLL H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2648,6 +3278,11 @@ static int op_undoc_slll(void)		/* SLL L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -2668,6 +3303,11 @@ static int op_undoc_sllhl(void)		/* SLL (HL) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 

--- a/z80core/simz80-ddcb.c
+++ b/z80core/simz80-ddcb.c
@@ -393,174 +393,342 @@ static int trap_ddcb(int data)
 
 static int op_tb0ixd(int data)		/* BIT 0,(IX+d) */
 {
+	WORD addr;
+
+	addr = IX + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IX + data) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
-				: (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
+			   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb1ixd(int data)		/* BIT 1,(IX+d) */
 {
+	WORD addr;
+
+	addr = IX + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IX + data) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
-				: (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
+			   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb2ixd(int data)		/* BIT 2,(IX+d) */
 {
+	WORD addr;
+
+	addr = IX + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IX + data) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
-				: (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
+			   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb3ixd(int data)		/* BIT 3,(IX+d) */
 {
+	WORD addr;
+
+	addr = IX + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IX + data) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
-				: (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
+			   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb4ixd(int data)		/* BIT 4,(IX+d) */
 {
+	WORD addr;
+
+	addr = IX + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IX + data) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
-				 : (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
+			    : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb5ixd(int data)		/* BIT 5,(IX+d) */
 {
+	WORD addr;
+
+	addr = IX + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IX + data) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
-				 : (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
+			    : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb6ixd(int data)		/* BIT 6,(IX+d) */
 {
+	WORD addr;
+
+	addr = IX + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IX + data) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
-				 : (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
+			    : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb7ixd(int data)		/* BIT 7,(IX+d) */
 {
+	WORD addr;
+
+	addr = IX + data;
 	F &= ~N_FLAG;
 	F |= H_FLAG;
-	if (memrdr(IX + data) & 128) {
+	if (memrdr(addr) & 128) {
 		F &= ~(Z_FLAG | P_FLAG);
 		F |= S_FLAG;
 	} else {
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_rb0ixd(int data)		/* RES 0,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) & ~1);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) & ~1);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb1ixd(int data)		/* RES 1,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) & ~2);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) & ~2);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb2ixd(int data)		/* RES 2,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) & ~4);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) & ~4);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb3ixd(int data)		/* RES 3,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) & ~8);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) & ~8);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb4ixd(int data)		/* RES 4,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) & ~16);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) & ~16);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb5ixd(int data)		/* RES 5,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) & ~32);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) & ~32);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb6ixd(int data)		/* RES 6,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) & ~64);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) & ~64);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb7ixd(int data)		/* RES 7,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) & ~128);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) & ~128);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb0ixd(int data)		/* SET 0,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) | 1);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) | 1);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb1ixd(int data)		/* SET 1,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) | 2);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) | 2);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb2ixd(int data)		/* SET 2,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) | 4);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) | 4);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb3ixd(int data)		/* SET 3,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) | 8);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) | 8);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb4ixd(int data)		/* SET 4,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) | 16);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) | 16);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb5ixd(int data)		/* SET 5,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) | 32);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) | 32);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb6ixd(int data)		/* SET 6,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) | 64);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) | 64);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb7ixd(int data)		/* SET 7,(IX+d) */
 {
-	memwrt(IX + data, memrdr(IX + data) | 128);
+	WORD addr;
+
+	addr = IX + data;
+	memwrt(addr, memrdr(addr) | 128);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
@@ -581,6 +749,12 @@ static int op_rlcixd(int data)		/* RLC (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -601,6 +775,12 @@ static int op_rrcixd(int data)		/* RRC (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -621,6 +801,12 @@ static int op_rlixd(int data)		/* RL (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -641,6 +827,12 @@ static int op_rrixd(int data)		/* RR (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -658,6 +850,12 @@ static int op_slaixd(int data)		/* SLA (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -677,6 +875,12 @@ static int op_sraixd(int data)		/* SRA (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -694,6 +898,12 @@ static int op_srlixd(int data)		/* SRL (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -771,1121 +981,1793 @@ static int op_undoc_tb7ixd(int data)	/* BIT 7,(IX+d) */
 
 static int op_undoc_rb0ixda(int data)	/* RES 0,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) & ~1;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) & ~1;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1ixda(int data)	/* RES 1,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) & ~2;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) & ~2;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2ixda(int data)	/* RES 2,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) & ~4;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) & ~4;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3ixda(int data)	/* RES 3,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) & ~8;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) & ~8;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4ixda(int data)	/* RES 4,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) & ~16;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) & ~16;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5ixda(int data)	/* RES 5,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) & ~32;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) & ~32;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6ixda(int data)	/* RES 6,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) & ~64;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) & ~64;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7ixda(int data)	/* RES 7,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) & ~128;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) & ~128;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0ixdb(int data)	/* RES 0,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) & ~1;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) & ~1;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1ixdb(int data)	/* RES 1,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) & ~2;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) & ~2;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2ixdb(int data)	/* RES 2,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) & ~4;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) & ~4;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3ixdb(int data)	/* RES 3,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) & ~8;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) & ~8;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4ixdb(int data)	/* RES 4,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) & ~16;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) & ~16;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5ixdb(int data)	/* RES 5,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) & ~32;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) & ~32;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6ixdb(int data)	/* RES 6,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) & ~64;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) & ~64;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7ixdb(int data)	/* RES 7,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) & ~128;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) & ~128;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0ixdc(int data)	/* RES 0,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) & ~1;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) & ~1;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1ixdc(int data)	/* RES 1,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) & ~2;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) & ~2;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2ixdc(int data)	/* RES 2,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) & ~4;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) & ~4;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3ixdc(int data)	/* RES 3,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) & ~8;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) & ~8;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4ixdc(int data)	/* RES 4,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) & ~16;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) & ~16;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5ixdc(int data)	/* RES 5,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) & ~32;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) & ~32;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6ixdc(int data)	/* RES 6,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) & ~64;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) & ~64;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7ixdc(int data)	/* RES 7,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) & ~128;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) & ~128;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0ixdd(int data)	/* RES 0,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) & ~1;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) & ~1;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1ixdd(int data)	/* RES 1,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) & ~2;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) & ~2;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2ixdd(int data)	/* RES 2,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) & ~4;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) & ~4;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3ixdd(int data)	/* RES 3,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) & ~8;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) & ~8;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4ixdd(int data)	/* RES 4,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) & ~16;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) & ~16;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5ixdd(int data)	/* RES 5,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) & ~32;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) & ~32;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6ixdd(int data)	/* RES 6,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) & ~64;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) & ~64;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7ixdd(int data)	/* RES 7,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) & ~128;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) & ~128;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0ixde(int data)	/* RES 0,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) & ~1;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) & ~1;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1ixde(int data)	/* RES 1,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) & ~2;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) & ~2;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2ixde(int data)	/* RES 2,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) & ~4;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) & ~4;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3ixde(int data)	/* RES 3,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) & ~8;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) & ~8;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4ixde(int data)	/* RES 4,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) & ~16;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) & ~16;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5ixde(int data)	/* RES 5,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) & ~32;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) & ~32;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6ixde(int data)	/* RES 6,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) & ~64;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) & ~64;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7ixde(int data)	/* RES 7,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) & ~128;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) & ~128;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0ixdh(int data)	/* RES 0,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) & ~1;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) & ~1;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1ixdh(int data)	/* RES 1,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) & ~2;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) & ~2;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2ixdh(int data)	/* RES 2,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) & ~4;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) & ~4;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3ixdh(int data)	/* RES 3,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) & ~8;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) & ~8;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4ixdh(int data)	/* RES 4,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) & ~16;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) & ~16;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5ixdh(int data)	/* RES 5,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) & ~32;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) & ~32;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6ixdh(int data)	/* RES 6,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) & ~64;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) & ~64;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7ixdh(int data)	/* RES 7,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) & ~128;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) & ~128;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0ixdl(int data)	/* RES 0,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) & ~1;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) & ~1;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1ixdl(int data)	/* RES 1,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) & ~2;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) & ~2;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2ixdl(int data)	/* RES 2,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) & ~4;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) & ~4;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3ixdl(int data)	/* RES 3,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) & ~8;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) & ~8;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4ixdl(int data)	/* RES 4,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) & ~16;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) & ~16;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5ixdl(int data)	/* RES 5,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) & ~32;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) & ~32;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6ixdl(int data)	/* RES 6,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) & ~64;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) & ~64;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7ixdl(int data)	/* RES 7,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) & ~128;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) & ~128;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0ixda(int data)	/* SET 0,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) | 1;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) | 1;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1ixda(int data)	/* SET 1,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) | 2;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) | 2;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2ixda(int data)	/* SET 2,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) | 4;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) | 4;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3ixda(int data)	/* SET 3,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) | 8;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) | 8;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4ixda(int data)	/* SET 4,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) | 16;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) | 16;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5ixda(int data)	/* SET 5,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) | 32;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) | 32;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6ixda(int data)	/* SET 6,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) | 64;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) | 64;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7ixda(int data)	/* SET 7,(IX+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	A = memrdr(IX + data) | 128;
-	memwrt(IX + data, A);
+	addr = IX + data;
+	A = memrdr(addr) | 128;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0ixdb(int data)	/* SET 0,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) | 1;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) | 1;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1ixdb(int data)	/* SET 1,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) | 2;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) | 2;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2ixdb(int data)	/* SET 2,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) | 4;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) | 4;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3ixdb(int data)	/* SET 3,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) | 8;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) | 8;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4ixdb(int data)	/* SET 4,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) | 16;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) | 16;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5ixdb(int data)	/* SET 5,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) | 32;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) | 32;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6ixdb(int data)	/* SET 6,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) | 64;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) | 64;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7ixdb(int data)	/* SET 7,(IX+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	B = memrdr(IX + data) | 128;
-	memwrt(IX + data, B);
+	addr = IX + data;
+	B = memrdr(addr) | 128;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0ixdc(int data)	/* SET 0,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) | 1;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) | 1;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1ixdc(int data)	/* SET 1,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) | 2;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) | 2;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2ixdc(int data)	/* SET 2,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) | 4;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) | 4;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3ixdc(int data)	/* SET 3,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) | 8;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) | 8;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4ixdc(int data)	/* SET 4,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) | 16;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) | 16;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5ixdc(int data)	/* SET 5,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) | 32;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) | 32;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6ixdc(int data)	/* SET 6,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) | 64;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) | 64;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7ixdc(int data)	/* SET 7,(IX+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	C = memrdr(IX + data) | 128;
-	memwrt(IX + data, C);
+	addr = IX + data;
+	C = memrdr(addr) | 128;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0ixdd(int data)	/* SET 0,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) | 1;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) | 1;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1ixdd(int data)	/* SET 1,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) | 2;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) | 2;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2ixdd(int data)	/* SET 2,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) | 4;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) | 4;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3ixdd(int data)	/* SET 3,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) | 8;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) | 8;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4ixdd(int data)	/* SET 4,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) | 16;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) | 16;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5ixdd(int data)	/* SET 5,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) | 32;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) | 32;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6ixdd(int data)	/* SET 6,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) | 64;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) | 64;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7ixdd(int data)	/* SET 7,(IX+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	D = memrdr(IX + data) | 128;
-	memwrt(IX + data, D);
+	addr = IX + data;
+	D = memrdr(addr) | 128;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0ixde(int data)	/* SET 0,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) | 1;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) | 1;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1ixde(int data)	/* SET 1,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) | 2;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) | 2;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2ixde(int data)	/* SET 2,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) | 4;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) | 4;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3ixde(int data)	/* SET 3,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) | 8;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) | 8;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4ixde(int data)	/* SET 4,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) | 16;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) | 16;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5ixde(int data)	/* SET 5,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) | 32;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) | 32;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6ixde(int data)	/* SET 6,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) | 64;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) | 64;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7ixde(int data)	/* SET 7,(IX+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	E = memrdr(IX + data) | 128;
-	memwrt(IX + data, E);
+	addr = IX + data;
+	E = memrdr(addr) | 128;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0ixdh(int data)	/* SET 0,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) | 1;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) | 1;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1ixdh(int data)	/* SET 1,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) | 2;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) | 2;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2ixdh(int data)	/* SET 2,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) | 4;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) | 4;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3ixdh(int data)	/* SET 3,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) | 8;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) | 8;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4ixdh(int data)	/* SET 4,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) | 16;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) | 16;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5ixdh(int data)	/* SET 5,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) | 32;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) | 32;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6ixdh(int data)	/* SET 6,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) | 64;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) | 64;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7ixdh(int data)	/* SET 7,(IX+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	H = memrdr(IX + data) | 128;
-	memwrt(IX + data, H);
+	addr = IX + data;
+	H = memrdr(addr) | 128;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0ixdl(int data)	/* SET 0,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) | 1;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) | 1;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1ixdl(int data)	/* SET 1,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) | 2;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) | 2;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2ixdl(int data)	/* SET 2,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) | 4;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) | 4;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3ixdl(int data)	/* SET 3,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) | 8;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) | 8;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4ixdl(int data)	/* SET 4,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) | 16;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) | 16;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5ixdl(int data)	/* SET 5,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) | 32;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) | 32;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6ixdl(int data)	/* SET 6,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) | 64;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) | 64;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7ixdl(int data)	/* SET 7,(IX+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_ddcb(0));
 
-	L = memrdr(IX + data) | 128;
-	memwrt(IX + data, L);
+	addr = IX + data;
+	L = memrdr(addr) | 128;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
@@ -1908,6 +2790,12 @@ static int op_undoc_rlcixda(int data)	/* RLC (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -1930,6 +2818,12 @@ static int op_undoc_rlcixdb(int data)	/* RLC (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -1952,6 +2846,12 @@ static int op_undoc_rlcixdc(int data)	/* RLC (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -1974,6 +2874,12 @@ static int op_undoc_rlcixdd(int data)	/* RLC (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -1996,6 +2902,12 @@ static int op_undoc_rlcixde(int data)	/* RLC (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2018,6 +2930,12 @@ static int op_undoc_rlcixdh(int data)	/* RLC (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2040,6 +2958,12 @@ static int op_undoc_rlcixdl(int data)	/* RLC (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2062,6 +2986,12 @@ static int op_undoc_rrcixda(int data)	/* RRC (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2084,6 +3014,12 @@ static int op_undoc_rrcixdb(int data)	/* RRC (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2106,6 +3042,12 @@ static int op_undoc_rrcixdc(int data)	/* RRC (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2128,6 +3070,12 @@ static int op_undoc_rrcixdd(int data)	/* RRC (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2150,6 +3098,12 @@ static int op_undoc_rrcixde(int data)	/* RRC (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2172,6 +3126,12 @@ static int op_undoc_rrcixdh(int data)	/* RRC (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2194,6 +3154,12 @@ static int op_undoc_rrcixdl(int data)	/* RRC (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2216,6 +3182,12 @@ static int op_undoc_rlixda(int data)	/* RL (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2238,6 +3210,12 @@ static int op_undoc_rlixdb(int data)	/* RL (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2260,6 +3238,12 @@ static int op_undoc_rlixdc(int data)	/* RL (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2282,6 +3266,12 @@ static int op_undoc_rlixdd(int data)	/* RL (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2304,6 +3294,12 @@ static int op_undoc_rlixde(int data)	/* RL (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2326,6 +3322,12 @@ static int op_undoc_rlixdh(int data)	/* RL (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2348,6 +3350,12 @@ static int op_undoc_rlixdl(int data)	/* RL (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2370,6 +3378,12 @@ static int op_undoc_rrixda(int data)	/* RR (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2392,6 +3406,12 @@ static int op_undoc_rrixdb(int data)	/* RR (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2414,6 +3434,12 @@ static int op_undoc_rrixdc(int data)	/* RR (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2436,6 +3462,12 @@ static int op_undoc_rrixdd(int data)	/* RR (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2458,6 +3490,12 @@ static int op_undoc_rrixde(int data)	/* RR (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2480,6 +3518,12 @@ static int op_undoc_rrixdh(int data)	/* RR (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2502,6 +3546,12 @@ static int op_undoc_rrixdl(int data)	/* RR (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2521,6 +3571,12 @@ static int op_undoc_slaixda(int data)	/* SLA (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2540,6 +3596,12 @@ static int op_undoc_slaixdb(int data)	/* SLA (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2559,6 +3621,12 @@ static int op_undoc_slaixdc(int data)	/* SLA (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2578,6 +3646,12 @@ static int op_undoc_slaixdd(int data)	/* SLA (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2597,6 +3671,12 @@ static int op_undoc_slaixde(int data)	/* SLA (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2616,6 +3696,12 @@ static int op_undoc_slaixdh(int data)	/* SLA (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2635,6 +3721,12 @@ static int op_undoc_slaixdl(int data)	/* SLA (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2656,6 +3748,12 @@ static int op_undoc_sraixda(int data)	/* SRA (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2677,6 +3775,12 @@ static int op_undoc_sraixdb(int data)	/* SRA (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2698,6 +3802,12 @@ static int op_undoc_sraixdc(int data)	/* SRA (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2719,6 +3829,12 @@ static int op_undoc_sraixdd(int data)	/* SRA (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2740,6 +3856,12 @@ static int op_undoc_sraixde(int data)	/* SRA (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2761,6 +3883,12 @@ static int op_undoc_sraixdh(int data)	/* SRA (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2782,6 +3910,12 @@ static int op_undoc_sraixdl(int data)	/* SRA (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2801,6 +3935,12 @@ static int op_undoc_sllixda(int data)	/* SLL (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2820,6 +3960,12 @@ static int op_undoc_sllixdb(int data)	/* SLL (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2839,6 +3985,12 @@ static int op_undoc_sllixdc(int data)	/* SLL (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2858,6 +4010,12 @@ static int op_undoc_sllixdd(int data)	/* SLL (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2877,6 +4035,12 @@ static int op_undoc_sllixde(int data)	/* SLL (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2896,6 +4060,12 @@ static int op_undoc_sllixdh(int data)	/* SLL (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2915,6 +4085,12 @@ static int op_undoc_sllixdl(int data)	/* SLL (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2935,6 +4111,12 @@ static int op_undoc_sllixd(int data)	/* SLL (IX+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2954,6 +4136,12 @@ static int op_undoc_srlixda(int data)	/* SRL (IX+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2973,6 +4161,12 @@ static int op_undoc_srlixdb(int data)	/* SRL (IX+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2992,6 +4186,12 @@ static int op_undoc_srlixdc(int data)	/* SRL (IX+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -3011,6 +4211,12 @@ static int op_undoc_srlixdd(int data)	/* SRL (IX+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -3030,6 +4236,12 @@ static int op_undoc_srlixde(int data)	/* SRL (IX+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -3049,6 +4261,12 @@ static int op_undoc_srlixdh(int data)	/* SRL (IX+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -3068,6 +4286,12 @@ static int op_undoc_srlixdl(int data)	/* SRL (IX+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -374,6 +374,9 @@ static int op_reti(void)		/* RETI */
 	i = memrdr(SP++);
 	i += memrdr(SP++) << 8;
 	PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (14);
 }
 
@@ -386,6 +389,9 @@ static int op_retn(void)		/* RETN */
 	PC = i;
 	if (IFF & 2)
 		IFF |= 1;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (14);
 }
 
@@ -398,6 +404,11 @@ static int op_neg(void)			/* NEG */
 	F |= N_FLAG;
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -405,11 +416,19 @@ static int op_inaic(void)		/* IN A,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	A = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -417,11 +436,19 @@ static int op_inbic(void)		/* IN B,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	B = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -429,11 +456,19 @@ static int op_incic(void)		/* IN C,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	C = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -441,11 +476,19 @@ static int op_indic(void)		/* IN D,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	D = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -453,11 +496,19 @@ static int op_ineic(void)		/* IN E,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	E = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -465,11 +516,19 @@ static int op_inhic(void)		/* IN H,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	H = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -477,11 +536,19 @@ static int op_inlic(void)		/* IN L,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	L = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 
@@ -490,6 +557,9 @@ static int op_outca(void)		/* OUT (C),A */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, A);
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	return (12);
 }
 
@@ -498,6 +568,9 @@ static int op_outcb(void)		/* OUT (C),B */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, B);
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	return (12);
 }
 
@@ -506,6 +579,9 @@ static int op_outcc(void)		/* OUT (C),C */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, C);
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	return (12);
 }
 
@@ -514,6 +590,9 @@ static int op_outcd(void)		/* OUT (C),D */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, D);
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	return (12);
 }
 
@@ -522,6 +601,9 @@ static int op_outce(void)		/* OUT (C),E */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, E);
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	return (12);
 }
 
@@ -530,6 +612,9 @@ static int op_outch(void)		/* OUT (C),H */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, H);
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	return (12);
 }
 
@@ -538,6 +623,9 @@ static int op_outcl(void)		/* OUT (C),L */
 	extern void io_out(BYTE, BYTE, BYTE);
 
 	io_out(C, B, L);
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	return (12);
 }
 
@@ -545,27 +633,32 @@ static int op_ini(void)			/* INI */
 {
 	extern BYTE io_in(BYTE, BYTE);
 	BYTE data;
-#ifndef Z80BLKIOF_DOC
-	WORD k;
-#endif
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	data = io_in(C, B);
+	B--;
 	memwrt((H << 8) + L, data);
 	L++;
 	if (!L)
 		H++;
-	B--;
-#ifdef Z80BLKIOF_DOC
+#if 0
 	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
 #else
 	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
-	k = (WORD) ((C + 1) & 0xff) + (WORD) data;
+	WORD k = (WORD) ((C + 1) & 0xff) + (WORD) data;
 	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
 	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 #endif
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (16);
 }
 
@@ -575,46 +668,66 @@ static int op_inir(void)		/* INIR */
 	extern BYTE io_in(BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-#ifndef Z80BLKIOF_DOC
-	WORD k;
-#endif
 	register int t = -21;
 
 	addr = (H << 8) + L;
 	R -= 2;
 	do {
 		data = io_in(C, B);
-		memwrt(addr++, data);
 		B--;
+		memwrt(addr++, data);
 		t += 21;
 		R += 2;
 	} while (B);
 	H = addr >> 8;
 	L = addr;
-#ifdef Z80BLKIOF_DOC
+#if 0
 	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
 #else
 	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
-	k = (WORD) ((C + 1) & 0xff) + (WORD) data;
+	WORD k = (WORD) ((C + 1) & 0xff) + (WORD) data;
 	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
-	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(parity[k & 0x07]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
 	F &= ~S_FLAG;
 #endif
 	F |= Z_FLAG;
+#ifdef UNDOC_FLAGS
+	F &= ~(N2_FLAG | N1_FLAG);
+	WZ = ((1 << 8) + C) + 1;
+	modF = 1;
+#endif
 	return (t + 16);
 }
 #else
 static int op_inir(void)		/* INIR */
 {
-	register int t;
+	register int t = 16;
 
 	op_ini();
 	if (!(F & Z_FLAG)) {
-		t = 21;
 		PC -= 2;
-	} else
-		t = 16;
+		t += 5;
+#ifdef UNDOC_FLAGS
+		register int i;
+		WZ = PC + 1;
+		(PC & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+		(PC & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+		if (F & C_FLAG) {
+			if (F & N_FLAG) {
+				i = parity[(B - 1) & 0x07];
+				((B & 0xf) == 0x0) ? (F |= H_FLAG)
+						   : (F &= ~H_FLAG);
+			} else {
+				i = parity[(B + 1) & 0x07];
+				((B & 0xf) == 0xf) ? (F |= H_FLAG)
+						   : (F &= ~H_FLAG);
+			}
+		} else
+			i = parity[B & 0x07];
+		(((F & P_FLAG) == 0) ^ i) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#endif
+	}
 	return (t);
 }
 #endif
@@ -623,27 +736,32 @@ static int op_ind(void)			/* IND */
 {
 	extern BYTE io_in(BYTE, BYTE);
 	BYTE data;
-#ifndef Z80BLKIOF_DOC
-	WORD k;
-#endif
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) - 1;
+#endif
 	data = io_in(C, B);
+	B--;
 	memwrt((H << 8) + L, data);
 	L--;
 	if (L == 0xff)
 		H--;
-	B--;
-#ifdef Z80BLKIOF_DOC
+#if 0
 	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
 #else
 	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
-	k = (WORD) ((C - 1) & 0xff) + (WORD) data;
+	WORD k = (WORD) ((C - 1) & 0xff) + (WORD) data;
 	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
 	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 #endif
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (16);
 }
 
@@ -653,9 +771,6 @@ static int op_indr(void)		/* INDR */
 	extern BYTE io_in(BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-#ifndef Z80BLKIOF_DOC
-	WORD k;
-#endif
 	register int t = -21;
 
 	addr = (H << 8) + L;
@@ -669,30 +784,53 @@ static int op_indr(void)		/* INDR */
 	} while (B);
 	H = addr >> 8;
 	L = addr;
-#ifdef Z80BLKIOF_DOC
+#if 0
 	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
 #else
 	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
-	k = (WORD) ((C - 1) & 0xff) + (WORD) data;
+	WORD k = (WORD) ((C - 1) & 0xff) + (WORD) data;
 	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
-	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(parity[k & 0x07]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
 	F &= ~S_FLAG;
 #endif
 	F |= Z_FLAG;
+#ifdef UNDOC_FLAGS
+	F &= ~(N2_FLAG | N1_FLAG);
+	WZ = ((1 << 8) + C) - 1;
+	modF = 1;
+#endif
 	return (t + 16);
 }
 #else
 static int op_indr(void)		/* INDR */
 {
-	register int t;
+	register int t = 16;
 
 	op_ind();
 	if (!(F & Z_FLAG)) {
-		t = 21;
 		PC -= 2;
-	} else
-		t = 16;
+		t += 5;
+#ifdef UNDOC_FLAGS
+		register int i;
+		WZ = PC + 1;
+		(PC & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+		(PC & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+		if (F & C_FLAG) {
+			if (F & N_FLAG) {
+				i = parity[(B - 1) & 0x07];
+				((B & 0xf) == 0x0) ? (F |= H_FLAG)
+						   : (F &= ~H_FLAG);
+			} else {
+				i = parity[(B + 1) & 0x07];
+				((B & 0xf) == 0xf) ? (F |= H_FLAG)
+						   : (F &= ~H_FLAG);
+			}
+		} else
+			i = parity[B & 0x07];
+		(((F & P_FLAG) == 0) ^ i) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#endif
+	}
 	return (t);
 }
 #endif
@@ -701,27 +839,30 @@ static int op_outi(void)		/* OUTI */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 	BYTE data;
-#ifndef Z80BLKIOF_DOC
-	WORD k;
-#endif
 
-	B--;
 	data = memrdr((H << 8) + L);
+	B--;
 	io_out(C, B, data);
 	L++;
 	if (!L)
 		H++;
-#ifdef Z80BLKIOF_DOC
+#if 0
 	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
 #else
 	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
-	k = (WORD) L + (WORD) data;
+	WORD k = (WORD) L + (WORD) data;
 	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
 	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 #endif
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = ((B << 8) + C) + 1;
+	modF = 1;
+#endif
 	return (16);
 }
 
@@ -731,9 +872,6 @@ static int op_otir(void)		/* OTIR */
 	extern void io_out(BYTE, BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-#ifndef Z80BLKIOF_DOC
-	WORD k;
-#endif
 	register int t = -21;
 
 	addr = (H << 8) + L;
@@ -747,30 +885,53 @@ static int op_otir(void)		/* OTIR */
 	} while (B);
 	H = addr >> 8;
 	L = addr;
-#ifdef Z80BLKIOF_DOC
+#if 0
 	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
 #else
 	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
-	k = (WORD) L + (WORD) data;
+	WORD k = (WORD) L + (WORD) data;
 	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
-	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(parity[k & 0x07]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
 	F &= ~S_FLAG;
 #endif
 	F |= Z_FLAG;
+#ifdef UNDOC_FLAGS
+	F &= ~(N2_FLAG | N1_FLAG);
+	WZ = (WORD) C + (WORD) 1;
+	modF = 1;
+#endif
 	return (t + 16);
 }
 #else
 static int op_otir(void)		/* OTIR */
 {
-	register int t;
+	register int t = 16;
 
 	op_outi();
 	if (!(F & Z_FLAG)) {
-		t = 21;
 		PC -= 2;
-	} else
-		t = 16;
+		t += 5;
+#ifdef UNDOC_FLAGS
+		register int i;
+		WZ = PC + 1;
+		(PC & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+		(PC & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+		if (F & C_FLAG) {
+			if (F & N_FLAG) {
+				i = parity[(B - 1) & 0x07];
+				((B & 0xf) == 0x0) ? (F |= H_FLAG)
+						   : (F &= ~H_FLAG);
+			} else {
+				i = parity[(B + 1) & 0x07];
+				((B & 0xf) == 0xf) ? (F |= H_FLAG)
+						   : (F &= ~H_FLAG);
+			}
+		} else
+			i = parity[B & 0x07];
+		(((F & P_FLAG) == 0) ^ i) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#endif
+	}
 	return (t);
 }
 #endif
@@ -779,27 +940,30 @@ static int op_outd(void)		/* OUTD */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 	BYTE data;
-#ifndef Z80BLKIOF_DOC
-	WORD k;
-#endif
 
-	B--;
 	data = memrdr((H << 8) + L);
+	B--;
 	io_out(C, B, data);
 	L--;
 	if (L == 0xff)
 		H--;
-#ifdef Z80BLKIOF_DOC
+#if 0
 	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
 #else
 	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
-	k = (WORD) L + (WORD) data;
+	WORD k = (WORD) L + (WORD) data;
 	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
 	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 #endif
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = ((B << 8) + C) - 1;
+	modF = 1;
+#endif
 	return (16);
 }
 
@@ -809,9 +973,6 @@ static int op_otdr(void)		/* OTDR */
 	extern void io_out(BYTE, BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-#ifndef Z80BLKIOF_DOC
-	WORD k;
-#endif
 	register int t = -21;
 
 	addr = (H << 8) + L;
@@ -825,30 +986,53 @@ static int op_otdr(void)		/* OTDR */
 	} while (B);
 	H = addr >> 8;
 	L = addr;
-#ifdef Z80BLKIOF_DOC
+#if 0
 	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
 #else
 	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
-	k = (WORD) L + (WORD) data;
+	WORD k = (WORD) L + (WORD) data;
 	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
-	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(parity[k & 0x07]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
 	F &= ~S_FLAG;
 #endif
 	F |= Z_FLAG;
+#ifdef UNDOC_FLAGS
+	F &= ~(N2_FLAG | N1_FLAG);
+	WZ = (WORD) C - (WORD) 1;
+	modF = 1;
+#endif
 	return (t + 16);
 }
 #else
 static int op_otdr(void)		/* OTDR */
 {
-	register int t;
+	register int t = 16;
 
 	op_outd();
 	if (!(F & Z_FLAG)) {
-		t = 21;
 		PC -= 2;
-	} else
-		t = 16;
+		t += 5;
+#ifdef UNDOC_FLAGS
+		register int i;
+		WZ = PC + 1;
+		(PC & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+		(PC & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+		if (F & C_FLAG) {
+			if (F & N_FLAG) {
+				i = parity[(B - 1) & 0x07];
+				((B & 0xf) == 0x0) ? (F |= H_FLAG)
+						   : (F &= ~H_FLAG);
+			} else {
+				i = parity[(B + 1) & 0x07];
+				((B & 0xf) == 0xf) ? (F |= H_FLAG)
+						   : (F &= ~H_FLAG);
+			}
+		} else
+			i = parity[B & 0x07];
+		(((F & P_FLAG) == 0) ^ i) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#endif
+	}
 	return (t);
 }
 #endif
@@ -860,6 +1044,11 @@ static int op_ldai(void)		/* LD A,I */
 	(IFF & 2) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (9);
 }
 
@@ -870,6 +1059,11 @@ static int op_ldar(void)		/* LD A,R */
 	(IFF & 2) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (9);
 }
 
@@ -893,6 +1087,9 @@ static int op_ldbcinn(void)		/* LD BC,(nn) */
 	i += memrdr(PC++) << 8;
 	C = memrdr(i++);
 	B = memrdr(i);
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (20);
 }
 
@@ -904,6 +1101,9 @@ static int op_lddeinn(void)		/* LD DE,(nn) */
 	i += memrdr(PC++) << 8;
 	E = memrdr(i++);
 	D = memrdr(i);
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (20);
 }
 
@@ -915,6 +1115,9 @@ static int op_ldhlinn(void)		/* LD HL,(nn) */
 	i += memrdr(PC++) << 8;
 	L = memrdr(i++);
 	H = memrdr(i);
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (20);
 }
 
@@ -926,6 +1129,9 @@ static int op_ldspinn(void)		/* LD SP,(nn) */
 	i += memrdr(PC++) << 8;
 	SP = memrdr(i++);
 	SP += memrdr(i) << 8;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (20);
 }
 
@@ -937,6 +1143,9 @@ static int op_ldinbc(void)		/* LD (nn),BC */
 	i += memrdr(PC++) << 8;
 	memwrt(i++, C);
 	memwrt(i, B);
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (20);
 }
 
@@ -948,6 +1157,9 @@ static int op_ldinde(void)		/* LD (nn),DE */
 	i += memrdr(PC++) << 8;
 	memwrt(i++, E);
 	memwrt(i, D);
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (20);
 }
 
@@ -959,6 +1171,9 @@ static int op_ldinhl(void)		/* LD (nn),HL */
 	i += memrdr(PC++) << 8;
 	memwrt(i++, L);
 	memwrt(i, H);
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (20);
 }
 
@@ -972,6 +1187,9 @@ static int op_ldinsp(void)		/* LD (nn),SP */
 	i = SP;
 	memwrt(addr++, i);
 	memwrt(addr, i >> 8);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (20);
 }
 
@@ -997,6 +1215,12 @@ static int op_adchb(void)		/* ADC HL,BC */
 	H = i >> 8;
 	L = i;
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = hl + 1;
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -1022,6 +1246,12 @@ static int op_adchd(void)		/* ADC HL,DE */
 	H = i >> 8;
 	L = i;
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = hl + 1;
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -1045,6 +1275,12 @@ static int op_adchh(void)		/* ADC HL,HL */
 	H = i >> 8;
 	L = i;
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = hl + 1;
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -1070,6 +1306,12 @@ static int op_adchs(void)		/* ADC HL,SP */
 	H = i >> 8;
 	L = i;
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = hl + 1;
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -1095,6 +1337,12 @@ static int op_sbchb(void)		/* SBC HL,BC */
 	H = i >> 8;
 	L = i;
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = hl + 1;
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -1120,6 +1368,12 @@ static int op_sbchd(void)		/* SBC HL,DE */
 	H = i >> 8;
 	L = i;
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = hl + 1;
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -1143,6 +1397,12 @@ static int op_sbchh(void)		/* SBC HL,HL */
 	H = i >> 8;
 	L = i;
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = hl + 1;
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -1168,12 +1428,21 @@ static int op_sbchs(void)		/* SBC HL,SP */
 	H = i >> 8;
 	L = i;
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = hl + 1;
+	modF = 1;
+#endif
 	return (15);
 }
 
 static int op_ldi(void)			/* LDI */
 {
-	memwrt((D << 8) + E, memrdr((H << 8) + L));
+	register BYTE tmp;
+
+	tmp = memrdr((H << 8) + L);
+	memwrt((D << 8) + E, tmp);
 	E++;
 	if (!E)
 		D++;
@@ -1185,6 +1454,12 @@ static int op_ldi(void)			/* LDI */
 		B--;
 	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	F &= ~(N_FLAG | H_FLAG);
+#ifdef UNDOC_FLAGS
+	tmp += A;
+	(tmp & 2) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(tmp & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (16);
 }
 
@@ -1194,13 +1469,19 @@ static int op_ldir(void)		/* LDIR */
 	register int t = -21;
 	register WORD i;
 	register WORD s, d;
+	BYTE tmp;
 
 	i = (B << 8) + C;
 	d = (D << 8) + E;
 	s = (H << 8) + L;
 	R -= 2;
+#ifdef UNDOC_FLAGS
+	if (i == 1)
+		WZ = PC - 1;
+#endif
 	do {
-		memwrt(d++, memrdr(s++));
+		tmp = memrdr(s++);
+		memwrt(d++, tmp);
 		t += 21;
 		R += 2;
 	} while (--i);
@@ -1210,26 +1491,39 @@ static int op_ldir(void)		/* LDIR */
 	H = s >> 8;
 	L = s;
 	F &= ~(N_FLAG | P_FLAG | H_FLAG);
+#ifdef UNDOC_FLAGS
+	tmp += A;
+	(tmp & 2) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(tmp & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (t + 16);
 }
 #else
 static int op_ldir(void)		/* LDIR */
 {
-	register int t;
+	register int t = 16;
 
 	op_ldi();
 	if (F & P_FLAG) {
-		t = 21;
 		PC -= 2;
-	} else
-		t = 16;
+		t += 5;
+#ifdef UNDOC_FLAGS
+		WZ = PC + 1;
+		(PC & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+		(PC & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+#endif
+	}
 	return (t);
 }
 #endif
 
 static int op_ldd(void)			/* LDD */
 {
-	memwrt((D << 8) + E, memrdr((H << 8) + L));
+	register BYTE tmp;
+
+	tmp = memrdr((H << 8) + L);
+	memwrt((D << 8) + E, tmp);
 	E--;
 	if (E == 0xff)
 		D--;
@@ -1241,6 +1535,12 @@ static int op_ldd(void)			/* LDD */
 		B--;
 	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	F &= ~(N_FLAG | H_FLAG);
+#ifdef UNDOC_FLAGS
+	tmp += A;
+	(tmp & 2) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(tmp & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (16);
 }
 
@@ -1250,13 +1550,19 @@ static int op_lddr(void)		/* LDDR */
 	register int t = -21;
 	register WORD i;
 	register WORD s, d;
+	BYTE tmp;
 
 	i = (B << 8) + C;
 	d = (D << 8) + E;
 	s = (H << 8) + L;
 	R -= 2;
+#ifdef UNDOC_FLAGS
+	if (i == 1)
+		WZ = PC - 1;
+#endif
 	do {
-		memwrt(d--, memrdr(s--));
+		tmp = memrdr(s--);
+		memwrt(d--, tmp);
 		t += 21;
 		R += 2;
 	} while (--i);
@@ -1266,6 +1572,12 @@ static int op_lddr(void)		/* LDDR */
 	H = s >> 8;
 	L = s;
 	F &= ~(N_FLAG | P_FLAG | H_FLAG);
+#ifdef UNDOC_FLAGS
+	tmp += A;
+	(tmp & 2) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(tmp & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (t + 16);
 }
 #else
@@ -1277,6 +1589,11 @@ static int op_lddr(void)		/* LDDR */
 	if (F & P_FLAG) {
 		t = 21;
 		PC -= 2;
+#ifdef UNDOC_FLAGS
+		WZ = PC + 1;
+		(PC & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+		(PC & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+#endif
 	} else
 		t = 16;
 	return (t);
@@ -1300,6 +1617,14 @@ static int op_cpi(void)			/* CPI */
 	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	if (F & H_FLAG)
+		i--;
+	(i & 2) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ++;
+	modF = 1;
+#endif
 	return (16);
 }
 
@@ -1310,7 +1635,7 @@ static int op_cpir(void)		/* CPIR */
 	register WORD s;
 	register BYTE d;
 	register WORD i;
-	register BYTE tmp;
+	BYTE tmp;
 
 	i = (B << 8) + C;
 	s = (H << 8) + L;
@@ -1321,6 +1646,12 @@ static int op_cpir(void)		/* CPIR */
 		d = A - tmp;
 		t += 21;
 		R += 2;
+#ifdef UNDOC_FLAGS
+		if (i == 1 || d == 0)
+			WZ++;
+		else
+			WZ = PC;
+#endif
 	} while (--i && d);
 	F |= N_FLAG;
 	B = i >> 8;
@@ -1330,19 +1661,30 @@ static int op_cpir(void)		/* CPIR */
 	(i) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(d) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(d & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	if (F & H_FLAG)
+		d--;
+	(d & 2) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(d & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (t + 16);
 }
 #else
 static int op_cpir(void)		/* CPIR */
 {
-	register int t;
+	register int t = 16;
 
 	op_cpi();
 	if ((F & (P_FLAG | Z_FLAG)) == P_FLAG) {
-		t = 21;
 		PC -= 2;
-	} else
-		t = 16;
+		t += 5;
+#ifdef UNDOC_FLAGS
+		WZ = PC + 1;
+		(PC & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+		(PC & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+#endif
+	}
 	return (t);
 }
 #endif
@@ -1364,17 +1706,25 @@ static int op_cpdop(void)		/* CPD */
 	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	if (F & H_FLAG)
+		i--;
+	(i & 2) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ--;
+	modF = 1;
+#endif
 	return (16);
 }
 
 #ifdef WANT_FASTB
 static int op_cpdr(void)		/* CPDR */
 {
-	register int t = -21;
 	register WORD s;
 	register BYTE d;
 	register WORD i;
 	register BYTE tmp;
+	register int t = -21;
 
 	i = (B << 8) + C;
 	s = (H << 8) + L;
@@ -1385,6 +1735,12 @@ static int op_cpdr(void)		/* CPDR */
 		d = A - tmp;
 		t += 21;
 		R += 2;
+#ifdef UNDOC_FLAGS
+		if (i == 1 || d == 0)
+			WZ--;
+		else
+			WZ = PC - 2;
+#endif
 	} while (--i && d);
 	F |= N_FLAG;
 	B = i >> 8;
@@ -1394,19 +1750,30 @@ static int op_cpdr(void)		/* CPDR */
 	(i) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(d) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(d & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	if (F & H_FLAG)
+		d--;
+	(d & 2) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(d & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (t + 16);
 }
 #else
 static int op_cpdr(void)		/* CPDR */
 {
-	register int t;
+	register int t = 16;
 
 	op_cpdop();
 	if ((F & (P_FLAG | Z_FLAG)) == P_FLAG) {
-		t = 21;
 		PC -= 2;
-	} else
-		t = 16;
+		t += 5;
+#ifdef UNDOC_FLAGS
+		WZ = PC + 1;
+		(PC & 0x2000) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+		(PC & 0x0800) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+#endif
+	}
 	return (t);
 }
 #endif
@@ -1414,32 +1781,48 @@ static int op_cpdr(void)		/* CPDR */
 static int op_oprld(void)		/* RLD (HL) */
 {
 	register BYTE i, j;
+	register WORD addr;
 
-	i = memrdr((H << 8) + L);
+	addr = (H << 8) + L;
+	i = memrdr(addr);
 	j = A & 0x0f;
 	A = (A & 0xf0) | (i >> 4);
 	i = (i << 4) | j;
-	memwrt((H << 8) + L, i);
+	memwrt(addr, i);
 	F &= ~(H_FLAG | N_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr + 1;
+	modF = 1;
+#endif
 	return (18);
 }
 
 static int op_oprrd(void)		/* RRD (HL) */
 {
 	register BYTE i, j;
+	register WORD addr;
 
-	i = memrdr((H << 8) + L);
+	addr = (H << 8) + L;
+	i = memrdr(addr);
 	j = A & 0x0f;
 	A = (A & 0xf0) | (i & 0x0f);
 	i = (i >> 4) | (j << 4);
-	memwrt((H << 8) + L, i);
+	memwrt(addr, i);
 	F &= ~(H_FLAG | N_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr + 1;
+	modF = 1;
+#endif
 	return (18);
 }
 
@@ -1459,6 +1842,9 @@ static int op_undoc_outc0(void)		/* OUT (C),0 */
 		return (trap_ed());
 
 	io_out(C, B, 0); /* NMOS, CMOS outputs 0xff */
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	return (12);
 }
 
@@ -1470,11 +1856,19 @@ static int op_undoc_infic(void)		/* IN F,(C) */
 	if (u_flag)
 		return (trap_ed());
 
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
 	tmp = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
 	(tmp) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(tmp & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[tmp]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(tmp & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(tmp & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (12);
 }
 

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -399,6 +399,9 @@ static int op_exspy(void)		/* EX (SP),IY */
 	memwrt(SP, IY);
 	memwrt(SP + 1, IY >> 8);
 	IY = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (23);
 }
 
@@ -421,8 +424,11 @@ static int op_ldiyinn(void)		/* LD IY,(nn) */
 
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
-	IY = memrdr(i);
-	IY += memrdr(i + 1) << 8;
+	IY = memrdr(i++);
+	IY += memrdr(i) << 8;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (20);
 }
 
@@ -432,8 +438,11 @@ static int op_ldiny(void)		/* LD (nn),IY */
 
 	i = memrdr(PC++);
 	i += memrdr(PC++) << 8;
-	memwrt(i, IY);
-	memwrt(i + 1, IY >> 8);
+	memwrt(i++, IY);
+	memwrt(i, IY >> 8);
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
 	return (20);
 }
 
@@ -441,8 +450,10 @@ static int op_adayd(void)		/* ADD A,(IY+d) */
 {
 	register int i;
 	register BYTE P;
+	WORD addr;
 
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	addr = IY + (signed char) memrdr(PC++);
+	P = memrdr(addr);
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
@@ -450,6 +461,12 @@ static int op_adayd(void)		/* ADD A,(IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (19);
 }
 
@@ -457,9 +474,11 @@ static int op_acayd(void)		/* ADC A,(IY+d) */
 {
 	register int i, carry;
 	register BYTE P;
+	WORD addr;
 
+	addr = IY + (signed char) memrdr(PC++);
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	P = memrdr(addr);
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
@@ -467,6 +486,12 @@ static int op_acayd(void)		/* ADC A,(IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (19);
 }
 
@@ -474,8 +499,10 @@ static int op_suayd(void)		/* SUB A,(IY+d) */
 {
 	register int i;
 	register BYTE P;
+	WORD addr;
 
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	addr = IY + (signed char) memrdr(PC++);
+	P = memrdr(addr);
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
@@ -483,6 +510,12 @@ static int op_suayd(void)		/* SUB A,(IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (19);
 }
 
@@ -490,9 +523,11 @@ static int op_scayd(void)		/* SBC A,(IY+d) */
 {
 	register int i, carry;
 	register BYTE P;
+	WORD addr;
 
+	addr = IY + (signed char) memrdr(PC++);
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	P = memrdr(addr);
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
@@ -500,37 +535,70 @@ static int op_scayd(void)		/* SBC A,(IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (19);
 }
 
 static int op_andyd(void)		/* AND (IY+d) */
 {
-	A &= memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	A &= memrdr(addr);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (19);
 }
 
 static int op_xoryd(void)		/* XOR (IY+d) */
 {
-	A ^= memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	A ^= memrdr(addr);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (19);
 }
 
 static int op_oryd(void)		/* OR (IY+d) */
 {
-	A |= memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	A |= memrdr(addr);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (19);
 }
 
@@ -538,8 +606,10 @@ static int op_cpyd(void)		/* CP (IY+d) */
 {
 	register int i;
 	register BYTE P;
+	WORD addr;
 
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	addr = IY + (signed char) memrdr(PC++);
+	P = memrdr(addr);
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = (signed char) A - (signed char) P;
@@ -547,6 +617,12 @@ static int op_cpyd(void)		/* CP (IY+d) */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (19);
 }
 
@@ -564,6 +640,12 @@ static int op_incyd(void)		/* INC (IY+d) */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -581,6 +663,12 @@ static int op_decyd(void)		/* DEC (IY+d) */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -590,6 +678,9 @@ static int op_addyb(void)		/* ADD IY,BC */
 	BYTE iyl = IY & 0xff;
 	BYTE iyh = IY >> 8;
 
+#ifdef UNDOC_FLAGS
+	WZ = IY + 1;
+#endif
 	carry = (iyl + C > 255) ? 1 : 0;
 	iyl += C;
 	((iyh & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -598,6 +689,11 @@ static int op_addyb(void)		/* ADD IY,BC */
 	iyh += B + carry;
 	IY = (iyh << 8) + iyl;
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(iyh & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(iyh & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -607,6 +703,9 @@ static int op_addyd(void)		/* ADD IY,DE */
 	BYTE iyl = IY & 0xff;
 	BYTE iyh = IY >> 8;
 
+#ifdef UNDOC_FLAGS
+	WZ = IY + 1;
+#endif
 	carry = (iyl + E > 255) ? 1 : 0;
 	iyl += E;
 	((iyh & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -615,6 +714,11 @@ static int op_addyd(void)		/* ADD IY,DE */
 	iyh += D + carry;
 	IY = (iyh << 8) + iyl;
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(iyh & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(iyh & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -626,6 +730,9 @@ static int op_addys(void)		/* ADD IY,SP */
 	BYTE spl = SP & 0xff;
 	BYTE sph = SP >> 8;
 
+#ifdef UNDOC_FLAGS
+	WZ = IY + 1;
+#endif
 	carry = (iyl + spl > 255) ? 1 : 0;
 	iyl += spl;
 	((iyh & 0xf) + (sph & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -634,6 +741,11 @@ static int op_addys(void)		/* ADD IY,SP */
 	iyh += sph + carry;
 	IY = (iyh << 8) + iyl;
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(iyh & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(iyh & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -643,6 +755,9 @@ static int op_addyy(void)		/* ADD IY,IY */
 	BYTE iyl = IY & 0xff;
 	BYTE iyh = IY >> 8;
 
+#ifdef UNDOC_FLAGS
+	WZ = IY + 1;
+#endif
 	carry = (iyl << 1 > 255) ? 1 : 0;
 	iyl <<= 1;
 	((iyh & 0xf) + (iyh & 0xf) + carry > 0xf) ? (F |= H_FLAG)
@@ -651,6 +766,11 @@ static int op_addyy(void)		/* ADD IY,IY */
 	iyh += iyh + carry;
 	IY = (iyh << 8) + iyl;
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(iyh & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(iyh & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (15);
 }
 
@@ -668,94 +788,181 @@ static int op_deciy(void)		/* DEC IY */
 
 static int op_ldayd(void)		/* LD A,(IY+d) */
 {
-	A = memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	A = memrdr(addr);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldbyd(void)		/* LD B,(IY+d) */
 {
-	B = memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	B = memrdr(addr);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldcyd(void)		/* LD C,(IY+d) */
 {
-	C = memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	C = memrdr(addr);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_lddyd(void)		/* LD D,(IY+d) */
 {
-	D = memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	D = memrdr(addr);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldeyd(void)		/* LD E,(IY+d) */
 {
-	E = memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	E = memrdr(addr);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldhyd(void)		/* LD H,(IY+d) */
 {
-	H = memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	H = memrdr(addr);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldlyd(void)		/* LD L,(IY+d) */
 {
-	L = memrdr(IY + (signed char) memrdr(PC++));
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	L = memrdr(addr);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldyda(void)		/* LD (IY+d),A */
 {
-	memwrt(IY + (signed char) memrdr(PC++), A);
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldydb(void)		/* LD (IY+d),B */
 {
-	memwrt(IY + (signed char) memrdr(PC++), B);
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldydc(void)		/* LD (IY+d),C */
 {
-	memwrt(IY + (signed char) memrdr(PC++), C);
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldydd(void)		/* LD (IY+d),D */
 {
-	memwrt(IY + (signed char) memrdr(PC++), D);
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldyde(void)		/* LD (IY+d),E */
 {
-	memwrt(IY + (signed char) memrdr(PC++), E);
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldydh(void)		/* LD (IY+d),H */
 {
-	memwrt(IY + (signed char) memrdr(PC++), H);
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldydl(void)		/* LD (IY+d),L */
 {
-	memwrt(IY + (signed char) memrdr(PC++), L);
+	WORD addr;
+
+	addr = IY + (signed char) memrdr(PC++);
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
 static int op_ldydn(void)		/* LD (IY+d),n */
 {
-	register signed char d;
+	WORD addr;
 
-	d = memrdr(PC++);
-	memwrt(IY + d, memrdr(PC++));
+	addr = IY + (signed char) memrdr(PC++);
+	memwrt(addr, memrdr(PC++));
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (19);
 }
 
@@ -1015,6 +1222,11 @@ static int op_undoc_cpiyl(void)		/* CP IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1034,6 +1246,11 @@ static int op_undoc_cpiyh(void)		/* CP IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1053,6 +1270,11 @@ static int op_undoc_adaiyl(void)	/* ADD A,IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1072,6 +1294,11 @@ static int op_undoc_adaiyh(void)	/* ADD A,IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1092,6 +1319,11 @@ static int op_undoc_acaiyl(void)	/* ADC A,IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1112,6 +1344,11 @@ static int op_undoc_acaiyh(void)	/* ADC A,IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1131,6 +1368,11 @@ static int op_undoc_suaiyl(void)	/* SUB A,IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1150,6 +1392,11 @@ static int op_undoc_suaiyh(void)	/* SUB A,IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1170,6 +1417,11 @@ static int op_undoc_scaiyl(void)	/* SBC A,IYL */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1190,6 +1442,11 @@ static int op_undoc_scaiyh(void)	/* SBC A,IYH */
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(i & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1203,6 +1460,11 @@ static int op_undoc_oraiyl(void)	/* OR IYL */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1216,6 +1478,11 @@ static int op_undoc_oraiyh(void)	/* OR IYH */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1229,6 +1496,11 @@ static int op_undoc_xoriyl(void)	/* XOR IYL */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1242,6 +1514,11 @@ static int op_undoc_xoriyh(void)	/* XOR IYH */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1256,6 +1533,11 @@ static int op_undoc_andiyl(void)	/* AND IYL */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1270,6 +1552,11 @@ static int op_undoc_andiyh(void)	/* AND IYH */
 	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1288,6 +1575,11 @@ static int op_undoc_inciyl(void)	/* INC IYL */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1306,6 +1598,11 @@ static int op_undoc_inciyh(void)	/* INC IYH */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1324,6 +1621,11 @@ static int op_undoc_deciyl(void)	/* DEC IYL */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 
@@ -1342,6 +1644,11 @@ static int op_undoc_deciyh(void)	/* DEC IYH */
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	modF = 1;
+#endif
 	return (8);
 }
 

--- a/z80core/simz80-fdcb.c
+++ b/z80core/simz80-fdcb.c
@@ -393,174 +393,342 @@ static int trap_fdcb(int data)
 
 static int op_tb0iyd(int data)		/* BIT 0,(IY+d) */
 {
+	WORD addr;
+
+	addr = IY + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IY + data) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
-				: (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
+			   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb1iyd(int data)		/* BIT 1,(IY+d) */
 {
+	WORD addr;
+
+	addr = IY + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IY + data) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
-				: (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
+			   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb2iyd(int data)		/* BIT 2,(IY+d) */
 {
+	WORD addr;
+
+	addr = IY + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IY + data) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
-				: (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
+			   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb3iyd(int data)		/* BIT 3,(IY+d) */
 {
+	WORD addr;
+
+	addr = IY + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IY + data) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
-				: (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
+			   : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb4iyd(int data)		/* BIT 4,(IY+d) */
 {
+	WORD addr;
+
+	addr = IY + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IY + data) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
-				 : (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
+			    : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb5iyd(int data)		/* BIT 5,(IY+d) */
 {
+	WORD addr;
+
+	addr = IY + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IY + data) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
-				 : (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
+			    : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb6iyd(int data)		/* BIT 6,(IY+d) */
 {
+	WORD addr;
+
+	addr = IY + data;
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
-	(memrdr(IY + data) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
-				 : (F |= (Z_FLAG | P_FLAG));
+	(memrdr(addr) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
+			    : (F |= (Z_FLAG | P_FLAG));
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_tb7iyd(int data)		/* BIT 7,(IY+d) */
 {
+	WORD addr;
+
+	addr = IY + data;
 	F &= ~N_FLAG;
 	F |= H_FLAG;
-	if (memrdr(IY + data) & 128) {
+	if (memrdr(addr) & 128) {
 		F &= ~(Z_FLAG | P_FLAG);
 		F |= S_FLAG;
 	} else {
 		F |= (Z_FLAG | P_FLAG);
 		F &= ~S_FLAG;
 	}
+#ifdef UNDOC_FLAGS
+	(addr & (32 << 8)) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(addr & (8 << 8)) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (20);
 }
 
 static int op_rb0iyd(int data)		/* RES 0,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) & ~1);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) & ~1);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb1iyd(int data)		/* RES 1,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) & ~2);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) & ~2);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb2iyd(int data)		/* RES 2,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) & ~4);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) & ~4);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb3iyd(int data)		/* RES 3,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) & ~8);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) & ~8);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb4iyd(int data)		/* RES 4,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) & ~16);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) & ~16);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb5iyd(int data)		/* RES 5,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) & ~32);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) & ~32);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb6iyd(int data)		/* RES 6,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) & ~64);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) & ~64);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_rb7iyd(int data)		/* RES 7,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) & ~128);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) & ~128);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb0iyd(int data)		/* SET 0,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) | 1);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) | 1);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb1iyd(int data)		/* SET 1,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) | 2);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) | 2);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb2iyd(int data)		/* SET 2,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) | 4);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) | 4);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb3iyd(int data)		/* SET 3,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) | 8);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) | 8);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb4iyd(int data)		/* SET 4,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) | 16);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) | 16);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb5iyd(int data)		/* SET 5,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) | 32);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) | 32);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb6iyd(int data)		/* SET 6,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) | 64);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) | 64);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_sb7iyd(int data)		/* SET 7,(IY+d) */
 {
-	memwrt(IY + data, memrdr(IY + data) | 128);
+	WORD addr;
+
+	addr = IY + data;
+	memwrt(addr, memrdr(addr) | 128);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
@@ -581,6 +749,12 @@ static int op_rlciyd(int data)		/* RLC (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -601,6 +775,12 @@ static int op_rrciyd(int data)		/* RRC (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -621,6 +801,12 @@ static int op_rliyd(int data)		/* RL (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -641,6 +827,12 @@ static int op_rriyd(int data)		/* RR (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -658,6 +850,12 @@ static int op_slaiyd(int data)		/* SLA (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -677,6 +875,12 @@ static int op_sraiyd(int data)		/* SRA (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -694,6 +898,12 @@ static int op_srliyd(int data)		/* SRL (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -771,1121 +981,1793 @@ static int op_undoc_tb7iyd(int data)	/* BIT 7,(IY+d) */
 
 static int op_undoc_rb0iyda(int data)	/* RES 0,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) & ~1;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) & ~1;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1iyda(int data)	/* RES 1,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) & ~2;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) & ~2;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2iyda(int data)	/* RES 2,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) & ~4;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) & ~4;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3iyda(int data)	/* RES 3,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) & ~8;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) & ~8;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4iyda(int data)	/* RES 4,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) & ~16;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) & ~16;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5iyda(int data)	/* RES 5,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) & ~32;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) & ~32;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6iyda(int data)	/* RES 6,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) & ~64;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) & ~64;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7iyda(int data)	/* RES 7,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) & ~128;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) & ~128;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0iydb(int data)	/* RES 0,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) & ~1;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) & ~1;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1iydb(int data)	/* RES 1,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) & ~2;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) & ~2;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2iydb(int data)	/* RES 2,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) & ~4;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) & ~4;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3iydb(int data)	/* RES 3,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) & ~8;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) & ~8;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4iydb(int data)	/* RES 4,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) & ~16;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) & ~16;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5iydb(int data)	/* RES 5,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) & ~32;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) & ~32;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6iydb(int data)	/* RES 6,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) & ~64;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) & ~64;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7iydb(int data)	/* RES 7,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) & ~128;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) & ~128;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0iydc(int data)	/* RES 0,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) & ~1;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) & ~1;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1iydc(int data)	/* RES 1,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) & ~2;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) & ~2;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2iydc(int data)	/* RES 2,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) & ~4;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) & ~4;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3iydc(int data)	/* RES 3,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) & ~8;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) & ~8;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4iydc(int data)	/* RES 4,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) & ~16;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) & ~16;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5iydc(int data)	/* RES 5,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) & ~32;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) & ~32;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6iydc(int data)	/* RES 6,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) & ~64;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) & ~64;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7iydc(int data)	/* RES 7,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) & ~128;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) & ~128;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0iydd(int data)	/* RES 0,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) & ~1;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) & ~1;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1iydd(int data)	/* RES 1,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) & ~2;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) & ~2;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2iydd(int data)	/* RES 2,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) & ~4;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) & ~4;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3iydd(int data)	/* RES 3,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) & ~8;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) & ~8;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4iydd(int data)	/* RES 4,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) & ~16;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) & ~16;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5iydd(int data)	/* RES 5,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) & ~32;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) & ~32;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6iydd(int data)	/* RES 6,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) & ~64;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) & ~64;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7iydd(int data)	/* RES 7,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) & ~128;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) & ~128;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0iyde(int data)	/* RES 0,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) & ~1;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) & ~1;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1iyde(int data)	/* RES 1,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) & ~2;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) & ~2;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2iyde(int data)	/* RES 2,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) & ~4;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) & ~4;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3iyde(int data)	/* RES 3,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) & ~8;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) & ~8;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4iyde(int data)	/* RES 4,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) & ~16;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) & ~16;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5iyde(int data)	/* RES 5,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) & ~32;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) & ~32;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6iyde(int data)	/* RES 6,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) & ~64;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) & ~64;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7iyde(int data)	/* RES 7,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) & ~128;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) & ~128;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0iydh(int data)	/* RES 0,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) & ~1;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) & ~1;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1iydh(int data)	/* RES 1,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) & ~2;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) & ~2;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2iydh(int data)	/* RES 2,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) & ~4;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) & ~4;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3iydh(int data)	/* RES 3,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) & ~8;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) & ~8;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4iydh(int data)	/* RES 4,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) & ~16;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) & ~16;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5iydh(int data)	/* RES 5,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) & ~32;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) & ~32;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6iydh(int data)	/* RES 6,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) & ~64;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) & ~64;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7iydh(int data)	/* RES 7,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) & ~128;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) & ~128;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb0iydl(int data)	/* RES 0,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) & ~1;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) & ~1;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb1iydl(int data)	/* RES 1,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) & ~2;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) & ~2;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb2iydl(int data)	/* RES 2,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) & ~4;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) & ~4;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb3iydl(int data)	/* RES 3,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) & ~8;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) & ~8;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb4iydl(int data)	/* RES 4,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) & ~16;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) & ~16;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb5iydl(int data)	/* RES 5,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) & ~32;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) & ~32;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb6iydl(int data)	/* RES 6,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) & ~64;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) & ~64;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_rb7iydl(int data)	/* RES 7,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) & ~128;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) & ~128;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0iyda(int data)	/* SET 0,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) | 1;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) | 1;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1iyda(int data)	/* SET 1,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) | 2;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) | 2;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2iyda(int data)	/* SET 2,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) | 4;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) | 4;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3iyda(int data)	/* SET 3,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) | 8;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) | 8;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4iyda(int data)	/* SET 4,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) | 16;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) | 16;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5iyda(int data)	/* SET 5,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) | 32;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) | 32;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6iyda(int data)	/* SET 6,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) | 64;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) | 64;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7iyda(int data)	/* SET 7,(IY+d),A */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	A = memrdr(IY + data) | 128;
-	memwrt(IY + data, A);
+	addr = IY + data;
+	A = memrdr(addr) | 128;
+	memwrt(addr, A);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0iydb(int data)	/* SET 0,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) | 1;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) | 1;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1iydb(int data)	/* SET 1,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) | 2;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) | 2;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2iydb(int data)	/* SET 2,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) | 4;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) | 4;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3iydb(int data)	/* SET 3,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) | 8;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) | 8;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4iydb(int data)	/* SET 4,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) | 16;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) | 16;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5iydb(int data)	/* SET 5,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) | 32;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) | 32;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6iydb(int data)	/* SET 6,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) | 64;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) | 64;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7iydb(int data)	/* SET 7,(IY+d),B */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	B = memrdr(IY + data) | 128;
-	memwrt(IY + data, B);
+	addr = IY + data;
+	B = memrdr(addr) | 128;
+	memwrt(addr, B);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0iydc(int data)	/* SET 0,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) | 1;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) | 1;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1iydc(int data)	/* SET 1,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) | 2;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) | 2;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2iydc(int data)	/* SET 2,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) | 4;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) | 4;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3iydc(int data)	/* SET 3,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) | 8;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) | 8;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4iydc(int data)	/* SET 4,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) | 16;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) | 16;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5iydc(int data)	/* SET 5,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) | 32;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) | 32;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6iydc(int data)	/* SET 6,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) | 64;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) | 64;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7iydc(int data)	/* SET 7,(IY+d),C */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	C = memrdr(IY + data) | 128;
-	memwrt(IY + data, C);
+	addr = IY + data;
+	C = memrdr(addr) | 128;
+	memwrt(addr, C);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0iydd(int data)	/* SET 0,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) | 1;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) | 1;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1iydd(int data)	/* SET 1,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) | 2;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) | 2;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2iydd(int data)	/* SET 2,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) | 4;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) | 4;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3iydd(int data)	/* SET 3,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) | 8;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) | 8;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4iydd(int data)	/* SET 4,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) | 16;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) | 16;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5iydd(int data)	/* SET 5,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) | 32;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) | 32;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6iydd(int data)	/* SET 6,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) | 64;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) | 64;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7iydd(int data)	/* SET 7,(IY+d),D */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	D = memrdr(IY + data) | 128;
-	memwrt(IY + data, D);
+	addr = IY + data;
+	D = memrdr(addr) | 128;
+	memwrt(addr, D);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0iyde(int data)	/* SET 0,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) | 1;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) | 1;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1iyde(int data)	/* SET 1,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) | 2;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) | 2;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2iyde(int data)	/* SET 2,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) | 4;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) | 4;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3iyde(int data)	/* SET 3,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) | 8;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) | 8;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4iyde(int data)	/* SET 4,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) | 16;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) | 16;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5iyde(int data)	/* SET 5,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) | 32;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) | 32;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6iyde(int data)	/* SET 6,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) | 64;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) | 64;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7iyde(int data)	/* SET 7,(IY+d),E */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	E = memrdr(IY + data) | 128;
-	memwrt(IY + data, E);
+	addr = IY + data;
+	E = memrdr(addr) | 128;
+	memwrt(addr, E);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0iydh(int data)	/* SET 0,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) | 1;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) | 1;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1iydh(int data)	/* SET 1,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) | 2;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) | 2;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2iydh(int data)	/* SET 2,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) | 4;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) | 4;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3iydh(int data)	/* SET 3,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) | 8;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) | 8;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4iydh(int data)	/* SET 4,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) | 16;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) | 16;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5iydh(int data)	/* SET 5,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) | 32;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) | 32;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6iydh(int data)	/* SET 6,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) | 64;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) | 64;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7iydh(int data)	/* SET 7,(IY+d),H */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	H = memrdr(IY + data) | 128;
-	memwrt(IY + data, H);
+	addr = IY + data;
+	H = memrdr(addr) | 128;
+	memwrt(addr, H);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb0iydl(int data)	/* SET 0,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) | 1;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) | 1;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb1iydl(int data)	/* SET 1,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) | 2;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) | 2;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb2iydl(int data)	/* SET 2,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) | 4;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) | 4;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb3iydl(int data)	/* SET 3,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) | 8;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) | 8;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb4iydl(int data)	/* SET 4,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) | 16;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) | 16;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb5iydl(int data)	/* SET 5,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) | 32;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) | 32;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb6iydl(int data)	/* SET 6,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) | 64;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) | 64;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
 static int op_undoc_sb7iydl(int data)	/* SET 7,(IY+d),L */
 {
+	WORD addr;
+
 	if (u_flag)
 		return (trap_fdcb(0));
 
-	L = memrdr(IY + data) | 128;
-	memwrt(IY + data, L);
+	addr = IY + data;
+	L = memrdr(addr) | 128;
+	memwrt(addr, L);
+#ifdef UNDOC_FLAGS
+	WZ = addr;
+#endif
 	return (23);
 }
 
@@ -1908,6 +2790,12 @@ static int op_undoc_rlciyda(int data)	/* RLC (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -1930,6 +2818,12 @@ static int op_undoc_rlciydb(int data)	/* RLC (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -1952,6 +2846,12 @@ static int op_undoc_rlciydc(int data)	/* RLC (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -1974,6 +2874,12 @@ static int op_undoc_rlciydd(int data)	/* RLC (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -1996,6 +2902,12 @@ static int op_undoc_rlciyde(int data)	/* RLC (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2018,6 +2930,12 @@ static int op_undoc_rlciydh(int data)	/* RLC (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2040,6 +2958,12 @@ static int op_undoc_rlciydl(int data)	/* RLC (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2062,6 +2986,12 @@ static int op_undoc_rrciyda(int data)	/* RRC (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2084,6 +3014,12 @@ static int op_undoc_rrciydb(int data)	/* RRC (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2106,6 +3042,12 @@ static int op_undoc_rrciydc(int data)	/* RRC (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2128,6 +3070,12 @@ static int op_undoc_rrciydd(int data)	/* RRC (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2150,6 +3098,12 @@ static int op_undoc_rrciyde(int data)	/* RRC (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2172,6 +3126,12 @@ static int op_undoc_rrciydh(int data)	/* RRC (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2194,6 +3154,12 @@ static int op_undoc_rrciydl(int data)	/* RRC (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2216,6 +3182,12 @@ static int op_undoc_rliyda(int data)	/* RL (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2238,6 +3210,12 @@ static int op_undoc_rliydb(int data)	/* RL (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2260,6 +3238,12 @@ static int op_undoc_rliydc(int data)	/* RL (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2282,6 +3266,12 @@ static int op_undoc_rliydd(int data)	/* RL (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2304,6 +3294,12 @@ static int op_undoc_rliyde(int data)	/* RL (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2326,6 +3322,12 @@ static int op_undoc_rliydh(int data)	/* RL (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2348,6 +3350,12 @@ static int op_undoc_rliydl(int data)	/* RL (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2370,6 +3378,12 @@ static int op_undoc_rriyda(int data)	/* RR (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2392,6 +3406,12 @@ static int op_undoc_rriydb(int data)	/* RR (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2414,6 +3434,12 @@ static int op_undoc_rriydc(int data)	/* RR (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2436,6 +3462,12 @@ static int op_undoc_rriydd(int data)	/* RR (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2458,6 +3490,12 @@ static int op_undoc_rriyde(int data)	/* RR (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2480,6 +3518,12 @@ static int op_undoc_rriydh(int data)	/* RR (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2502,6 +3546,12 @@ static int op_undoc_rriydl(int data)	/* RR (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2521,6 +3571,12 @@ static int op_undoc_slaiyda(int data)	/* SLA (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2540,6 +3596,12 @@ static int op_undoc_slaiydb(int data)	/* SLA (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2559,6 +3621,12 @@ static int op_undoc_slaiydc(int data)	/* SLA (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2578,6 +3646,12 @@ static int op_undoc_slaiydd(int data)	/* SLA (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2597,6 +3671,12 @@ static int op_undoc_slaiyde(int data)	/* SLA (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2616,6 +3696,12 @@ static int op_undoc_slaiydh(int data)	/* SLA (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2635,6 +3721,12 @@ static int op_undoc_slaiydl(int data)	/* SLA (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2656,6 +3748,12 @@ static int op_undoc_sraiyda(int data)	/* SRA (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2677,6 +3775,12 @@ static int op_undoc_sraiydb(int data)	/* SRA (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2698,6 +3802,12 @@ static int op_undoc_sraiydc(int data)	/* SRA (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2719,6 +3829,12 @@ static int op_undoc_sraiydd(int data)	/* SRA (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2740,6 +3856,12 @@ static int op_undoc_sraiyde(int data)	/* SRA (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2761,6 +3883,12 @@ static int op_undoc_sraiydh(int data)	/* SRA (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2782,6 +3910,12 @@ static int op_undoc_sraiydl(int data)	/* SRA (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2801,6 +3935,12 @@ static int op_undoc_slliyda(int data)	/* SLL (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2820,6 +3960,12 @@ static int op_undoc_slliydb(int data)	/* SLL (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2839,6 +3985,12 @@ static int op_undoc_slliydc(int data)	/* SLL (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2858,6 +4010,12 @@ static int op_undoc_slliydd(int data)	/* SLL (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2877,6 +4035,12 @@ static int op_undoc_slliyde(int data)	/* SLL (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2896,6 +4060,12 @@ static int op_undoc_slliydh(int data)	/* SLL (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2915,6 +4085,12 @@ static int op_undoc_slliydl(int data)	/* SLL (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2935,6 +4111,12 @@ static int op_undoc_slliyd(int data)	/* SLL (IY+d) */
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(P & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2954,6 +4136,12 @@ static int op_undoc_srliyda(int data)	/* SRL (IY+d),A */
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(A & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2973,6 +4161,12 @@ static int op_undoc_srliydb(int data)	/* SRL (IY+d),B */
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(B & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -2992,6 +4186,12 @@ static int op_undoc_srliydc(int data)	/* SRL (IY+d),C */
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(C & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -3011,6 +4211,12 @@ static int op_undoc_srliydd(int data)	/* SRL (IY+d),D */
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(D & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -3030,6 +4236,12 @@ static int op_undoc_srliyde(int data)	/* SRL (IY+d),E */
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(E & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -3049,6 +4261,12 @@ static int op_undoc_srliydh(int data)	/* SRL (IY+d),H */
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(H & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 
@@ -3068,6 +4286,12 @@ static int op_undoc_srliydl(int data)	/* SRL (IY+d),L */
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= N2_FLAG) : (F &= ~N2_FLAG);
+	(L & 8) ? (F |= N1_FLAG) : (F &= ~N1_FLAG);
+	WZ = addr;
+	modF = 1;
+#endif
 	return (23);
 }
 

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -13,6 +13,7 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_FLAGS	/* compile undocumented flags */
 /*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
 /*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
 

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -14,6 +14,7 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_FLAGS	/* compile undocumented flags */
 #define WANT_FASTB	/* much faster but not accurate Z80 block instr. */
 /*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
 


### PR DESCRIPTION
All behind the new UNDOC_FLAGS define.
Passes EVERY test from https://github.com/raxoft/z80test and of course ex.mac assembled with exkind=2.

Modifications to existing code kept to a minimum:

Needed to split of the address calculation from memrdr calls in some instructions.

Changed conditional JP/JR/DJNZ/CALL instructions to always fetch the destination address/offset as a real CPU does. Did the same for sim8080.

Some small cosmetic changes.

Additional references:
http://www.grimware.org/lib/exe/fetch.php/documentations/devices/z80/z80.memptr.eng.txt https://github.com/hoglet67/Z80Decoder/wiki/Undocumented-Flags