### PR TITLE
one counter to rule them all

### DIFF
--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -40,7 +40,7 @@ WORD PC;			/* program counter */
 WORD SP;			/* stack pointer */
 BYTE IFF;			/* interrupt flags */
 Tstates_t T;			/* CPU clock */
-unsigned long long cpu_start, cpu_stop; /* timestamps in ms */
+unsigned long long cpu_start, cpu_stop; /* timestamps in us */
 
 #ifdef BUS_8080
 BYTE cpu_bus;			/* CPU bus status, for frontpanels */

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -86,10 +86,13 @@ int sb_next;			/* index into breakpoint memory */
 /*
  *	Variables for runtime measurement
  */
-long t_states;			/* number of counted T states */
+#ifdef WANT_TIM
+Tstates_t t_states_s;		/* T states marker at start of measurement */
+Tstates_t t_states_e;		/* T states marker at end of measurement */
 int t_flag;			/* flag, 1 = on, 0 = off */
 WORD t_start = 65535;		/* start address for measurement */
 WORD t_end = 65535;		/* end address for measurement */
+#endif
 
 /*
  *	Variables for frontpanel emulation

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -72,9 +72,11 @@ extern struct	softbreak soft[];
 extern int	sb_next;
 #endif
 
-extern long	t_states;
+#ifdef WANT_TIM
+extern Tstates_t t_states_s, t_states_e;
 extern int	t_flag;
 extern WORD	t_start, t_end;
+#endif
 
 #ifdef FRONTPANEL
 extern unsigned long long fp_clock;

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -824,16 +824,16 @@ static void do_count(char *s)
 		s++;
 	if (*s == '\0') {
 		puts("start  stop  status  T-states");
-		printf("%04x   %04x    %s   %lu\n",
+		printf("%04x   %04x    %s   %llu\n",
 		       t_start, t_end,
-		       t_flag ? "on " : "off", t_states);
+		       t_flag ? "on " : "off", t_states_e - t_states_s);
 	} else {
 		t_start = exatoi(s);
 		while (*s != ',' && *s != '\0')
 			s++;
 		if (*s)
 			t_end = exatoi(++s);
-		t_states = 0L;
+		t_states_s = t_states_e = T;
 		t_flag = 0;
 	}
 #endif


### PR DESCRIPTION
Things found when compiling with "-fsanitize=undefined".

t T-State counter overflowed without f_flag.
ADD A,A and ADC A,A used undefined signed left shift.

changed code to use only one T-counter (T).