### PR TITLE
use in-tree z80asm for building and use "install" for installing files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ BIOSES = cpmsim/srccpm2 cpmsim/srccpm3 cpmsim/srcmpm cpmsim/srcucsd-iv \
 MISC = z80sim cpmtools
 MACHINES = altairsim cpmsim cromemcosim imsaisim mosteksim z80sim
 
-Z80ASM_FLAGS = -fh -e16 -l -sn -p0
+Z80ASMDIR = z80asm
+Z80ASM = $(Z80ASMDIR)/z80asm
+Z80ASMOPTS = -l -sn -p0
 
 ALTAIR_8080 = \
 	altairsim/basic8k78.asm \
@@ -69,17 +71,12 @@ IMSAI_8080 = \
 IMSAI_Z80 = \
 	imsaisim/roms/basic4k.asm
 
-help:
-	@echo "This Makefile is primarily for developers."
-	@echo "Please consult the files in the doc directory."
+all: tools libs bioses misc machines
 
-all: z80asm cpmtools libs bioses misc machines
-
-z80asm:
-	$(MAKE) -C z80asm "DESTDIR=$(DESTDIR)" install
-
-cpmtools:
-	$(MAKE) -C cpmsim/srctools "DESTDIR=$(DESTDIR)" install
+tools:
+	@set -e; for subdir in $(TOOLS); do \
+		$(MAKE) -C $$subdir; \
+	done
 
 libs:
 	@set -e; for subdir in $(LIBS); do \
@@ -101,13 +98,16 @@ machines:
 		$(MAKE) -C $$subdir/srcsim; \
 	done
 
-reassemble: z80asm
+reassemble: $(Z80ASM)
 	@set -e; for file in $(ALTAIR_8080) $(CROMEMCO_8080) $(IMSAI_8080); do \
-		z80asm -8 $(Z80ASM_FLAGS) "$$file"; \
+		$(Z80ASM) $(Z80ASMOPTS) -8 -fh -e16 "$$file"; \
 	done
 	@set -e; for file in $(ALTAIR_Z80) $(CROMEMCO_Z80) $(IMSAI_Z80); do \
-		z80asm $(Z80ASM_FLAGS) "$$file"; \
+		$(Z80ASM) $(Z80ASMOPTS) -fh -e16 "$$file"; \
 	done
+
+$(Z80ASM):
+	$(MAKE) -C $(Z80ASMDIR) z80asm
 
 clean:
 	@set -e; for subdir in $(TOOLS) $(LIBS) $(BIOSES) $(MISC); do \
@@ -125,4 +125,4 @@ allclean:
 		$(MAKE) -C $$subdir/srcsim allclean; \
 	done
 
-.PHONY: all z80asm cpmtools libs bioses misc machines reassemble clean allclean
+.PHONY: all tools libs bioses misc machines reassemble clean allclean

--- a/cpmsim/srccpm2/Makefile
+++ b/cpmsim/srccpm2/Makefile
@@ -3,6 +3,10 @@ CWARNS= -Wall -Wextra -Wwrite-strings
 CFLAGS= -O $(CSTDS) $(CWARNS)
 LDFLAGS= -s
 
+Z80ASMDIR = ../../z80asm
+Z80ASM = $(Z80ASMDIR)/z80asm
+Z80ASMOPTS = -l -sn -p0
+
 all: putsys bios.bin boot.bin
 	@echo
 	@echo "Done."
@@ -11,11 +15,14 @@ all: putsys bios.bin boot.bin
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
 
-bios.bin: bios.asm
-	z80asm -fb -l -sn -p0 -x $<
+bios.bin: bios.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fb -x $<
 
-boot.bin: boot.asm
-	z80asm -fb -l -sn -p0 $<
+boot.bin: boot.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fb $<
+
+$(Z80ASM):
+	$(MAKE) -C $(Z80ASMDIR) z80asm
 
 clean:
 	rm -f putsys bios.bin bios.lis boot.bin boot.lis

--- a/cpmsim/srccpm3/Makefile
+++ b/cpmsim/srccpm3/Makefile
@@ -3,6 +3,10 @@ CWARNS= -Wall -Wextra -Wwrite-strings
 CFLAGS= -O $(CSTDS) $(CWARNS)
 LDFLAGS= -s
 
+Z80ASMDIR = ../../z80asm
+Z80ASM = $(Z80ASMDIR)/z80asm
+Z80ASMOPTS = -l -sn -p0
+
 all: putsys boot.bin
 	@echo
 	@echo "Done."
@@ -11,8 +15,11 @@ all: putsys boot.bin
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
 
-boot.bin: boot.asm
-	z80asm -fb -l -sn -p0 $<
+boot.bin: boot.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fb $<
+
+$(Z80ASM):
+	$(MAKE) -C $(Z80ASMDIR) z80asm
 
 clean:
 	rm -f putsys boot.bin boot.lis

--- a/cpmsim/srcmpm/Makefile
+++ b/cpmsim/srcmpm/Makefile
@@ -3,6 +3,10 @@ CWARNS= -Wall -Wextra -Wwrite-strings
 CFLAGS= -O $(CSTDS) $(CWARNS)
 LDFLAGS= -s
 
+Z80ASMDIR = ../../z80asm
+Z80ASM = $(Z80ASMDIR)/z80asm
+Z80ASMOPTS = -l -sn -p0
+
 all: putsys boot.bin
 	@echo
 	@echo "Done."
@@ -11,8 +15,11 @@ all: putsys boot.bin
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
 
-boot.bin: boot.asm
-	z80asm -fb -l -sn -p0 $<
+boot.bin: boot.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fb $<
+
+$(Z80ASM):
+	$(MAKE) -C $(Z80ASMDIR) z80asm
 
 clean:
 	rm -f putsys boot.bin boot.lis

--- a/cpmsim/srctools/Makefile
+++ b/cpmsim/srctools/Makefile
@@ -1,21 +1,20 @@
 #
 # some places where the tools usually are installed
 #
-DESTDIR=${HOME}/bin
+DESTDIR=$(HOME)/bin
 #DESTDIR=/usr/local/bin
 
 CSTDS = -std=c99 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CWARNS= -Wall -Wextra -Wwrite-strings
 CFLAGS= -O3 $(CSTDS) $(CWARNS)
 
-all: test mkdskimg bin2hex cpmsend cpmrecv ptp2bin
+TOOLS = mkdskimg bin2hex cpmsend cpmrecv ptp2bin
+
+all: $(TOOLS)
 	@echo
 	@echo "Done."
 	@echo "Now run make install"
 	@echo
-
-test:
-	@test -d ${DESTDIR} || (echo "${DESTDIR} doesn't exist, fix DESTDIR"; exit 1)
 
 mkdskimg: mkdskimg.c
 	$(CC) $(CFLAGS) -o mkdskimg mkdskimg.c
@@ -32,19 +31,16 @@ cpmrecv: cpmrecv.c
 ptp2bin: ptp2bin.c
 	$(CC) $(CFLAGS) -o ptp2bin ptp2bin.c
 
-install: all
-	cp mkdskimg ${DESTDIR}
-	cp bin2hex ${DESTDIR}
-	cp cpmsend ${DESTDIR}
-	cp cpmrecv ${DESTDIR}
-	cp ptp2bin ${DESTDIR}
+install: $(TOOLS)
+	install -d $(DESTDIR)
+	install -s $(TOOLS) $(DESTDIR)
 	@echo
 	@echo "Tools installed in ${DESTDIR}, make sure it is"
 	@echo "included in the systems search PATH"
 	@echo
 
 clean:
-	rm -f mkdskimg bin2hex cpmsend cpmrecv ptp2bin
+	rm -f $(TOOLS)
 
 allclean: clean
 

--- a/cpmsim/srcucsd-iv/Makefile
+++ b/cpmsim/srcucsd-iv/Makefile
@@ -3,6 +3,10 @@ CWARNS= -Wall -Wextra -Wwrite-strings
 CFLAGS= -O $(CSTDS) $(CWARNS)
 LDFLAGS= -s
 
+Z80ASMDIR = ../../z80asm
+Z80ASM = $(Z80ASMDIR)/z80asm
+Z80ASMOPTS = -l -sn -p0
+
 all: putsys boot.bin bios.bin
 	@echo
 	@echo "Done."
@@ -11,11 +15,14 @@ all: putsys boot.bin bios.bin
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
 
-boot.bin: boot.asm
-	z80asm -fb -l -sn -p0 $<
+boot.bin: boot.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fb $<
 
-bios.bin: bios.asm
-	z80asm -fb -l -sn -p0 $<
+bios.bin: bios.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fb $<
+
+$(Z80ASM):
+	$(MAKE) -C $(Z80ASMDIR) z80asm
 
 clean:
 	rm -f putsys boot.bin boot.lis bios.bin bios.lis

--- a/cpmtools/Makefile
+++ b/cpmtools/Makefile
@@ -4,46 +4,53 @@ TOOLS = r.com w.com bye.com reset.com sw8080.com swz80.com
 # CPU tests by various authors, modified for using the CPU switch feature
 CPUTESTS = ex8080.com exz80doc.com exz80all.com prelim.com 8080pre.com test8080.com
 
+Z80ASMDIR = ../z80asm
+Z80ASM = $(Z80ASMDIR)/z80asm
+Z80ASMOPTS = -l -sn -p0
+
 all: $(TOOLS) $(CPUTESTS)
 	@echo
 	@echo "Done."
 	@echo
 
-r.com: r.asm
-	z80asm -8 -fb -l -sn -p0 -o$@ $<
+r.com: r.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
 
-w.com: w.asm
-	z80asm -8 -fb -l -sn -p0 -o$@ $<
+w.com: w.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
 
-bye.com: bye.asm
-	z80asm -8 -fb -l -sn -p0 -o$@ $<
+bye.com: bye.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
 
-reset.com: reset.asm
-	z80asm -8 -fb -l -sn -p0 -o$@ $<
+reset.com: reset.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
 
-sw8080.com: sw8080.asm
-	z80asm -8 -fb -l -sn -p0 -o$@ $<
+sw8080.com: sw8080.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
 
-swz80.com: swz80.asm
-	z80asm -8 -fb -l -sn -p0 -o$@ $<
+swz80.com: swz80.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
 
-ex8080.com: ex.mac
-	z80asm -dex8080 -fb -l$(@:.com=.lis) -sn -p0 -o$@ $<
+ex8080.com: ex.mac $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -dex8080 -fb -l$(@:.com=.lis) -o$@ $<
 
-exz80doc.com: ex.mac
-	z80asm -dexz80doc -fb -l$(@:.com=.lis) -sn -p0 -o$@ $<
+exz80doc.com: ex.mac $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -dexz80doc -fb -l$(@:.com=.lis) -o$@ $<
 
-exz80all.com: ex.mac
-	z80asm -dexz80all -fb -l$(@:.com=.lis) -sn -p0 -o$@ $<
+exz80all.com: ex.mac $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -dexz80all -fb -l$(@:.com=.lis) -o$@ $<
 
-prelim.com: prelim.mac
-	z80asm -fb -l -sn -p0 -o$@ $<
+prelim.com: prelim.mac $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fb -o$@ $<
 
-8080pre.com: 8080pre.mac
-	z80asm -8 -fb -l -sn -p0 -o$@ $<
+8080pre.com: 8080pre.mac $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
 
-test8080.com: test8080.asm
-	z80asm -8 -fb -l -sn -p0 -o$@ $<
+test8080.com: test8080.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
+
+$(Z80ASM):
+	$(MAKE) -C $(Z80ASMDIR) z80asm
 
 clean:
 	rm -f $(TOOLS) $(TOOLS:.com=.lis) $(CPUTESTS) $(CPUTESTS:.com=.lis)

--- a/imsaisim/srcucsd-iv/Makefile
+++ b/imsaisim/srcucsd-iv/Makefile
@@ -3,6 +3,10 @@ CWARNS= -Wall -Wextra -Wwrite-strings
 CFLAGS= -O $(CSTDS) $(CWARNS)
 LDFLAGS= -s
 
+Z80ASMDIR = ../../z80asm
+Z80ASM = $(Z80ASMDIR)/z80asm
+Z80ASMOPTS = -l -sn -p0
+
 all: putsys boot.bin bios.bin
 	@echo
 	@echo "Done."
@@ -11,11 +15,14 @@ all: putsys boot.bin bios.bin
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
 
-boot.bin: boot.asm
-	z80asm -fb -l -sn -p0 $<
+boot.bin: boot.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fb $<
 
 bios.bin: bios.asm
-	z80asm -fb -l -sn -p0 $<
+	$(Z80ASM) $(Z80ASMOPTS) -fb $<
+
+$(Z80ASM):
+	$(MAKE) -C $(Z80ASMDIR) z80asm
 
 clean:
 	rm -f putsys boot.bin boot.lis bios.bin bios.lis

--- a/picosim/src-examples/Makefile
+++ b/picosim/src-examples/Makefile
@@ -1,16 +1,23 @@
+Z80ASMDIR = ../../z80asm
+Z80ASM = $(Z80ASMDIR)/z80asm
+Z80ASMOPTS = -l -sn -p0
+
 all: serial.c tb.c blink.c
 	@echo
 	@echo "Done."
 	@echo
 
-serial.c: serial.asm
-	z80asm -fc -l -sn -p0 $<
+serial.c: serial.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fc $<
 
-tb.c: tb.asm
-	z80asm -8 -fc -l -sn -p0 -x $<
+tb.c: tb.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -8 -fc -x $<
 
-blink.c: blink.asm
-	z80asm -fc -l -sn -p0 $<
+blink.c: blink.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fc $<
+
+$(Z80ASM):
+	$(MAKE) -C $(Z80ASMDIR) z80asm
 
 clean:
 	rm -f serial.c tb.c blink.c

--- a/z80asm/Makefile
+++ b/z80asm/Makefile
@@ -27,6 +27,11 @@ OBJS =	z80amain.o \
 	z80aopc.o \
 	z80aglb.o
 
+all: z80asm
+	@echo
+	@echo "Done."
+	@echo
+
 z80asm: $(OBJS)
 	$(CC) $(OBJS) $(LDFLAGS) -o z80asm
 
@@ -63,7 +68,11 @@ clean:
 allclean: clean
 
 install: z80asm
+	install -d $(DESTDIR)
+	install -s z80asm $(DESTDIR)
+
+instcoh: z80asm
 	strip z80asm
 	cp z80asm ${DESTDIR}
 
-.PHONY: clean allclean install
+.PHONY: clean allclean install install-coh

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -18,7 +18,6 @@
 #ifdef UNDOC_INST
 #define UNDOC(f) f
 #else
-static int trap_undoc(void);
 #define UNDOC(f) trap_undoc
 #endif
 
@@ -26,6 +25,7 @@ static int trap_undoc(void);
 extern void check_gui_break(void);
 #endif
 
+static int trap_undoc(void);
 static int op_nop(void), op_hlt(void), op_stc(void);
 static int op_cmc(void), op_cma(void), op_daa(void), op_ei(void), op_di(void);
 static int op_out(void), op_in(void);

--- a/z80sim/Makefile
+++ b/z80sim/Makefile
@@ -1,16 +1,23 @@
+Z80ASMDIR = ../z80asm
+Z80ASM = $(Z80ASMDIR)/z80asm
+Z80ASMOPTS = -l -sn -p0
+
 all: float.hex z80main.hex z80opsall.hex 8080opsall.hex
 
-float.hex: float.asm
-	z80asm -fh -l -sn -p0 $<
+float.hex: float.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fh $<
 
-z80main.hex: z80main.asm z80dis.asm z80ops.asm
-	z80asm -fh -l -sn -p0 $<
+z80main.hex: z80main.asm z80dis.asm z80ops.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fh $<
 
-z80opsall.hex: z80opsall.asm
-	z80asm -u -fh -l -sn -p0 $<
+z80opsall.hex: z80opsall.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -u -fh $<
 
-8080opsall.hex: 8080opsall.asm
-	z80asm -fh -l -sn -p0 $<
+8080opsall.hex: 8080opsall.asm $(Z80ASM)
+	$(Z80ASM) $(Z80ASMOPTS) -fh $<
+
+$(Z80ASM):
+	cd $(Z80ASMDIR) && $(MAKE)
 
 clean:
 	rm -f float.hex float.lis z80main.hex z80main.lis \


### PR DESCRIPTION
So you can build everything without having to install anything from z80pack.

move trap_undoc declaration to where it is in the z80 files.
