### PR TITLE
remove directory/pipes creation from makefile

### DIFF
--- a/cpmsim/srcsim/Makefile
+++ b/cpmsim/srcsim/Makefile
@@ -83,20 +83,10 @@ SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)
 
-all: /tmp/.z80pack/cpmsim.auxin /tmp/.z80pack/cpmsim.auxout $(SIM)
+all: $(SIM)
 	@echo
 	@echo "Done."
 	@echo
-
-/tmp/.z80pack/cpmsim.auxin:
-	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
-	test -f /tmp/.z80pack/cpmsim.auxin || \
-		mkfifo /tmp/.z80pack/cpmsim.auxin
-
-/tmp/.z80pack/cpmsim.auxout:
-	test -d /tmp/.z80pack || mkdir /tmp/.z80pack
-	test -f /tmp/.z80pack/cpmsim.auxout || \
-		mkfifo /tmp/.z80pack/cpmsim.auxout
 
 $(SIM): $(OBJS) $(MACHINE_LIBS)
 	$(CC) $(OBJS) $(LDFLAGS) -o $@

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -853,9 +853,8 @@ void init_io(void)
 		exit(EXIT_FAILURE);
 		break;
 	case 0:
-		/* . might not be in path, so check that first */
-		if (access("./cpmrecv", X_OK) == 0)
-			execlp("./cpmrecv", "cpmrecv", "auxiliaryout.txt",
+		if (access("./srctools/cpmrecv", X_OK) == 0)
+			execlp("./srctools/cpmrecv", "cpmrecv", "auxiliaryout.txt",
 			       (char *) NULL);
 		/* should be in path somewhere */
 		else


### PR DESCRIPTION
cpmsim and iodevices/unix_network.c already create these automatically.

Change "./cpmrecv" to "./srctools/cpmrecv" so one can run cpmsim without installing the tools in srctools.

I can't see a scenario where cpmrecv would be in .