### PR TITLE
a small change, avoid compiler warnings, and Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,5 @@
-# Developer Makefile to easily build/clean everything.
-# Don't use indiscriminately, because "make all" will install files.
-#
-# Targets:
-#	all - build all tools and simulators
-#	reassemble - reassemble all ROMs and assembler programs
-#	clean
-#	allclean
-
-DESTDIR=${HOME}/bin
-#DESTDIR=/usr/local/bin
+PREFIX ?= $(HOME)
+#PREFIX ?= /usr/local
 
 TOOLS = z80asm cpmsim/srctools
 LIBS = frontpanel webfrontend/civetweb
@@ -106,8 +97,26 @@ reassemble: $(Z80ASM)
 		$(Z80ASM) $(Z80ASMOPTS) -fh -e16 "$$file"; \
 	done
 
-$(Z80ASM):
-	$(MAKE) -C $(Z80ASMDIR) z80asm
+$(Z80ASM): FORCE
+	$(MAKE) -C $(Z80ASMDIR)
+
+FORCE:
+
+install:
+	@set -e; for subdir in $(TOOLS) $(LIBS) $(BIOSES) $(MISC); do \
+		$(MAKE) -C $$subdir install; \
+	done
+	@set -e; for subdir in $(MACHINES); do \
+		$(MAKE) -C $$subdir/srcsim install; \
+	done
+
+uninstall:
+	@set -e; for subdir in $(TOOLS) $(LIBS) $(BIOSES) $(MISC); do \
+		$(MAKE) -C $$subdir uninstall; \
+	done
+	@set -e; for subdir in $(MACHINES); do \
+		$(MAKE) -C $$subdir/srcsim uinstall; \
+	done
 
 clean:
 	@set -e; for subdir in $(TOOLS) $(LIBS) $(BIOSES) $(MISC); do \
@@ -117,12 +126,13 @@ clean:
 		$(MAKE) -C $$subdir/srcsim clean; \
 	done
 
-allclean:
+distclean:
 	@set -e; for subdir in $(TOOLS) $(LIBS) $(BIOSES) $(MISC); do \
-		$(MAKE) -C $$subdir allclean; \
+		$(MAKE) -C $$subdir distclean; \
 	done
 	@set -e; for subdir in $(MACHINES); do \
-		$(MAKE) -C $$subdir/srcsim allclean; \
+		$(MAKE) -C $$subdir/srcsim distclean; \
 	done
 
-.PHONY: all tools libs bioses misc machines reassemble clean allclean
+.PHONY: all tools libs bioses misc machines reassemble FORCE \
+		install uninstall clean distclean

--- a/altairsim/srcsim/Makefile
+++ b/altairsim/srcsim/Makefile
@@ -1,38 +1,39 @@
 ###
 ### START MACHINE DEPENDENT VARIABLES
 ###
-# (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
+# (simple) machine name - will be suffixed with 'sim'
+# and the executable saved as '../machinesim'
 MACHINE = altair
 # emulate a machine's frontpanel
 FRONTPANEL = YES
 # machine specific system source files
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
-IO_SRCS = cromemco-dazzler.c proctec-vdm.c tarbell_fdc.c altair-88-dcdd.c altair-88-sio.c \
-	altair-88-2sio.c unix_terminal.c unix_network.c simbdos.c
-# machine specific libraries
-MACHINE_LIBS =
+IO_SRCS = cromemco-dazzler.c proctec-vdm.c tarbell_fdc.c altair-88-dcdd.c \
+	altair-88-sio.c altair-88-2sio.c unix_terminal.c unix_network.c \
+	simbdos.c
 
 # Installation directories by convention
 # http://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+PACKAGE = z80pack
 CPROG = $(MACHINE)sim
 PREFIX ?= /usr/local
 EXEC_PREFIX = $(PREFIX)
 BINDIR = $(EXEC_PREFIX)/bin
 DATAROOTDIR = $(PREFIX)/share
-DOCDIR = $(DATAROOTDIR)/doc/$(CPROG)
+DATADIR = $(DATAROOTDIR)/$(PACKAGE)/$(CPROG)
 SYSCONFDIR = $(PREFIX)/etc
+INCLUDEDIR = $(PREFIX)/include
+DOCDIR = $(DATAROOTDIR)/doc/$(PACKAGE)/$(CPROG)
 HTMLDIR = $(DOCDIR)
-INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
-LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
+LIBDIR = $(EXEC_PREFIX)/lib
 
-ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 # system wide location for machines configuration files
-CONF_DIR = $(ROOT_DIR)/conf
+CONF_DIR = $(DATADIR)/conf
 # system wide location for disk images
-DISKS_DIR = $(ROOT_DIR)/disks
+DISKS_DIR = $(DATADIR)/disks
 # default boot ROM path
-ROMS_DIR = $(ROOT_DIR)/roms
+ROMS_DIR = $(DATADIR)/roms
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -43,15 +44,17 @@ ROMS_DIR = $(ROOT_DIR)/roms
 ifeq ($(FRONTPANEL),YES)
 FP_SRCS = fpmain.cpp
 FP_DEFS = -DFRONTPANEL
-FP_LIB = -lfrontpanel
-FP_LDFLAGS = $(FP_LIB) -ljpeg -lGL -lGLU
-CCLD = $(CXX)
+FP_LIB = $(FP_DIR)/libfrontpanel.a
+FP_LDLIBS = -lfrontpanel -ljpeg -lGL -lGLU
+LINK = $(CXX)
+LINKFLAGS = $(CXXFLAGS)
 else
 FP_SRCS =
 FP_DEFS =
 FP_LIB =
-FP_LDFLAGS =
-CCLD = $(CC)
+FP_LDLIBS =
+LINK = $(CC)
+LINKFLAGS = $(CFLAGS)
 endif
 ###
 ### END FRONTPANEL VARIABLES
@@ -73,10 +76,10 @@ include $(CORE_DIR)/Makefile.in-os
 ifeq ($(TARGET_OS),BSD)
 PLAT_INCS = -I/usr/local/include
 PLAT_LDFLAGS = -L/usr/local/lib
-PLAT_LIBS = -lthr
+PLAT_LDLIBS = -lthr
 endif
 ifeq ($(TARGET_OS),LINUX)
-PLAT_LIBS = -lm -lpthread
+PLAT_LDLIBS = -lm -lpthread
 endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCS = -I/opt/X11/include
@@ -86,8 +89,10 @@ endif
 ### END O/S DEPENDENT VARIABLES
 ###
 
-DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" \
+	-DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
 INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) $(PLAT_INCS)
+CPPFLAGS = $(DEFS) $(INCS)
 
 CSTDS = -std=c99 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CWARNS = -Wall -Wextra -Wwrite-strings
@@ -95,57 +100,66 @@ CXXSTDS = -std=c++03 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CXXWARNS = -Wall -Wextra
 
 # Production - the default
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -U_FORTIFY_SOURCE $(DEFS) $(INCS)
-CXXFLAGS = -O3 $(CXXSTDS) $(CXXWARNS) $(PLAT_CXXFLAGS) -U_FORTIFY_SOURCE $(DEFS) $(INCS)
+COPTS = -O3 -U_FORTIFY_SOURCE
+CXXOPTS = -O3 -U_FORTIFY_SOURCE
 
 # Development - use `MODE=DEV make build`
 ifeq ($(MODE),DEV)
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(DEFS) $(INCS)
-CXXFLAGS = -O3 $(CXXSTDS) $(CXXWARNS) $(PLAT_CXXFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(DEFS) $(INCS)
+COPTS = -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2
+CXXOPTS = -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2
 endif
 
 # Debug - use `DEBUG=1 make build`
 ifneq ($(DEBUG),)
-CFLAGS = -O -g $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) $(DEFS) $(INCS)
-CXXFLAGS = -O -g $(CXXSTDS) $(CXXWARNS) $(PLAT_CXXFLAGS) $(DEFS) $(INCS)
+COPTS = -O -g
+CXXOPTS = -O -g
 endif
 
-LDFLAGS = -L$(FP_DIR) $(PLAT_LDFLAGS) $(MACHINE_LIBS) \
-	  $(FP_LDFLAGS) -lX11 $(PLAT_LIBS)
+CFLAGS = $(CSTDS) $(COPTS) $(CWARNS) $(PLAT_CFLAGS)
+CXXFLAGS = $(CXXSTDS) $(CXXOPTS) $(CXXWARNS) $(PLAT_CXXFLAGS)
 
-# core system source files for the CPU simulation - only change if the core changes
-CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c simmain.c \
-	simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c simz80-fd.c simz80-fdcb.c
+LDFLAGS = -L$(FP_DIR) $(PLAT_LDFLAGS)
+LDLIBS = $(FP_LDLIBS) -lX11 $(PLAT_LDLIBS)
+
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = $(INSTALL) -m 644
+
+# core system source files for the CPU simulation
+CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 XXSRCS = $(FP_SRCS)
 OBJS = $(SRCS:.c=.o) $(XXSRCS:.cpp=.o)
 DEPS = $(SRCS:.c=.d) $(XXSRCS:.cpp=.d)
 
 all: $(SIM)
-	@echo
-	@echo "Done."
-	@echo
 
-$(SIM): $(OBJS) $(MACHINE_LIBS) $(FP_LIB)
-	$(CCLD) $(OBJS) $(LDFLAGS) -o $@
+$(SIM): $(OBJS) $(FP_LIB)
+	$(LINK) $(LINKFLAGS) $(CPPFLAGS) $(LDFLAGS) $(OBJS) $(LDLIBS) -o $@
 
 %.d: %.c
-	@$(CC) -MM $(CFLAGS) $< > $@
+	@$(CC) -MM $(CFLAGS) $(CPPFLAGS) $< > $@
 
 %.d: %.cpp
-	@$(CXX) -MM $(CXXFLAGS) $< > $@
+	@$(CXX) -MM $(CXXFLAGS) $(CPPFLAGS) $< > $@
 
 -include $(DEPS)
 
--lfrontpanel: $(FP_DIR:=/Makefile)
-	$(MAKE) -B -C $(FP_DIR)
+$(FP_LIB): FORCE
+	$(MAKE) -C $(FP_DIR)
+
+FORCE:
 
 build: _rm_obj all
 
-install:
-	@echo
-	@echo Waiting to be written...
-	@echo
+install: $(SIM)
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) -s $(SIM) $(DESTDIR)$(BINDIR)
+
+uninstall:
+	cd $(DESTDIR)$(BINDIR) && rm -f $(SIM)
 
 clean: _rm_obj _rm_deps
 
@@ -155,10 +169,10 @@ _rm_obj:
 _rm_deps:
 	rm -f $(DEPS)
 
-allclean: clean
+distclean: clean
 	rm -f $(SIM)
 	rm -f ../disks/drive*.dsk
 	rm -f ../disks/mits_*.dsk
 	rm -f ../printer.txt
 
-.PHONY: all build install clean allclean
+.PHONY: all FORCE build install uninstall clean distclean

--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -46,25 +46,24 @@
 #include "../../frontpanel/frontpanel.h"
 #include "memory.h"
 #include "../../iodevices/unix_terminal.h"
+#ifdef FRONTPANEL
 #include "log.h"
+#endif
 
 extern void reset_cpu(void), reset_io(void);
 extern void run_cpu(void), step_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
 extern unsigned long long get_clock_us(void);
 
+#ifdef FRONTPANEL
 static const char *TAG = "system";
 
-int  boot_switch;		/* boot address for switch */
-#ifdef FRONTPANEL
 static BYTE fp_led_wait;
 static int cpu_switch;
 static int reset;
 static BYTE power_switch = 1;
 static int power;
-#endif
 
-#ifdef FRONTPANEL
 static void run_clicked(int, int), step_clicked(int, int);
 static void reset_clicked(int, int);
 static void examine_clicked(int, int), deposit_clicked(int, int);
@@ -73,6 +72,8 @@ static void power_clicked(int, int);
 static void int_clicked(int, int);
 static void quit_callback(void);
 #endif
+
+int  boot_switch;		/* boot address for switch */
 
 /*
  *	This function initializes the front panel and terminal.

--- a/cpmsim/srccpm2/Makefile
+++ b/cpmsim/srccpm2/Makefile
@@ -8,9 +8,6 @@ Z80ASM = $(Z80ASMDIR)/z80asm
 Z80ASMOPTS = -l -sn -p0
 
 all: putsys bios.bin boot.bin
-	@echo
-	@echo "Done."
-	@echo
 
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
@@ -21,12 +18,18 @@ bios.bin: bios.asm $(Z80ASM)
 boot.bin: boot.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMOPTS) -fb $<
 
-$(Z80ASM):
-	$(MAKE) -C $(Z80ASMDIR) z80asm
+$(Z80ASM): FORCE
+	$(MAKE) -C $(Z80ASMDIR)
+
+FORCE:
+
+install:
+
+uninstall:
 
 clean:
 	rm -f putsys bios.bin bios.lis boot.bin boot.lis
 
-allclean: clean
+distclean: clean
 
-.PHONY: all clean allclean
+.PHONY: all FORCE install uninstall clean distclean

--- a/cpmsim/srccpm3/Makefile
+++ b/cpmsim/srccpm3/Makefile
@@ -8,9 +8,6 @@ Z80ASM = $(Z80ASMDIR)/z80asm
 Z80ASMOPTS = -l -sn -p0
 
 all: putsys boot.bin
-	@echo
-	@echo "Done."
-	@echo
 
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
@@ -18,12 +15,18 @@ putsys: putsys.c
 boot.bin: boot.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMOPTS) -fb $<
 
-$(Z80ASM):
-	$(MAKE) -C $(Z80ASMDIR) z80asm
+$(Z80ASM): FORCE
+	$(MAKE) -C $(Z80ASMDIR)
+
+FORCE:
+
+install:
+
+uninstall:
 
 clean:
 	rm -f putsys boot.bin boot.lis
 
-allclean: clean
+distclean: clean
 
-.PHONY: all clean allclean
+.PHONY: all FORCE install uninstall clean distclean

--- a/cpmsim/srcmpm/Makefile
+++ b/cpmsim/srcmpm/Makefile
@@ -8,9 +8,6 @@ Z80ASM = $(Z80ASMDIR)/z80asm
 Z80ASMOPTS = -l -sn -p0
 
 all: putsys boot.bin
-	@echo
-	@echo "Done."
-	@echo
 
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
@@ -18,12 +15,18 @@ putsys: putsys.c
 boot.bin: boot.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMOPTS) -fb $<
 
-$(Z80ASM):
-	$(MAKE) -C $(Z80ASMDIR) z80asm
+$(Z80ASM): FORCE
+	$(MAKE) -C $(Z80ASMDIR)
+
+FORCE:
+
+install:
+
+uninstall:
 
 clean:
 	rm -f putsys boot.bin boot.lis
 
-allclean: clean
+distclean: clean
 
-.PHONY: all clean allclean
+.PHONY: all FORCE install uninstall clean distclean

--- a/cpmsim/srcsim/Makefile
+++ b/cpmsim/srcsim/Makefile
@@ -1,33 +1,33 @@
 ###
 ### START MACHINE DEPENDENT VARIABLES
 ###
-# (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
+# (simple) machine name - will be suffixed with 'sim'
+# and the executable saved as '../machinesim'
 MACHINE = cpm
 # machine specific system source files
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
 IO_SRCS = unix_terminal.c rtc.c simbdos.c
-# machine specific libraries
-MACHINE_LIBS =
 
 # Installation directories by convention
 # http://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+PACKAGE = z80pack
 CPROG = $(MACHINE)sim
 PREFIX ?= /usr/local
 EXEC_PREFIX = $(PREFIX)
 BINDIR = $(EXEC_PREFIX)/bin
 DATAROOTDIR = $(PREFIX)/share
-DOCDIR = $(DATAROOTDIR)/doc/$(CPROG)
+DATADIR = $(DATAROOTDIR)/$(PACKAGE)/$(CPROG)
 SYSCONFDIR = $(PREFIX)/etc
+INCLUDEDIR = $(PREFIX)/include
+DOCDIR = $(DATAROOTDIR)/doc/$(PACKAGE)/$(CPROG)
 HTMLDIR = $(DOCDIR)
-INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
-LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
+LIBDIR = $(EXEC_PREFIX)/lib
 
-ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 # system wide location for machines configuration files
-CONF_DIR = $(ROOT_DIR)/conf
+CONF_DIR = $(DATADIR)/conf
 # system wide location for disk images
-DISKS_DIR = $(ROOT_DIR)/disks
+DISKS_DIR = $(DATADIR)/disks
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -56,52 +56,60 @@ endif
 
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\"
 INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
+CPPFLAGS = $(DEFS) $(INCS)
 
 CSTDS = -std=c99 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CWARNS = -Wall -Wextra -Wwrite-strings
 
 # Production - the default
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -U_FORTIFY_SOURCE $(DEFS) $(INCS)
+COPTS = -O3 -U_FORTIFY_SOURCE
 
 # Development - use `MODE=DEV make build`
 ifeq ($(MODE),DEV)
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(DEFS) $(INCS)
+COPTS = -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2
 endif
 
 # Debug - use `DEBUG=1 make build`
 ifneq ($(DEBUG),)
-CFLAGS = -O -g $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) $(DEFS) $(INCS)
+COPTS = -O -g
 endif
 
-LDFLAGS = $(PLAT_LDFLAGS) $(MACHINE_LIBS) \
-	  $(PLAT_LIBS)
+CFLAGS = $(CSTDS) $(COPTS) $(CWARNS) $(PLAT_CFLAGS)
+CXXFLAGS = $(CXXSTDS) $(CXXOPTS) $(CXXWARNS) $(PLAT_CXXFLAGS)
 
-# core system source files for the CPU simulation - only change if the core changes
-CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c simmain.c \
-	simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c simz80-fd.c simz80-fdcb.c
+LDFLAGS = $(PLAT_LDFLAGS)
+LDLIBS = $(PLAT_LDLIBS)
+
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = $(INSTALL) -m 644
+
+# core system source files for the CPU simulation
+CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)
 
 all: $(SIM)
-	@echo
-	@echo "Done."
-	@echo
 
-$(SIM): $(OBJS) $(MACHINE_LIBS)
-	$(CC) $(OBJS) $(LDFLAGS) -o $@
+$(SIM): $(OBJS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(OBJS) $(LDLIBS) -o $@
 
 %.d: %.c
-	@$(CC) -MM $(CFLAGS) $< > $@
+	@$(CC) -MM $(CFLAGS) $(CPPFLAGS) $< > $@
 
 -include $(DEPS)
 
 build: _rm_obj all
 
-install:
-	@echo
-	@echo Waiting to be written...
-	@echo
+install: $(SIM)
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) -s $(SIM) $(DESTDIR)$(BINDIR)
+
+uninstall:
+	cd $(DESTDIR)$(BINDIR) && rm -f $(SIM)
 
 clean: _rm_obj _rm_deps
 
@@ -111,9 +119,9 @@ _rm_obj:
 _rm_deps:
 	rm -f $(DEPS)
 
-allclean: clean
+distclean: clean
 	rm -f $(SIM)
 	rm -f ../disks/drive*.dsk
 	rm -f ../auxiliaryin.txt ../auxiliaryout.txt ../printer.txt
 
-.PHONY: all build install clean allclean
+.PHONY: all build install uninstall clean distclean

--- a/cpmsim/srctools/Makefile
+++ b/cpmsim/srctools/Makefile
@@ -1,8 +1,14 @@
 #
 # some places where the tools usually are installed
 #
-DESTDIR=$(HOME)/bin
-#DESTDIR=/usr/local/bin
+PREFIX ?= $(HOME)
+#PREFIX ?= /usr/local
+EXEC_PREFIX = $(PREFIX)
+BINDIR = $(EXEC_PREFIX)/bin
+
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = $(INSTALL) -m 644
 
 CSTDS = -std=c99 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CWARNS= -Wall -Wextra -Wwrite-strings
@@ -11,10 +17,6 @@ CFLAGS= -O3 $(CSTDS) $(CWARNS)
 TOOLS = mkdskimg bin2hex cpmsend cpmrecv ptp2bin
 
 all: $(TOOLS)
-	@echo
-	@echo "Done."
-	@echo "Now run make install"
-	@echo
 
 mkdskimg: mkdskimg.c
 	$(CC) $(CFLAGS) -o mkdskimg mkdskimg.c
@@ -32,16 +34,15 @@ ptp2bin: ptp2bin.c
 	$(CC) $(CFLAGS) -o ptp2bin ptp2bin.c
 
 install: $(TOOLS)
-	install -d $(DESTDIR)
-	install -s $(TOOLS) $(DESTDIR)
-	@echo
-	@echo "Tools installed in ${DESTDIR}, make sure it is"
-	@echo "included in the systems search PATH"
-	@echo
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) -s $(TOOLS) $(DESTDIR)$(BINDIR)
+
+uninstall:
+	cd $(DESTDIR)$(BINDIR) && rm -f $(TOOLS)
 
 clean:
 	rm -f $(TOOLS)
 
-allclean: clean
+distclean: clean
 
-.PHONY: all test install clean allclean
+.PHONY: all test install uninstall clean distclean

--- a/cpmsim/srcucsd-iv/Makefile
+++ b/cpmsim/srcucsd-iv/Makefile
@@ -8,9 +8,6 @@ Z80ASM = $(Z80ASMDIR)/z80asm
 Z80ASMOPTS = -l -sn -p0
 
 all: putsys boot.bin bios.bin
-	@echo
-	@echo "Done."
-	@echo
 
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
@@ -21,12 +18,18 @@ boot.bin: boot.asm $(Z80ASM)
 bios.bin: bios.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMOPTS) -fb $<
 
-$(Z80ASM):
+$(Z80ASM): FORCE
 	$(MAKE) -C $(Z80ASMDIR) z80asm
+
+FORCE:
+
+install:
+
+uninstall:
 
 clean:
 	rm -f putsys boot.bin boot.lis bios.bin bios.lis
 
-allclean: clean
+distclean: clean
 
-.PHONY: all clean allclean
+.PHONY: all FORCE install uninstall clean distclean

--- a/cpmtools/Makefile
+++ b/cpmtools/Makefile
@@ -9,9 +9,6 @@ Z80ASM = $(Z80ASMDIR)/z80asm
 Z80ASMOPTS = -l -sn -p0
 
 all: $(TOOLS) $(CPUTESTS)
-	@echo
-	@echo "Done."
-	@echo
 
 r.com: r.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
@@ -49,12 +46,18 @@ prelim.com: prelim.mac $(Z80ASM)
 test8080.com: test8080.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMOPTS) -8 -fb -o$@ $<
 
-$(Z80ASM):
-	$(MAKE) -C $(Z80ASMDIR) z80asm
+$(Z80ASM): FORCE
+	$(MAKE) -C $(Z80ASMDIR)
+
+FORCE:
+
+install:
+
+uninstall:
 
 clean:
 	rm -f $(TOOLS) $(TOOLS:.com=.lis) $(CPUTESTS) $(CPUTESTS:.com=.lis)
 
-allclean: clean
+distclean: clean
 
-.PHONY: all clean allclean
+.PHONY: all FORCE install uninstall clean distclean

--- a/cromemcosim/srcsim/Makefile
+++ b/cromemcosim/srcsim/Makefile
@@ -1,39 +1,42 @@
 ###
 ### START MACHINE DEPENDENT VARIABLES
 ###
-# (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
+# (simple) machine name - will be suffixed with 'sim'
+# and the executable saved as '../machinesim'
 MACHINE = cromemco
 # emulate a machine's frontpanel
 FRONTPANEL = YES
 # machine specific system source files
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
-IO_SRCS = cromemco-wdi.c cromemco-d+7a.c cromemco-dazzler.c cromemco-fdc.c cromemco-tu-art.c \
-	cromemco-hal.c unix_terminal.c unix_network.c simbdos.c netsrv.c generic-at-modem.c \
-	libtelnet.c diskmanager.c
-# machine specific libraries
-MACHINE_LIBS = -lcivetweb
+IO_SRCS = cromemco-wdi.c cromemco-d+7a.c cromemco-dazzler.c cromemco-fdc.c \
+	cromemco-tu-art.c cromemco-hal.c unix_terminal.c unix_network.c \
+	simbdos.c netsrv.c generic-at-modem.c libtelnet.c diskmanager.c
+# CivetWeb library
+CIV_LIB = $(CIV_DIR)/libcivetweb.a
+CIV_LDLIBS = -lcivetweb
 
 # Installation directories by convention
 # http://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+PACKAGE = z80pack
 CPROG = $(MACHINE)sim
 PREFIX ?= /usr/local
 EXEC_PREFIX = $(PREFIX)
 BINDIR = $(EXEC_PREFIX)/bin
 DATAROOTDIR = $(PREFIX)/share
-DOCDIR = $(DATAROOTDIR)/doc/$(CPROG)
+DATADIR = $(DATAROOTDIR)/$(PACKAGE)/$(CPROG)
 SYSCONFDIR = $(PREFIX)/etc
+INCLUDEDIR = $(PREFIX)/include
+DOCDIR = $(DATAROOTDIR)/doc/$(PACKAGE)/$(CPROG)
 HTMLDIR = $(DOCDIR)
-INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
-LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
+LIBDIR = $(EXEC_PREFIX)/lib
 
-ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 # system wide location for machines configuration files
-CONF_DIR = $(ROOT_DIR)/conf
+CONF_DIR = $(DATADIR)/conf
 # system wide location for disk images
-DISKS_DIR = $(ROOT_DIR)/disks
+DISKS_DIR = $(DATADIR)/disks
 # default boot ROM path
-ROMS_DIR = $(ROOT_DIR)/roms
+ROMS_DIR = $(DATADIR)/roms
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -44,15 +47,17 @@ ROMS_DIR = $(ROOT_DIR)/roms
 ifeq ($(FRONTPANEL),YES)
 FP_SRCS = fpmain.cpp
 FP_DEFS = -DFRONTPANEL
-FP_LIB = -lfrontpanel
-FP_LDFLAGS = $(FP_LIB) -ljpeg -lGL -lGLU
-CCLD = $(CXX)
+FP_LIB = $(FP_DIR)/libfrontpanel.a
+FP_LDLIBS = -lfrontpanel -ljpeg -lGL -lGLU
+LINK = $(CXX)
+LINKFLAGS = $(CXXFLAGS)
 else
 FP_SRCS =
 FP_DEFS =
 FP_LIB =
-FP_LDFLAGS =
-CCLD = $(CC)
+FP_LDLIBS =
+LINK = $(CC)
+LINKFLAGS = $(CFLAGS)
 endif
 ###
 ### END FRONTPANEL VARIABLES
@@ -64,7 +69,7 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 FP_DIR = ../../frontpanel
 NET_DIR = ../../webfrontend
-CIV_DIR = $(NET_DIR:=/civetweb)
+CIV_DIR = $(NET_DIR)/civetweb
 
 VPATH = $(CORE_DIR) $(IO_DIR) $(FP_DIR) $(NET_DIR) $(CIV_DIR)
 
@@ -76,10 +81,10 @@ include $(CORE_DIR)/Makefile.in-os
 ifeq ($(TARGET_OS),BSD)
 PLAT_INCS = -I/usr/local/include
 PLAT_LDFLAGS = -L/usr/local/lib
-PLAT_LIBS = -lthr
+PLAT_LDLIBS = -lthr
 endif
 ifeq ($(TARGET_OS),LINUX)
-PLAT_LIBS = -lm -lpthread
+PLAT_LDLIBS = -lm -lpthread
 endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCS = -I/opt/X11/include
@@ -89,8 +94,11 @@ endif
 ### END O/S DEPENDENT VARIABLES
 ###
 
-DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
-INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR:=/include) $(PLAT_INCS)
+DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" \
+	-DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) \
+	-I$(CIV_DIR)/include $(PLAT_INCS)
+CPPFLAGS = $(DEFS) $(INCS)
 
 CSTDS = -std=c99 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CWARNS = -Wall -Wextra -Wwrite-strings
@@ -98,60 +106,69 @@ CXXSTDS = -std=c++03 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CXXWARNS = -Wall -Wextra
 
 # Production - the default
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -U_FORTIFY_SOURCE $(DEFS) $(INCS)
-CXXFLAGS = -O3 $(CXXSTDS) $(CXXWARNS) $(PLAT_CXXFLAGS) -U_FORTIFY_SOURCE $(DEFS) $(INCS)
+COPTS = -O3 -U_FORTIFY_SOURCE
+CXXOPTS = -O3 -U_FORTIFY_SOURCE
 
 # Development - use `MODE=DEV make build`
 ifeq ($(MODE),DEV)
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(DEFS) $(INCS)
-CXXFLAGS = -O3 $(CXXSTDS) $(CXXWARNS) $(PLAT_CXXFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(DEFS) $(INCS)
+COPTS = -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2
+CXXOPTS = -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2
 endif
 
 # Debug - use `DEBUG=1 make build`
 ifneq ($(DEBUG),)
-CFLAGS = -O -g $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) $(DEFS) $(INCS)
-CXXFLAGS = -O -g $(CXXSTDS) $(CXXWARNS) $(PLAT_CXXFLAGS) $(DEFS) $(INCS)
+COPTS = -O -g
+CXXOPTS = -O -g
 endif
 
-LDFLAGS = -L$(FP_DIR) -L$(CIV_DIR) $(PLAT_LDFLAGS) $(MACHINE_LIBS) \
-	  $(FP_LDFLAGS) -lX11 $(PLAT_LIBS)
+CFLAGS = $(CSTDS) $(COPTS) $(CWARNS) $(PLAT_CFLAGS)
+CXXFLAGS = $(CXXSTDS) $(CXXOPTS) $(CXXWARNS) $(PLAT_CXXFLAGS)
 
-# core system source files for the CPU simulation - only change if the core changes
-CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c simmain.c \
-	simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c simz80-fd.c simz80-fdcb.c
+LDFLAGS = -L$(FP_DIR) -L$(CIV_DIR) $(PLAT_LDFLAGS)
+LDLIBS = $(CIV_LDLIBS) $(FP_LDLIBS) -lX11 $(PLAT_LDLIBS)
+
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = $(INSTALL) -m 644
+
+# core system source files for the CPU simulation
+CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 XXSRCS = $(FP_SRCS)
 OBJS = $(SRCS:.c=.o) $(XXSRCS:.cpp=.o)
 DEPS = $(SRCS:.c=.d) $(XXSRCS:.cpp=.d)
 
 all: $(SIM)
-	@echo
-	@echo "Done."
-	@echo
 
-$(SIM): $(OBJS) $(MACHINE_LIBS) $(FP_LIB)
-	$(CCLD) $(OBJS) $(LDFLAGS) -o $@
+$(SIM): $(OBJS) $(CIV_LIB) $(FP_LIB)
+	$(LINK) $(LINKFLAGS) $(CPPFLAGS) $(LDFLAGS) $(OBJS) $(LDLIBS) -o $@
 
 %.d: %.c
-	@$(CC) -MM $(CFLAGS) $< > $@
+	@$(CC) -MM $(CFLAGS) $(CPPFLAGS) $< > $@
 
 %.d: %.cpp
-	@$(CXX) -MM $(CXXFLAGS) $< > $@
+	@$(CXX) -MM $(CXXFLAGS) $(CPPFLAGS) $< > $@
 
 -include $(DEPS)
 
--lcivetweb: $(CIV_DIR:=/Makefile)
-	$(MAKE) -B -C $(CIV_DIR)
+$(CIV_LIB): FORCE
+	$(MAKE) -C $(CIV_DIR)
 
--lfrontpanel: $(FP_DIR:=/Makefile)
-	$(MAKE) -B -C $(FP_DIR)
+$(FP_LIB): FORCE
+	$(MAKE) -C $(FP_DIR)
+
+FORCE:
 
 build: _rm_obj all
 
-install:
-	@echo
-	@echo Waiting to be written...
-	@echo
+install: $(SIM)
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) -s $(SIM) $(DESTDIR)$(BINDIR)
+
+uninstall:
+	cd $(DESTDIR)$(BINDIR) && rm -f $(SIM)
 
 clean: _rm_obj _rm_deps
 
@@ -161,9 +178,9 @@ _rm_obj:
 _rm_deps:
 	rm -f $(DEPS)
 
-allclean: clean
+distclean: clean
 	rm -f $(SIM)
 	rm -f ../disks/drive*.dsk
 	rm -f ../lpt[12].txt
 
-.PHONY: all build install clean allclean
+.PHONY: all FORCE build install uninstall clean distclean

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -41,24 +41,24 @@
 #include "../../frontpanel/frontpanel.h"
 #include "memory.h"
 #include "../../iodevices/unix_terminal.h"
+#ifdef FRONTPANEL
 #include "log.h"
+#endif
 
 extern void reset_cpu(void), reset_io(void);
 extern void run_cpu(void), step_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
 extern unsigned long long get_clock_us(void);
 
+#ifdef FRONTPANEL
 static const char *TAG = "system";
 
-#ifdef FRONTPANEL
 static BYTE fp_led_wait;
 static BYTE fp_led_speed;
 static int cpu_switch;
 static int reset;
 static int power;
-#endif
 
-#ifdef FRONTPANEL
 static void run_clicked(int, int), step_clicked(int, int);
 static void reset_clicked(int, int);
 static void examine_clicked(int, int), deposit_clicked(int, int);

--- a/frontpanel/Makefile
+++ b/frontpanel/Makefile
@@ -42,9 +42,6 @@ OBJS = $(SRCS:.cpp=.o)
 DEPS = $(SRCS:.cpp=.d)
 
 all: $(LIB)
-	@echo
-	@echo "Done."
-	@echo
 
 $(LIB): $(OBJS)
 	@rm -f $@
@@ -57,6 +54,10 @@ $(LIB): $(OBJS)
 
 build: _rm_obj all
 
+install:
+
+uninstall:
+
 clean: _rm_obj _rm_deps
 	rm -f $(LIB)
 
@@ -66,6 +67,6 @@ _rm_obj:
 _rm_deps:
 	rm -f $(DEPS)
 
-allclean: clean
+distclean: clean
 
-.PHONY: all build clean allclean
+.PHONY: all build install uninstall clean distclean

--- a/imsaisim/srcsim/Makefile
+++ b/imsaisim/srcsim/Makefile
@@ -1,39 +1,43 @@
 ###
 ### START MACHINE DEPENDENT VARIABLES
 ###
-# (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
+# (simple) machine name - will be suffixed with 'sim'
+# and the executable saved as '../machinesim'
 MACHINE = imsai
 # emulate a machine's frontpanel
 FRONTPANEL = YES
 # machine specific system source files
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
-IO_SRCS = cromemco-dazzler.c cromemco-88ccc.c cromemco-d+7a.c diskmanager.c imsai-fif.c \
-	imsai-sio2.c imsai-hal.c imsai-vio.c unix_terminal.c unix_network.c netsrv.c \
-	generic-at-modem.c libtelnet.c rtc.c simbdos.c am9511.c floatcnv.c ova.c
+IO_SRCS = cromemco-dazzler.c cromemco-88ccc.c cromemco-d+7a.c diskmanager.c \
+	imsai-fif.c imsai-sio2.c imsai-hal.c imsai-vio.c unix_terminal.c \
+	unix_network.c netsrv.c generic-at-modem.c libtelnet.c rtc.c \
+	simbdos.c am9511.c floatcnv.c ova.c
 # machine specific libraries
-MACHINE_LIBS = -lcivetweb
+CIV_LIB = $(CIV_DIR)/libcivetweb.a
+CIV_LDLIBS = -lcivetweb
 
 # Installation directories by convention
 # http://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+PACKAGE = z80pack
 CPROG = $(MACHINE)sim
 PREFIX ?= /usr/local
 EXEC_PREFIX = $(PREFIX)
 BINDIR = $(EXEC_PREFIX)/bin
 DATAROOTDIR = $(PREFIX)/share
-DOCDIR = $(DATAROOTDIR)/doc/$(CPROG)
+DATADIR = $(DATAROOTDIR)/$(PACKAGE)/$(CPROG)
 SYSCONFDIR = $(PREFIX)/etc
+INCLUDEDIR = $(PREFIX)/include
+DOCDIR = $(DATAROOTDIR)/doc/$(PACKAGE)/$(CPROG)
 HTMLDIR = $(DOCDIR)
-INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
-LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
+LIBDIR = $(EXEC_PREFIX)/lib
 
-ROOT_DIR = $(DATAROOTDIR)/$(CPROG)
 # system wide location for machines configuration files
-CONF_DIR = $(ROOT_DIR)/conf
+CONF_DIR = $(DATADIR)/conf
 # system wide location for disk images
-DISKS_DIR = $(ROOT_DIR)/disks
+DISKS_DIR = $(DATADIR)/disks
 # default boot ROM path
-ROMS_DIR = $(ROOT_DIR)/roms
+ROMS_DIR = $(DATADIR)/roms
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -44,15 +48,17 @@ ROMS_DIR = $(ROOT_DIR)/roms
 ifeq ($(FRONTPANEL),YES)
 FP_SRCS = fpmain.cpp
 FP_DEFS = -DFRONTPANEL
-FP_LIB = -lfrontpanel
-FP_LDFLAGS = $(FP_LIB) -ljpeg -lGL -lGLU
-CCLD = $(CXX)
+FP_LIB = $(FP_DIR)/libfrontpanel.a
+FP_LDLIBS = -lfrontpanel -ljpeg -lGL -lGLU
+LINK = $(CXX)
+LINKFLAGS = $(CXXFLAGS)
 else
 FP_SRCS =
 FP_DEFS =
 FP_LIB =
-FP_LDFLAGS =
-CCLD = $(CC)
+FP_LDLIBS =
+LINK = $(CC)
+LINKFLAGS = $(CFLAGS)
 endif
 ###
 ### END FRONTPANEL VARIABLES
@@ -64,9 +70,9 @@ CORE_DIR = ../../z80core
 IO_DIR = ../../iodevices
 FP_DIR = ../../frontpanel
 NET_DIR = ../../webfrontend
-CIV_DIR = $(NET_DIR:=/civetweb)
+CIV_DIR = $(NET_DIR)/civetweb
 
-VPATH = $(CORE_DIR) $(IO_DIR) $(IO_DIR:=/apu) $(FP_DIR) $(NET_DIR) $(CIV_DIR)
+VPATH = $(CORE_DIR) $(IO_DIR) $(IO_DIR)/apu $(FP_DIR) $(NET_DIR) $(CIV_DIR)
 
 ###
 ### START O/S PLATFORM DEPENDENT VARIABLES
@@ -76,10 +82,10 @@ include $(CORE_DIR)/Makefile.in-os
 ifeq ($(TARGET_OS),BSD)
 PLAT_INCS = -I/usr/local/include
 PLAT_LDFLAGS = -L/usr/local/lib
-PLAT_LIBS = -lthr -lm
+PLAT_LDLIBS = -lthr -lm
 endif
 ifeq ($(TARGET_OS),LINUX)
-PLAT_LIBS = -lm -lpthread
+PLAT_LDLIBS = -lm -lpthread
 endif
 ifeq ($(TARGET_OS),OSX)
 PLAT_INCS = -I/opt/X11/include
@@ -89,8 +95,11 @@ endif
 ### END O/S DEPENDENT VARIABLES
 ###
 
-DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" -DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
-INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) -I$(CIV_DIR:=/include) $(PLAT_INCS)
+DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" \
+	-DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) \
+	-I$(CIV_DIR)/include $(PLAT_INCS)
+CPPFLAGS = $(DEFS) $(INCS)
 
 CSTDS = -std=c99 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CWARNS = -Wall -Wextra -Wwrite-strings
@@ -98,60 +107,69 @@ CXXSTDS = -std=c++03 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CXXWARNS = -Wall -Wextra
 
 # Production - the default
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -U_FORTIFY_SOURCE $(DEFS) $(INCS)
-CXXFLAGS = -O3 $(CXXSTDS) $(CXXWARNS) $(PLAT_CXXFLAGS) -U_FORTIFY_SOURCE $(DEFS) $(INCS)
+COPTS = -O3 -U_FORTIFY_SOURCE
+CXXOPTS = -O3 -U_FORTIFY_SOURCE
 
 # Development - use `MODE=DEV make build`
 ifeq ($(MODE),DEV)
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(DEFS) $(INCS)
-CXXFLAGS = -O3 $(CXXSTDS) $(CXXWARNS) $(PLAT_CXXFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(DEFS) $(INCS)
+COPTS = -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2
+CXXOPTS = -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2
 endif
 
 # Debug - use `DEBUG=1 make build`
 ifneq ($(DEBUG),)
-CFLAGS = -O -g $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) $(DEFS) $(INCS)
-CXXFLAGS = -O -g $(CXXSTDS) $(CXXWARNS) $(PLAT_CXXFLAGS) $(DEFS) $(INCS)
+COPTS = -O -g
+CXXOPTS = -O -g
 endif
 
-LDFLAGS = -L$(FP_DIR) -L$(CIV_DIR) $(PLAT_LDFLAGS) $(MACHINE_LIBS) \
-	  $(FP_LDFLAGS) -lX11 $(PLAT_LIBS)
+CFLAGS = $(CSTDS) $(COPTS) $(CWARNS) $(PLAT_CFLAGS)
+CXXFLAGS = $(CXXSTDS) $(CXXOPTS) $(CXXWARNS) $(PLAT_CXXFLAGS)
 
-# core system source files for the CPU simulation - only change if the core changes
-CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c simmain.c \
-	simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c simz80-fd.c simz80-fdcb.c
+LDFLAGS = -L$(FP_DIR) -L$(CIV_DIR) $(PLAT_LDFLAGS)
+LDLIBS = $(CIV_LDLIBS) $(FP_LDLIBS) -lX11 $(PLAT_LDLIBS)
+
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = $(INSTALL) -m 644
+
+# core system source files for the CPU simulation
+CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 XXSRCS = $(FP_SRCS)
 OBJS = $(SRCS:.c=.o) $(XXSRCS:.cpp=.o)
 DEPS = $(SRCS:.c=.d) $(XXSRCS:.cpp=.d)
 
 all: $(SIM)
-	@echo
-	@echo "Done."
-	@echo
 
-$(SIM): $(OBJS) $(MACHINE_LIBS) $(FP_LIB)
-	$(CCLD) $(OBJS) $(LDFLAGS) -o $@
+$(SIM): $(OBJS) $(CIV_LIB) $(FP_LIB)
+	$(LINK) $(LINKFLAGS) $(CPPFLAGS) $(LDFLAGS) $(OBJS) $(LDLIBS) -o $@
 
 %.d: %.c
-	@$(CC) -MM $(CFLAGS) $< > $@
+	@$(CC) -MM $(CFLAGS) $(CPPFLAGS) $< > $@
 
 %.d: %.cpp
-	@$(CXX) -MM $(CXXFLAGS) $< > $@
+	@$(CXX) -MM $(CXXFLAGS) $(CPPFLAGS) $< > $@
 
 -include $(DEPS)
 
--lcivetweb: $(CIV_DIR:=/Makefile)
-	$(MAKE) -B -C $(CIV_DIR)
+$(CIV_LIB): FORCE
+	$(MAKE) -C $(CIV_DIR)
 
--lfrontpanel: $(FP_DIR:=/Makefile)
-	$(MAKE) -B -C $(FP_DIR)
+$(FP_LIB): FORCE
+	$(MAKE) -C $(FP_DIR)
+
+FORCE:
 
 build: _rm_obj all
 
-install:
-	@echo
-	@echo Waiting to be written...
-	@echo
+install: $(SIM)
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) -s $(SIM) $(DESTDIR)$(BINDIR)
+
+uninstall:
+	cd $(DESTDIR)$(BINDIR) && rm -f $(SIM)
 
 clean: _rm_obj _rm_deps
 
@@ -161,9 +179,9 @@ _rm_obj:
 _rm_deps:
 	rm -f $(DEPS)
 
-allclean: clean
+distclean: clean
 	rm -f $(SIM)
 	rm -f ../disks/drive*.dsk
 	rm -f ../printer.txt
 
-.PHONY: all build install clean allclean
+.PHONY: all FORCE build install uninstall clean distclean

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -45,23 +45,23 @@
 #ifdef UNIX_TERMINAL
 #include "../../iodevices/unix_terminal.h"
 #endif
+#ifdef FRONTPANEL
 #include "log.h"
+#endif
 
 extern void reset_cpu(void), reset_io(void);
 extern void run_cpu(void), step_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
 extern unsigned long long get_clock_us(void);
 
+#ifdef FRONTPANEL
 static const char *TAG = "system";
 
-#ifdef FRONTPANEL
 static BYTE fp_led_wait;
 static int cpu_switch;
 static int reset;
 static int power;
-#endif
 
-#ifdef FRONTPANEL
 static void run_clicked(int, int), step_clicked(int, int);
 static void reset_clicked(int, int);
 static void examine_clicked(int, int), deposit_clicked(int, int);

--- a/imsaisim/srcucsd-iv/Makefile
+++ b/imsaisim/srcucsd-iv/Makefile
@@ -8,9 +8,6 @@ Z80ASM = $(Z80ASMDIR)/z80asm
 Z80ASMOPTS = -l -sn -p0
 
 all: putsys boot.bin bios.bin
-	@echo
-	@echo "Done."
-	@echo
 
 putsys: putsys.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o putsys putsys.c
@@ -21,12 +18,18 @@ boot.bin: boot.asm $(Z80ASM)
 bios.bin: bios.asm
 	$(Z80ASM) $(Z80ASMOPTS) -fb $<
 
-$(Z80ASM):
-	$(MAKE) -C $(Z80ASMDIR) z80asm
+$(Z80ASM): FORCE
+	$(MAKE) -C $(Z80ASMDIR)
+
+FORCE:
+
+install:
+
+uninstall:
 
 clean:
 	rm -f putsys boot.bin boot.lis bios.bin bios.lis
 
-allclean: clean
+distclean: clean
 
-.PHONY: all clean allclean
+.PHONY: all FORCE install uninstall clean distclean

--- a/mosteksim/srcsim/Makefile
+++ b/mosteksim/srcsim/Makefile
@@ -1,27 +1,28 @@
 ###
 ### START MACHINE DEPENDENT VARIABLES
 ###
-# (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
+# (simple) machine name - will be suffixed with 'sim'
+# and the executable saved as '../machinesim'
 MACHINE = mostek
 # machine specific system source files
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
 IO_SRCS = simbdos.c unix_terminal.c mostek-cpu.c mostek-fdc.c
-# machine specific libraries
-MACHINE_LIBS =
 
 # Installation directories by convention
 # http://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+PACKAGE = z80pack
 CPROG = $(MACHINE)sim
 PREFIX ?= /usr/local
 EXEC_PREFIX = $(PREFIX)
 BINDIR = $(EXEC_PREFIX)/bin
 DATAROOTDIR = $(PREFIX)/share
-DOCDIR = $(DATAROOTDIR)/doc/$(CPROG)
+DATADIR = $(DATAROOTDIR)/$(PACKAGE)/$(CPROG)
 SYSCONFDIR = $(PREFIX)/etc
+INCLUDEDIR = $(PREFIX)/include
+DOCDIR = $(DATAROOTDIR)/doc/$(PACKAGE)/$(CPROG)
 HTMLDIR = $(DOCDIR)
-INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
-LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
+LIBDIR = $(EXEC_PREFIX)/lib
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -50,52 +51,60 @@ endif
 
 DEFS =
 INCS = -iquote . -I$(CORE_DIR) -I$(IO_DIR) $(PLAT_INCS)
+CPPFLAGS = $(DEFS) $(INCS)
 
 CSTDS = -std=c99 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CWARNS = -Wall -Wextra -Wwrite-strings
 
 # Production - the default
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -U_FORTIFY_SOURCE $(DEFS) $(INCS)
+COPTS = -O3 -U_FORTIFY_SOURCE
 
 # Development - use `MODE=DEV make build`
 ifeq ($(MODE),DEV)
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(DEFS) $(INCS)
+COPTS = -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2
 endif
 
 # Debug - use `DEBUG=1 make build`
 ifneq ($(DEBUG),)
-CFLAGS = -O -g $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) $(DEFS) $(INCS)
+COPTS = -O -g
 endif
 
-LDFLAGS = $(PLAT_LDFLAGS) $(MACHINE_LIBS) \
-	  $(PLAT_LIBS)
+CFLAGS = $(CSTDS) $(COPTS) $(CWARNS) $(PLAT_CFLAGS)
+CXXFLAGS = $(CXXSTDS) $(CXXOPTS) $(CXXWARNS) $(PLAT_CXXFLAGS)
 
-# core system source files for the CPU simulation - only change if the core changes
-CORE_SRCS = simcore.c simdis.c simfun.c simglb.c simice.c simint.c simmain.c \
-	simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c simz80-fd.c simz80-fdcb.c
+LDFLAGS = $(PLAT_LDFLAGS)
+LDLIBS = $(PLAT_LDLIBS)
+
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = $(INSTALL) -m 644
+
+# core system source files for the CPU simulation
+CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)
 
 all: $(SIM)
-	@echo
-	@echo "Done."
-	@echo
 
-$(SIM): $(OBJS) $(MACHINE_LIBS)
-	$(CC) $(OBJS) $(LDFLAGS) -o $@
+$(SIM): $(OBJS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(OBJS) $(LDLIBS) -o $@
 
 %.d: %.c
-	@$(CC) -MM $(CFLAGS) $< > $@
+	@$(CC) -MM $(CFLAGS) $(CPPFLAGS) $< > $@
 
 -include $(DEPS)
 
 build: _rm_obj all
 
-install:
-	@echo
-	@echo Waiting to be written...
-	@echo
+install: $(SIM)
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) -s $(SIM) $(DESTDIR)$(BINDIR)
+
+uninstall:
+	cd $(DESTDIR)$(BINDIR) && rm -f $(SIM)
 
 clean: _rm_obj _rm_deps
 
@@ -105,7 +114,7 @@ _rm_obj:
 _rm_deps:
 	rm -f $(DEPS)
 
-allclean: clean
+distclean: clean
 	rm -f $(SIM)
 
-.PHONY: all build install clean allclean
+.PHONY: all build install uninstall clean distclean

--- a/picosim/src-examples/Makefile
+++ b/picosim/src-examples/Makefile
@@ -3,9 +3,6 @@ Z80ASM = $(Z80ASMDIR)/z80asm
 Z80ASMOPTS = -l -sn -p0
 
 all: serial.c tb.c blink.c
-	@echo
-	@echo "Done."
-	@echo
 
 serial.c: serial.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMOPTS) -fc $<
@@ -16,12 +13,18 @@ tb.c: tb.asm $(Z80ASM)
 blink.c: blink.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMOPTS) -fc $<
 
-$(Z80ASM):
-	$(MAKE) -C $(Z80ASMDIR) z80asm
+$(Z80ASM): FORCE
+	$(MAKE) -C $(Z80ASMDIR)
+
+FORCE:
+
+install:
+
+uninstall:
 
 clean:
 	rm -f serial.c tb.c blink.c
 
-allclean: clean
+distclean: clean
 
-.PHONY: all clean allclean
+.PHONY: all FORCE install uninstall clean distclean

--- a/webfrontend/civetweb/Makefile
+++ b/webfrontend/civetweb/Makefile
@@ -190,7 +190,7 @@ LIB_OBJECTS = $(filter-out $(MAIN_OBJECTS), $(BUILD_OBJECTS))
 
 ifeq ($(TARGET_OS),LINUX)
   LIBS += -lrt -ldl
-  CAN_INSTALL = 1
+  CAN_INSTALL = 0
 endif
 
 ifeq ($(TARGET_OS),WIN32)
@@ -330,8 +330,6 @@ clean:
 	$(RMRF) $(CPROG)
 	$(RMF) $(UNIT_TEST_PROG)
 
-allclean: clean
-
 distclean: clean
 	@$(RMRF) VS2012/Debug VS2012/*/Debug  VS2012/*/*/Debug
 	@$(RMRF) VS2012/Release VS2012/*/Release  VS2012/*/*/Release
@@ -385,5 +383,5 @@ $(BUILD_RESOURCES) : $(WINDOWS_RESOURCES)
 indent:
 	astyle --suffix=none --style=linux --indent=spaces=4 --lineend=linux  include/*.h src/*.c src/*.cpp src/*.inl examples/*/*.c  examples/*/*.cpp
 
-.PHONY: default all help build unit_test install install-headers install-lib install-slib lib slib clean distclean allclean indent
+.PHONY: all help build install clean lib so
 

--- a/z80asm/Makefile
+++ b/z80asm/Makefile
@@ -14,8 +14,14 @@ CFLAGS = -O3 $(CSTDS) $(CWARNS)
 #
 # installation directory
 #
-DESTDIR = "${HOME}/bin"
-#DESTDIR = /usr/local/bin
+PREFIX ?= $(HOME)
+#PREFIX ?= /usr/local
+EXEC_PREFIX = $(PREFIX)
+BINDIR = $(EXEC_PREFIX)/bin
+
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = $(INSTALL) -m 644
 
 OBJS =	z80amain.o \
 	z80atab.o \
@@ -28,12 +34,9 @@ OBJS =	z80amain.o \
 	z80aglb.o
 
 all: z80asm
-	@echo
-	@echo "Done."
-	@echo
 
 z80asm: $(OBJS)
-	$(CC) $(OBJS) $(LDFLAGS) -o z80asm
+	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) -o z80asm
 
 z80amain.o: z80amain.c z80a.h z80aglb.h
 	$(CC) $(CFLAGS) -c z80amain.c
@@ -62,17 +65,20 @@ z80aopc.o: z80aopc.c z80a.h z80aglb.h
 z80aglb.o: z80aglb.c z80a.h
 	$(CC) $(CFLAGS) -c z80aglb.c
 
+instcoh: z80asm
+	strip z80asm
+	cp z80asm $(DESTDIR)$(BINDIR)
+
+install: z80asm
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) -s z80asm $(DESTDIR)$(BINDIR)
+
+uninstall:
+	rm $(DESTDIR)$(BINDIR)/z80asm
+
 clean:
 	rm -f core $(OBJS) z80asm
 
-allclean: clean
+distclean: clean
 
-install: z80asm
-	install -d $(DESTDIR)
-	install -s z80asm $(DESTDIR)
-
-instcoh: z80asm
-	strip z80asm
-	cp z80asm ${DESTDIR}
-
-.PHONY: clean allclean install install-coh
+.PHONY: all instcoh install uninstall clean distclean

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -914,7 +914,7 @@ static void do_show(void)
 	switch (cpu) {
 #ifndef EXCLUDE_Z80
 	case Z80:
-		fputs("Z80", stdout);
+		fputs("z80", stdout);
 		break;
 #endif
 #ifndef EXCLUDE_I8080
@@ -925,7 +925,7 @@ static void do_show(void)
 	default:
 		break;
 	}
-	printf("-Sim Release: %s\n", RELEASE);
+	printf("sim Release: %s\n", RELEASE);
 #ifdef HISIZE
 	i = HISIZE;
 #else

--- a/z80sim/Makefile
+++ b/z80sim/Makefile
@@ -16,13 +16,19 @@ z80opsall.hex: z80opsall.asm $(Z80ASM)
 8080opsall.hex: 8080opsall.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMOPTS) -fh $<
 
-$(Z80ASM):
-	cd $(Z80ASMDIR) && $(MAKE)
+$(Z80ASM): FORCE
+	$(MAKE) -C $(Z80ASMDIR)
+
+FORCE:
+
+install:
+
+uninstall:
 
 clean:
 	rm -f float.hex float.lis z80main.hex z80main.lis \
 		z80opsall.hex z80opsall.lis 8080opsall.hex 8080opsall.lis
 
-allclean: clean
+distclean: clean
 
-.PHONY: all clean allclean
+.PHONY: all FORCE install uninstall clean distclean

--- a/z80sim/srcsim/Makefile
+++ b/z80sim/srcsim/Makefile
@@ -1,27 +1,28 @@
 ###
 ### START MACHINE DEPENDENT VARIABLES
 ###
-# (simple) machine name - will be suffixed with 'sim' and the executable saved as '../machinesim'
+# (simple) machine name - will be suffixed with 'sim'
+# and the executable saved as '../machinesim'
 MACHINE = z80
 # machine specific system source files
 MACHINE_SRCS = config.c iosim.c memory.c simctl.c
 # machine specific I/O source files
 IO_SRCS = unix_terminal.c
-# machine specific libraries
-MACHINE_LIBS =
 
 # Installation directories by convention
 # http://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+PACKAGE = z80pack
 CPROG = $(MACHINE)sim
 PREFIX ?= /usr/local
 EXEC_PREFIX = $(PREFIX)
 BINDIR = $(EXEC_PREFIX)/bin
 DATAROOTDIR = $(PREFIX)/share
-DOCDIR = $(DATAROOTDIR)/doc/$(CPROG)
+DATADIR = $(DATAROOTDIR)/$(PACKAGE)/$(CPROG)
 SYSCONFDIR = $(PREFIX)/etc
+INCLUDEDIR = $(PREFIX)/include
+DOCDIR = $(DATAROOTDIR)/doc/$(PACKAGE)/$(CPROG)
 HTMLDIR = $(DOCDIR)
-INCLUDEDIR = $(DESTDIR)$(PREFIX)/include
-LIBDIR = $(DESTDIR)$(EXEC_PREFIX)/lib
+LIBDIR = $(EXEC_PREFIX)/lib
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -50,50 +51,60 @@ endif
 
 DEFS =
 INCS = -iquote . -I$(CORE_DIR) $(PLAT_INCS)
+CPPFLAGS = $(DEFS) $(INCS)
 
 CSTDS = -std=c99 -D_DEFAULT_SOURCE # -D_XOPEN_SOURCE=700L
 CWARNS = -Wall -Wextra -Wwrite-strings
 
 # Production - the default
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -U_FORTIFY_SOURCE $(DEFS) $(INCS)
+COPTS = -O3 -U_FORTIFY_SOURCE
 
 # Development - use `MODE=DEV make build`
 ifeq ($(MODE),DEV)
-CFLAGS = -O3 $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(DEFS) $(INCS)
+COPTS = -O3 -fstack-protector-all -D_FORTIFY_SOURCE=2
 endif
 
 # Debug - use `DEBUG=1 make build`
 ifneq ($(DEBUG),)
-CFLAGS = -O -g $(CSTDS) $(CWARNS) $(PLAT_CFLAGS) $(DEFS) $(INCS)
+COPTS = -O -g
 endif
 
-LDFLAGS = $(PLAT_LDFLAGS) $(MACHINE_LIBS) \
-	  $(PLAT_LIBS)
+CFLAGS = $(CSTDS) $(COPTS) $(CWARNS) $(PLAT_CFLAGS)
+CXXFLAGS = $(CXXSTDS) $(CXXOPTS) $(CXXWARNS) $(PLAT_CXXFLAGS)
 
-# core system source files for the CPU simulation - only change if the core changes
-CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c simmain.c \
-	simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c simz80-fd.c simz80-fdcb.c
+LDFLAGS = $(PLAT_LDFLAGS)
+LDLIBS = $(PLAT_LDLIBS)
+
+INSTALL = install
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA = $(INSTALL) -m 644
+
+# core system source files for the CPU simulation
+CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)
 
 all: $(SIM)
-	@echo
-	@echo "Done."
-	@echo
 
-$(SIM): $(OBJS) $(MACHINE_LIBS)
-	$(CC) $(OBJS) $(LDFLAGS) -o $@
+$(SIM): $(OBJS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(OBJS) $(LDLIBS) -o $@
 
 %.d: %.c
-	@$(CC) -MM $(CFLAGS) $< > $@
+	@$(CC) -MM $(CFLAGS) $(CPPFLAGS) $< > $@
 
 -include $(DEPS)
 
 build: _rm_obj all
 
 install: $(SIM)
-	cp $(SIM) ${HOME}/bin
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) -s $(SIM) $(DESTDIR)$(BINDIR)
+
+uninstall:
+	cd $(DESTDIR)$(BINDIR) && rm -f $(SIM)
 
 clean: _rm_obj _rm_deps
 
@@ -103,7 +114,7 @@ _rm_obj:
 _rm_deps:
 	rm -f $(DEPS)
 
-allclean: clean
+distclean: clean
 	rm -f $(SIM)
 
-.PHONY: all build install clean allclean
+.PHONY: all build install uninstall clean distclean


### PR DESCRIPTION
Tweaked program name shown by 's' ICE command.

Avoid compiler warning when building with FRONTPANEL=NO.

Renamed allclean to distclean (more standard).
Force visit to z80asm directory.
Working toward proper "make install/uninstall" (not done yet).
Setup and use CPPFLAGS.
Split link options in LDFLAGS and LDLIBS.
Redid frontpanel and civetweb library rules ("-lfrontpanel:" looked just strange to me).
