### PR TITLE
Add -T option to z80asm to disable time stamps in listings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MACHINES = altairsim cpmsim cromemcosim imsaisim mosteksim z80sim
 
 Z80ASMDIR = z80asm
 Z80ASM = $(Z80ASMDIR)/z80asm
-Z80ASMOPTS = -l -sn -p0
+Z80ASMOPTS = -l -T -sn -p0
 
 ALTAIR_8080 = \
 	altairsim/basic8k78.asm \

--- a/altairsim/basic8k78.lis
+++ b/altairsim/basic8k78.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/dzmation.lis
+++ b/altairsim/dzmation.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; HAND DISASSEMBLY OF THE DAZZLEMATION MEMORY IMAGE PROVIDED IN THE

--- a/altairsim/fdct1.lis
+++ b/altairsim/fdct1.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/killbits.lis
+++ b/altairsim/killbits.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/killbits2.lis
+++ b/altairsim/killbits2.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/kscope.lis
+++ b/altairsim/kscope.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/life.lis
+++ b/altairsim/life.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; LIFE .... VERSION 2.0

--- a/altairsim/microchess.lis
+++ b/altairsim/microchess.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '8080 MICROCHESS'

--- a/altairsim/roms/als8-rom.lis
+++ b/altairsim/roms/als8-rom.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/roms/apple.lis
+++ b/altairsim/roms/apple.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '<APPLE MONITOR, *ECT ROM* V1.0  JAN 07, 1979>'

--- a/altairsim/roms/bootromt-old.lis
+++ b/altairsim/roms/bootromt-old.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;******************************************************************

--- a/altairsim/roms/bootromt.lis
+++ b/altairsim/roms/bootromt.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;******************************************************************

--- a/altairsim/roms/cuter-mits.lis
+++ b/altairsim/roms/cuter-mits.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>

--- a/altairsim/roms/dbl.lis
+++ b/altairsim/roms/dbl.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;***************************************************************

--- a/altairsim/roms/mbl.lis
+++ b/altairsim/roms/mbl.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; MBL - MULTI BOOT LOADER FOR THE ALTAIR 8800

--- a/altairsim/roms/miniboot.lis
+++ b/altairsim/roms/miniboot.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/roms/tinybasic-1.0.lis
+++ b/altairsim/roms/tinybasic-1.0.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/altairsim/roms/tinybasic-2.0.lis
+++ b/altairsim/roms/tinybasic-2.0.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/altairsim/roms/turnmon.lis
+++ b/altairsim/roms/turnmon.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; **************************************************************

--- a/altairsim/roms/umzapex.lis
+++ b/altairsim/roms/umzapex.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 	TITLE	<Zapple Monitor Extension for MITS ALTAIR>

--- a/altairsim/roms/zapple.lis
+++ b/altairsim/roms/zapple.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;	<< ZAPPLE 2-K MONITOR SYSTEM >>

--- a/cpmsim/srccpm2/Makefile
+++ b/cpmsim/srccpm2/Makefile
@@ -5,7 +5,7 @@ LDFLAGS= -s
 
 Z80ASMDIR = ../../z80asm
 Z80ASM = $(Z80ASMDIR)/z80asm
-Z80ASMOPTS = -l -sn -p0
+Z80ASMOPTS = -l -T -sn -p0
 
 all: putsys bios.bin boot.bin
 

--- a/cpmsim/srccpm3/Makefile
+++ b/cpmsim/srccpm3/Makefile
@@ -5,7 +5,7 @@ LDFLAGS= -s
 
 Z80ASMDIR = ../../z80asm
 Z80ASM = $(Z80ASMDIR)/z80asm
-Z80ASMOPTS = -l -sn -p0
+Z80ASMOPTS = -l -T -sn -p0
 
 all: putsys boot.bin
 

--- a/cpmsim/srcmpm/Makefile
+++ b/cpmsim/srcmpm/Makefile
@@ -5,7 +5,7 @@ LDFLAGS= -s
 
 Z80ASMDIR = ../../z80asm
 Z80ASM = $(Z80ASMDIR)/z80asm
-Z80ASMOPTS = -l -sn -p0
+Z80ASMOPTS = -l -T -sn -p0
 
 all: putsys boot.bin
 

--- a/cpmsim/srcucsd-iv/Makefile
+++ b/cpmsim/srcucsd-iv/Makefile
@@ -5,7 +5,7 @@ LDFLAGS= -s
 
 Z80ASMDIR = ../../z80asm
 Z80ASM = $(Z80ASMDIR)/z80asm
-Z80ASMOPTS = -l -sn -p0
+Z80ASMOPTS = -l -T -sn -p0
 
 all: putsys boot.bin bios.bin
 

--- a/cpmtools/Makefile
+++ b/cpmtools/Makefile
@@ -6,7 +6,7 @@ CPUTESTS = ex8080.com exz80doc.com exz80all.com prelim.com 8080pre.com test8080.
 
 Z80ASMDIR = ../z80asm
 Z80ASM = $(Z80ASMDIR)/z80asm
-Z80ASMOPTS = -l -sn -p0
+Z80ASMOPTS = -l -T -sn -p0
 
 all: $(TOOLS) $(CPUTESTS)
 

--- a/cromemcosim/dzmation.lis
+++ b/cromemcosim/dzmation.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; HAND DISASSEMBLY OF THE DAZZLEMATION MEMORY IMAGE PROVIDED IN THE

--- a/cromemcosim/kscope.lis
+++ b/cromemcosim/kscope.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/cromemcosim/life.lis
+++ b/cromemcosim/life.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; LIFE .... VERSION 2.0

--- a/cromemcosim/microchess.lis
+++ b/cromemcosim/microchess.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '8080 MICROCHESS'

--- a/cromemcosim/roms/rdos1.lis
+++ b/cromemcosim/roms/rdos1.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; COPYRIGHT (C) 1977, CROMEMCO, INC.

--- a/cromemcosim/roms/rdos252.lis
+++ b/cromemcosim/roms/rdos252.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/cromemcosim/roms/z1mon-1.0.lis
+++ b/cromemcosim/roms/z1mon-1.0.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/cromemcosim/roms/z1mon-1.4.lis
+++ b/cromemcosim/roms/z1mon-1.4.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -1,13 +1,19 @@
 Usage:
 
-z80asm -f{b|m|h|c} -s[n|a] -p<num> -e<num> -h<num> -c<num> -x -8 -u
-       -v -m -U -o<file> -l[<file>] -d<symbol> ... <file> ...
+z80asm -8 -u -f{b|m|h|c} -s[n|a] -p<num> -e<num> -h<num> -c<num>
+       -x -v -m -U -T -o<file> -l[<file>] -d<symbol> ... <file> ...
 
 If the file name of a source doesn't have an extension the default
 extension ".asm" will be appended.
 
 Source lines have a maximum length of 128 characters, excluding the
 new line character. Any characters after this limit are ignored.
+
+Option 8:
+Change default instruction set to 8080.
+
+Option u:
+Accept undocumented Z80 instructions.
 
 Option f:
 Format of the output file:
@@ -55,12 +61,6 @@ Useful to make CP/M BIOS's, where unallocated data doesn't need to be a
 part of the system image, fit on the system tracks.
 This option is a no-op for Intel HEX output.
 
-Option 8:
-Change default instruction set to 8080.
-
-Option u:
-Accept undocumented Z80 instructions.
-
 Option v:
 Verbose operation of the assembler.
 
@@ -71,6 +71,9 @@ The default is to list only macro expansions that produce object code.
 
 Option U:
 Convert everything to upper case for compatibility with old source code.
+
+Option T:
+Don't print time stamp in list file headers.
 
 Option o:
 To override the default name of the output file. The extension ".bin",

--- a/imsaisim/dzmation.lis
+++ b/imsaisim/dzmation.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; HAND DISASSEMBLY OF THE DAZZLEMATION MEMORY IMAGE PROVIDED IN THE

--- a/imsaisim/kscope.lis
+++ b/imsaisim/kscope.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/imsaisim/life.lis
+++ b/imsaisim/life.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; LIFE .... VERSION 2.0

--- a/imsaisim/microchess.lis
+++ b/imsaisim/microchess.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '8080 MICROCHESS'

--- a/imsaisim/roms/basic4k.lis
+++ b/imsaisim/roms/basic4k.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 *HEADING IMSAI 8080 4K BASIC

--- a/imsaisim/roms/basic8k.lis
+++ b/imsaisim/roms/basic8k.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Sat Apr 27 09:29:22 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;EDITS:

--- a/imsaisim/roms/memon80.lis
+++ b/imsaisim/roms/memon80.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;==============================================================

--- a/imsaisim/roms/viofm1.lis
+++ b/imsaisim/roms/viofm1.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/imsaisim/scs1.lis
+++ b/imsaisim/scs1.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Fri Apr 26 14:45:38 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE           'IMSAI SCS-1 REV. 2 06 OCT. 1976'

--- a/imsaisim/srcucsd-iv/Makefile
+++ b/imsaisim/srcucsd-iv/Makefile
@@ -5,7 +5,7 @@ LDFLAGS= -s
 
 Z80ASMDIR = ../../z80asm
 Z80ASM = $(Z80ASMDIR)/z80asm
-Z80ASMOPTS = -l -sn -p0
+Z80ASMOPTS = -l -T -sn -p0
 
 all: putsys boot.bin bios.bin
 

--- a/picosim/src-examples/Makefile
+++ b/picosim/src-examples/Makefile
@@ -1,6 +1,6 @@
 Z80ASMDIR = ../../z80asm
 Z80ASM = $(Z80ASMDIR)/z80asm
-Z80ASMOPTS = -l -sn -p0
+Z80ASMOPTS = -l -T -sn -p0
 
 all: serial.c tb.c blink.c
 

--- a/picosim/src-examples/blink.lis
+++ b/picosim/src-examples/blink.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Tue Apr 30 11:12:33 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/picosim/src-examples/serial.lis
+++ b/picosim/src-examples/serial.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Tue Apr 30 11:12:33 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/picosim/src-examples/tb.lis
+++ b/picosim/src-examples/tb.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0	Wed May  8 09:21:34 2024
+Z80/8080-Macro-Assembler  Release 2.0
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -34,6 +34,7 @@ WORD rpc,			/* real program counter */
      carylen = CARYLEN;		/* C array bytes per line */
 
 int  list_flag,			/* flag for option -l */
+     nodate_flag,		/* flag for option -T */
      sym_flag,			/* flag for option -s */
      undoc_flag,		/* flag for option -u */
      ver_flag,			/* flag for option -v */

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -33,6 +33,7 @@ extern WORD	rpc,
 		carylen;
 
 extern int	list_flag,
+		nodate_flag,
 		sym_flag,
 		undoc_flag,
 		ver_flag,

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -57,8 +57,9 @@ extern void put_label(void);
 static const char *errmsg[] = {		/* error messages for fatal() */
 	"out of memory: %s",		/* 0 */
 	("z80asm version %s\n"
-	 "usage: z80asm -f{b|m|h|c} -s[n|a] -p<num> -e<num> -h<num> -c<num>\n"
-	 "              -x -8 -u -v -m -U -o<file> -l[<file>] "
+	 "usage: z80asm -8 -u -f{b|m|h|c} -s[n|a] "
+	 "-p<num> -e<num> -h<num> -c<num>\n"
+	 "              -x -v -m -U -T -o<file> -l[<file>] "
 	 "-d<symbol> ... <file> ..."),	/* 1 */
 	"Assembly halted",		/* 2 */
 	"can't open file %s",		/* 3 */
@@ -131,6 +132,9 @@ void options(int argc, char *argv[])
 					s += (strlen(s) - 1);
 				}
 				list_flag = TRUE;
+				break;
+			case 'T':
+				nodate_flag = TRUE;
 				break;
 			case 's':
 				if (*(s + 1) == '\0')

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -104,14 +104,21 @@ void asmerr(int i)
 void lst_header(void)
 {
 	static int header_done;
-	time_t tloc = time(&tloc);
+	time_t tloc;
 
 	if (header_done && ppl != 0)
 		fputc('\f', lstfp);
-	if (!header_done || ppl != 0)
-		fprintf(lstfp, "Z80/8080-Macro-Assembler  Release %s\t%.24s",
-			RELEASE, ctime(&tloc));
+	if (!header_done || ppl != 0) {
+		fprintf(lstfp, "Z80/8080-Macro-Assembler  Release %s",
+			RELEASE);
+		if (!nodate_flag) {
+			tloc = time(&tloc);
+			fprintf(lstfp, "\t%.24s", ctime(&tloc));
+		}
+	}
 	if (ppl != 0) {
+		if (nodate_flag)
+			fputs("\t\t\t\t", lstfp);
 		fprintf(lstfp, "\tPage %d\n", ++page);
 		fprintf(lstfp, "Source file: %s\n", srcfn);
 		fprintf(lstfp, "Title:       %s", title);

--- a/z80sim/Makefile
+++ b/z80sim/Makefile
@@ -1,6 +1,6 @@
 Z80ASMDIR = ../z80asm
 Z80ASM = $(Z80ASMDIR)/z80asm
-Z80ASMOPTS = -l -sn -p0
+Z80ASMOPTS = -l -T -sn -p0
 
 all: float.hex z80main.hex z80opsall.hex 8080opsall.hex
 


### PR DESCRIPTION
And use it as standard option.

Reassemble files to get rid of time stamp in listings.
