### PR TITLE
make front panel an runtime opt-out feature

### DIFF
--- a/altairsim/srcsim/config.c
+++ b/altairsim/srcsim/config.c
@@ -37,7 +37,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "log.h"
-#include "frontpanel.h"
 #include "memsim.h"
 
 #define BUFSIZE 256	/* max line length of command buffer */

--- a/altairsim/srcsim/memsim.c
+++ b/altairsim/srcsim/memsim.c
@@ -23,7 +23,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
-#include "frontpanel.h"
 #include "memsim.h"
 /* #define LOG_LOCAL_LEVEL LOG_DEBUG */
 #include "log.h"

--- a/altairsim/srcsim/memsim.h
+++ b/altairsim/srcsim/memsim.h
@@ -65,11 +65,13 @@ static inline void memwrt(WORD addr, BYTE data)
 #endif
 
 #ifdef FRONTPANEL
-	fp_clock++;
-	fp_led_address = addr;
-	fp_led_data = 0xff;
-	fp_sampleData();
-	wait_step();
+	if (fp_enabled) {
+		fp_clock++;
+		fp_led_address = addr;
+		fp_led_data = 0xff;
+		fp_sampleData();
+		wait_step();
+	}
 #endif
 
 	if (p_tab[addr >> 8] == MEM_RW) {
@@ -104,11 +106,13 @@ static inline BYTE memrdr(WORD addr)
 #endif
 
 #ifdef FRONTPANEL
-	fp_clock++;
-	fp_led_address = addr;
-	fp_led_data = data;
-	fp_sampleData();
-	wait_step();
+	if (fp_enabled) {
+		fp_clock++;
+		fp_led_address = addr;
+		fp_led_data = data;
+		fp_sampleData();
+		wait_step();
+	}
 #endif
 
 	return (data);

--- a/cromemcosim/srcsim/config.c
+++ b/cromemcosim/srcsim/config.c
@@ -24,7 +24,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "log.h"
-#include "frontpanel.h"
 #include "memsim.h"
 
 #define BUFSIZE 256	/* max line length of command buffer */

--- a/cromemcosim/srcsim/iosim.c
+++ b/cromemcosim/srcsim/iosim.c
@@ -54,7 +54,9 @@
 #include "cromemco-fdc.h"
 #include "cromemco-dazzler.h"
 #include "cromemco-d+7a.h"
+#ifdef FRONTPANEL
 #include "frontpanel.h"
+#endif
 #include "memsim.h"
 #include "config.h"
 #ifdef HAS_NETSERVER
@@ -747,15 +749,17 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 #endif
 
 #ifdef FRONTPANEL
-	fp_clock += 3;
-	fp_led_address = (addrh << 8) + addrl;
-	fp_led_data = io_data;
-	fp_sampleData();
-	val = wait_step();
+	if (fp_enabled) {
+		fp_clock += 3;
+		fp_led_address = (addrh << 8) + addrl;
+		fp_led_data = io_data;
+		fp_sampleData();
+		val = wait_step();
 
-	/* when single stepped INP get last set value of port */
-	if (val)
-		io_data = (*port_in[io_port])();
+		/* when single stepped INP get last set value of port */
+		if (val)
+			io_data = (*port_in[io_port])();
+	}
 #endif
 
 	return (io_data);
@@ -780,11 +784,13 @@ void io_out(BYTE addrl, BYTE addrh, BYTE data)
 #endif
 
 #ifdef FRONTPANEL
-	fp_clock += 6;
-	fp_led_address = (addrh << 8) + addrl;
-	fp_led_data = io_data;
-	fp_sampleData();
-	wait_step();
+	if (fp_enabled) {
+		fp_clock += 6;
+		fp_led_address = (addrh << 8) + addrl;
+		fp_led_data = io_data;
+		fp_sampleData();
+		wait_step();
+	}
 #endif
 }
 
@@ -825,9 +831,13 @@ static void io_trap_out(BYTE data)
 static BYTE fp_in(void)
 {
 #ifdef FRONTPANEL
-	return (address_switch >> 8);
-#else
-	return (fp_port);
+	if (fp_enabled)
+		return (address_switch >> 8);
+	else {
+#endif
+		return (fp_port);
+#ifdef FRONTPANEL
+	}
 #endif
 }
 
@@ -837,9 +847,13 @@ static BYTE fp_in(void)
 static void fp_out(BYTE data)
 {
 #ifdef FRONTPANEL
-	fp_led_output = data;
-#else
-	UNUSED(data);
+	if (fp_enabled)
+		fp_led_output = data;
+	else {
+#endif
+		UNUSED(data);
+#ifdef FRONTPANEL
+	}
 #endif
 }
 

--- a/cromemcosim/srcsim/memsim.c
+++ b/cromemcosim/srcsim/memsim.c
@@ -21,7 +21,6 @@
 #include <string.h>
 #include "sim.h"
 #include "simglb.h"
-#include "frontpanel.h"
 #include "memsim.h"
 #include "log.h"
 

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -38,7 +38,9 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
+#ifdef FRONTPANEL
 #include "frontpanel.h"
+#endif
 #include "memsim.h"
 #include "unix_terminal.h"
 #ifdef FRONTPANEL
@@ -83,46 +85,50 @@ void mon(void)
 #endif
 
 #ifdef FRONTPANEL
-	/* initialize front panel */
-	XInitThreads();
+	if (fp_enabled) {
+		/* initialize front panel */
+		XInitThreads();
 
-	if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
-		LOGE(TAG, "frontpanel error");
-		exit(EXIT_FAILURE);
+		if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
+			LOGE(TAG, "frontpanel error");
+			exit(EXIT_FAILURE);
+		}
+
+		fp_addQuitCallback(quit_callback);
+		fp_framerate(fp_fps);
+		fp_bindSimclock(&fp_clock);
+		fp_bindRunFlag(&cpu_state);
+
+		/* bind frontpanel LED's to variables */
+		fp_bindLight16("LED_ADDR_{00-15}", &fp_led_address, 1);
+		fp_bindLight8("LED_DATA_{00-07}", &fp_led_data, 1);
+		fp_bindLight8("LED_STATUS_00", &cpu_bus, 1);
+		fp_bindLight8("LED_STATUS_01", &cpu_bus, 2);
+		fp_bindLight8("LED_STATUS_02", &fp_led_speed, 1);
+		fp_bindLight8("LED_STATUS_03", &cpu_bus, 4);
+		fp_bindLight8("LED_STATUS_04", &cpu_bus, 5);
+		fp_bindLight8("LED_STATUS_05", &cpu_bus, 6);
+		fp_bindLight8("LED_STATUS_06", &cpu_bus, 7);
+		fp_bindLight8("LED_STATUS_07", &cpu_bus, 8);
+		fp_bindLight8invert("LED_DATOUT_{00-07}",
+				    &fp_led_output, 1, 255);
+		fp_bindLight8("LED_RUN", &cpu_state, 1);
+		fp_bindLight8("LED_WAIT", &fp_led_wait, 1);
+		fp_bindLight8("LED_INTEN", &IFF, 1);
+		fp_bindLight8("LED_HOLD", &bus_request, 1);
+
+		/* bind frontpanel switches to variables */
+		fp_bindSwitch16("SW_{00-15}", &address_switch,
+				&address_switch, 1);
+
+		/* add callbacks for front panel switches */
+		fp_addSwitchCallback("SW_RUN", run_clicked, 0);
+		fp_addSwitchCallback("SW_STEP", step_clicked, 0);
+		fp_addSwitchCallback("SW_RESET", reset_clicked, 0);
+		fp_addSwitchCallback("SW_EXAMINE", examine_clicked, 0);
+		fp_addSwitchCallback("SW_DEPOSIT", deposit_clicked, 0);
+		fp_addSwitchCallback("SW_PWR", power_clicked, 0);
 	}
-
-	fp_addQuitCallback(quit_callback);
-	fp_framerate(fp_fps);
-	fp_bindSimclock(&fp_clock);
-	fp_bindRunFlag(&cpu_state);
-
-	/* bind frontpanel LED's to variables */
-	fp_bindLight16("LED_ADDR_{00-15}", &fp_led_address, 1);
-	fp_bindLight8("LED_DATA_{00-07}", &fp_led_data, 1);
-	fp_bindLight8("LED_STATUS_00", &cpu_bus, 1);
-	fp_bindLight8("LED_STATUS_01", &cpu_bus, 2);
-	fp_bindLight8("LED_STATUS_02", &fp_led_speed, 1);
-	fp_bindLight8("LED_STATUS_03", &cpu_bus, 4);
-	fp_bindLight8("LED_STATUS_04", &cpu_bus, 5);
-	fp_bindLight8("LED_STATUS_05", &cpu_bus, 6);
-	fp_bindLight8("LED_STATUS_06", &cpu_bus, 7);
-	fp_bindLight8("LED_STATUS_07", &cpu_bus, 8);
-	fp_bindLight8invert("LED_DATOUT_{00-07}", &fp_led_output, 1, 255);
-	fp_bindLight8("LED_RUN", &cpu_state, 1);
-	fp_bindLight8("LED_WAIT", &fp_led_wait, 1);
-	fp_bindLight8("LED_INTEN", &IFF, 1);
-	fp_bindLight8("LED_HOLD", &bus_request, 1);
-
-	/* bind frontpanel switches to variables */
-	fp_bindSwitch16("SW_{00-15}", &address_switch, &address_switch, 1);
-
-	/* add callbacks for front panel switches */
-	fp_addSwitchCallback("SW_RUN", run_clicked, 0);
-	fp_addSwitchCallback("SW_STEP", step_clicked, 0);
-	fp_addSwitchCallback("SW_RESET", reset_clicked, 0);
-	fp_addSwitchCallback("SW_EXAMINE", examine_clicked, 0);
-	fp_addSwitchCallback("SW_DEPOSIT", deposit_clicked, 0);
-	fp_addSwitchCallback("SW_PWR", power_clicked, 0);
 #endif
 
 	/* give threads a bit time and then empty buffer */
@@ -136,71 +142,76 @@ void mon(void)
 	atexit(reset_unix_terminal);
 
 #ifdef FRONTPANEL
-	/* operate machine from front panel */
-	while (cpu_error == NONE) {
-		/* update frontpanel LED's */
-		if (reset) {
-			cpu_bus = 0xff;
-			fp_led_address = 0xffff;
-			fp_led_data = 0xff;
-		} else {
-			if (power) {
-				fp_led_address = PC;
-				if (!(cpu_bus & CPU_INTA))
-					fp_led_data = getmem(PC);
-				else
-					fp_led_data = (int_data != -1) ?
-						      (BYTE) int_data : 0xff;
+	if (fp_enabled) {
+		/* operate machine from front panel */
+		while (cpu_error == NONE) {
+			/* update frontpanel LED's */
+			if (reset) {
+				cpu_bus = 0xff;
+				fp_led_address = 0xffff;
+				fp_led_data = 0xff;
+			} else {
+				if (power) {
+					fp_led_address = PC;
+					if (!(cpu_bus & CPU_INTA))
+						fp_led_data = getmem(PC);
+					else
+						fp_led_data = (int_data != -1)
+							      ? (BYTE) int_data
+							      : 0xff;
+				}
 			}
-		}
 
-		/* set FDC autoboot flag from fp switch */
-		if (address_switch & 256)
-			fdc_flags |= 64;
+			/* set FDC autoboot flag from fp switch */
+			if (address_switch & 256)
+				fdc_flags |= 64;
 
-		fp_clock++;
-		fp_sampleData();
+			fp_clock++;
+			fp_sampleData();
 
-		/* run CPU if not idling */
-		switch (cpu_switch) {
-		case 1:
-			if (!reset) {
-				cpu_start = get_clock_us();
-				run_cpu();
-				cpu_stop = get_clock_us();
+			/* run CPU if not idling */
+			switch (cpu_switch) {
+			case 1:
+				if (!reset) {
+					cpu_start = get_clock_us();
+					run_cpu();
+					cpu_stop = get_clock_us();
+				}
+				break;
+			case 2:
+				step_cpu();
+				if (cpu_switch == 2)
+					cpu_switch = 0;
+				break;
+			default:
+				break;
 			}
-			break;
-		case 2:
-			step_cpu();
-			if (cpu_switch == 2)
-				cpu_switch = 0;
-			break;
-		default:
-			break;
+
+			fp_clock++;
+			fp_sampleData();
+
+			/* wait a bit, system is idling */
+			SLEEP_MS(10);
 		}
-
-		fp_clock++;
-		fp_sampleData();
-
-		/* wait a bit, system is idling */
-		SLEEP_MS(10);
-	}
-#else
-	/* set FDC autoboot flag from fp switch */
-	if (fp_port & 1)
-		fdc_flags |= 64;
-#ifdef WANT_ICE
-	extern void ice_cmd_loop(int), ice_go(void), ice_break(void);
-
-	ice_before_go = ice_go;
-	ice_after_go = ice_break;
-	ice_cmd_loop(0);
-#else
-	/* run the CPU */
-	cpu_start = get_clock_us();
-	run_cpu();
-	cpu_stop = get_clock_us();
+	} else {
 #endif
+		/* set FDC autoboot flag from fp switch */
+		if (fp_port & 1)
+			fdc_flags |= 64;
+#ifdef WANT_ICE
+		extern void ice_cmd_loop(int), ice_go(void), ice_break(void);
+
+		ice_before_go = ice_go;
+		ice_after_go = ice_break;
+		ice_cmd_loop(0);
+#else
+		/* run the CPU */
+		cpu_start = get_clock_us();
+		run_cpu();
+		cpu_stop = get_clock_us();
+#endif
+#ifdef FRONTPANEL
+	}
 #endif
 
 #ifndef WANT_ICE
@@ -210,22 +221,24 @@ void mon(void)
 	putchar('\n');
 
 #ifdef FRONTPANEL
-	/* all LED's off and update front panel */
-	cpu_bus = 0;
-	bus_request = 0;
-	IFF = 0;
-	fp_led_wait = 0;
-	fp_led_speed = 0;
-	fp_led_output = 0xff;
-	fp_led_address = 0;
-	fp_led_data = 0;
-	fp_sampleData();
+	if (fp_enabled) {
+		/* all LED's off and update front panel */
+		cpu_bus = 0;
+		bus_request = 0;
+		IFF = 0;
+		fp_led_wait = 0;
+		fp_led_speed = 0;
+		fp_led_output = 0xff;
+		fp_led_address = 0;
+		fp_led_data = 0;
+		fp_sampleData();
 
-	/* wait a bit before termination */
-	SLEEP_MS(999);
+		/* wait a bit before termination */
+		SLEEP_MS(999);
 
-	/* shutdown frontpanel */
-	fp_quit();
+		/* shutdown frontpanel */
+		fp_quit();
+	}
 #endif
 
 	/* check for CPU emulation errors and report */

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -40,7 +40,9 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
+#ifdef FRONTPANEL
 #include "frontpanel.h"
+#endif
 #include "memsim.h"
 #ifdef UNIX_TERMINAL
 #include "unix_terminal.h"
@@ -85,40 +87,44 @@ void mon(void)
 #endif
 
 #ifdef FRONTPANEL
-	/* initialize front panel */
-	XInitThreads();
+	if (fp_enabled) {
+		/* initialize front panel */
+		XInitThreads();
 
-	putchar('\n');
-	if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
-		LOGE(TAG, "frontpanel error");
-		exit(EXIT_FAILURE);
+		putchar('\n');
+		if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
+			LOGE(TAG, "frontpanel error");
+			exit(EXIT_FAILURE);
+		}
+
+		fp_addQuitCallback(quit_callback);
+		fp_framerate(fp_fps);
+		fp_bindSimclock(&fp_clock);
+		fp_bindRunFlag(&cpu_state);
+
+		/* bind frontpanel LED's to variables */
+		fp_bindLight16("LED_ADDR_{00-15}", &fp_led_address, 1);
+		fp_bindLight8("LED_DATA_{00-07}", &fp_led_data, 1);
+		fp_bindLight8("LED_STATUS_{00-07}", &cpu_bus, 1);
+		fp_bindLight8invert("LED_DATOUT_{00-07}",
+				    &fp_led_output, 1, 255);
+		fp_bindLight8("LED_RUN", &cpu_state, 1);
+		fp_bindLight8("LED_WAIT", &fp_led_wait, 1);
+		fp_bindLight8("LED_INTEN", &IFF, 1);
+		fp_bindLight8("LED_HOLD", &bus_request, 1);
+
+		/* bind frontpanel switches to variables */
+		fp_bindSwitch16("SW_{00-15}", &address_switch,
+				&address_switch, 1);
+
+		/* add callbacks for front panel switches */
+		fp_addSwitchCallback("SW_RUN", run_clicked, 0);
+		fp_addSwitchCallback("SW_STEP", step_clicked, 0);
+		fp_addSwitchCallback("SW_RESET", reset_clicked, 0);
+		fp_addSwitchCallback("SW_EXAMINE", examine_clicked, 0);
+		fp_addSwitchCallback("SW_DEPOSIT", deposit_clicked, 0);
+		fp_addSwitchCallback("SW_PWR", power_clicked, 0);
 	}
-
-	fp_addQuitCallback(quit_callback);
-	fp_framerate(fp_fps);
-	fp_bindSimclock(&fp_clock);
-	fp_bindRunFlag(&cpu_state);
-
-	/* bind frontpanel LED's to variables */
-	fp_bindLight16("LED_ADDR_{00-15}", &fp_led_address, 1);
-	fp_bindLight8("LED_DATA_{00-07}", &fp_led_data, 1);
-	fp_bindLight8("LED_STATUS_{00-07}", &cpu_bus, 1);
-	fp_bindLight8invert("LED_DATOUT_{00-07}", &fp_led_output, 1, 255);
-	fp_bindLight8("LED_RUN", &cpu_state, 1);
-	fp_bindLight8("LED_WAIT", &fp_led_wait, 1);
-	fp_bindLight8("LED_INTEN", &IFF, 1);
-	fp_bindLight8("LED_HOLD", &bus_request, 1);
-
-	/* bind frontpanel switches to variables */
-	fp_bindSwitch16("SW_{00-15}", &address_switch, &address_switch, 1);
-
-	/* add callbacks for front panel switches */
-	fp_addSwitchCallback("SW_RUN", run_clicked, 0);
-	fp_addSwitchCallback("SW_STEP", step_clicked, 0);
-	fp_addSwitchCallback("SW_RESET", reset_clicked, 0);
-	fp_addSwitchCallback("SW_EXAMINE", examine_clicked, 0);
-	fp_addSwitchCallback("SW_DEPOSIT", deposit_clicked, 0);
-	fp_addSwitchCallback("SW_PWR", power_clicked, 0);
 #endif
 
 #ifdef UNIX_TERMINAL
@@ -139,65 +145,70 @@ void mon(void)
 #endif
 
 #ifdef FRONTPANEL
-	/* operate machine from front panel */
-	while (cpu_error == NONE) {
-		/* update frontpanel LED's */
-		if (reset) {
-			cpu_bus = 0xff;
-			fp_led_address = 0xffff;
-			fp_led_data = 0xff;
-		} else {
-			if (power) {
-				fp_led_address = PC;
-				if (!(cpu_bus & CPU_INTA))
-					fp_led_data = getmem(PC);
-				else
-					fp_led_data = (int_data != -1) ?
-						      (BYTE) int_data : 0xff;
+	if (fp_enabled) {
+		/* operate machine from front panel */
+		while (cpu_error == NONE) {
+			/* update frontpanel LED's */
+			if (reset) {
+				cpu_bus = 0xff;
+				fp_led_address = 0xffff;
+				fp_led_data = 0xff;
+			} else {
+				if (power) {
+					fp_led_address = PC;
+					if (!(cpu_bus & CPU_INTA))
+						fp_led_data = getmem(PC);
+					else
+						fp_led_data = (int_data != -1)
+							      ? (BYTE) int_data
+							      : 0xff;
+				}
 			}
-		}
 
-		fp_clock++;
-		fp_sampleData();
+			fp_clock++;
+			fp_sampleData();
 
-		switch (cpu_switch) {
-		case 1:
-			if (!reset) {
-				cpu_start = get_clock_us();
-				run_cpu();
-				cpu_stop = get_clock_us();
+			switch (cpu_switch) {
+			case 1:
+				if (!reset) {
+					cpu_start = get_clock_us();
+					run_cpu();
+					cpu_stop = get_clock_us();
+				}
+				break;
+			case 2:
+				step_cpu();
+				if (cpu_switch == 2)
+					cpu_switch = 0;
+				break;
+			default:
+				break;
 			}
-			break;
-		case 2:
-			step_cpu();
-			if (cpu_switch == 2)
-				cpu_switch = 0;
-			break;
-		default:
-			break;
+
+			fp_clock++;
+			fp_sampleData();
+
+			/* wait a bit, system is idling */
+			SLEEP_MS(10);
 		}
-
-		fp_clock++;
-		fp_sampleData();
-
-		/* wait a bit, system is idling */
-		SLEEP_MS(10);
-	}
-#else
-#ifdef WANT_ICE
-	extern void ice_cmd_loop(int);
-
-	ice_before_go = set_unix_terminal;
-	ice_after_go = reset_unix_terminal;
-	atexit(reset_unix_terminal);
-
-	ice_cmd_loop(0);
-#else
-	/* run the CPU */
-	cpu_start = get_clock_us();
-	run_cpu();
-	cpu_stop = get_clock_us();
+	} else {
 #endif
+#ifdef WANT_ICE
+		extern void ice_cmd_loop(int);
+
+		ice_before_go = set_unix_terminal;
+		ice_after_go = reset_unix_terminal;
+		atexit(reset_unix_terminal);
+
+		ice_cmd_loop(0);
+#else
+		/* run the CPU */
+		cpu_start = get_clock_us();
+		run_cpu();
+		cpu_stop = get_clock_us();
+#endif
+#ifdef FRONTPANEL
+	}
 #endif
 
 #ifdef UNIX_TERMINAL
@@ -209,21 +220,23 @@ void mon(void)
 #endif
 
 #ifdef FRONTPANEL
-	/* all LED's off and update front panel */
-	cpu_bus = 0;
-	bus_request = 0;
-	IFF = 0;
-	fp_led_wait = 0;
-	fp_led_output = 0xff;
-	fp_led_address = 0;
-	fp_led_data = 0;
-	fp_sampleData();
+	if (fp_enabled) {
+		/* all LED's off and update front panel */
+		cpu_bus = 0;
+		bus_request = 0;
+		IFF = 0;
+		fp_led_wait = 0;
+		fp_led_output = 0xff;
+		fp_led_address = 0;
+		fp_led_data = 0;
+		fp_sampleData();
 
-	/* wait a bit before termination */
-	SLEEP_MS(999);
+		/* wait a bit before termination */
+		SLEEP_MS(999);
 
-	/* stop frontpanel */
-	fp_quit();
+		/* stop frontpanel */
+		fp_quit();
+	}
 #endif
 
 	/* check for CPU emulation errors and report */

--- a/iodevices/cromemco-88ccc.c
+++ b/iodevices/cromemco-88ccc.c
@@ -21,7 +21,6 @@
 #ifdef HAS_CYCLOPS
 
 #include "config.h"
-#include "frontpanel.h"
 #include "memsim.h"
 #ifdef HAS_NETSERVER
 #include "netsrv.h"

--- a/iodevices/cromemco-dazzler.c
+++ b/iodevices/cromemco-dazzler.c
@@ -35,7 +35,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
-#include "frontpanel.h"
 #include "memsim.h"
 #ifdef HAS_NETSERVER
 #include "netsrv.h"

--- a/iodevices/cromemco-fdc.c
+++ b/iodevices/cromemco-fdc.c
@@ -779,47 +779,51 @@ BYTE cromemco_fdc_aux_in(void)
 	}
 
 #ifdef FRONTPANEL
-	/* get front panel switch bits */
-	if ((address_switch >> 8) & 16)
-		fdc_aux &= ~8;
-	else
-		fdc_aux |= 8;
+	if (fp_enabled) {
+		/* get front panel switch bits */
+		if ((address_switch >> 8) & 16)
+			fdc_aux &= ~8;
+		else
+			fdc_aux |= 8;
 
-	if ((address_switch >> 8) & 32)
-		fdc_aux &= ~4;
-	else
-		fdc_aux |= 4;
+		if ((address_switch >> 8) & 32)
+			fdc_aux &= ~4;
+		else
+			fdc_aux |= 4;
 
-	if ((address_switch >> 8) & 64)
-		fdc_aux &= ~2;
-	else
-		fdc_aux |= 2;
+		if ((address_switch >> 8) & 64)
+			fdc_aux &= ~2;
+		else
+			fdc_aux |= 2;
 
-	if ((address_switch >> 8) & 128)
-		fdc_aux &= ~1;
-	else
-		fdc_aux |= 1;
-#else
-	/* get front panel switch bits */
-	if (fp_port & 16)
-		fdc_aux &= ~8;
-	else
-		fdc_aux |= 8;
+		if ((address_switch >> 8) & 128)
+			fdc_aux &= ~1;
+		else
+			fdc_aux |= 1;
+	} else {
+#endif
+		/* get front panel switch bits */
+		if (fp_port & 16)
+			fdc_aux &= ~8;
+		else
+			fdc_aux |= 8;
 
-	if (fp_port & 32)
-		fdc_aux &= ~4;
-	else
-		fdc_aux |= 4;
+		if (fp_port & 32)
+			fdc_aux &= ~4;
+		else
+			fdc_aux |= 4;
 
-	if (fp_port & 64)
-		fdc_aux &= ~2;
-	else
-		fdc_aux |= 2;
+		if (fp_port & 64)
+			fdc_aux &= ~2;
+		else
+			fdc_aux |= 2;
 
-	if (fp_port & 128)
-		fdc_aux &= ~1;
-	else
-		fdc_aux |= 1;
+		if (fp_port & 128)
+			fdc_aux &= ~1;
+		else
+			fdc_aux |= 1;
+#ifdef FRONTPANEL
+	}
 #endif
 
 	return (fdc_aux);

--- a/iodevices/imsai-fif.c
+++ b/iodevices/imsai-fif.c
@@ -36,7 +36,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
-#include "frontpanel.h"
 #include "memsim.h"
 /* #define LOG_LOCAL_LEVEL LOG_DEBUG */
 #include "log.h"

--- a/iodevices/imsai-vio.c
+++ b/iodevices/imsai-vio.c
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include "sim.h"
 #include "simglb.h"
-#include "frontpanel.h"
 #include "memsim.h"
 #ifdef HAS_NETSERVER
 #include "netsrv.h"

--- a/iodevices/proctec-vdm.c
+++ b/iodevices/proctec-vdm.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include "sim.h"
 #include "simglb.h"
-#include "frontpanel.h"
 #include "memsim.h"
 #include "log.h"
 #include "proctec-vdm-charset.h"

--- a/iodevices/simbdos.c
+++ b/iodevices/simbdos.c
@@ -36,9 +36,6 @@
 #include <ctype.h>
 #include "sim.h"
 #include "simglb.h"
-#ifdef FRONTPANEL
-#include "frontpanel.h"
-#endif
 #include "memsim.h"
 
 /* BDOS Equates */

--- a/webfrontend/netsrv.c
+++ b/webfrontend/netsrv.c
@@ -25,7 +25,6 @@
 
 #ifdef HAS_NETSERVER
 
-#include "frontpanel.h"
 #include "memsim.h"
 #include "log.h"
 #include "netsrv.h"
@@ -307,7 +306,9 @@ int SystemHandler(HttpdConnection_t *conn, void *unused) {
                     httpdPrintf(conn, "\"%s\": \"%s\", ", "bootrom", xfn);
                 }
 #ifdef FRONTPANEL
-                    httpdPrintf(conn, "\"%s\": %d, ", "cpa", 1);
+                    if (fp_enabled) {
+                        httpdPrintf(conn, "\"%s\": %d, ", "cpa", 1);
+                    }
 #endif
                 httpdPrintf(conn, "\"%s\": %d ", "clock", f_flag);
             httpdPrintf(conn, "} ");

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -98,6 +98,7 @@ WORD t_end = 65535;		/* end address for measurement */
  *	Variables for frontpanel emulation
  */
 #ifdef FRONTPANEL
+int fp_enabled = 1;		/* frontpanel enabled flag */
 unsigned long long fp_clock;	/* simulation clock */
 float fp_fps = 30.0;		/* frame rate, default 30 usually works */
 WORD fp_led_address;		/* lights for address bus */

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -79,6 +79,7 @@ extern WORD	t_start, t_end;
 #endif
 
 #ifdef FRONTPANEL
+extern int	fp_enabled;
 extern unsigned long long fp_clock;
 extern float	fp_fps;
 extern WORD 	fp_led_address;

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -28,9 +28,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
-#ifdef FRONTPANEL
-#include "frontpanel.h"
-#endif
 #include "memsim.h"
 
 static void save_core(void);
@@ -232,6 +229,11 @@ int main(int argc, char *argv[])
 				cpu = Z80;
 				break;
 #endif
+#ifdef FRONTPANEL
+			case 'F':
+				fp_enabled = 0;
+				break;
+#endif
 
 			case '?':
 			case 'h':
@@ -243,7 +245,7 @@ int main(int argc, char *argv[])
 usage:
 
 				printf("usage:\t%s%s%s -s -l -i -u %s-m val "
-				       "-f freq -x filename", pn,
+				       "-f freq\n\t\t-x filename", pn,
 #ifndef EXCLUDE_Z80
 				       " -z",
 #else
@@ -267,7 +269,10 @@ usage:
 #ifdef HAS_BANKED_ROM
 				fputs(" -R", stdout);
 #endif
-				putchar('\n');
+#ifdef FRONTPANEL
+				fputs(" -F", stdout);
+#endif
+				fputs("\n\n", stdout);
 #ifndef EXCLUDE_Z80
 				puts("\t-z = emulate Zilog Z80");
 #endif
@@ -311,6 +316,9 @@ usage:
 #endif
 #ifdef HAS_BANKED_ROM
 				puts("\t-R = enable banked ROM");
+#endif
+#ifdef FRONTPANEL
+				puts("\t-F = disable front panel");
 #endif
 				exit(EXIT_FAILURE);
 			}

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -373,9 +373,11 @@ int op_cb_handle(void)
 	m1_step = 1;
 #endif
 #ifdef FRONTPANEL
-	/* update frontpanel */
-	fp_clock++;
-	fp_sampleLightGroup(0, 0);
+	if (fp_enabled) {
+		/* update frontpanel */
+		fp_clock++;
+		fp_sampleLightGroup(0, 0);
+	}
 #endif
 
 	R++;				/* increment refresh register */

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -340,9 +340,11 @@ int op_dd_handle(void)
 	m1_step = 1;
 #endif
 #ifdef FRONTPANEL
-	/* update frontpanel */
-	fp_clock++;
-	fp_sampleLightGroup(0, 0);
+	if (fp_enabled) {
+		/* update frontpanel */
+		fp_clock++;
+		fp_sampleLightGroup(0, 0);
+	}
 #endif
 
 	R++;				/* increment refresh register */

--- a/z80core/simz80-ddcb.c
+++ b/z80core/simz80-ddcb.c
@@ -13,9 +13,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
-#ifdef FRONTPANEL
-#include "frontpanel.h"
-#endif
 #include "memsim.h"
 
 #ifndef EXCLUDE_Z80

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -326,9 +326,11 @@ int op_ed_handle(void)
 	m1_step = 1;
 #endif
 #ifdef FRONTPANEL
-	/* update frontpanel */
-	fp_clock++;
-	fp_sampleLightGroup(0, 0);
+	if (fp_enabled) {
+		/* update frontpanel */
+		fp_clock++;
+		fp_sampleLightGroup(0, 0);
+	}
 #endif
 
 	R++;				/* increment refresh register */

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -340,9 +340,11 @@ int op_fd_handle(void)
 	m1_step = 1;
 #endif
 #ifdef FRONTPANEL
-	/* update frontpanel */
-	fp_clock++;
-	fp_sampleLightGroup(0, 0);
+	if (fp_enabled) {
+		/* update frontpanel */
+		fp_clock++;
+		fp_sampleLightGroup(0, 0);
+	}
 #endif
 
 	R++;				/* increment refresh register */

--- a/z80core/simz80-fdcb.c
+++ b/z80core/simz80-fdcb.c
@@ -13,9 +13,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
-#ifdef FRONTPANEL
-#include "frontpanel.h"
-#endif
 #include "memsim.h"
 
 #ifndef EXCLUDE_Z80


### PR DESCRIPTION
When the front panel code is compiled in, it can now be disabled at runtime with the new option -F.

Clean-up frontpanel.h include statements (remove unnecessary ones, guard all others).

Synchronize coding style of memwrt & memrdr in memsim.h of altairsim, cromemcosim, and imsaisim.