### PR TITLE
make web-based frontend a runtime opt-in feature

### DIFF
--- a/cromemcosim/conf_2d/system.conf
+++ b/cromemcosim/conf_2d/system.conf
@@ -5,6 +5,9 @@ fp_size		800
 # front panel port value for machine without fp in hex (00 - FF)
 fp_port		10
 
+# web-based frontend port number (1024 - 65535)
+ns_port		8080
+
 # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 # memory configurations in pages a 256 bytes
 #	start,size (numbers in decimal, hexadecimal, octal)

--- a/cromemcosim/conf_3d/system.conf
+++ b/cromemcosim/conf_3d/system.conf
@@ -5,6 +5,9 @@ fp_size		800
 # front panel port value for machine without fp in hex (00 - FF)
 fp_port		10
 
+# web-based frontend port number (1024 - 65535)
+ns_port		8080
+
 # <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
 # memory configurations in pages a 256 bytes
 #	start,size (numbers in decimal, hexadecimal, octal)

--- a/cromemcosim/srcsim/Makefile
+++ b/cromemcosim/srcsim/Makefile
@@ -37,6 +37,8 @@ CONF_DIR = $(DATADIR)/conf
 DISKS_DIR = $(DATADIR)/disks
 # default boot ROM path
 ROMS_DIR = $(DATADIR)/roms
+# web-based frontend document root
+DOCROOT_DIR = $(DATADIR)/www
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -95,7 +97,7 @@ endif
 ###
 
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" \
-	-DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+	-DBOOTROM=\"$(ROMS_DIR)\" -DSYSDOCROOT=\"$(DOCROOT_DIR)\" $(FP_DEFS)
 INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) \
 	-I$(CIV_DIR)/include $(PLAT_INCS)
 CPPFLAGS = $(DEFS) $(INCS)

--- a/cromemcosim/srcsim/config.c
+++ b/cromemcosim/srcsim/config.c
@@ -76,6 +76,15 @@ void config(void)
 #ifdef FRONTPANEL
 				fp_size = atoi(t2);
 #endif
+			} else if (!strcmp(t1, "ns_port")) {
+#ifdef HAS_NETSERVER
+				ns_port = atoi(t2);
+				if (ns_port < 1024 || ns_port > 65535) {
+					LOGW(TAG, "invalid port number %d",
+					     ns_port);
+					ns_port = NS_DEF_PORT;
+				}
+#endif
 			} else if (!strcmp(t1, "ram")) {
 				if (num_segs >= MAXMEMMAP) {
 					LOGW(TAG, "too many rom/ram statements");
@@ -157,6 +166,11 @@ void config(void)
 #ifndef HAS_NETSERVER
 	LOG(TAG, "Web server not builtin\r\n");
 #else
-	LOG(TAG, "Web server builtin, URL is http://localhost:8080\r\n");
+	if (ns_enabled) {
+		LOG(TAG, "Web server builtin, URL is http://localhost:%d\r\n",
+		    ns_port);
+	} else {
+		LOG(TAG, "Web server builtin, but disabled\r\n");
+	}
 #endif
 }

--- a/cromemcosim/srcsim/iosim.c
+++ b/cromemcosim/srcsim/iosim.c
@@ -59,9 +59,6 @@
 #endif
 #include "memsim.h"
 #include "config.h"
-#ifdef HAS_NETSERVER
-#include "netsrv.h"
-#endif
 /* #define LOG_LOCAL_LEVEL LOG_DEBUG */
 #include "log.h"
 #include "cromemco-hal.h"

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -51,7 +51,8 @@
 #define HAS_BANKED_ROM	/* has banked RDOS ROM */
 
 /*#define HAS_DISKMANAGER*/	/* uses file based disk map for disks[] */
-/*#define HAS_NETSERVER*/	/* uses civet webserver to present a web based frontend */
+#define HAS_NETSERVER		/* uses civet webserver to present a web based frontend */
+#define NS_DEF_PORT 8080	/* default port number for civet webserver */
 #define HAS_MODEM		/* has simulated 'AT' style modem over TCP/IP (telnet) */
 #define HAS_HAL			/* implements a hardware abstraction layer (HAL) for TU-ART devices */
 

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -80,8 +80,10 @@ void mon(void)
 {
 	extern BYTE fdc_flags;
 #ifdef HAS_NETSERVER
-	extern int start_net_services(void);
-	start_net_services();
+	extern int start_net_services(int);
+
+	if (ns_enabled)
+		start_net_services(ns_port);
 #endif
 
 #ifdef FRONTPANEL

--- a/imsaisim/conf_2d/system.conf
+++ b/imsaisim/conf_2d/system.conf
@@ -35,6 +35,9 @@ fp_size			800
 # front panel port value for machine without fp in hex (00 - FF)
 fp_port			0
 
+# web-based frontend port number (1024 - 65535)
+ns_port			8080
+
 # VIO background and foreground colors in hex RGB format
 # white Monitor
 vio_bg			303030

--- a/imsaisim/conf_3d/system.conf
+++ b/imsaisim/conf_3d/system.conf
@@ -35,6 +35,9 @@ fp_size			800
 # front panel port value for machine without fp in hex (00 - FF)
 fp_port			0
 
+# web-based frontend port number (1024 - 65535)
+ns_port			8080
+
 # VIO background and foreground colors in hex RGB format
 # white Monitor
 vio_bg			303030

--- a/imsaisim/srcsim/Makefile
+++ b/imsaisim/srcsim/Makefile
@@ -38,6 +38,8 @@ CONF_DIR = $(DATADIR)/conf
 DISKS_DIR = $(DATADIR)/disks
 # default boot ROM path
 ROMS_DIR = $(DATADIR)/roms
+# web-based frontend document root
+DOCROOT_DIR = $(DATADIR)/www
 ###
 ### END MACHINE DEPENDENT VARIABLES
 ###
@@ -96,7 +98,7 @@ endif
 ###
 
 DEFS = -DCONFDIR=\"$(CONF_DIR)\" -DDISKSDIR=\"$(DISKS_DIR)\" \
-	-DBOOTROM=\"$(ROMS_DIR)\" $(FP_DEFS)
+	-DBOOTROM=\"$(ROMS_DIR)\" -DSYSDOCROOT=\"$(DOCROOT_DIR)\" $(FP_DEFS)
 INCS = -I. -I$(CORE_DIR) -I$(IO_DIR) -I$(FP_DIR) -I$(NET_DIR) \
 	-I$(CIV_DIR)/include $(PLAT_INCS)
 CPPFLAGS = $(DEFS) $(INCS)

--- a/imsaisim/srcsim/config.c
+++ b/imsaisim/srcsim/config.c
@@ -272,6 +272,15 @@ void config(void)
 #ifdef FRONTPANEL
 				fp_size = atoi(t2);
 #endif
+			} else if (!strcmp(t1, "ns_port")) {
+#ifdef HAS_NETSERVER
+				ns_port = atoi(t2);
+				if (ns_port < 1024 || ns_port > 65535) {
+					LOGW(TAG, "invalid port number %d",
+					     ns_port);
+					ns_port = NS_DEF_PORT;
+				}
+#endif
 			} else if (!strcmp(t1, "vio_bg")) {
 				strncpy(&bg_color[1], t2, 6);
 			} else if (!strcmp(t1, "vio_fg")) {
@@ -365,6 +374,11 @@ void config(void)
 #ifndef HAS_NETSERVER
 	LOG(TAG, "Web server not builtin\r\n");
 #else
-	LOG(TAG, "Web server builtin, URL is http://localhost:8080\r\n");
+	if (ns_enabled) {
+		LOG(TAG, "Web server builtin, URL is http://localhost:%d\r\n",
+		    ns_port);
+	} else {
+		LOG(TAG, "Web server builtin, but disabled\r\n");
+	}
 #endif
 }

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -1003,7 +1003,8 @@ static void lpt_out(BYTE data)
 	if (data == 0x80) {
 		lpt_reset();
 #ifdef HAS_NETSERVER
-		net_device_send(DEV_LPT, (char *) &data, 1);
+		if (ns_enabled)
+			net_device_send(DEV_LPT, (char *) &data, 1);
 #endif
 		return;
 	}
@@ -1021,7 +1022,8 @@ again:
 		}
 
 #ifdef HAS_NETSERVER
-		net_device_send(DEV_LPT, (char *) &data, 1);
+		if (ns_enabled)
+			net_device_send(DEV_LPT, (char *) &data, 1);
 #endif
 	}
 }

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -54,7 +54,8 @@
 #define HAS_BANKED_ROM	/* emulate IMSAI MPU-B banked ROM & RAM */
 
 /*#define HAS_DISKMANAGER*/	/* uses file based disk map for disks[] */
-/*#define HAS_NETSERVER*/	/* uses civet webserver to present a web based frontend */
+#define HAS_NETSERVER		/* uses civet webserver to present a web based frontend */
+#define NS_DEF_PORT 8080	/* default port number for civet webserver */
 #define HAS_MODEM		/* has simulated 'AT' style modem over TCP/IP (telnet) */
 #define HAS_APU			/* has simulated AM9511 floating point maths coprocessor */
 #define HAS_HAL			/* implements a hardware abstraction layer (HAL) for SIO ports */

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -82,8 +82,10 @@ static void quit_callback(void);
 void mon(void)
 {
 #ifdef HAS_NETSERVER
-	extern int start_net_services(void);
-	start_net_services();
+	extern int start_net_services(int);
+
+	if (ns_enabled)
+		start_net_services(ns_port);
 #endif
 
 #ifdef FRONTPANEL

--- a/iodevices/cromemco-88ccc.c
+++ b/iodevices/cromemco-88ccc.c
@@ -18,13 +18,11 @@
 #include "sim.h"
 #include "simglb.h"
 
-#ifdef HAS_CYCLOPS
+#if defined(HAS_NETSERVER) && defined(HAS_CYCLOPS)
 
 #include "config.h"
 #include "memsim.h"
-#ifdef HAS_NETSERVER
 #include "netsrv.h"
-#endif
 /* #define LOG_LOCAL_LEVEL LOG_DEBUG */
 #include "log.h"
 
@@ -161,4 +159,4 @@ BYTE cromemco_88ccc_ctrl_a_in(void)
 	return (flags | (state << 7));
 }
 
-#endif /* HAS_CYCLOPS */
+#endif /* HAS_NETSERVER && HAS_CYCLOPS */

--- a/iodevices/cromemco-d+7a.c
+++ b/iodevices/cromemco-d+7a.c
@@ -40,7 +40,9 @@ void cromemco_d7a_init(void) {
     inPort[0] = 0xFF;
 
 #ifdef HAS_NETSERVER
-    net_device_service(DEV_D7AIO, cromemco_d7a_callback);
+    if (ns_enabled) {
+        net_device_service(DEV_D7AIO, cromemco_d7a_callback);
+    }
 #endif
 
 }
@@ -52,9 +54,11 @@ void cromemco_d7a_out(BYTE port, BYTE data)
     LOGD(TAG, "Output %d on port %d", data, port);
 
 #ifdef HAS_NETSERVER
-    // if (net_device_alive(DEV_D7AIO)) {
-        net_device_send(DEV_D7AIO, (char *)&data, 1);
-    // }
+    if (ns_enabled) {
+        // if (net_device_alive(DEV_D7AIO)) {
+            net_device_send(DEV_D7AIO, (char *)&data, 1);
+        // }
+    }
 #endif
 }
 

--- a/iodevices/cromemco-hal.c
+++ b/iodevices/cromemco-hal.c
@@ -67,21 +67,34 @@ void null_out(int dev, BYTE data) {
 
 #ifdef HAS_NETSERVER
 int net_tty_alive(int dev) {
-    // LOG(TAG, "WEBTTY %d: %d\r\n", dev, net_device_alive(dev));
-    return net_device_alive((net_device_t) dev); /* WEBTTY is only alive if websocket is connected */
+    if (ns_enabled) {
+        // LOG(TAG, "WEBTTY %d: %d\r\n", dev, net_device_alive(dev));
+        /* WEBTTY is only alive if websocket is connected */
+        return net_device_alive((net_device_t) dev);
+    } else {
+        return 0;
+    }
 }
 void net_tty_status(int dev, BYTE *stat) {
     *stat &= (BYTE)(~3);
-    if (net_device_poll((net_device_t) dev)) {
-        *stat |= 2;
+    if (ns_enabled) {
+        if (net_device_poll((net_device_t) dev)) {
+            *stat |= 2;
+        }
+        *stat |= 1;
     }
-    *stat |= 1;
 }
 int net_tty_in(int dev) {
-    return net_device_get((net_device_t) dev);
+    if (ns_enabled) {
+        return net_device_get((net_device_t) dev);
+    } else {
+        return -1;
+    }
 }
 void net_tty_out(int dev, BYTE data) {
-    net_device_send((net_device_t) dev, (char *)&data, 1);
+    if (ns_enabled) {
+        net_device_send((net_device_t) dev, (char *)&data, 1);
+    }
 }
 #endif
 

--- a/iodevices/cromemco-tu-art.c
+++ b/iodevices/cromemco-tu-art.c
@@ -469,7 +469,8 @@ again:
 		}
 
 #ifdef HAS_NETSERVER
-		net_device_send(DEV_LPT, (char *) &data, 1);
+		if (ns_enabled)
+			net_device_send(DEV_LPT, (char *) &data, 1);
 #endif
 	}
 }

--- a/iodevices/imsai-hal.c
+++ b/iodevices/imsai-hal.c
@@ -62,9 +62,15 @@ int null_cd(void) {
 
 int vio_kbd_alive(void) {
 #ifdef HAS_NETSERVER
-    return net_device_alive(DEV_VIO); /* VIO (webUI) keyboard is only alive if websocket is connected */
-#else
-    return 1; /* VIO (xterm) keyboard is always alive */
+    if (ns_enabled) {
+        /* VIO (webUI) keyboard is only alive if websocket is connected */
+        return net_device_alive(DEV_VIO);
+    } else {
+#endif
+        /* VIO (xterm) keyboard is always alive */
+        return 1;
+#ifdef HAS_NETSERVER
+    }
 #endif
 
 }
@@ -96,20 +102,33 @@ void vio_kbd_out(BYTE data) {
 
 #ifdef HAS_NETSERVER
 int net_tty_alive(void) {
-    return net_device_alive(DEV_TTY); /* WEBTTY is only alive if websocket is connected */
+    if (ns_enabled) {
+        /* WEBTTY is only alive if websocket is connected */
+        return net_device_alive(DEV_TTY);
+    } else {
+        return 0;
+    }
 }
 void net_tty_status(BYTE *stat) {
     *stat &= (BYTE)(~3);
-    if (net_device_poll(DEV_TTY)) {
-        *stat |= 2;
+    if (ns_enabled) {
+        if (net_device_poll(DEV_TTY)) {
+            *stat |= 2;
+        }
+        *stat |= 1;
     }
-    *stat |= 1;
 }
 int net_tty_in(void) {
-    return net_device_get(DEV_TTY);
+    if (ns_enabled) {
+        return net_device_get(DEV_TTY);
+    } else {
+        return -1;
+    }
 }
 void net_tty_out(BYTE data) {
-    net_device_send(DEV_TTY, (char *)&data, 1);
+    if (ns_enabled) {
+        net_device_send(DEV_TTY, (char *)&data, 1);
+    }
 }
 #endif
 
@@ -117,20 +136,33 @@ void net_tty_out(BYTE data) {
 
 #ifdef HAS_NETSERVER
 int net_ptr_alive(void) {
-    return net_device_alive(DEV_PTR); /* WEBPTR is only alive if websocket is connected */
+    if (ns_enabled) {
+        /* WEBPTR is only alive if websocket is connected */
+        return net_device_alive(DEV_PTR);
+    } else {
+        return 0;
+    }
 }
 void net_ptr_status(BYTE *stat) {
     *stat &= (BYTE)(~3);
-    if (net_device_poll(DEV_PTR)) {
-        *stat |= 2;
+    if (ns_enabled) {
+        if (net_device_poll(DEV_PTR)) {
+            *stat |= 2;
+        }
+        *stat |= 1;
     }
-    *stat |= 1;
 }
 int net_ptr_in(void) {
-    return net_device_get(DEV_PTR);
+    if (ns_enabled) {
+        return net_device_get(DEV_PTR);
+    } else {
+        return -1;
+    }
 }
 void net_ptr_out(BYTE data) {
-    net_device_send(DEV_PTR, (char *)&data, 1);
+    if (ns_enabled) {
+        net_device_send(DEV_PTR, (char *)&data, 1);
+    }
 }
 #endif
 

--- a/webfrontend/netsrv.c
+++ b/webfrontend/netsrv.c
@@ -39,8 +39,6 @@
 #endif
 #endif 
 
-#define PORT "8080"
-
 #define MAX_WS_CLIENTS (_DEV_MAX)
 static const char *TAG = "netsrv";
 
@@ -753,15 +751,19 @@ void stop_net_services (void) {
 	}
 }
 
-int start_net_services (void) {
+int start_net_services (int port) {
+	//TODO: add config for DOCUMENT_ROOT
 
-	//TODO: add config for DOCUMENT_ROOT, PORT
+    char sport[6];
+#ifdef SYSDOCROOT
+	struct stat sbuf;
+#endif
 
 	const char *options[] = {
 	    "document_root",
 	    DOCUMENT_ROOT,
 	    "listening_ports",
-	    PORT,
+	    sport,
 	    "request_timeout_ms",
 	    "10000",
 	    "error_log_file",
@@ -784,6 +786,14 @@ int start_net_services (void) {
 #endif
 
 	atexit(stop_net_services);
+
+	snprintf(sport, sizeof(sport), "%d", port);
+
+#ifdef SYSDOCROOT
+	if (stat(DOCUMENT_ROOT, &sbuf) == -1 || !S_ISDIR(sbuf.st_mode)) {
+		options[1] = SYSDOCROOT;
+	}
+#endif
 
     /* Start CivetWeb web server */
 	memset(&callbacks, 0, sizeof(callbacks));

--- a/webfrontend/netsrv.h
+++ b/webfrontend/netsrv.h
@@ -7,6 +7,9 @@
  * 12-JUL-2018	1.0	Initial Release
  */
 
+#ifndef NETSRV_INC
+#define NETSRV_INC
+
 /**
  * This web server module provides...
  */
@@ -84,3 +87,5 @@ struct request {
 typedef struct request request_t;
 
 extern request_t *get_request(const HttpdConnection_t *);
+
+#endif

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -108,6 +108,14 @@ BYTE fp_led_output = 0xff;	/* inverted IMSAI/Cromemco programmed output */
 #endif
 
 /*
+ *	Variables for web-based frontend
+ */
+#ifdef HAS_NETSERVER
+int ns_enabled;			/* web-based frontend enabled flag */
+int ns_port = NS_DEF_PORT;	/* port number to run server on */
+#endif
+
+/*
  *	Flags to control operation of simulation
  */
 int s_flag;			/* flag for -s option */

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -88,6 +88,11 @@ extern WORD 	address_switch;
 extern BYTE 	fp_led_output;
 #endif
 
+#ifdef HAS_NETSERVER
+extern int	ns_enabled;
+extern int	ns_port;
+#endif
+
 extern int	s_flag, l_flag, m_flag, x_flag, i_flag, f_flag,
 		u_flag, r_flag, c_flag;
 #ifdef HAS_CONFIG

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -219,19 +219,24 @@ int main(int argc, char *argv[])
 #endif
 
 #ifndef EXCLUDE_I8080
-			case '8':
+			case '8':	/* emulate Intel 8080 */
 				cpu = I8080;
 				break;
 #endif
 
 #ifndef EXCLUDE_Z80
-			case 'z':
+			case 'z':	/* emulate Zilog Z80 */
 				cpu = Z80;
 				break;
 #endif
 #ifdef FRONTPANEL
-			case 'F':
+			case 'F':	/* disable front panel emulation */
 				fp_enabled = 0;
+				break;
+#endif
+#ifdef HAS_NETSERVER
+			case 'n':	/* enable web-based frontend */
+				ns_enabled = 1;
 				break;
 #endif
 
@@ -271,6 +276,9 @@ usage:
 #endif
 #ifdef FRONTPANEL
 				fputs(" -F", stdout);
+#endif
+#ifdef HAS_NETSERVER
+				fputs(" -n", stdout);
 #endif
 				fputs("\n\n", stdout);
 #ifndef EXCLUDE_Z80
@@ -318,7 +326,10 @@ usage:
 				puts("\t-R = enable banked ROM");
 #endif
 #ifdef FRONTPANEL
-				puts("\t-F = disable front panel");
+				puts("\t-F = disable front panel emulation");
+#endif
+#ifdef HAS_NETSERVER
+				puts("\t-n = enable web-based frontend");
 #endif
 				exit(EXIT_FAILURE);
 			}


### PR DESCRIPTION
When the web-based frontend code is compiled in, it can now be enabled at runtime with the new option -n.

Default port number is set in sim.h, but it can be changed with a new configuration file option "ns_port".

Added SYSDOCROOT define to Makefile. This directory will be used when ../../webfrontend/www/<machine> can't be found.