### PR TITLE
simz80: implement optional faster & smaller instruction dispatching

### DIFF
--- a/altairsim/srcsim/Makefile
+++ b/altairsim/srcsim/Makefile
@@ -123,8 +123,7 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
-	simz80-fd.c simz80-fdcb.c
+	simmain.c simz80.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 XXSRCS = $(FP_SRCS)
 OBJS = $(SRCS:.c=.o) $(XXSRCS:.cpp=.o)

--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -37,9 +37,10 @@
 /*#define AMD8080*/	/* AMD 8080 instead of Intel 8080 */
 #define CPU_SPEED 2	/* default CPU speed */
 #define UNDOC_INST	/* compile undocumented instructions */
-#define UNDOC_FLAGS	/* compile undocumented flags */
-/*#define FAST_INSTR*/	/* faster instructions, but less debuggable */
-/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
+#define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
+#define UNDOC_FLAGS	/* compile undocumented Z80 flags */
+/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */
 /*#define WANT_TIM*/	/* don't count t-states */

--- a/cpmsim/srcsim/Makefile
+++ b/cpmsim/srcsim/Makefile
@@ -82,8 +82,7 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
-	simz80-fd.c simz80-fdcb.c
+	simmain.c simz80.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -14,9 +14,10 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define UNDOC_INST	/* compile undocumented instructions */
-#define UNDOC_FLAGS	/* compile undocumented flags */
-#define FAST_INSTR	/* faster instructions, but less debuggable */
-#define WANT_FASTB	/* much faster but not accurate Z80 block instr. */
+#define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
+#define UNDOC_FLAGS	/* compile undocumented Z80 flags */
+#define FAST_INSTR	/* faster instr. & smaller size, but less debuggable */
+#define FAST_BLOCK	/* much faster but not accurate Z80 block instr. */
 
 /*#define WANT_ICE*/	/* attach ICE to machine */
 /*#define WANT_TIM*/	/* don't count t-states */

--- a/cromemcosim/srcsim/Makefile
+++ b/cromemcosim/srcsim/Makefile
@@ -131,8 +131,7 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
-	simz80-fd.c simz80-fdcb.c
+	simmain.c simz80.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 XXSRCS = $(FP_SRCS)
 OBJS = $(SRCS:.c=.o) $(XXSRCS:.cpp=.o)

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -38,9 +38,10 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 4	/* default CPU speed */
 #define UNDOC_INST	/* compile undocumented instructions */
-#define UNDOC_FLAGS	/* compile undocumented flags */
-/*#define FAST_INSTR*/	/* faster instructions, but less debuggable */
-/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
+#define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
+#define UNDOC_FLAGS	/* compile undocumented Z80 flags */
+/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */
 /*#define WANT_TIM*/	/* don't count t-states */

--- a/imsaisim/srcsim/Makefile
+++ b/imsaisim/srcsim/Makefile
@@ -132,8 +132,7 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
-	simz80-fd.c simz80-fdcb.c
+	simmain.c simz80.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 XXSRCS = $(FP_SRCS)
 OBJS = $(SRCS:.c=.o) $(XXSRCS:.cpp=.o)

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -38,9 +38,10 @@
 /*#define AMD8080*/	/* AMD 8080 instead of Intel 8080 */
 #define CPU_SPEED 2	/* default CPU speed */
 #define UNDOC_INST	/* compile undocumented instructions */
-#define UNDOC_FLAGS	/* compile undocumented flags */
-/*#define FAST_INSTR*/	/* faster instructions, but less debuggable */
-/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
+#define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
+#define UNDOC_FLAGS	/* compile undocumented Z80 flags */
+/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */
 /*#define WANT_TIM*/	/* don't count t-states */

--- a/mosteksim/srcsim/Makefile
+++ b/mosteksim/srcsim/Makefile
@@ -85,8 +85,7 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
-	simz80-fd.c simz80-fdcb.c
+	simmain.c simz80.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -23,9 +23,10 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define UNDOC_INST	/* compile undocumented instructions */
-#define UNDOC_FLAGS	/* compile undocumented flags */
-/*#define FAST_INSTR*/	/* faster instructions, but less debuggable */
-/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
+#define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
+#define UNDOC_FLAGS	/* compile undocumented Z80 flags */
+/8#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 #define EXCLUDE_I8080	/* this was a Z80 machine */
 
 #define WANT_ICE	/* attach ICE to headless machine */

--- a/picosim/CMakeLists.txt
+++ b/picosim/CMakeLists.txt
@@ -18,12 +18,6 @@ add_executable(picosim
 	../z80core/simice.c
 	../z80core/sim8080.c
 	../z80core/simz80.c
-	../z80core/simz80-cb.c
-	../z80core/simz80-dd.c
-	../z80core/simz80-ddcb.c
-	../z80core/simz80-ed.c
-	../z80core/simz80-fd.c
-	../z80core/simz80-fdcb.c
 	config.c
 	memsim.c
 	iosim.c

--- a/picosim/sim.h
+++ b/picosim/sim.h
@@ -15,9 +15,10 @@
 //#define EXCLUDE_I8080	/* don't include 8080, for now we want both */
 #define CPU_SPEED 4	/* CPU speed 0=unlimited */
 #define UNDOC_INST	/* compile undocumented instructions */
-#define UNDOC_FLAGS	/* compile undocumented flags */
-/*#define FAST_INSTR*/	/* faster instructions, but less debuggable */
-/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
+#define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
+#define UNDOC_FLAGS	/* compile undocumented Z80 flags */
+/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 #define BAREMETAL	/* set up the simulator core for bare metal use */
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */

--- a/z80core/sim8080-00.c
+++ b/z80core/sim8080-00.c
@@ -5,13 +5,10 @@
  * Copyright (C) 2024 by Thomas Eberhardt
  */
 
-#ifndef FAST_INSTR
-#define INSTR(opcode, func)	static int func(void)
-#define STATES(states)		return (states)
-#else
-#define INSTR(opcode, func)	case opcode:
-#define STATES(states)		t = states; break
-#endif
+/*
+ *	This module contains the implementation of all
+ *	8080 instructions
+ */
 
 INSTR(0x00, op_nop)			/* NOP */
 {
@@ -50,7 +47,8 @@ INSTR(0x76, op_hlt)			/* HLT */
 		fp_led_data = 0xff;
 
 		if (IFF == 0) {
-			/* INT disabled, wait for frontpanel reset or user interrupt */
+			/* INT disabled, wait for
+			   frontpanel reset or user interrupt */
 			while (!(cpu_state & RESET)) {
 				fp_clock++;
 				fp_sampleData();
@@ -2885,7 +2883,17 @@ INSTR(0xff, op_rst7)			/* RST 7 */
 
 #ifdef UNDOC_INST
 
-INSTR(0x08, op_undoc_nop1)		/* NOP* */
+#ifndef FAST_INSTR
+static int op_undoc_nop(void)		/* NOP */
+#else
+case 0x08:				/* NOP */
+case 0x10:				/* NOP */
+case 0x18:				/* NOP */
+case 0x20:				/* NOP */
+case 0x28:				/* NOP */
+case 0x30:				/* NOP */
+case 0x38:				/* NOP */
+#endif
 {
 	if (u_flag) {
 		STATES(trap_undoc());
@@ -2894,61 +2902,7 @@ INSTR(0x08, op_undoc_nop1)		/* NOP* */
 	STATES(4);
 }
 
-INSTR(0x10, op_undoc_nop2)		/* NOP* */
-{
-	if (u_flag) {
-		STATES(trap_undoc());
-	}
-
-	STATES(4);
-}
-
-INSTR(0x18, op_undoc_nop3)		/* NOP* */
-{
-	if (u_flag) {
-		STATES(trap_undoc());
-	}
-
-	STATES(4);
-}
-
-INSTR(0x20, op_undoc_nop4)		/* NOP* */
-{
-	if (u_flag) {
-		STATES(trap_undoc());
-	}
-
-	STATES(4);
-}
-
-INSTR(0x28, op_undoc_nop5)		/* NOP* */
-{
-	if (u_flag) {
-		STATES(trap_undoc());
-	}
-
-	STATES(4);
-}
-
-INSTR(0x30, op_undoc_nop6)		/* NOP* */
-{
-	if (u_flag) {
-		STATES(trap_undoc());
-	}
-
-	STATES(4);
-}
-
-INSTR(0x38, op_undoc_nop7)		/* NOP* */
-{
-	if (u_flag) {
-		STATES(trap_undoc());
-	}
-
-	STATES(4);
-}
-
-INSTR(0xcb, op_undoc_jmp)		/* JMP* nn */
+INSTR(0xcb, op_undoc_jmp)		/* JMP nn */
 {
 	register WORD i;
 
@@ -2962,45 +2916,13 @@ INSTR(0xcb, op_undoc_jmp)		/* JMP* nn */
 	STATES(10);
 }
 
-INSTR(0xdd, op_undoc_call1)		/* CALL* nn */
-{
-	register WORD i;
-
-	if (u_flag) {
-		STATES(trap_undoc());
-	}
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-#ifdef BUS_8080
-	cpu_bus = CPU_STACK;
+#ifndef FAST_INSTR
+static int op_undoc_call(void)		/* CALL nn */
+#else
+case 0xdd:				/* CALL nn */
+case 0xed:				/* CALL nn */
+case 0xfd:				/* CALL nn */
 #endif
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = i;
-	STATES(17);
-}
-
-INSTR(0xed, op_undoc_call2)		/* CALL* nn */
-{
-	register WORD i;
-
-	if (u_flag) {
-		STATES(trap_undoc());
-	}
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-#ifdef BUS_8080
-	cpu_bus = CPU_STACK;
-#endif
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = i;
-	STATES(17);
-}
-
-INSTR(0xfd, op_undoc_call3)		/* CALL* nn */
 {
 	register WORD i;
 
@@ -3036,4 +2958,4 @@ INSTR(0xd9, op_undoc_ret)		/* RET */
 	STATES(10);
 }
 
-#endif
+#endif /* UNDOC_INST */

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -222,7 +222,7 @@ void report_cpu_error(void)
 	default:
 		printf("Unknown error %d\n", cpu_error);
 		break;
-#else
+#else /* !BAREMETAL */
 	case OPHALT:
 		LOG(TAG, "INT disabled and HALT Op-Code reached at 0x%04x\r\n",
 		    PC - 1);
@@ -266,7 +266,7 @@ void report_cpu_error(void)
 	default:
 		LOGW(TAG, "Unknown error %d", cpu_error);
 		break;
-#endif
+#endif /* !BAREMETAL */
 	}
 }
 

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -42,6 +42,10 @@
 #define N_FLAG		2	/* add/subtract flag */
 #define C_FLAG		1	/* carry flag */
 
+#ifdef FAST_INSTR
+#define SZP_FLAGS	(S_FLAG | Z_FLAG | P_FLAG)
+#endif
+
 				/* bit definitions for CPU bus status */
 #define CPU_MEMR	128	/* memory read */
 #define CPU_INP		64	/* input device address */

--- a/z80core/simdis.c
+++ b/z80core/simdis.c
@@ -279,7 +279,7 @@ static struct opt optabed_5[32] = {
 	{ opout,  "NOP*"		},	/* 0xbe */ /* undocumented */
 	{ opout,  "NOP*"		}	/* 0xbf */ /* undocumented */
 };
-#endif
+#endif /* !EXCLUDE_Z80 */
 
 #ifndef EXCLUDE_I8080
 static struct opt optabi8080_01[64] = {
@@ -415,7 +415,7 @@ static struct opt optabi8080_67[64] = {
 	{ nout,   "CPI\t"		},	/* 0xfe */
 	{ opout,  "RST\t7"		}	/* 0xff */
 };
-#endif
+#endif /* !EXCLUDE_I8080 */
 
 #ifndef EXCLUDE_Z80
 static const char *reg[]     = { "B", "C", "D", "E", "H", "L", "(HL)", "A" };
@@ -892,6 +892,6 @@ static int ddfd(const char *s, WORD a)
 	}
 }
 
-#endif
+#endif /* !EXCLUDE_Z80 */
 
-#endif
+#endif /* WANT_ICE */

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -147,6 +147,7 @@ char conffn[MAX_LFN];		/* configuration file (option -c) */
 char rompath[MAX_LFN];		/* path for boot ROM files */
 #endif
 
+#if !defined(FAST_INSTR) || !defined(EXCLUDE_Z80)
 /*
  *	Precompiled table to get parity as fast as possible
  */
@@ -216,3 +217,52 @@ const char parity[256] = {
 	1 /* 11111000 */, 0 /* 11111001 */, 0 /* 11111010 */, 1 /* 11111011 */,
 	0 /* 11111100 */, 1 /* 11111101 */, 1 /* 11111110 */, 0 /* 11111111 */
 };
+#endif /* !FAST_INSTR && !EXCLUDE_Z80 */
+
+#ifdef FAST_INSTR
+/*
+ *	Precomputed table for fast sign, zero and parity flag calculation
+ */
+#define _ 0
+#define S S_FLAG
+#define Z Z_FLAG
+#define P P_FLAG
+const BYTE szp_flags[256] = {
+/*00*/	Z | P,	_,	_,	P,	_,	P,	P,	_,
+/*08*/	_,	P,	P,	_,	P,	_,	_,	P,
+/*10*/	_,	P,	P,	_,	P,	_,	_,	P,
+/*18*/	P,	_,	_,	P,	_,	P,	P,	_,
+/*20*/	_,	P,	P,	_,	P,	_,	_,	P,
+/*28*/	P,	_,	_,	P,	_,	P,	P,	_,
+/*30*/	P,	_,	_,	P,	_,	P,	P,	_,
+/*38*/	_,	P,	P,	_,	P,	_,	_,	P,
+/*40*/	_,	P,	P,	_,	P,	_,	_,	P,
+/*48*/	P,	_,	_,	P,	_,	P,	P,	_,
+/*50*/	P,	_,	_,	P,	_,	P,	P,	_,
+/*58*/	_,	P,	P,	_,	P,	_,	_,	P,
+/*60*/	P,	_,	_,	P,	_,	P,	P,	_,
+/*68*/	_,	P,	P,	_,	P,	_,	_,	P,
+/*70*/	_,	P,	P,	_,	P,	_,	_,	P,
+/*78*/	P,	_,	_,	P,	_,	P,	P,	_,
+/*80*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
+/*88*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
+/*90*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
+/*98*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
+/*a0*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
+/*a8*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
+/*b0*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
+/*b8*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
+/*c0*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
+/*c8*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
+/*d0*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
+/*d8*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
+/*e0*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
+/*e8*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
+/*f0*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
+/*f8*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P
+};
+#undef _
+#undef S
+#undef Z
+#undef P
+#endif /* FAST_INSTR */

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -114,6 +114,11 @@ extern char	conffn[];
 extern char	rompath[];
 #endif
 
+#if !defined(FAST_INSTR) || !defined(EXCLUDE_Z80)
 extern const char parity[];
+#endif
+#ifdef FAST_INSTR
+extern const BYTE szp_flags[];
+#endif
 
 #endif

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -708,7 +708,7 @@ static void do_break(char *s)
 
 	puts("Sorry, no breakpoints available");
 	puts("Please recompile with SBSIZE defined in sim.h");
-#else
+#else /* SBSIZE */
 	register int i;
 
 	if (*s == '\n') {
@@ -750,7 +750,7 @@ static void do_break(char *s)
 	else
 		soft[i].sb_pass = exatoi(++s);
 	soft[i].sb_passcount = 0;
-#endif
+#endif /* SBSIZE */
 }
 
 /*
@@ -763,7 +763,7 @@ static void do_hist(char *s)
 
 	puts("Sorry, no history available");
 	puts("Please recompile with HISIZE defined in sim.h");
-#else
+#else /* HISIZE */
 	int i, l, b, e, sa;
 
 	while (isspace((unsigned char) *s))
@@ -830,7 +830,7 @@ static void do_hist(char *s)
 		}
 		break;
 	}
-#endif
+#endif /* HISIZE */
 }
 
 /*
@@ -902,7 +902,7 @@ static void do_switch(char *s)
 		print_reg();
 	}
 }
-#endif
+#endif /* !EXCLUDE_I8080 && !EXCLUDE_Z80 */
 
 /*
  *	Output information about compiling options
@@ -1112,6 +1112,6 @@ static void do_unix(char *s)
 	int_on();
 }
 
-#endif
+#endif /* !BAREMETAL */
 
-#endif
+#endif /* WANT_ICE */

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -147,14 +147,14 @@ int main(int argc, char *argv[])
 				*p = '\0';
 				s--;
 				break;
-#else
+#else /* !HAS_CONFIG */
 #ifdef BOOTROM
 			case 'r':	/* load default boot ROM */
 				r_flag = 1;
 				x_flag = 1;
 				strcpy(xfn, BOOTROM);
 #endif
-#endif
+#endif /* !HAS_CONFIG */
 
 #ifdef HAS_DISKS
 			case 'd':	/* get path for disk images */
@@ -209,7 +209,7 @@ int main(int argc, char *argv[])
 				break;
 #endif
 
-#endif
+#endif /* HAS_CONFIG */
 
 #ifdef HAS_BANKED_ROM
 			case 'R':	/* enable banked ROM for machines

--- a/z80core/simz80-00.c
+++ b/z80core/simz80-00.c
@@ -1,0 +1,4559 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 1987-2024 by Udo Munk
+ * Copyright (C) 2024 by Thomas Eberhardt
+ */
+
+/*
+ *	This module contains the implementation of all Z80 single byte
+ *	instructions and dispatchers for the prefixes 0xcb, 0xdd, 0xed,
+ *	and 0xfd.
+ */
+
+INSTR(0x00, op_nop)			/* NOP */
+{
+	STATES(4);
+}
+
+INSTR(0x76, op_halt)			/* HALT */
+{
+#ifdef BUS_8080
+	cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
+#endif
+
+#ifdef FRONTPANEL
+	if (!F_flag) {
+#endif
+		if (IFF == 0) {
+			/* without a frontpanel DI + HALT stops the machine */
+			cpu_error = OPHALT;
+			cpu_state = STOPPED;
+		} else {
+			/* else wait for INT, NMI or user interrupt */
+			while ((int_int == 0) && (int_nmi == 0) &&
+			       (cpu_state == CONTIN_RUN)) {
+				SLEEP_MS(1);
+				R += 99;
+			}
+		}
+#ifdef BUS_8080
+		if (int_int)
+			cpu_bus = CPU_INTA | CPU_WO | CPU_HLTA | CPU_M1;
+#endif
+
+		busy_loop_cnt = 0;
+
+#ifdef FRONTPANEL
+	} else {
+		fp_led_address = 0xffff;
+		fp_led_data = 0xff;
+
+		if (IFF == 0) {
+			/* INT disabled, wait for NMI,
+			   frontpanel reset or user interrupt */
+			while ((int_nmi == 0) && !(cpu_state & RESET)) {
+				fp_clock++;
+				fp_sampleData();
+				SLEEP_MS(1);
+				R += 99;
+				if (cpu_error != NONE)
+					break;
+			}
+		} else {
+			/* else wait for INT, NMI,
+			   frontpanel reset or user interrupt */
+			while ((int_int == 0) && (int_nmi == 0) &&
+			       !(cpu_state & RESET)) {
+				fp_clock++;
+				fp_sampleData();
+				SLEEP_MS(1);
+				R += 99;
+				if (cpu_error != NONE)
+					break;
+			}
+			if (int_int) {
+				cpu_bus = CPU_INTA | CPU_WO |
+					  CPU_HLTA | CPU_M1;
+				fp_clock++;
+				fp_sampleLightGroup(0, 0);
+			}
+		}
+	}
+#endif
+
+	STATES(4);
+}
+
+INSTR(0x37, op_scf)			/* SCF */
+{
+	F |= C_FLAG;
+	F &= ~(N_FLAG | H_FLAG);
+#ifdef UNDOC_FLAGS
+	/* This is Zilog/Mostek NMOS Z80 behaviour */
+	(A & 32) ? (F |= Y_FLAG) : (pmodF ? (F &= ~Y_FLAG) : 0);
+	(A & 8) ? (F |= X_FLAG) : (pmodF ? (F &= ~X_FLAG) : 0);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x3f, op_ccf)			/* CCF */
+{
+	if (F & C_FLAG) {
+		F |= H_FLAG;
+		F &= ~C_FLAG;
+	} else {
+		F &= ~H_FLAG;
+		F |= C_FLAG;
+	}
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	/* This is Zilog/Mostek NMOS Z80 behaviour */
+	(A & 32) ? (F |= Y_FLAG) : (pmodF ? (F &= ~Y_FLAG) : 0);
+	(A & 8) ? (F |= X_FLAG) : (pmodF ? (F &= ~X_FLAG) : 0);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x2f, op_cpl)			/* CPL */
+{
+	A = ~A;
+	F |= H_FLAG | N_FLAG;
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+/*
+ * This is my original implementation of the DAA instruction.
+ * It implements the instruction as described in Z80 data sheets
+ * and books, but it won't pass the ex.com instruction exerciser.
+ * Below is a contributed implementation active, that also passes
+ * the tests done by ex.com.
+ */
+#if 0
+INSTR(0x27, op_daa)			/* DAA */
+{
+	if (F & N_FLAG) {		/* subtractions */
+		if (((A & 0x0f) > 9) || (F & H_FLAG)) {
+			(((A & 0x0f) - 6) < 0) ? (F |= H_FLAG)
+					       : (F &= ~H_FLAG);
+			A -= 6;
+		}
+		if (((A & 0xf0) > 0x90) || (F & C_FLAG)) {
+			if (((A & 0xf0) - 0x60) < 0)
+				F |= C_FLAG;
+			A -= 0x60;
+		}
+	} else {			/* additions */
+		if (((A & 0x0f) > 9) || (F & H_FLAG)) {
+			(((A & 0x0f) + 6) > 0x0f) ? (F |= H_FLAG)
+						  : (F &= ~H_FLAG);
+			A += 6;
+		}
+		if (((A & 0xf0) > 0x90) || (F & C_FLAG)) {
+			if (((A & 0xf0) + 0x60) > 0xf0)
+				F |= C_FLAG;
+			A += 0x60;
+		}
+	}
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+#endif
+
+/*
+ * This implementation was contributed by Mark Garlanger,
+ * see http://heathkit.garlanger.com/
+ * It passes the instruction exerciser test from ex.com
+ * and is correct.
+ */
+INSTR(0x27, op_daa)			/* DAA */
+{
+	int tmp_a = A;
+	int low_nibble = A & 0x0f;
+	int carry = (F & C_FLAG);
+
+	if (F & N_FLAG) {		/* subtraction */
+		int adjustment = (carry || (tmp_a > 0x99)) ? 0x160 : 0x00;
+
+		if ((F & H_FLAG) || (low_nibble > 9)) {
+			if (low_nibble > 5) {
+				F &= ~H_FLAG;
+			}
+			tmp_a = (tmp_a - 6) & 0xff;
+		}
+		tmp_a -= adjustment;
+	} else {			/* addition */
+		if ((low_nibble > 9) || (F & H_FLAG)) {
+			(low_nibble > 9) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+			tmp_a += 6;
+		}
+		if (((tmp_a & 0x1f0) > 0x90) || carry) {
+			tmp_a += 0x60;
+		}
+	}
+
+	(carry || (tmp_a & 0x100)) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = (tmp_a & 0xff);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xfb, op_ei)			/* EI */
+{
+	IFF = 3;
+	int_protection = 1;		/* protect next instruction */
+	STATES(4);
+}
+
+INSTR(0xf3, op_di)			/* DI */
+{
+	IFF = 0;
+	STATES(4);
+}
+
+INSTR(0xdb, op_in)			/* IN A,(n) */
+{
+	extern BYTE io_in(BYTE, BYTE);
+	BYTE addr;
+
+	addr = memrdr(PC++);
+#ifdef UNDOC_FLAGS
+	WZ = (A << 8) + ((addr + 1) & 0xff);
+#endif
+	A = io_in(addr, A);
+	STATES(11);
+}
+
+INSTR(0xd3, op_out)			/* OUT (n),A */
+{
+	extern void io_out(BYTE, BYTE, BYTE);
+	BYTE addr;
+
+	addr = memrdr(PC++);
+	io_out(addr, A, A);
+#ifdef UNDOC_FLAGS
+	WZ = (A << 8) + ((addr + 1) & 0xff);
+#endif
+	STATES(11);
+}
+
+INSTR(0x3e, op_ldan)			/* LD A,n */
+{
+	A = memrdr(PC++);
+	STATES(7);
+}
+
+INSTR(0x06, op_ldbn)			/* LD B,n */
+{
+	B = memrdr(PC++);
+	STATES(7);
+}
+
+INSTR(0x0e, op_ldcn)			/* LD C,n */
+{
+	C = memrdr(PC++);
+	STATES(7);
+}
+
+INSTR(0x16, op_lddn)			/* LD D,n */
+{
+	D = memrdr(PC++);
+	STATES(7);
+}
+
+INSTR(0x1e, op_lden)			/* LD E,n */
+{
+	E = memrdr(PC++);
+	STATES(7);
+}
+
+INSTR(0x26, op_ldhn)			/* LD H,n */
+{
+	H = memrdr(PC++);
+	STATES(7);
+}
+
+INSTR(0x2e, op_ldln)			/* LD L,n */
+{
+	L = memrdr(PC++);
+	STATES(7);
+}
+
+INSTR(0x0a, op_ldabc)			/* LD A,(BC) */
+{
+	register WORD i;
+
+	i = (B << 8) + C;
+	A = memrdr(i);
+#ifdef UNDOC_FLAGS
+	WZ = i + 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0x1a, op_ldade)			/* LD A,(DE) */
+{
+	register WORD i;
+
+	i = (D << 8) + E;
+	A = memrdr(i);
+#ifdef UNDOC_FLAGS
+	WZ = i + 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0x3a, op_ldann)			/* LD A,(nn) */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	A = memrdr(i);
+#ifdef UNDOC_FLAGS
+	WZ = i + 1;
+#endif
+	STATES(13);
+}
+
+INSTR(0x02, op_ldbca)			/* LD (BC),A */
+{
+	memwrt((B << 8) + C, A);
+#ifdef UNDOC_FLAGS
+	WZ = (A << 8) + ((C + 1) & 0xff);
+#endif
+	STATES(7);
+}
+
+INSTR(0x12, op_lddea)			/* LD (DE),A */
+{
+	memwrt((D << 8) + E, A);
+#ifdef UNDOC_FLAGS
+	WZ = (A << 8) + ((E + 1) & 0xff);
+#endif
+	STATES(7);
+}
+
+INSTR(0x32, op_ldnna)			/* LD (nn),A */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	memwrt(i, A);
+#ifdef UNDOC_FLAGS
+	WZ = (A << 8) + ((i + 1) & 0xff);
+#endif
+	STATES(13);
+}
+
+INSTR(0x77, op_ldhla)			/* LD (HL),A */
+{
+	memwrt((H << 8) + L, A);
+	STATES(7);
+}
+
+INSTR(0x70, op_ldhlb)			/* LD (HL),B */
+{
+	memwrt((H << 8) + L, B);
+	STATES(7);
+}
+
+INSTR(0x71, op_ldhlc)			/* LD (HL),C */
+{
+	memwrt((H << 8) + L, C);
+	STATES(7);
+}
+
+INSTR(0x72, op_ldhld)			/* LD (HL),D */
+{
+	memwrt((H << 8) + L, D);
+	STATES(7);
+}
+
+INSTR(0x73, op_ldhle)			/* LD (HL),E */
+{
+	memwrt((H << 8) + L, E);
+	STATES(7);
+}
+
+INSTR(0x74, op_ldhlh)			/* LD (HL),H */
+{
+	memwrt((H << 8) + L, H);
+	STATES(7);
+}
+
+INSTR(0x75, op_ldhll)			/* LD (HL),L */
+{
+	memwrt((H << 8) + L, L);
+	STATES(7);
+}
+
+INSTR(0x36, op_ldhl1)			/* LD (HL),n */
+{
+	memwrt((H << 8) + L, memrdr(PC++));
+	STATES(10);
+}
+
+INSTR(0x7f, op_ldaa)			/* LD A,A */
+{
+	STATES(4);
+}
+
+INSTR(0x78, op_ldab)			/* LD A,B */
+{
+	A = B;
+	STATES(4);
+}
+
+INSTR(0x79, op_ldac)			/* LD A,C */
+{
+	A = C;
+	STATES(4);
+}
+
+INSTR(0x7a, op_ldad)			/* LD A,D */
+{
+	A = D;
+	STATES(4);
+}
+
+INSTR(0x7b, op_ldae)			/* LD A,E */
+{
+	A = E;
+	STATES(4);
+}
+
+INSTR(0x7c, op_ldah)			/* LD A,H */
+{
+	A = H;
+	STATES(4);
+}
+
+INSTR(0x7d, op_ldal)			/* LD A,L */
+{
+	A = L;
+	STATES(4);
+}
+
+INSTR(0x7e, op_ldahl)			/* LD A,(HL) */
+{
+	A = memrdr((H << 8) + L);
+	STATES(7);
+}
+
+INSTR(0x47, op_ldba)			/* LD B,A */
+{
+	B = A;
+	STATES(4);
+}
+
+INSTR(0x40, op_ldbb)			/* LD B,B */
+{
+	STATES(4);
+}
+
+INSTR(0x41, op_ldbc)			/* LD B,C */
+{
+	B = C;
+	STATES(4);
+}
+
+INSTR(0x42, op_ldbd)			/* LD B,D */
+{
+	B = D;
+	STATES(4);
+}
+
+INSTR(0x43, op_ldbe)			/* LD B,E */
+{
+	B = E;
+	STATES(4);
+}
+
+INSTR(0x44, op_ldbh)			/* LD B,H */
+{
+	B = H;
+	STATES(4);
+}
+
+INSTR(0x45, op_ldbl)			/* LD B,L */
+{
+	B = L;
+	STATES(4);
+}
+
+INSTR(0x46, op_ldbhl)			/* LD B,(HL) */
+{
+	B = memrdr((H << 8) + L);
+	STATES(7);
+}
+
+INSTR(0x4f, op_ldca)			/* LD C,A */
+{
+	C = A;
+	STATES(4);
+}
+
+INSTR(0x48, op_ldcb)			/* LD C,B */
+{
+	C = B;
+	STATES(4);
+}
+
+INSTR(0x49, op_ldcc)			/* LD C,C */
+{
+	STATES(4);
+}
+
+INSTR(0x4a, op_ldcd)			/* LD C,D */
+{
+	C = D;
+	STATES(4);
+}
+
+INSTR(0x4b, op_ldce)			/* LD C,E */
+{
+	C = E;
+	STATES(4);
+}
+
+INSTR(0x4c, op_ldch)			/* LD C,H */
+{
+	C = H;
+	STATES(4);
+}
+
+INSTR(0x4d, op_ldcl)			/* LD C,L */
+{
+	C = L;
+	STATES(4);
+}
+
+INSTR(0x4e, op_ldchl)			/* LD C,(HL) */
+{
+	C = memrdr((H << 8) + L);
+	STATES(7);
+}
+
+INSTR(0x57, op_ldda)			/* LD D,A */
+{
+	D = A;
+	STATES(4);
+}
+
+INSTR(0x50, op_lddb)			/* LD D,B */
+{
+	D = B;
+	STATES(4);
+}
+
+INSTR(0x51, op_lddc)			/* LD D,C */
+{
+	D = C;
+	STATES(4);
+}
+
+INSTR(0x52, op_lddd)			/* LD D,D */
+{
+	STATES(4);
+}
+
+INSTR(0x53, op_ldde)			/* LD D,E */
+{
+	D = E;
+	STATES(4);
+}
+
+INSTR(0x54, op_lddh)			/* LD D,H */
+{
+	D = H;
+	STATES(4);
+}
+
+INSTR(0x55, op_lddl)			/* LD D,L */
+{
+	D = L;
+	STATES(4);
+}
+
+INSTR(0x56, op_lddhl)			/* LD D,(HL) */
+{
+	D = memrdr((H << 8) + L);
+	STATES(7);
+}
+
+INSTR(0x5f, op_ldea)			/* LD E,A */
+{
+	E = A;
+	STATES(4);
+}
+
+INSTR(0x58, op_ldeb)			/* LD E,B */
+{
+	E = B;
+	STATES(4);
+}
+
+INSTR(0x59, op_ldec)			/* LD E,C */
+{
+	E = C;
+	STATES(4);
+}
+
+INSTR(0x5a, op_lded)			/* LD E,D */
+{
+	E = D;
+	STATES(4);
+}
+
+INSTR(0x5b, op_ldee)			/* LD E,E */
+{
+	STATES(4);
+}
+
+INSTR(0x5c, op_ldeh)			/* LD E,H */
+{
+	E = H;
+	STATES(4);
+}
+
+INSTR(0x5d, op_ldel)			/* LD E,L */
+{
+	E = L;
+	STATES(4);
+}
+
+INSTR(0x5e, op_ldehl)			/* LD E,(HL) */
+{
+	E = memrdr((H << 8) + L);
+	STATES(7);
+}
+
+INSTR(0x67, op_ldha)			/* LD H,A */
+{
+	H = A;
+	STATES(4);
+}
+
+INSTR(0x60, op_ldhb)			/* LD H,B */
+{
+	H = B;
+	STATES(4);
+}
+
+INSTR(0x61, op_ldhc)			/* LD H,C */
+{
+	H = C;
+	STATES(4);
+}
+
+INSTR(0x62, op_ldhd)			/* LD H,D */
+{
+	H = D;
+	STATES(4);
+}
+
+INSTR(0x63, op_ldhe)			/* LD H,E */
+{
+	H = E;
+	STATES(4);
+}
+
+INSTR(0x64, op_ldhh)			/* LD H,H */
+{
+	STATES(4);
+}
+
+INSTR(0x65, op_ldhl)			/* LD H,L */
+{
+	H = L;
+	STATES(4);
+}
+
+INSTR(0x66, op_ldhhl)			/* LD H,(HL) */
+{
+	H = memrdr((H << 8) + L);
+	STATES(7);
+}
+
+INSTR(0x6f, op_ldla)			/* LD L,A */
+{
+	L = A;
+	STATES(4);
+}
+
+INSTR(0x68, op_ldlb)			/* LD L,B */
+{
+	L = B;
+	STATES(4);
+}
+
+INSTR(0x69, op_ldlc)			/* LD L,C */
+{
+	L = C;
+	STATES(4);
+}
+
+INSTR(0x6a, op_ldld)			/* LD L,D */
+{
+	L = D;
+	STATES(4);
+}
+
+INSTR(0x6b, op_ldle)			/* LD L,E */
+{
+	L = E;
+	STATES(4);
+}
+
+INSTR(0x6c, op_ldlh)			/* LD L,H */
+{
+	L = H;
+	STATES(4);
+}
+
+INSTR(0x6d, op_ldll)			/* LD L,L */
+{
+	STATES(4);
+}
+
+INSTR(0x6e, op_ldlhl)			/* LD L,(HL) */
+{
+	L = memrdr((H << 8) + L);
+	STATES(7);
+}
+
+INSTR(0x01, op_ldbcnn)			/* LD BC,nn */
+{
+	C = memrdr(PC++);
+	B = memrdr(PC++);
+	STATES(10);
+}
+
+INSTR(0x11, op_lddenn)			/* LD DE,nn */
+{
+	E = memrdr(PC++);
+	D = memrdr(PC++);
+	STATES(10);
+}
+
+INSTR(0x21, op_ldhlnn)			/* LD HL,nn */
+{
+	L = memrdr(PC++);
+	H = memrdr(PC++);
+	STATES(10);
+}
+
+INSTR(0x31, op_ldspnn)			/* LD SP,nn */
+{
+	SP = memrdr(PC++);
+	SP += memrdr(PC++) << 8;
+	STATES(10);
+}
+
+INSTR(0xf9, op_ldsphl)			/* LD SP,HL */
+{
+	SP = (H << 8) + L;
+	STATES(6);
+}
+
+INSTR(0x2a, op_ldhlin)			/* LD HL,(nn) */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	L = memrdr(i++);
+	H = memrdr(i);
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(16);
+}
+
+INSTR(0x22, op_ldinhl)			/* LD (nn),HL */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	memwrt(i++, L);
+	memwrt(i, H);
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(16);
+}
+
+INSTR(0x03, op_incbc)			/* INC BC */
+{
+	C++;
+	if (!C)
+		B++;
+	STATES(6);
+}
+
+INSTR(0x13, op_incde)			/* INC DE */
+{
+	E++;
+	if (!E)
+		D++;
+	STATES(6);
+}
+
+INSTR(0x23, op_inchl)			/* INC HL */
+{
+	L++;
+	if (!L)
+		H++;
+	STATES(6);
+}
+
+INSTR(0x33, op_incsp)			/* INC SP */
+{
+	SP++;
+	STATES(6);
+}
+
+INSTR(0x0b, op_decbc)			/* DEC BC */
+{
+	C--;
+	if (C == 0xff)
+		B--;
+	STATES(6);
+}
+
+INSTR(0x1b, op_decde)			/* DEC DE */
+{
+	E--;
+	if (E == 0xff)
+		D--;
+	STATES(6);
+}
+
+INSTR(0x2b, op_dechl)			/* DEC HL */
+{
+	L--;
+	if (L == 0xff)
+		H--;
+	STATES(6);
+}
+
+INSTR(0x3b, op_decsp)			/* DEC SP */
+{
+	SP--;
+	STATES(6);
+}
+
+INSTR(0x09, op_adhlbc)			/* ADD HL,BC */
+{
+	register int carry;
+
+#ifdef UNDOC_FLAGS
+	WZ = ((H << 8) + L) + 1;
+#endif
+	carry = (L + C > 255) ? 1 : 0;
+	L += C;
+	((H & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(H + B + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H += B + carry;
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(11);
+}
+
+INSTR(0x19, op_adhlde)			/* ADD HL,DE */
+{
+	register int carry;
+
+#ifdef UNDOC_FLAGS
+	WZ = ((H << 8) + L) + 1;
+#endif
+	carry = (L + E > 255) ? 1 : 0;
+	L += E;
+	((H & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(H + D + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H += D + carry;
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(11);
+}
+
+INSTR(0x29, op_adhlhl)			/* ADD HL,HL */
+{
+	register int carry;
+
+#ifdef UNDOC_FLAGS
+	WZ = ((H << 8) + L) + 1;
+#endif
+	carry = (L << 1 > 255) ? 1 : 0;
+	L <<= 1;
+	((H & 0xf) + (H & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(H + H + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H += H + carry;
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(11);
+}
+
+INSTR(0x39, op_adhlsp)			/* ADD HL,SP */
+{
+	register int carry;
+
+	BYTE spl = SP & 0xff;
+	BYTE sph = SP >> 8;
+
+#ifdef UNDOC_FLAGS
+	WZ = ((H << 8) + L) + 1;
+#endif
+	carry = (L + spl > 255) ? 1 : 0;
+	L += spl;
+	((H & 0xf) + (sph & 0xf) + carry > 0xf) ? (F |= H_FLAG)
+						: (F &= ~H_FLAG);
+	(H + sph + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	H += sph + carry;
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(11);
+}
+
+INSTR(0xa7, op_anda)			/* AND A */
+{
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= H_FLAG;
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xa0, op_andb)			/* AND B */
+{
+	A &= B;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= H_FLAG;
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xa1, op_andc)			/* AND C */
+{
+	A &= C;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= H_FLAG;
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xa2, op_andd)			/* AND D */
+{
+	A &= D;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= H_FLAG;
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xa3, op_ande)			/* AND E */
+{
+	A &= E;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= H_FLAG;
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xa4, op_andh)			/* AND H */
+{
+	A &= H;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= H_FLAG;
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xa5, op_andl)			/* AND L */
+{
+	A &= L;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= H_FLAG;
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xa6, op_andhl)			/* AND (HL) */
+{
+	A &= memrdr((H << 8) + L);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= H_FLAG;
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xe6, op_andn)			/* AND n */
+{
+	A &= memrdr(PC++);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= H_FLAG;
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xb7, op_ora)			/* OR A */
+{
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xb0, op_orb)			/* OR B */
+{
+	A |= B;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xb1, op_orc)			/* OR C */
+{
+	A |= C;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xb2, op_ord)			/* OR D */
+{
+	A |= D;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xb3, op_ore)			/* OR E */
+{
+	A |= E;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xb4, op_orh)			/* OR H */
+{
+	A |= H;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xb5, op_orl)			/* OR L */
+{
+	A |= L;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xb6, op_orhl)			/* OR (HL) */
+{
+	A |= memrdr((H << 8) + L);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xf6, op_orn)			/* OR n */
+{
+	A |= memrdr(PC++);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xaf, op_xora)			/* XOR A */
+{
+	A = 0;
+	F &= ~(S_FLAG | H_FLAG | N_FLAG | C_FLAG);
+	F |= Z_FLAG | P_FLAG;
+#ifdef UNDOC_FLAGS
+	F &= ~(Y_FLAG | X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xa8, op_xorb)			/* XOR B */
+{
+	A ^= B;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xa9, op_xorc)			/* XOR C */
+{
+	A ^= C;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xaa, op_xord)			/* XOR D */
+{
+	A ^= D;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xab, op_xore)			/* XOR E */
+{
+	A ^= E;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xac, op_xorh)			/* XOR H */
+{
+	A ^= H;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xad, op_xorl)			/* XOR L */
+{
+	A ^= L;
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xae, op_xorhl)			/* XOR (HL) */
+{
+	A ^= memrdr((H << 8) + L);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xee, op_xorn)			/* XOR n */
+{
+	A ^= memrdr(PC++);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0x87, op_adda)			/* ADD A,A */
+{
+	register int i;
+
+	((A & 0xf) + (A & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	((A << 1) > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) A;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x80, op_addb)			/* ADD A,B */
+{
+	register int i;
+
+	((A & 0xf) + (B & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + B > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) B;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x81, op_addc)			/* ADD A,C */
+{
+	register int i;
+
+	((A & 0xf) + (C & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + C > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) C;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x82, op_addd)			/* ADD A,D */
+{
+	register int i;
+
+	((A & 0xf) + (D & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + D > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) D;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x83, op_adde)			/* ADD A,E */
+{
+	register int i;
+
+	((A & 0xf) + (E & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + E > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) E;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x84, op_addh)			/* ADD A,H */
+{
+	register int i;
+
+	((A & 0xf) + (H & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + H > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) H;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x85, op_addl)			/* ADD A,L */
+{
+	register int i;
+
+	((A & 0xf) + (L & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + L > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) L;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x86, op_addhl)			/* ADD A,(HL) */
+{
+	register int i;
+	register BYTE P;
+
+	P = memrdr((H << 8) + L);
+	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) P;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xc6, op_addn)			/* ADD A,n */
+{
+	register int i;
+	register BYTE P;
+
+	P = memrdr(PC++);
+	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) P;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0x8f, op_adca)			/* ADC A,A */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((A & 0xf) + (A & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	((A << 1) + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) A + carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x88, op_adcb)			/* ADC A,B */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((A & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + B + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) B + carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x89, op_adcc)			/* ADC A,C */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((A & 0xf) + (C & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + C + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) C + carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x8a, op_adcd)			/* ADC A,D */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((A & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + D + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) D + carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x8b, op_adce)			/* ADC A,E */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((A & 0xf) + (E & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + E + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) E + carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x8c, op_adch)			/* ADC A,H */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((A & 0xf) + (H & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + H + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) H + carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x8d, op_adcl)			/* ADC A,L */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((A & 0xf) + (L & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + L + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) L + carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x8e, op_adchl)			/* ADC A,(HL) */
+{
+	register int i, carry;
+	register BYTE P;
+
+	P = memrdr((H << 8) + L);
+	carry = (F & C_FLAG) ? 1 : 0;
+	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) P + carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xce, op_adcn)			/* ADC A,n */
+{
+	register int i, carry;
+	register BYTE P;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	P = memrdr(PC++);
+	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A + (signed char) P + carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0x97, op_suba)			/* SUB A,A */
+{
+	A = 0;
+	F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
+	F |= Z_FLAG | N_FLAG;
+#ifdef UNDOC_FLAGS
+	F &= ~(Y_FLAG | X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x90, op_subb)			/* SUB A,B */
+{
+	register int i;
+
+	((B & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(B > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) B;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x91, op_subc)			/* SUB A,C */
+{
+	register int i;
+
+	((C & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(C > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) C;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x92, op_subd)			/* SUB A,D */
+{
+	register int i;
+
+	((D & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(D > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) D;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x93, op_sube)			/* SUB A,E */
+{
+	register int i;
+
+	((E & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(E > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) E;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x94, op_subh)			/* SUB A,H */
+{
+	register int i;
+
+	((H & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(H > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) H;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x95, op_subl)			/* SUB A,L */
+{
+	register int i;
+
+	((L & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(L > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) L;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x96, op_subhl)			/* SUB A,(HL) */
+{
+	register int i;
+	register BYTE P;
+
+	P = memrdr((H << 8) + L);
+	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) P;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xd6, op_subn)			/* SUB A,n */
+{
+	register int i;
+	register BYTE P;
+
+	P = memrdr(PC++);
+	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) P;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0x9f, op_sbca)			/* SBC A,A */
+{
+	if (F & C_FLAG) {
+		A = 255;
+		F |= S_FLAG | H_FLAG | N_FLAG | C_FLAG;
+		F &= ~(Z_FLAG | P_FLAG);
+#ifdef UNDOC_FLAGS
+		F |= Y_FLAG | X_FLAG;
+		modF = 1;
+#endif
+	} else {
+		A = 0;
+		F |= Z_FLAG | N_FLAG;
+		F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
+#ifdef UNDOC_FLAGS
+		F &= ~(Y_FLAG | X_FLAG);
+		modF = 1;
+#endif
+	}
+	STATES(4);
+}
+
+INSTR(0x98, op_sbcb)			/* SBC A,B */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((B & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(B + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) B - carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x99, op_sbcc)			/* SBC A,C */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((C & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(C + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) C - carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x9a, op_sbcd)			/* SBC A,D */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((D & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(D + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) D - carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x9b, op_sbce)			/* SBC A,E */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((E & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(E + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) E - carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x9c, op_sbch)			/* SBC A,H */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((H & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(H + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) H - carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x9d, op_sbcl)			/* SBC A,L */
+{
+	register int i, carry;
+
+	carry = (F & C_FLAG) ? 1 : 0;
+	((L & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(L + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) L - carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x9e, op_sbchl)			/* SBC A,(HL) */
+{
+	register int i, carry;
+	register BYTE P;
+
+	P = memrdr((H << 8) + L);
+	carry = (F & C_FLAG) ? 1 : 0;
+	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) P - carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xde, op_sbcn)			/* SBC A,n */
+{
+	register int i, carry;
+	register BYTE P;
+
+	P = memrdr(PC++);
+	carry = (F & C_FLAG) ? 1 : 0;
+	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	A = i = (signed char) A - (signed char) P - carry;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xbf, op_cpa)			/* CP A */
+{
+	F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
+	F |= Z_FLAG | N_FLAG;
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xb8, op_cpb)			/* CP B */
+{
+	register int i;
+
+	((B & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(B > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	i = (signed char) A - (signed char) B;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xb9, op_cpc)			/* CP C */
+{
+	register int i;
+
+	((C & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(C > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	i = (signed char) A - (signed char) C;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xba, op_cpd)			/* CP D */
+{
+	register int i;
+
+	((D & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(D > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	i = (signed char) A - (signed char) D;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xbb, op_cpe)			/* CP E */
+{
+	register int i;
+
+	((E & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(E > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	i = (signed char) A - (signed char) E;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xbc, op_cph)			/* CP H */
+{
+	register int i;
+
+	((H & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(H > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	i = (signed char) A - (signed char) H;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xbd, op_cplr)			/* CP L */
+{
+	register int i;
+
+	((L & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(L > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	i = (signed char) A - (signed char) L;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xbe, op_cphl)			/* CP (HL) */
+{
+	register int i;
+	register BYTE P;
+
+	P = memrdr((H << 8) + L);
+	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	i = (signed char) A - (signed char) P;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0xfe, op_cpn)			/* CP n */
+{
+	register int i;
+	register BYTE P;
+
+	P = memrdr(PC++);
+	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	i = (signed char) A - (signed char) P;
+	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(7);
+}
+
+INSTR(0x3c, op_inca)			/* INC A */
+{
+	A++;
+	((A & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x04, op_incb)			/* INC B */
+{
+	B++;
+	((B & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(B == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x0c, op_incc)			/* INC C */
+{
+	C++;
+	((C & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(C == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x14, op_incd)			/* INC D */
+{
+	D++;
+	((D & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(D == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x1c, op_ince)			/* INC E */
+{
+	E++;
+	((E & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(E == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x24, op_inch)			/* INC H */
+{
+	H++;
+	((H & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(H == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x2c, op_incl)			/* INC L */
+{
+	L++;
+	((L & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(L == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x34, op_incihl)			/* INC (HL) */
+{
+	register BYTE P;
+	WORD addr;
+
+	addr = (H << 8) + L;
+	P = memrdr(addr);
+	P++;
+	memwrt(addr, P);
+	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(P == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F &= ~N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(11);
+}
+
+INSTR(0x3d, op_deca)			/* DEC A */
+{
+	A--;
+	((A & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(A == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x05, op_decb)			/* DEC B */
+{
+	B--;
+	((B & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(B == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x0d, op_decc)			/* DEC C */
+{
+	C--;
+	((C & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(C == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x15, op_decd)			/* DEC D */
+{
+	D--;
+	((D & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(D == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x1d, op_dece)			/* DEC E */
+{
+	E--;
+	((E & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(E == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x25, op_dech)			/* DEC H */
+{
+	H--;
+	((H & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(H == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x2d, op_decl)			/* DEC L */
+{
+	L--;
+	((L & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(L == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x35, op_decihl)			/* DEC (HL) */
+{
+	register BYTE P;
+	WORD addr;
+
+	addr = (H << 8) + L;
+	P = memrdr(addr);
+	P--;
+	memwrt(addr, P);
+	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(P == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	F |= N_FLAG;
+#ifdef UNDOC_FLAGS
+	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(11);
+}
+
+INSTR(0x07, op_rlca)			/* RLCA */
+{
+	register int i;
+
+	i = (A & 128) ? 1 : 0;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	F &= ~(H_FLAG | N_FLAG);
+	A <<= 1;
+	A |= i;
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x0f, op_rrca)			/* RRCA */
+{
+	register int i;
+
+	i = A & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	F &= ~(H_FLAG | N_FLAG);
+	A >>= 1;
+	if (i) A |= 128;
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x17, op_rla)			/* RLA */
+{
+	register int old_c_flag;
+
+	old_c_flag = F & C_FLAG;
+	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	F &= ~(H_FLAG | N_FLAG);
+	A <<= 1;
+	if (old_c_flag) A |= 1;
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0x1f, op_rra)			/* RRA */
+{
+	register int i, old_c_flag;
+
+	old_c_flag = F & C_FLAG;
+	i = A & 1;
+	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	F &= ~(H_FLAG | N_FLAG);
+	A >>= 1;
+	if (old_c_flag) A |= 128;
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(4);
+}
+
+INSTR(0xeb, op_exdehl)			/* EX DE,HL */
+{
+	register BYTE i;
+
+	i = D;
+	D = H;
+	H = i;
+	i = E;
+	E = L;
+	L = i;
+	STATES(4);
+}
+
+INSTR(0x08, op_exafaf)			/* EX AF,AF' */
+{
+	register BYTE i;
+
+	i = A;
+	A = A_;
+	A_ = i;
+	i = F;
+	F = F_;
+	F_ = i;
+	STATES(4);
+}
+
+INSTR(0xd9, op_exx)			/* EXX */
+{
+	register BYTE i;
+
+	i = B;
+	B = B_;
+	B_ = i;
+	i = C;
+	C = C_;
+	C_ = i;
+	i = D;
+	D = D_;
+	D_ = i;
+	i = E;
+	E = E_;
+	E_ = i;
+	i = H;
+	H = H_;
+	H_ = i;
+	i = L;
+	L = L_;
+	L_ = i;
+	STATES(4);
+}
+
+INSTR(0xe3, op_exsphl)			/* EX (SP),HL */
+{
+	register BYTE i;
+
+	i = memrdr(SP);
+	memwrt(SP, L);
+	L = i;
+	i = memrdr(SP + 1);
+	memwrt(SP + 1, H);
+	H = i;
+#ifdef UNDOC_FLAGS
+	WZ = (H << 8) + L;
+#endif
+	STATES(19);
+}
+
+INSTR(0xf5, op_pushaf)			/* PUSH AF */
+{
+	memwrt(--SP, A);
+	memwrt(--SP, F);
+	STATES(11);
+}
+
+INSTR(0xc5, op_pushbc)			/* PUSH BC */
+{
+	memwrt(--SP, B);
+	memwrt(--SP, C);
+	STATES(11);
+}
+
+INSTR(0xd5, op_pushde)			/* PUSH DE */
+{
+	memwrt(--SP, D);
+	memwrt(--SP, E);
+	STATES(11);
+}
+
+INSTR(0xe5, op_pushhl)			/* PUSH HL */
+{
+	memwrt(--SP, H);
+	memwrt(--SP, L);
+	STATES(11);
+}
+
+INSTR(0xf1, op_popaf)			/* POP AF */
+{
+	F = memrdr(SP++);
+	A = memrdr(SP++);
+	STATES(10);
+}
+
+INSTR(0xc1, op_popbc)			/* POP BC */
+{
+	C = memrdr(SP++);
+	B = memrdr(SP++);
+	STATES(10);
+}
+
+INSTR(0xd1, op_popde)			/* POP DE */
+{
+	E = memrdr(SP++);
+	D = memrdr(SP++);
+	STATES(10);
+}
+
+INSTR(0xe1, op_pophl)			/* POP HL */
+{
+	L = memrdr(SP++);
+	H = memrdr(SP++);
+	STATES(10);
+}
+
+INSTR(0xc3, op_jp)			/* JP nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC) << 8;
+	PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xe9, op_jphl)			/* JP (HL) */
+{
+	PC = (H << 8) + L;
+	STATES(4);
+}
+
+INSTR(0x18, op_jr)			/* JR n */
+{
+	register int d;
+
+	d = (signed char) memrdr(PC++);
+	PC += d;
+#ifdef UNDOC_FLAGS
+	WZ = PC;
+#endif
+	STATES(12);
+}
+
+INSTR(0x10, op_djnz)			/* DJNZ n */
+{
+	register int d;
+
+	d = (signed char) memrdr(PC++);
+	if (--B) {
+		PC += d;
+#ifdef UNDOC_FLAGS
+		WZ = PC;
+#endif
+		STATES(13);
+	}
+	STATES(5);
+}
+
+INSTR(0xcd, op_call)			/* CALL nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC);
+	PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(17);
+}
+
+INSTR(0xc9, op_ret)			/* RET */
+{
+	register WORD i;
+
+	i = memrdr(SP++);
+	i += memrdr(SP++) << 8;
+	PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xca, op_jpz)			/* JP Z,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & Z_FLAG)
+		PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xc2, op_jpnz)			/* JP NZ,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & Z_FLAG))
+		PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xda, op_jpc)			/* JP C,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & C_FLAG)
+		PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xd2, op_jpnc)			/* JP NC,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & C_FLAG))
+		PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xea, op_jppe)			/* JP PE,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & P_FLAG)
+		PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xe2, op_jppo)			/* JP PO,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & P_FLAG))
+		PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xfa, op_jpm)			/* JP M,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & S_FLAG)
+		PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xf2, op_jpp)			/* JP P,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & S_FLAG))
+		PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xcc, op_calz)			/* CALL Z,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & Z_FLAG) {
+		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC);
+		PC = i;
+		STATES(17);
+	}
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xc4, op_calnz)			/* CALL NZ,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & Z_FLAG)) {
+		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC);
+		PC = i;
+		STATES(17);
+	}
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xdc, op_calc)			/* CALL C,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & C_FLAG) {
+		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC);
+		PC = i;
+		STATES(17);
+	}
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xd4, op_calnc)			/* CALL NC,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & C_FLAG)) {
+		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC);
+		PC = i;
+		STATES(17);
+	}
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xec, op_calpe)			/* CALL PE,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & P_FLAG) {
+		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC);
+		PC = i;
+		STATES(17);
+	}
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xe4, op_calpo)			/* CALL PO,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & P_FLAG)) {
+		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC);
+		PC = i;
+		STATES(17);
+	}
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xfc, op_calm)			/* CALL M,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (F & S_FLAG) {
+		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC);
+		PC = i;
+		STATES(17);
+	}
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xf4, op_calp)			/* CALL P,nn */
+{
+	register WORD i;
+
+	i = memrdr(PC++);
+	i += memrdr(PC++) << 8;
+	if (!(F & S_FLAG)) {
+		memwrt(--SP, PC >> 8);
+		memwrt(--SP, PC);
+		PC = i;
+		STATES(17);
+	}
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(10);
+}
+
+INSTR(0xc8, op_retz)			/* RET Z */
+{
+	register WORD i;
+
+	if (F & Z_FLAG) {
+		i = memrdr(SP++);
+		i += memrdr(SP++) << 8;
+		PC = i;
+#ifdef UNDOC_FLAGS
+		WZ = i;
+#endif
+		STATES(11);
+	}
+	STATES(5);
+}
+
+INSTR(0xc0, op_retnz)			/* RET NZ */
+{
+	register WORD i;
+
+	if (!(F & Z_FLAG)) {
+		i = memrdr(SP++);
+		i += memrdr(SP++) << 8;
+		PC = i;
+#ifdef UNDOC_FLAGS
+		WZ = i;
+#endif
+		STATES(11);
+	}
+	STATES(5);
+}
+
+INSTR(0xd8, op_retc)			/* RET C */
+{
+	register WORD i;
+
+	if (F & C_FLAG) {
+		i = memrdr(SP++);
+		i += memrdr(SP++) << 8;
+		PC = i;
+#ifdef UNDOC_FLAGS
+		WZ = i;
+		STATES(11);
+#endif
+	}
+	STATES(5);
+}
+
+INSTR(0xd0, op_retnc)			/* RET NC */
+{
+	register WORD i;
+
+	if (!(F & C_FLAG)) {
+		i = memrdr(SP++);
+		i += memrdr(SP++) << 8;
+		PC = i;
+#ifdef UNDOC_FLAGS
+		WZ = i;
+#endif
+		STATES(11);
+	}
+	STATES(5);
+}
+
+INSTR(0xe8, op_retpe)			/* RET PE */
+{
+	register WORD i;
+
+	if (F & P_FLAG) {
+		i = memrdr(SP++);
+		i += memrdr(SP++) << 8;
+		PC = i;
+#ifdef UNDOC_FLAGS
+		WZ = i;
+#endif
+		STATES(11);
+	}
+	STATES(5);
+}
+
+INSTR(0xe0, op_retpo)			/* RET PO */
+{
+	register WORD i;
+
+	if (!(F & P_FLAG)) {
+		i = memrdr(SP++);
+		i += memrdr(SP++) << 8;
+		PC = i;
+#ifdef UNDOC_FLAGS
+		WZ = i;
+#endif
+		STATES(11);
+	}
+	STATES(5);
+}
+
+INSTR(0xf8, op_retm)			/* RET M */
+{
+	register WORD i;
+
+	if (F & S_FLAG) {
+		i = memrdr(SP++);
+		i += memrdr(SP++) << 8;
+		PC = i;
+#ifdef UNDOC_FLAGS
+		WZ = i;
+#endif
+		STATES(11);
+	}
+	STATES(5);
+}
+
+INSTR(0xf0, op_retp)			/* RET P */
+{
+	register WORD i;
+
+	if (!(F & S_FLAG)) {
+		i = memrdr(SP++);
+		i += memrdr(SP++) << 8;
+		PC = i;
+#ifdef UNDOC_FLAGS
+		WZ = i;
+#endif
+		STATES(11);
+	}
+	STATES(5);
+}
+
+INSTR(0x28, op_jrz)			/* JR Z,n */
+{
+	register int d;
+
+	d = (signed char) memrdr(PC++);
+	if (F & Z_FLAG) {
+		PC += d;
+#ifdef UNDOC_FLAGS
+		WZ = PC;
+#endif
+		STATES(12);
+	}
+	STATES(7);
+}
+
+INSTR(0x20, op_jrnz)			/* JR NZ,n */
+{
+	register int d;
+
+	d = (signed char) memrdr(PC++);
+	if (!(F & Z_FLAG)) {
+		PC += d;
+#ifdef UNDOC_FLAGS
+		WZ = PC;
+#endif
+		STATES(12);
+	}
+	STATES(7);
+}
+
+INSTR(0x38, op_jrc)			/* JR C,n */
+{
+	register int d;
+
+	d = (signed char) memrdr(PC++);
+	if (F & C_FLAG) {
+		PC += d;
+#ifdef UNDOC_FLAGS
+		WZ = PC;
+#endif
+		STATES(12);
+	}
+	STATES(7);
+}
+
+INSTR(0x30, op_jrnc)			/* JR NC,n */
+{
+	register int d;
+
+	d = (signed char) memrdr(PC++);
+	if (!(F & C_FLAG)) {
+		PC += d;
+#ifdef UNDOC_FLAGS
+		WZ = PC;
+#endif
+		STATES(12);
+	}
+	STATES(7);
+}
+
+INSTR(0xc7, op_rst00)			/* RST 00 */
+{
+	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC);
+	PC = 0;
+#ifdef UNDOC_FLAGS
+	WZ = PC;
+#endif
+	STATES(11);
+}
+
+INSTR(0xcf, op_rst08)			/* RST 08 */
+{
+	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC);
+	PC = 0x08;
+#ifdef UNDOC_FLAGS
+	WZ = PC;
+#endif
+	STATES(11);
+}
+
+INSTR(0xd7, op_rst10)			/* RST 10 */
+{
+	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC);
+	PC = 0x10;
+#ifdef UNDOC_FLAGS
+	WZ = PC;
+#endif
+	STATES(11);
+}
+
+INSTR(0xdf, op_rst18)			/* RST 18 */
+{
+	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC);
+	PC = 0x18;
+#ifdef UNDOC_FLAGS
+	WZ = PC;
+#endif
+	STATES(11);
+}
+
+INSTR(0xe7, op_rst20)			/* RST 20 */
+{
+	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC);
+	PC = 0x20;
+#ifdef UNDOC_FLAGS
+	WZ = PC;
+#endif
+	STATES(11);
+}
+
+INSTR(0xef, op_rst28)			/* RST 28 */
+{
+	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC);
+	PC = 0x28;
+#ifdef UNDOC_FLAGS
+	WZ = PC;
+#endif
+	STATES(11);
+}
+
+INSTR(0xf7, op_rst30)			/* RST 30 */
+{
+	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC);
+	PC = 0x30;
+#ifdef UNDOC_FLAGS
+	WZ = PC;
+#endif
+	STATES(11);
+}
+
+INSTR(0xff, op_rst38)			/* RST 38 */
+{
+	memwrt(--SP, PC >> 8);
+	memwrt(--SP, PC);
+	PC = 0x38;
+#ifdef UNDOC_FLAGS
+	WZ = PC;
+#endif
+	STATES(11);
+}
+
+INSTR(0xcb, op_cb_handle)		/* 0xcb prefix */
+{
+#ifndef FAST_INSTR
+
+#ifdef UNDOC_INST
+#define UNDOC(f) f
+#else
+#define UNDOC(f) trap_cb
+#endif
+
+	static int (*op_cb[256])(void) = {
+		op_rlcb,			/* 0x00 */
+		op_rlcc,			/* 0x01 */
+		op_rlcd,			/* 0x02 */
+		op_rlce,			/* 0x03 */
+		op_rlch,			/* 0x04 */
+		op_rlcl,			/* 0x05 */
+		op_rlchl,			/* 0x06 */
+		op_rlcra,			/* 0x07 */
+		op_rrcb,			/* 0x08 */
+		op_rrcc,			/* 0x09 */
+		op_rrcd,			/* 0x0a */
+		op_rrce,			/* 0x0b */
+		op_rrch,			/* 0x0c */
+		op_rrcl,			/* 0x0d */
+		op_rrchl,			/* 0x0e */
+		op_rrcra,			/* 0x0f */
+		op_rlb,				/* 0x10 */
+		op_rlc,				/* 0x11 */
+		op_rld,				/* 0x12 */
+		op_rle,				/* 0x13 */
+		op_rlh,				/* 0x14 */
+		op_rll,				/* 0x15 */
+		op_rlhl,			/* 0x16 */
+		op_rlra,			/* 0x17 */
+		op_rrb,				/* 0x18 */
+		op_rrc,				/* 0x19 */
+		op_rrd,				/* 0x1a */
+		op_rre,				/* 0x1b */
+		op_rrh,				/* 0x1c */
+		op_rrl,				/* 0x1d */
+		op_rrhl,			/* 0x1e */
+		op_rrra,			/* 0x1f */
+		op_slab,			/* 0x20 */
+		op_slac,			/* 0x21 */
+		op_slad,			/* 0x22 */
+		op_slae,			/* 0x23 */
+		op_slah,			/* 0x24 */
+		op_slal,			/* 0x25 */
+		op_slahl,			/* 0x26 */
+		op_slaa,			/* 0x27 */
+		op_srab,			/* 0x28 */
+		op_srac,			/* 0x29 */
+		op_srad,			/* 0x2a */
+		op_srae,			/* 0x2b */
+		op_srah,			/* 0x2c */
+		op_sral,			/* 0x2d */
+		op_srahl,			/* 0x2e */
+		op_sraa,			/* 0x2f */
+		UNDOC(op_undoc_sllb),		/* 0x30 */
+		UNDOC(op_undoc_sllc),		/* 0x31 */
+		UNDOC(op_undoc_slld),		/* 0x32 */
+		UNDOC(op_undoc_slle),		/* 0x33 */
+		UNDOC(op_undoc_sllh),		/* 0x34 */
+		UNDOC(op_undoc_slll),		/* 0x35 */
+		UNDOC(op_undoc_sllhl),		/* 0x36 */
+		op_undoc_slla,			/* 0x37 */
+		op_srlb,			/* 0x38 */
+		op_srlc,			/* 0x39 */
+		op_srld,			/* 0x3a */
+		op_srle,			/* 0x3b */
+		op_srlh,			/* 0x3c */
+		op_srll,			/* 0x3d */
+		op_srlhl,			/* 0x3e */
+		op_srla,			/* 0x3f */
+		op_tb0b,			/* 0x40 */
+		op_tb0c,			/* 0x41 */
+		op_tb0d,			/* 0x42 */
+		op_tb0e,			/* 0x43 */
+		op_tb0h,			/* 0x44 */
+		op_tb0l,			/* 0x45 */
+		op_tb0hl,			/* 0x46 */
+		op_tb0a,			/* 0x47 */
+		op_tb1b,			/* 0x48 */
+		op_tb1c,			/* 0x49 */
+		op_tb1d,			/* 0x4a */
+		op_tb1e,			/* 0x4b */
+		op_tb1h,			/* 0x4c */
+		op_tb1l,			/* 0x4d */
+		op_tb1hl,			/* 0x4e */
+		op_tb1a,			/* 0x4f */
+		op_tb2b,			/* 0x50 */
+		op_tb2c,			/* 0x51 */
+		op_tb2d,			/* 0x52 */
+		op_tb2e,			/* 0x53 */
+		op_tb2h,			/* 0x54 */
+		op_tb2l,			/* 0x55 */
+		op_tb2hl,			/* 0x56 */
+		op_tb2a,			/* 0x57 */
+		op_tb3b,			/* 0x58 */
+		op_tb3c,			/* 0x59 */
+		op_tb3d,			/* 0x5a */
+		op_tb3e,			/* 0x5b */
+		op_tb3h,			/* 0x5c */
+		op_tb3l,			/* 0x5d */
+		op_tb3hl,			/* 0x5e */
+		op_tb3a,			/* 0x5f */
+		op_tb4b,			/* 0x60 */
+		op_tb4c,			/* 0x61 */
+		op_tb4d,			/* 0x62 */
+		op_tb4e,			/* 0x63 */
+		op_tb4h,			/* 0x64 */
+		op_tb4l,			/* 0x65 */
+		op_tb4hl,			/* 0x66 */
+		op_tb4a,			/* 0x67 */
+		op_tb5b,			/* 0x68 */
+		op_tb5c,			/* 0x69 */
+		op_tb5d,			/* 0x6a */
+		op_tb5e,			/* 0x6b */
+		op_tb5h,			/* 0x6c */
+		op_tb5l,			/* 0x6d */
+		op_tb5hl,			/* 0x6e */
+		op_tb5a,			/* 0x6f */
+		op_tb6b,			/* 0x70 */
+		op_tb6c,			/* 0x71 */
+		op_tb6d,			/* 0x72 */
+		op_tb6e,			/* 0x73 */
+		op_tb6h,			/* 0x74 */
+		op_tb6l,			/* 0x75 */
+		op_tb6hl,			/* 0x76 */
+		op_tb6a,			/* 0x77 */
+		op_tb7b,			/* 0x78 */
+		op_tb7c,			/* 0x79 */
+		op_tb7d,			/* 0x7a */
+		op_tb7e,			/* 0x7b */
+		op_tb7h,			/* 0x7c */
+		op_tb7l,			/* 0x7d */
+		op_tb7hl,			/* 0x7e */
+		op_tb7a,			/* 0x7f */
+		op_rb0b,			/* 0x80 */
+		op_rb0c,			/* 0x81 */
+		op_rb0d,			/* 0x82 */
+		op_rb0e,			/* 0x83 */
+		op_rb0h,			/* 0x84 */
+		op_rb0l,			/* 0x85 */
+		op_rb0hl,			/* 0x86 */
+		op_rb0a,			/* 0x87 */
+		op_rb1b,			/* 0x88 */
+		op_rb1c,			/* 0x89 */
+		op_rb1d,			/* 0x8a */
+		op_rb1e,			/* 0x8b */
+		op_rb1h,			/* 0x8c */
+		op_rb1l,			/* 0x8d */
+		op_rb1hl,			/* 0x8e */
+		op_rb1a,			/* 0x8f */
+		op_rb2b,			/* 0x90 */
+		op_rb2c,			/* 0x91 */
+		op_rb2d,			/* 0x92 */
+		op_rb2e,			/* 0x93 */
+		op_rb2h,			/* 0x94 */
+		op_rb2l,			/* 0x95 */
+		op_rb2hl,			/* 0x96 */
+		op_rb2a,			/* 0x97 */
+		op_rb3b,			/* 0x98 */
+		op_rb3c,			/* 0x99 */
+		op_rb3d,			/* 0x9a */
+		op_rb3e,			/* 0x9b */
+		op_rb3h,			/* 0x9c */
+		op_rb3l,			/* 0x9d */
+		op_rb3hl,			/* 0x9e */
+		op_rb3a,			/* 0x9f */
+		op_rb4b,			/* 0xa0 */
+		op_rb4c,			/* 0xa1 */
+		op_rb4d,			/* 0xa2 */
+		op_rb4e,			/* 0xa3 */
+		op_rb4h,			/* 0xa4 */
+		op_rb4l,			/* 0xa5 */
+		op_rb4hl,			/* 0xa6 */
+		op_rb4a,			/* 0xa7 */
+		op_rb5b,			/* 0xa8 */
+		op_rb5c,			/* 0xa9 */
+		op_rb5d,			/* 0xaa */
+		op_rb5e,			/* 0xab */
+		op_rb5h,			/* 0xac */
+		op_rb5l,			/* 0xad */
+		op_rb5hl,			/* 0xae */
+		op_rb5a,			/* 0xaf */
+		op_rb6b,			/* 0xb0 */
+		op_rb6c,			/* 0xb1 */
+		op_rb6d,			/* 0xb2 */
+		op_rb6e,			/* 0xb3 */
+		op_rb6h,			/* 0xb4 */
+		op_rb6l,			/* 0xb5 */
+		op_rb6hl,			/* 0xb6 */
+		op_rb6a,			/* 0xb7 */
+		op_rb7b,			/* 0xb8 */
+		op_rb7c,			/* 0xb9 */
+		op_rb7d,			/* 0xba */
+		op_rb7e,			/* 0xbb */
+		op_rb7h,			/* 0xbc */
+		op_rb7l,			/* 0xbd */
+		op_rb7hl,			/* 0xbe */
+		op_rb7a,			/* 0xbf */
+		op_sb0b,			/* 0xc0 */
+		op_sb0c,			/* 0xc1 */
+		op_sb0d,			/* 0xc2 */
+		op_sb0e,			/* 0xc3 */
+		op_sb0h,			/* 0xc4 */
+		op_sb0l,			/* 0xc5 */
+		op_sb0hl,			/* 0xc6 */
+		op_sb0a,			/* 0xc7 */
+		op_sb1b,			/* 0xc8 */
+		op_sb1c,			/* 0xc9 */
+		op_sb1d,			/* 0xca */
+		op_sb1e,			/* 0xcb */
+		op_sb1h,			/* 0xcc */
+		op_sb1l,			/* 0xcd */
+		op_sb1hl,			/* 0xce */
+		op_sb1a,			/* 0xcf */
+		op_sb2b,			/* 0xd0 */
+		op_sb2c,			/* 0xd1 */
+		op_sb2d,			/* 0xd2 */
+		op_sb2e,			/* 0xd3 */
+		op_sb2h,			/* 0xd4 */
+		op_sb2l,			/* 0xd5 */
+		op_sb2hl,			/* 0xd6 */
+		op_sb2a,			/* 0xd7 */
+		op_sb3b,			/* 0xd8 */
+		op_sb3c,			/* 0xd9 */
+		op_sb3d,			/* 0xda */
+		op_sb3e,			/* 0xdb */
+		op_sb3h,			/* 0xdc */
+		op_sb3l,			/* 0xdd */
+		op_sb3hl,			/* 0xde */
+		op_sb3a,			/* 0xdf */
+		op_sb4b,			/* 0xe0 */
+		op_sb4c,			/* 0xe1 */
+		op_sb4d,			/* 0xe2 */
+		op_sb4e,			/* 0xe3 */
+		op_sb4h,			/* 0xe4 */
+		op_sb4l,			/* 0xe5 */
+		op_sb4hl,			/* 0xe6 */
+		op_sb4a,			/* 0xe7 */
+		op_sb5b,			/* 0xe8 */
+		op_sb5c,			/* 0xe9 */
+		op_sb5d,			/* 0xea */
+		op_sb5e,			/* 0xeb */
+		op_sb5h,			/* 0xec */
+		op_sb5l,			/* 0xed */
+		op_sb5hl,			/* 0xee */
+		op_sb5a,			/* 0xef */
+		op_sb6b,			/* 0xf0 */
+		op_sb6c,			/* 0xf1 */
+		op_sb6d,			/* 0xf2 */
+		op_sb6e,			/* 0xf3 */
+		op_sb6h,			/* 0xf4 */
+		op_sb6l,			/* 0xf5 */
+		op_sb6hl,			/* 0xf6 */
+		op_sb6a,			/* 0xf7 */
+		op_sb7b,			/* 0xf8 */
+		op_sb7c,			/* 0xf9 */
+		op_sb7d,			/* 0xfa */
+		op_sb7e,			/* 0xfb */
+		op_sb7h,			/* 0xfc */
+		op_sb7l,			/* 0xfd */
+		op_sb7hl,			/* 0xfe */
+		op_sb7a				/* 0xff */
+	};
+
+#undef UNDOC
+
+	register int t;
+
+#endif /* !FAST_INSTR */
+
+#ifdef BUS_8080
+	/* M1 opcode fetch */
+	cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
+	m1_step = 1;
+#endif
+#ifdef FRONTPANEL
+	if (F_flag) {
+		/* update frontpanel */
+		fp_clock++;
+		fp_sampleLightGroup(0, 0);
+	}
+#endif
+
+	R++;				/* increment refresh register */
+
+#ifndef FAST_INSTR
+	t = (*op_cb[memrdr(PC++)])();	/* execute next opcode */
+#else
+	switch (memrdr(PC++)) {		/* execute next opcode */
+
+#include "simz80-cb.c"
+
+	default:
+		t = trap_cb();
+		break;
+	}
+#endif
+
+	STATES(t);
+}
+
+#ifndef FAST_INSTR
+#include "simz80-cb.c"
+#endif
+
+INSTR(0xdd, op_dd_handle)		/* 0xdd prefix */
+{
+#ifndef FAST_INSTR
+
+#ifdef UNDOC_INST
+#define UNDOC(f) f
+#else
+#define UNDOC(f) trap_dd
+#endif
+
+	static int (*op_dd[256])(void) = {
+		trap_dd,			/* 0x00 */
+		trap_dd,			/* 0x01 */
+		trap_dd,			/* 0x02 */
+		trap_dd,			/* 0x03 */
+		trap_dd,			/* 0x04 */
+		trap_dd,			/* 0x05 */
+		trap_dd,			/* 0x06 */
+		trap_dd,			/* 0x07 */
+		trap_dd,			/* 0x08 */
+		op_addxb,			/* 0x09 */
+		trap_dd,			/* 0x0a */
+		trap_dd,			/* 0x0b */
+		trap_dd,			/* 0x0c */
+		trap_dd,			/* 0x0d */
+		trap_dd,			/* 0x0e */
+		trap_dd,			/* 0x0f */
+		trap_dd,			/* 0x10 */
+		trap_dd,			/* 0x11 */
+		trap_dd,			/* 0x12 */
+		trap_dd,			/* 0x13 */
+		trap_dd,			/* 0x14 */
+		trap_dd,			/* 0x15 */
+		trap_dd,			/* 0x16 */
+		trap_dd,			/* 0x17 */
+		trap_dd,			/* 0x18 */
+		op_addxd,			/* 0x19 */
+		trap_dd,			/* 0x1a */
+		trap_dd,			/* 0x1b */
+		trap_dd,			/* 0x1c */
+		trap_dd,			/* 0x1d */
+		trap_dd,			/* 0x1e */
+		trap_dd,			/* 0x1f */
+		trap_dd,			/* 0x20 */
+		op_ldixnn,			/* 0x21 */
+		op_ldinx,			/* 0x22 */
+		op_incix,			/* 0x23 */
+		UNDOC(op_undoc_incixh),		/* 0x24 */
+		UNDOC(op_undoc_decixh),		/* 0x25 */
+		UNDOC(op_undoc_ldixhn),		/* 0x26 */
+		trap_dd,			/* 0x27 */
+		trap_dd,			/* 0x28 */
+		op_addxx,			/* 0x29 */
+		op_ldixinn,			/* 0x2a */
+		op_decix,			/* 0x2b */
+		UNDOC(op_undoc_incixl),		/* 0x2c */
+		UNDOC(op_undoc_decixl),		/* 0x2d */
+		UNDOC(op_undoc_ldixln),		/* 0x2e */
+		trap_dd,			/* 0x2f */
+		trap_dd,			/* 0x30 */
+		trap_dd,			/* 0x31 */
+		trap_dd,			/* 0x32 */
+		trap_dd,			/* 0x33 */
+		op_incxd,			/* 0x34 */
+		op_decxd,			/* 0x35 */
+		op_ldxdn,			/* 0x36 */
+		trap_dd,			/* 0x37 */
+		trap_dd,			/* 0x38 */
+		op_addxs,			/* 0x39 */
+		trap_dd,			/* 0x3a */
+		trap_dd,			/* 0x3b */
+		trap_dd,			/* 0x3c */
+		trap_dd,			/* 0x3d */
+		trap_dd,			/* 0x3e */
+		trap_dd,			/* 0x3f */
+		trap_dd,			/* 0x40 */
+		trap_dd,			/* 0x41 */
+		trap_dd,			/* 0x42 */
+		trap_dd,			/* 0x43 */
+		UNDOC(op_undoc_ldbixh),		/* 0x44 */
+		UNDOC(op_undoc_ldbixl),		/* 0x45 */
+		op_ldbxd,			/* 0x46 */
+		trap_dd,			/* 0x47 */
+		trap_dd,			/* 0x48 */
+		trap_dd,			/* 0x49 */
+		trap_dd,			/* 0x4a */
+		trap_dd,			/* 0x4b */
+		UNDOC(op_undoc_ldcixh),		/* 0x4c */
+		UNDOC(op_undoc_ldcixl),		/* 0x4d */
+		op_ldcxd,			/* 0x4e */
+		trap_dd,			/* 0x4f */
+		trap_dd,			/* 0x50 */
+		trap_dd,			/* 0x51 */
+		trap_dd,			/* 0x52 */
+		trap_dd,			/* 0x53 */
+		UNDOC(op_undoc_lddixh),		/* 0x54 */
+		UNDOC(op_undoc_lddixl),		/* 0x55 */
+		op_lddxd,			/* 0x56 */
+		trap_dd,			/* 0x57 */
+		trap_dd,			/* 0x58 */
+		trap_dd,			/* 0x59 */
+		trap_dd,			/* 0x5a */
+		trap_dd,			/* 0x5b */
+		UNDOC(op_undoc_ldeixh),		/* 0x5c */
+		UNDOC(op_undoc_ldeixl),		/* 0x5d */
+		op_ldexd,			/* 0x5e */
+		trap_dd,			/* 0x5f */
+		UNDOC(op_undoc_ldixhb),		/* 0x60 */
+		UNDOC(op_undoc_ldixhc),		/* 0x61 */
+		UNDOC(op_undoc_ldixhd),		/* 0x62 */
+		UNDOC(op_undoc_ldixhe),		/* 0x63 */
+		UNDOC(op_undoc_ldixhixh),	/* 0x64 */
+		UNDOC(op_undoc_ldixhixl),	/* 0x65 */
+		op_ldhxd,			/* 0x66 */
+		UNDOC(op_undoc_ldixha),		/* 0x67 */
+		UNDOC(op_undoc_ldixlb),		/* 0x68 */
+		UNDOC(op_undoc_ldixlc),		/* 0x69 */
+		UNDOC(op_undoc_ldixld),		/* 0x6a */
+		UNDOC(op_undoc_ldixle),		/* 0x6b */
+		UNDOC(op_undoc_ldixlixh),	/* 0x6c */
+		UNDOC(op_undoc_ldixlixl),	/* 0x6d */
+		op_ldlxd,			/* 0x6e */
+		UNDOC(op_undoc_ldixla),		/* 0x6f */
+		op_ldxdb,			/* 0x70 */
+		op_ldxdc,			/* 0x71 */
+		op_ldxdd,			/* 0x72 */
+		op_ldxde,			/* 0x73 */
+		op_ldxdh,			/* 0x74 */
+		op_ldxdl,			/* 0x75 */
+		trap_dd,			/* 0x76 */
+		op_ldxda,			/* 0x77 */
+		trap_dd,			/* 0x78 */
+		trap_dd,			/* 0x79 */
+		trap_dd,			/* 0x7a */
+		trap_dd,			/* 0x7b */
+		UNDOC(op_undoc_ldaixh),		/* 0x7c */
+		UNDOC(op_undoc_ldaixl),		/* 0x7d */
+		op_ldaxd,			/* 0x7e */
+		trap_dd,			/* 0x7f */
+		trap_dd,			/* 0x80 */
+		trap_dd,			/* 0x81 */
+		trap_dd,			/* 0x82 */
+		trap_dd,			/* 0x83 */
+		UNDOC(op_undoc_adaixh),		/* 0x84 */
+		UNDOC(op_undoc_adaixl),		/* 0x85 */
+		op_adaxd,			/* 0x86 */
+		trap_dd,			/* 0x87 */
+		trap_dd,			/* 0x88 */
+		trap_dd,			/* 0x89 */
+		trap_dd,			/* 0x8a */
+		trap_dd,			/* 0x8b */
+		UNDOC(op_undoc_acaixh),		/* 0x8c */
+		UNDOC(op_undoc_acaixl),		/* 0x8d */
+		op_acaxd,			/* 0x8e */
+		trap_dd,			/* 0x8f */
+		trap_dd,			/* 0x90 */
+		trap_dd,			/* 0x91 */
+		trap_dd,			/* 0x92 */
+		trap_dd,			/* 0x93 */
+		UNDOC(op_undoc_suaixh),		/* 0x94 */
+		UNDOC(op_undoc_suaixl),		/* 0x95 */
+		op_suaxd,			/* 0x96 */
+		trap_dd,			/* 0x97 */
+		trap_dd,			/* 0x98 */
+		trap_dd,			/* 0x99 */
+		trap_dd,			/* 0x9a */
+		trap_dd,			/* 0x9b */
+		UNDOC(op_undoc_scaixh),		/* 0x9c */
+		UNDOC(op_undoc_scaixl),		/* 0x9d */
+		op_scaxd,			/* 0x9e */
+		trap_dd,			/* 0x9f */
+		trap_dd,			/* 0xa0 */
+		trap_dd,			/* 0xa1 */
+		trap_dd,			/* 0xa2 */
+		trap_dd,			/* 0xa3 */
+		UNDOC(op_undoc_andixh),		/* 0xa4 */
+		UNDOC(op_undoc_andixl),		/* 0xa5 */
+		op_andxd,			/* 0xa6 */
+		trap_dd,			/* 0xa7 */
+		trap_dd,			/* 0xa8 */
+		trap_dd,			/* 0xa9 */
+		trap_dd,			/* 0xaa */
+		trap_dd,			/* 0xab */
+		UNDOC(op_undoc_xorixh),		/* 0xac */
+		UNDOC(op_undoc_xorixl),		/* 0xad */
+		op_xorxd,			/* 0xae */
+		trap_dd,			/* 0xaf */
+		trap_dd,			/* 0xb0 */
+		trap_dd,			/* 0xb1 */
+		trap_dd,			/* 0xb2 */
+		trap_dd,			/* 0xb3 */
+		UNDOC(op_undoc_oraixh),		/* 0xb4 */
+		UNDOC(op_undoc_oraixl),		/* 0xb5 */
+		op_orxd,			/* 0xb6 */
+		trap_dd,			/* 0xb7 */
+		trap_dd,			/* 0xb8 */
+		trap_dd,			/* 0xb9 */
+		trap_dd,			/* 0xba */
+		trap_dd,			/* 0xbb */
+		UNDOC(op_undoc_cpixh),		/* 0xbc */
+		UNDOC(op_undoc_cpixl),		/* 0xbd */
+		op_cpxd,			/* 0xbe */
+		trap_dd,			/* 0xbf */
+		trap_dd,			/* 0xc0 */
+		trap_dd,			/* 0xc1 */
+		trap_dd,			/* 0xc2 */
+		trap_dd,			/* 0xc3 */
+		trap_dd,			/* 0xc4 */
+		trap_dd,			/* 0xc5 */
+		trap_dd,			/* 0xc6 */
+		trap_dd,			/* 0xc7 */
+		trap_dd,			/* 0xc8 */
+		trap_dd,			/* 0xc9 */
+		trap_dd,			/* 0xca */
+		op_ddcb_handle,			/* 0xcb */
+		trap_dd,			/* 0xcc */
+		trap_dd,			/* 0xcd */
+		trap_dd,			/* 0xce */
+		trap_dd,			/* 0xcf */
+		trap_dd,			/* 0xd0 */
+		trap_dd,			/* 0xd1 */
+		trap_dd,			/* 0xd2 */
+		trap_dd,			/* 0xd3 */
+		trap_dd,			/* 0xd4 */
+		trap_dd,			/* 0xd5 */
+		trap_dd,			/* 0xd6 */
+		trap_dd,			/* 0xd7 */
+		trap_dd,			/* 0xd8 */
+		trap_dd,			/* 0xd9 */
+		trap_dd,			/* 0xda */
+		trap_dd,			/* 0xdb */
+		trap_dd,			/* 0xdc */
+		trap_dd,			/* 0xdd */
+		trap_dd,			/* 0xde */
+		trap_dd,			/* 0xdf */
+		trap_dd,			/* 0xe0 */
+		op_popix,			/* 0xe1 */
+		trap_dd,			/* 0xe2 */
+		op_exspx,			/* 0xe3 */
+		trap_dd,			/* 0xe4 */
+		op_pusix,			/* 0xe5 */
+		trap_dd,			/* 0xe6 */
+		trap_dd,			/* 0xe7 */
+		trap_dd,			/* 0xe8 */
+		op_jpix,			/* 0xe9 */
+		trap_dd,			/* 0xea */
+		trap_dd,			/* 0xeb */
+		trap_dd,			/* 0xec */
+		trap_dd,			/* 0xed */
+		trap_dd,			/* 0xee */
+		trap_dd,			/* 0xef */
+		trap_dd,			/* 0xf0 */
+		trap_dd,			/* 0xf1 */
+		trap_dd,			/* 0xf2 */
+		trap_dd,			/* 0xf3 */
+		trap_dd,			/* 0xf4 */
+		trap_dd,			/* 0xf5 */
+		trap_dd,			/* 0xf6 */
+		trap_dd,			/* 0xf7 */
+		trap_dd,			/* 0xf8 */
+		op_ldspx,			/* 0xf9 */
+		trap_dd,			/* 0xfa */
+		trap_dd,			/* 0xfb */
+		trap_dd,			/* 0xfc */
+		trap_dd,			/* 0xfd */
+		trap_dd,			/* 0xfe */
+		trap_dd				/* 0xff */
+	};
+
+#undef UNDOC
+
+	register int t;
+
+#endif /* !FAST_INSTR */
+
+#ifdef BUS_8080
+	/* M1 opcode fetch */
+	cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
+	m1_step = 1;
+#endif
+#ifdef FRONTPANEL
+	if (F_flag) {
+		/* update frontpanel */
+		fp_clock++;
+		fp_sampleLightGroup(0, 0);
+	}
+#endif
+
+	R++;				/* increment refresh register */
+
+#ifndef FAST_INSTR
+	t = (*op_dd[memrdr(PC++)])();	/* execute next opcode */
+#else
+	switch (memrdr(PC++)) {		/* execute next opcode */
+
+#include "simz80-dd.c"
+
+	default:
+		t = trap_dd();
+		break;
+	}
+#endif
+
+	STATES(t);
+}
+
+#ifndef FAST_INSTR
+#include "simz80-dd.c"
+#endif
+
+INSTR(0xed, op_ed_handle)		/* 0xed prefix */
+{
+#ifndef FAST_INSTR
+
+#ifdef UNDOC_INST
+#define UNDOC(f) f
+#ifdef UNDOC_IALL
+#define UNDOCA(f) f
+#else
+#define UNDOCA(f) trap_ed
+#endif
+#else
+#define UNDOC(f) trap_ed
+#define UNDOCA(f) trap_ed
+#endif
+
+	static int (*op_ed[256])(void) = {
+		UNDOCA(op_undoc_nop),		/* 0x00 */
+		UNDOCA(op_undoc_nop),		/* 0x01 */
+		UNDOCA(op_undoc_nop),		/* 0x02 */
+		UNDOCA(op_undoc_nop),		/* 0x03 */
+		UNDOCA(op_undoc_nop),		/* 0x04 */
+		UNDOCA(op_undoc_nop),		/* 0x05 */
+		UNDOCA(op_undoc_nop),		/* 0x06 */
+		UNDOCA(op_undoc_nop),		/* 0x07 */
+		UNDOCA(op_undoc_nop),		/* 0x08 */
+		UNDOCA(op_undoc_nop),		/* 0x09 */
+		UNDOCA(op_undoc_nop),		/* 0x0a */
+		UNDOCA(op_undoc_nop),		/* 0x0b */
+		UNDOCA(op_undoc_nop),		/* 0x0c */
+		UNDOCA(op_undoc_nop),		/* 0x0d */
+		UNDOCA(op_undoc_nop),		/* 0x0e */
+		UNDOCA(op_undoc_nop),		/* 0x0f */
+		UNDOCA(op_undoc_nop),		/* 0x10 */
+		UNDOCA(op_undoc_nop),		/* 0x11 */
+		UNDOCA(op_undoc_nop),		/* 0x12 */
+		UNDOCA(op_undoc_nop),		/* 0x13 */
+		UNDOCA(op_undoc_nop),		/* 0x14 */
+		UNDOCA(op_undoc_nop),		/* 0x15 */
+		UNDOCA(op_undoc_nop),		/* 0x16 */
+		UNDOCA(op_undoc_nop),		/* 0x17 */
+		UNDOCA(op_undoc_nop),		/* 0x18 */
+		UNDOCA(op_undoc_nop),		/* 0x19 */
+		UNDOCA(op_undoc_nop),		/* 0x1a */
+		UNDOCA(op_undoc_nop),		/* 0x1b */
+		UNDOCA(op_undoc_nop),		/* 0x1c */
+		UNDOCA(op_undoc_nop),		/* 0x1d */
+		UNDOCA(op_undoc_nop),		/* 0x1e */
+		UNDOCA(op_undoc_nop),		/* 0x1f */
+		UNDOCA(op_undoc_nop),		/* 0x20 */
+		UNDOCA(op_undoc_nop),		/* 0x21 */
+		UNDOCA(op_undoc_nop),		/* 0x22 */
+		UNDOCA(op_undoc_nop),		/* 0x23 */
+		UNDOCA(op_undoc_nop),		/* 0x24 */
+		UNDOCA(op_undoc_nop),		/* 0x25 */
+		UNDOCA(op_undoc_nop),		/* 0x26 */
+		UNDOCA(op_undoc_nop),		/* 0x27 */
+		UNDOCA(op_undoc_nop),		/* 0x28 */
+		UNDOCA(op_undoc_nop),		/* 0x29 */
+		UNDOCA(op_undoc_nop),		/* 0x2a */
+		UNDOCA(op_undoc_nop),		/* 0x2b */
+		UNDOCA(op_undoc_nop),		/* 0x2c */
+		UNDOCA(op_undoc_nop),		/* 0x2d */
+		UNDOCA(op_undoc_nop),		/* 0x2e */
+		UNDOCA(op_undoc_nop),		/* 0x2f */
+		UNDOCA(op_undoc_nop),		/* 0x30 */
+		UNDOCA(op_undoc_nop),		/* 0x31 */
+		UNDOCA(op_undoc_nop),		/* 0x32 */
+		UNDOCA(op_undoc_nop),		/* 0x33 */
+		UNDOCA(op_undoc_nop),		/* 0x34 */
+		UNDOCA(op_undoc_nop),		/* 0x35 */
+		UNDOCA(op_undoc_nop),		/* 0x36 */
+		UNDOCA(op_undoc_nop),		/* 0x37 */
+		UNDOCA(op_undoc_nop),		/* 0x38 */
+		UNDOCA(op_undoc_nop),		/* 0x39 */
+		UNDOCA(op_undoc_nop),		/* 0x3a */
+		UNDOCA(op_undoc_nop),		/* 0x3b */
+		UNDOCA(op_undoc_nop),		/* 0x3c */
+		UNDOCA(op_undoc_nop),		/* 0x3d */
+		UNDOCA(op_undoc_nop),		/* 0x3e */
+		UNDOCA(op_undoc_nop),		/* 0x3f */
+		op_inbic,			/* 0x40 */
+		op_outcb,			/* 0x41 */
+		op_sbchb,			/* 0x42 */
+		op_ldinbc,			/* 0x43 */
+		op_neg,				/* 0x44 */
+		op_retn,			/* 0x45 */
+		op_im0,				/* 0x46 */
+		op_ldia,			/* 0x47 */
+		op_incic,			/* 0x48 */
+		op_outcc,			/* 0x49 */
+		op_adchb,			/* 0x4a */
+		op_ldbcinn,			/* 0x4b */
+		UNDOCA(op_undoc_neg),		/* 0x4c */
+		op_reti,			/* 0x4d */
+		UNDOCA(op_undoc_im0),		/* 0x4e */
+		op_ldra,			/* 0x4f */
+		op_indic,			/* 0x50 */
+		op_outcd,			/* 0x51 */
+		op_sbchd,			/* 0x52 */
+		op_ldinde,			/* 0x53 */
+		UNDOCA(op_undoc_neg),		/* 0x54 */
+		UNDOCA(op_undoc_retn),		/* 0x55 */
+		op_im1,				/* 0x56 */
+		op_ldai,			/* 0x57 */
+		op_ineic,			/* 0x58 */
+		op_outce,			/* 0x59 */
+		op_adchd,			/* 0x5a */
+		op_lddeinn,			/* 0x5b */
+		UNDOCA(op_undoc_neg),		/* 0x5c */
+		UNDOCA(op_undoc_reti),		/* 0x5d */
+		op_im2,				/* 0x5e */
+		op_ldar,			/* 0x5f */
+		op_inhic,			/* 0x60 */
+		op_outch,			/* 0x61 */
+		op_sbchh,			/* 0x62 */
+		op_ldinhl2,			/* 0x63 */
+		UNDOCA(op_undoc_neg),		/* 0x64 */
+		UNDOCA(op_undoc_retn),		/* 0x65 */
+		UNDOCA(op_undoc_im0),		/* 0x66 */
+		op_oprrd,			/* 0x67 */
+		op_inlic,			/* 0x68 */
+		op_outcl,			/* 0x69 */
+		op_adchh,			/* 0x6a */
+		op_ldhlinn,			/* 0x6b */
+		UNDOCA(op_undoc_neg),		/* 0x6c */
+		UNDOCA(op_undoc_reti),		/* 0x6d */
+		UNDOCA(op_undoc_im0),		/* 0x6e */
+		op_oprld,			/* 0x6f */
+		UNDOC(op_undoc_infic),		/* 0x70 */
+		UNDOC(op_undoc_outc0),		/* 0x71 */
+		op_sbchs,			/* 0x72 */
+		op_ldinsp,			/* 0x73 */
+		UNDOCA(op_undoc_neg),		/* 0x74 */
+		UNDOCA(op_undoc_retn),		/* 0x75 */
+		UNDOCA(op_undoc_im1),		/* 0x76 */
+		UNDOCA(op_undoc_nop),		/* 0x77 */
+		op_inaic,			/* 0x78 */
+		op_outca,			/* 0x79 */
+		op_adchs,			/* 0x7a */
+		op_ldspinn,			/* 0x7b */
+		UNDOCA(op_undoc_neg),		/* 0x7c */
+		UNDOCA(op_undoc_reti),		/* 0x7d */
+		UNDOCA(op_undoc_im2),		/* 0x7e */
+		UNDOCA(op_undoc_nop),		/* 0x7f */
+		UNDOCA(op_undoc_nop),		/* 0x80 */
+		UNDOCA(op_undoc_nop),		/* 0x81 */
+		UNDOCA(op_undoc_nop),		/* 0x82 */
+		UNDOCA(op_undoc_nop),		/* 0x83 */
+		UNDOCA(op_undoc_nop),		/* 0x84 */
+		UNDOCA(op_undoc_nop),		/* 0x85 */
+		UNDOCA(op_undoc_nop),		/* 0x86 */
+		UNDOCA(op_undoc_nop),		/* 0x87 */
+		UNDOCA(op_undoc_nop),		/* 0x88 */
+		UNDOCA(op_undoc_nop),		/* 0x89 */
+		UNDOCA(op_undoc_nop),		/* 0x8a */
+		UNDOCA(op_undoc_nop),		/* 0x8b */
+		UNDOCA(op_undoc_nop),		/* 0x8c */
+		UNDOCA(op_undoc_nop),		/* 0x8d */
+		UNDOCA(op_undoc_nop),		/* 0x8e */
+		UNDOCA(op_undoc_nop),		/* 0x8f */
+		UNDOCA(op_undoc_nop),		/* 0x90 */
+		UNDOCA(op_undoc_nop),		/* 0x91 */
+		UNDOCA(op_undoc_nop),		/* 0x92 */
+		UNDOCA(op_undoc_nop),		/* 0x93 */
+		UNDOCA(op_undoc_nop),		/* 0x94 */
+		UNDOCA(op_undoc_nop),		/* 0x95 */
+		UNDOCA(op_undoc_nop),		/* 0x96 */
+		UNDOCA(op_undoc_nop),		/* 0x97 */
+		UNDOCA(op_undoc_nop),		/* 0x98 */
+		UNDOCA(op_undoc_nop),		/* 0x99 */
+		UNDOCA(op_undoc_nop),		/* 0x9a */
+		UNDOCA(op_undoc_nop),		/* 0x9b */
+		UNDOCA(op_undoc_nop),		/* 0x9c */
+		UNDOCA(op_undoc_nop),		/* 0x9d */
+		UNDOCA(op_undoc_nop),		/* 0x9e */
+		UNDOCA(op_undoc_nop),		/* 0x9f */
+		op_ldi,				/* 0xa0 */
+		op_cpi,				/* 0xa1 */
+		op_ini,				/* 0xa2 */
+		op_outi,			/* 0xa3 */
+		UNDOCA(op_undoc_nop),		/* 0xa4 */
+		UNDOCA(op_undoc_nop),		/* 0xa5 */
+		UNDOCA(op_undoc_nop),		/* 0xa6 */
+		UNDOCA(op_undoc_nop),		/* 0xa7 */
+		op_ldd,				/* 0xa8 */
+		op_cpdop,			/* 0xa9 */
+		op_ind,				/* 0xaa */
+		op_outd,			/* 0xab */
+		UNDOCA(op_undoc_nop),		/* 0xac */
+		UNDOCA(op_undoc_nop),		/* 0xad */
+		UNDOCA(op_undoc_nop),		/* 0xae */
+		UNDOCA(op_undoc_nop),		/* 0xaf */
+		op_ldir,			/* 0xb0 */
+		op_cpir,			/* 0xb1 */
+		op_inir,			/* 0xb2 */
+		op_otir,			/* 0xb3 */
+		UNDOCA(op_undoc_nop),		/* 0xb4 */
+		UNDOCA(op_undoc_nop),		/* 0xb5 */
+		UNDOCA(op_undoc_nop),		/* 0xb6 */
+		UNDOCA(op_undoc_nop),		/* 0xb7 */
+		op_lddr,			/* 0xb8 */
+		op_cpdr,			/* 0xb9 */
+		op_indr,			/* 0xba */
+		op_otdr,			/* 0xbb */
+		UNDOCA(op_undoc_nop),		/* 0xbc */
+		UNDOCA(op_undoc_nop),		/* 0xbd */
+		UNDOCA(op_undoc_nop),		/* 0xbe */
+		UNDOCA(op_undoc_nop),		/* 0xbf */
+		UNDOCA(op_undoc_nop),		/* 0xc0 */
+		UNDOCA(op_undoc_nop),		/* 0xc1 */
+		UNDOCA(op_undoc_nop),		/* 0xc2 */
+		UNDOCA(op_undoc_nop),		/* 0xc3 */
+		UNDOCA(op_undoc_nop),		/* 0xc4 */
+		UNDOCA(op_undoc_nop),		/* 0xc5 */
+		UNDOCA(op_undoc_nop),		/* 0xc6 */
+		UNDOCA(op_undoc_nop),		/* 0xc7 */
+		UNDOCA(op_undoc_nop),		/* 0xc8 */
+		UNDOCA(op_undoc_nop),		/* 0xc9 */
+		UNDOCA(op_undoc_nop),		/* 0xca */
+		UNDOCA(op_undoc_nop),		/* 0xcb */
+		UNDOCA(op_undoc_nop),		/* 0xcc */
+		UNDOCA(op_undoc_nop),		/* 0xcd */
+		UNDOCA(op_undoc_nop),		/* 0xce */
+		UNDOCA(op_undoc_nop),		/* 0xcf */
+		UNDOCA(op_undoc_nop),		/* 0xd0 */
+		UNDOCA(op_undoc_nop),		/* 0xd1 */
+		UNDOCA(op_undoc_nop),		/* 0xd2 */
+		UNDOCA(op_undoc_nop),		/* 0xd3 */
+		UNDOCA(op_undoc_nop),		/* 0xd4 */
+		UNDOCA(op_undoc_nop),		/* 0xd5 */
+		UNDOCA(op_undoc_nop),		/* 0xd6 */
+		UNDOCA(op_undoc_nop),		/* 0xd7 */
+		UNDOCA(op_undoc_nop),		/* 0xd8 */
+		UNDOCA(op_undoc_nop),		/* 0xd9 */
+		UNDOCA(op_undoc_nop),		/* 0xda */
+		UNDOCA(op_undoc_nop),		/* 0xdb */
+		UNDOCA(op_undoc_nop),		/* 0xdc */
+		UNDOCA(op_undoc_nop),		/* 0xdd */
+		UNDOCA(op_undoc_nop),		/* 0xde */
+		UNDOCA(op_undoc_nop),		/* 0xdf */
+		UNDOCA(op_undoc_nop),		/* 0xe0 */
+		UNDOCA(op_undoc_nop),		/* 0xe1 */
+		UNDOCA(op_undoc_nop),		/* 0xe2 */
+		UNDOCA(op_undoc_nop),		/* 0xe3 */
+		UNDOCA(op_undoc_nop),		/* 0xe4 */
+		UNDOCA(op_undoc_nop),		/* 0xe5 */
+		UNDOCA(op_undoc_nop),		/* 0xe6 */
+		UNDOCA(op_undoc_nop),		/* 0xe7 */
+		UNDOCA(op_undoc_nop),		/* 0xe8 */
+		UNDOCA(op_undoc_nop),		/* 0xe9 */
+		UNDOCA(op_undoc_nop),		/* 0xea */
+		UNDOCA(op_undoc_nop),		/* 0xeb */
+		UNDOCA(op_undoc_nop),		/* 0xec */
+		UNDOCA(op_undoc_nop),		/* 0xed */
+		UNDOCA(op_undoc_nop),		/* 0xee */
+		UNDOCA(op_undoc_nop),		/* 0xef */
+		UNDOCA(op_undoc_nop),		/* 0xf0 */
+		UNDOCA(op_undoc_nop),		/* 0xf1 */
+		UNDOCA(op_undoc_nop),		/* 0xf2 */
+		UNDOCA(op_undoc_nop),		/* 0xf3 */
+		UNDOCA(op_undoc_nop),		/* 0xf4 */
+		UNDOCA(op_undoc_nop),		/* 0xf5 */
+		UNDOCA(op_undoc_nop),		/* 0xf6 */
+		UNDOCA(op_undoc_nop),		/* 0xf7 */
+		UNDOCA(op_undoc_nop),		/* 0xf8 */
+		UNDOCA(op_undoc_nop),		/* 0xf9 */
+		UNDOCA(op_undoc_nop),		/* 0xfa */
+		UNDOCA(op_undoc_nop),		/* 0xfb */
+		UNDOCA(op_undoc_nop),		/* 0xfc */
+		UNDOCA(op_undoc_nop),		/* 0xfd */
+		UNDOCA(op_undoc_nop),		/* 0xfe */
+		UNDOCA(op_undoc_nop)		/* 0xff */
+	};
+
+#undef UNDOC
+#undef UNDOCA
+
+	register int t;
+
+#endif /* !FAST_INSTR */
+
+#ifdef BUS_8080
+	/* M1 opcode fetch */
+	cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
+	m1_step = 1;
+#endif
+#ifdef FRONTPANEL
+	if (F_flag) {
+		/* update frontpanel */
+		fp_clock++;
+		fp_sampleLightGroup(0, 0);
+	}
+#endif
+
+	R++;				/* increment refresh register */
+
+#ifndef FAST_INSTR
+	t = (*op_ed[memrdr(PC++)])();	/* execute next opcode */
+#else
+	switch (memrdr(PC++)) {		/* execute next opcode */
+
+#include "simz80-ed.c"
+
+	default:
+		t = trap_ed();
+		break;
+	}
+#endif
+
+	STATES(t);
+}
+
+#ifndef FAST_INSTR
+#include "simz80-ed.c"
+#endif
+
+INSTR(0xfd, op_fd_handle)		/* 0xfd prefix */
+{
+#ifndef FAST_INSTR
+
+#ifdef UNDOC_INST
+#define UNDOC(f) f
+#else
+#define UNDOC(f) trap_fd
+#endif
+
+	static int (*op_fd[256])(void) = {
+		trap_fd,			/* 0x00 */
+		trap_fd,			/* 0x01 */
+		trap_fd,			/* 0x02 */
+		trap_fd,			/* 0x03 */
+		trap_fd,			/* 0x04 */
+		trap_fd,			/* 0x05 */
+		trap_fd,			/* 0x06 */
+		trap_fd,			/* 0x07 */
+		trap_fd,			/* 0x08 */
+		op_addyb,			/* 0x09 */
+		trap_fd,			/* 0x0a */
+		trap_fd,			/* 0x0b */
+		trap_fd,			/* 0x0c */
+		trap_fd,			/* 0x0d */
+		trap_fd,			/* 0x0e */
+		trap_fd,			/* 0x0f */
+		trap_fd,			/* 0x10 */
+		trap_fd,			/* 0x11 */
+		trap_fd,			/* 0x12 */
+		trap_fd,			/* 0x13 */
+		trap_fd,			/* 0x14 */
+		trap_fd,			/* 0x15 */
+		trap_fd,			/* 0x16 */
+		trap_fd,			/* 0x17 */
+		trap_fd,			/* 0x18 */
+		op_addyd,			/* 0x19 */
+		trap_fd,			/* 0x1a */
+		trap_fd,			/* 0x1b */
+		trap_fd,			/* 0x1c */
+		trap_fd,			/* 0x1d */
+		trap_fd,			/* 0x1e */
+		trap_fd,			/* 0x1f */
+		trap_fd,			/* 0x20 */
+		op_ldiynn,			/* 0x21 */
+		op_ldiny,			/* 0x22 */
+		op_inciy,			/* 0x23 */
+		UNDOC(op_undoc_inciyh),		/* 0x24 */
+		UNDOC(op_undoc_deciyh),		/* 0x25 */
+		UNDOC(op_undoc_ldiyhn),		/* 0x26 */
+		trap_fd,			/* 0x27 */
+		trap_fd,			/* 0x28 */
+		op_addyy,			/* 0x29 */
+		op_ldiyinn,			/* 0x2a */
+		op_deciy,			/* 0x2b */
+		UNDOC(op_undoc_inciyl),		/* 0x2c */
+		UNDOC(op_undoc_deciyl),		/* 0x2d */
+		UNDOC(op_undoc_ldiyln),		/* 0x2e */
+		trap_fd,			/* 0x2f */
+		trap_fd,			/* 0x30 */
+		trap_fd,			/* 0x31 */
+		trap_fd,			/* 0x32 */
+		trap_fd,			/* 0x33 */
+		op_incyd,			/* 0x34 */
+		op_decyd,			/* 0x35 */
+		op_ldydn,			/* 0x36 */
+		trap_fd,			/* 0x37 */
+		trap_fd,			/* 0x38 */
+		op_addys,			/* 0x39 */
+		trap_fd,			/* 0x3a */
+		trap_fd,			/* 0x3b */
+		trap_fd,			/* 0x3c */
+		trap_fd,			/* 0x3d */
+		trap_fd,			/* 0x3e */
+		trap_fd,			/* 0x3f */
+		trap_fd,			/* 0x40 */
+		trap_fd,			/* 0x41 */
+		trap_fd,			/* 0x42 */
+		trap_fd,			/* 0x43 */
+		UNDOC(op_undoc_ldbiyh),		/* 0x44 */
+		UNDOC(op_undoc_ldbiyl),		/* 0x45 */
+		op_ldbyd,			/* 0x46 */
+		trap_fd,			/* 0x47 */
+		trap_fd,			/* 0x48 */
+		trap_fd,			/* 0x49 */
+		trap_fd,			/* 0x4a */
+		trap_fd,			/* 0x4b */
+		UNDOC(op_undoc_ldciyh),		/* 0x4c */
+		UNDOC(op_undoc_ldciyl),		/* 0x4d */
+		op_ldcyd,			/* 0x4e */
+		trap_fd,			/* 0x4f */
+		trap_fd,			/* 0x50 */
+		trap_fd,			/* 0x51 */
+		trap_fd,			/* 0x52 */
+		trap_fd,			/* 0x53 */
+		UNDOC(op_undoc_lddiyh),		/* 0x54 */
+		UNDOC(op_undoc_lddiyl),		/* 0x55 */
+		op_lddyd,			/* 0x56 */
+		trap_fd,			/* 0x57 */
+		trap_fd,			/* 0x58 */
+		trap_fd,			/* 0x59 */
+		trap_fd,			/* 0x5a */
+		trap_fd,			/* 0x5b */
+		UNDOC(op_undoc_ldeiyh),		/* 0x5c */
+		UNDOC(op_undoc_ldeiyl),		/* 0x5d */
+		op_ldeyd,			/* 0x5e */
+		trap_fd,			/* 0x5f */
+		UNDOC(op_undoc_ldiyhb),		/* 0x60 */
+		UNDOC(op_undoc_ldiyhc),		/* 0x61 */
+		UNDOC(op_undoc_ldiyhd),		/* 0x62 */
+		UNDOC(op_undoc_ldiyhe),		/* 0x63 */
+		UNDOC(op_undoc_ldiyhiyh),	/* 0x64 */
+		UNDOC(op_undoc_ldiyhiyl),	/* 0x65 */
+		op_ldhyd,			/* 0x66 */
+		UNDOC(op_undoc_ldiyha),		/* 0x67 */
+		UNDOC(op_undoc_ldiylb),		/* 0x68 */
+		UNDOC(op_undoc_ldiylc),		/* 0x69 */
+		UNDOC(op_undoc_ldiyld),		/* 0x6a */
+		UNDOC(op_undoc_ldiyle),		/* 0x6b */
+		UNDOC(op_undoc_ldiyliyh),	/* 0x6c */
+		UNDOC(op_undoc_ldiyliyl),	/* 0x6d */
+		op_ldlyd,			/* 0x6e */
+		UNDOC(op_undoc_ldiyla),		/* 0x6f */
+		op_ldydb,			/* 0x70 */
+		op_ldydc,			/* 0x71 */
+		op_ldydd,			/* 0x72 */
+		op_ldyde,			/* 0x73 */
+		op_ldydh,			/* 0x74 */
+		op_ldydl,			/* 0x75 */
+		trap_fd,			/* 0x76 */
+		op_ldyda,			/* 0x77 */
+		trap_fd,			/* 0x78 */
+		trap_fd,			/* 0x79 */
+		trap_fd,			/* 0x7a */
+		trap_fd,			/* 0x7b */
+		UNDOC(op_undoc_ldaiyh),		/* 0x7c */
+		UNDOC(op_undoc_ldaiyl),		/* 0x7d */
+		op_ldayd,			/* 0x7e */
+		trap_fd,			/* 0x7f */
+		trap_fd,			/* 0x80 */
+		trap_fd,			/* 0x81 */
+		trap_fd,			/* 0x82 */
+		trap_fd,			/* 0x83 */
+		UNDOC(op_undoc_adaiyh),		/* 0x84 */
+		UNDOC(op_undoc_adaiyl),		/* 0x85 */
+		op_adayd,			/* 0x86 */
+		trap_fd,			/* 0x87 */
+		trap_fd,			/* 0x88 */
+		trap_fd,			/* 0x89 */
+		trap_fd,			/* 0x8a */
+		trap_fd,			/* 0x8b */
+		UNDOC(op_undoc_acaiyh),		/* 0x8c */
+		UNDOC(op_undoc_acaiyl),		/* 0x8d */
+		op_acayd,			/* 0x8e */
+		trap_fd,			/* 0x8f */
+		trap_fd,			/* 0x90 */
+		trap_fd,			/* 0x91 */
+		trap_fd,			/* 0x92 */
+		trap_fd,			/* 0x93 */
+		UNDOC(op_undoc_suaiyh),		/* 0x94 */
+		UNDOC(op_undoc_suaiyl),		/* 0x95 */
+		op_suayd,			/* 0x96 */
+		trap_fd,			/* 0x97 */
+		trap_fd,			/* 0x98 */
+		trap_fd,			/* 0x99 */
+		trap_fd,			/* 0x9a */
+		trap_fd,			/* 0x9b */
+		UNDOC(op_undoc_scaiyh),		/* 0x9c */
+		UNDOC(op_undoc_scaiyl),		/* 0x9d */
+		op_scayd,			/* 0x9e */
+		trap_fd,			/* 0x9f */
+		trap_fd,			/* 0xa0 */
+		trap_fd,			/* 0xa1 */
+		trap_fd,			/* 0xa2 */
+		trap_fd,			/* 0xa3 */
+		UNDOC(op_undoc_andiyh),		/* 0xa4 */
+		UNDOC(op_undoc_andiyl),		/* 0xa5 */
+		op_andyd,			/* 0xa6 */
+		trap_fd,			/* 0xa7 */
+		trap_fd,			/* 0xa8 */
+		trap_fd,			/* 0xa9 */
+		trap_fd,			/* 0xaa */
+		trap_fd,			/* 0xab */
+		UNDOC(op_undoc_xoriyh),		/* 0xac */
+		UNDOC(op_undoc_xoriyl),		/* 0xad */
+		op_xoryd,			/* 0xae */
+		trap_fd,			/* 0xaf */
+		trap_fd,			/* 0xb0 */
+		trap_fd,			/* 0xb1 */
+		trap_fd,			/* 0xb2 */
+		trap_fd,			/* 0xb3 */
+		UNDOC(op_undoc_oraiyh),		/* 0xb4 */
+		UNDOC(op_undoc_oraiyl),		/* 0xb5 */
+		op_oryd,			/* 0xb6 */
+		trap_fd,			/* 0xb7 */
+		trap_fd,			/* 0xb8 */
+		trap_fd,			/* 0xb9 */
+		trap_fd,			/* 0xba */
+		trap_fd,			/* 0xbb */
+		UNDOC(op_undoc_cpiyh),		/* 0xbc */
+		UNDOC(op_undoc_cpiyl),		/* 0xbd */
+		op_cpyd,			/* 0xbe */
+		trap_fd,			/* 0xbf */
+		trap_fd,			/* 0xc0 */
+		trap_fd,			/* 0xc1 */
+		trap_fd,			/* 0xc2 */
+		trap_fd,			/* 0xc3 */
+		trap_fd,			/* 0xc4 */
+		trap_fd,			/* 0xc5 */
+		trap_fd,			/* 0xc6 */
+		trap_fd,			/* 0xc7 */
+		trap_fd,			/* 0xc8 */
+		trap_fd,			/* 0xc9 */
+		trap_fd,			/* 0xca */
+		op_fdcb_handle,			/* 0xcb */
+		trap_fd,			/* 0xcc */
+		trap_fd,			/* 0xcd */
+		trap_fd,			/* 0xce */
+		trap_fd,			/* 0xcf */
+		trap_fd,			/* 0xd0 */
+		trap_fd,			/* 0xd1 */
+		trap_fd,			/* 0xd2 */
+		trap_fd,			/* 0xd3 */
+		trap_fd,			/* 0xd4 */
+		trap_fd,			/* 0xd5 */
+		trap_fd,			/* 0xd6 */
+		trap_fd,			/* 0xd7 */
+		trap_fd,			/* 0xd8 */
+		trap_fd,			/* 0xd9 */
+		trap_fd,			/* 0xda */
+		trap_fd,			/* 0xdb */
+		trap_fd,			/* 0xdc */
+		trap_fd,			/* 0xdd */
+		trap_fd,			/* 0xde */
+		trap_fd,			/* 0xdf */
+		trap_fd,			/* 0xe0 */
+		op_popiy,			/* 0xe1 */
+		trap_fd,			/* 0xe2 */
+		op_exspy,			/* 0xe3 */
+		trap_fd,			/* 0xe4 */
+		op_pusiy,			/* 0xe5 */
+		trap_fd,			/* 0xe6 */
+		trap_fd,			/* 0xe7 */
+		trap_fd,			/* 0xe8 */
+		op_jpiy,			/* 0xe9 */
+		trap_fd,			/* 0xea */
+		trap_fd,			/* 0xeb */
+		trap_fd,			/* 0xec */
+		trap_fd,			/* 0xed */
+		trap_fd,			/* 0xee */
+		trap_fd,			/* 0xef */
+		trap_fd,			/* 0xf0 */
+		trap_fd,			/* 0xf1 */
+		trap_fd,			/* 0xf2 */
+		trap_fd,			/* 0xf3 */
+		trap_fd,			/* 0xf4 */
+		trap_fd,			/* 0xf5 */
+		trap_fd,			/* 0xf6 */
+		trap_fd,			/* 0xf7 */
+		trap_fd,			/* 0xf8 */
+		op_ldspy,			/* 0xf9 */
+		trap_fd,			/* 0xfa */
+		trap_fd,			/* 0xfb */
+		trap_fd,			/* 0xfc */
+		trap_fd,			/* 0xfd */
+		trap_fd,			/* 0xfe */
+		trap_fd				/* 0xff */
+	};
+
+#undef UNDOC
+
+	register int t;
+
+#endif /* !FAST_INSTR */
+
+#ifdef BUS_8080
+	/* M1 opcode fetch */
+	cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
+	m1_step = 1;
+#endif
+#ifdef FRONTPANEL
+	if (F_flag) {
+		/* update frontpanel */
+		fp_clock++;
+		fp_sampleLightGroup(0, 0);
+	}
+#endif
+
+	R++;				/* increment refresh register */
+
+#ifndef FAST_INSTR
+	t = (*op_fd[memrdr(PC++)])();	/* execute next opcode */
+#else
+	switch (memrdr(PC++)) {		/* execute next opcode */
+
+#include "simz80-fd.c"
+
+	default:
+		t = trap_fd();
+		break;
+	}
+#endif
+
+	STATES(t);
+}
+
+#ifndef FAST_INSTR
+#include "simz80-fd.c"
+#endif

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -6,399 +6,11 @@
  */
 
 /*
- *	Like the function "cpu_z80()" this one emulates multi byte opcodes
- *	starting with 0xcb
+ *	This module contains the implementation of all Z80 instructions
+ *	beginning with the prefix 0xcb
  */
 
-#include "sim.h"
-#include "simglb.h"
-#include "config.h"
-#ifdef FRONTPANEL
-#include "frontpanel.h"
-#endif
-#include "memsim.h"
-
-#ifndef EXCLUDE_Z80
-
-#ifdef UNDOC_INST
-#define UNDOC(f) f
-#else
-#define UNDOC(f) trap_cb
-#endif
-
-static int trap_cb(void);
-static int op_srla(void), op_srlb(void), op_srlc(void);
-static int op_srld(void), op_srle(void);
-static int op_srlh(void), op_srll(void), op_srlhl(void);
-static int op_slaa(void), op_slab(void), op_slac(void);
-static int op_slad(void), op_slae(void);
-static int op_slah(void), op_slal(void), op_slahl(void);
-static int op_rlra(void), op_rlb(void), op_rlc(void);
-static int op_rld(void), op_rle(void);
-static int op_rlh(void), op_rll(void), op_rlhl(void);
-static int op_rrra(void), op_rrb(void), op_rrc(void);
-static int op_rrd(void), op_rre(void);
-static int op_rrh(void), op_rrl(void), op_rrhl(void);
-static int op_rrcra(void), op_rrcb(void), op_rrcc(void);
-static int op_rrcd(void), op_rrce(void);
-static int op_rrch(void), op_rrcl(void), op_rrchl(void);
-static int op_rlcra(void), op_rlcb(void), op_rlcc(void);
-static int op_rlcd(void), op_rlce(void);
-static int op_rlch(void), op_rlcl(void), op_rlchl(void);
-static int op_sraa(void), op_srab(void), op_srac(void);
-static int op_srad(void), op_srae(void);
-static int op_srah(void), op_sral(void), op_srahl(void);
-static int op_sb0a(void), op_sb1a(void), op_sb2a(void), op_sb3a(void);
-static int op_sb4a(void), op_sb5a(void), op_sb6a(void), op_sb7a(void);
-static int op_sb0b(void), op_sb1b(void), op_sb2b(void), op_sb3b(void);
-static int op_sb4b(void), op_sb5b(void), op_sb6b(void), op_sb7b(void);
-static int op_sb0c(void), op_sb1c(void), op_sb2c(void), op_sb3c(void);
-static int op_sb4c(void), op_sb5c(void), op_sb6c(void), op_sb7c(void);
-static int op_sb0d(void), op_sb1d(void), op_sb2d(void), op_sb3d(void);
-static int op_sb4d(void), op_sb5d(void), op_sb6d(void), op_sb7d(void);
-static int op_sb0e(void), op_sb1e(void), op_sb2e(void), op_sb3e(void);
-static int op_sb4e(void), op_sb5e(void), op_sb6e(void), op_sb7e(void);
-static int op_sb0h(void), op_sb1h(void), op_sb2h(void), op_sb3h(void);
-static int op_sb4h(void), op_sb5h(void), op_sb6h(void), op_sb7h(void);
-static int op_sb0l(void), op_sb1l(void), op_sb2l(void), op_sb3l(void);
-static int op_sb4l(void), op_sb5l(void), op_sb6l(void), op_sb7l(void);
-static int op_sb0hl(void), op_sb1hl(void), op_sb2hl(void), op_sb3hl(void);
-static int op_sb4hl(void), op_sb5hl(void), op_sb6hl(void), op_sb7hl(void);
-static int op_rb0a(void), op_rb1a(void), op_rb2a(void), op_rb3a(void);
-static int op_rb4a(void), op_rb5a(void), op_rb6a(void), op_rb7a(void);
-static int op_rb0b(void), op_rb1b(void), op_rb2b(void), op_rb3b(void);
-static int op_rb4b(void), op_rb5b(void), op_rb6b(void), op_rb7b(void);
-static int op_rb0c(void), op_rb1c(void), op_rb2c(void), op_rb3c(void);
-static int op_rb4c(void), op_rb5c(void), op_rb6c(void), op_rb7c(void);
-static int op_rb0d(void), op_rb1d(void), op_rb2d(void), op_rb3d(void);
-static int op_rb4d(void), op_rb5d(void), op_rb6d(void), op_rb7d(void);
-static int op_rb0e(void), op_rb1e(void), op_rb2e(void), op_rb3e(void);
-static int op_rb4e(void), op_rb5e(void), op_rb6e(void), op_rb7e(void);
-static int op_rb0h(void), op_rb1h(void), op_rb2h(void), op_rb3h(void);
-static int op_rb4h(void), op_rb5h(void), op_rb6h(void), op_rb7h(void);
-static int op_rb0l(void), op_rb1l(void), op_rb2l(void), op_rb3l(void);
-static int op_rb4l(void), op_rb5l(void), op_rb6l(void), op_rb7l(void);
-static int op_rb0hl(void), op_rb1hl(void), op_rb2hl(void), op_rb3hl(void);
-static int op_rb4hl(void), op_rb5hl(void), op_rb6hl(void), op_rb7hl(void);
-static int op_tb0a(void), op_tb1a(void), op_tb2a(void), op_tb3a(void);
-static int op_tb4a(void), op_tb5a(void), op_tb6a(void), op_tb7a(void);
-static int op_tb0b(void), op_tb1b(void), op_tb2b(void), op_tb3b(void);
-static int op_tb4b(void), op_tb5b(void), op_tb6b(void), op_tb7b(void);
-static int op_tb0c(void), op_tb1c(void), op_tb2c(void), op_tb3c(void);
-static int op_tb4c(void), op_tb5c(void), op_tb6c(void), op_tb7c(void);
-static int op_tb0d(void), op_tb1d(void), op_tb2d(void), op_tb3d(void);
-static int op_tb4d(void), op_tb5d(void), op_tb6d(void), op_tb7d(void);
-static int op_tb0e(void), op_tb1e(void), op_tb2e(void), op_tb3e(void);
-static int op_tb4e(void), op_tb5e(void), op_tb6e(void), op_tb7e(void);
-static int op_tb0h(void), op_tb1h(void), op_tb2h(void), op_tb3h(void);
-static int op_tb4h(void), op_tb5h(void), op_tb6h(void), op_tb7h(void);
-static int op_tb0l(void), op_tb1l(void), op_tb2l(void), op_tb3l(void);
-static int op_tb4l(void), op_tb5l(void), op_tb6l(void), op_tb7l(void);
-static int op_tb0hl(void), op_tb1hl(void), op_tb2hl(void), op_tb3hl(void);
-static int op_tb4hl(void), op_tb5hl(void), op_tb6hl(void), op_tb7hl(void);
-
-static int op_undoc_slla(void);
-#ifdef UNDOC_INST
-static int op_undoc_sllb(void), op_undoc_sllc(void), op_undoc_slld(void);
-static int op_undoc_slle(void), op_undoc_sllh(void), op_undoc_slll(void);
-static int op_undoc_sllhl(void);
-#endif
-
-int op_cb_handle(void)
-{
-	register int t;
-
-	static int (*op_cb[256])(void) = {
-		op_rlcb,			/* 0x00 */
-		op_rlcc,			/* 0x01 */
-		op_rlcd,			/* 0x02 */
-		op_rlce,			/* 0x03 */
-		op_rlch,			/* 0x04 */
-		op_rlcl,			/* 0x05 */
-		op_rlchl,			/* 0x06 */
-		op_rlcra,			/* 0x07 */
-		op_rrcb,			/* 0x08 */
-		op_rrcc,			/* 0x09 */
-		op_rrcd,			/* 0x0a */
-		op_rrce,			/* 0x0b */
-		op_rrch,			/* 0x0c */
-		op_rrcl,			/* 0x0d */
-		op_rrchl,			/* 0x0e */
-		op_rrcra,			/* 0x0f */
-		op_rlb,				/* 0x10 */
-		op_rlc,				/* 0x11 */
-		op_rld,				/* 0x12 */
-		op_rle,				/* 0x13 */
-		op_rlh,				/* 0x14 */
-		op_rll,				/* 0x15 */
-		op_rlhl,			/* 0x16 */
-		op_rlra,			/* 0x17 */
-		op_rrb,				/* 0x18 */
-		op_rrc,				/* 0x19 */
-		op_rrd,				/* 0x1a */
-		op_rre,				/* 0x1b */
-		op_rrh,				/* 0x1c */
-		op_rrl,				/* 0x1d */
-		op_rrhl,			/* 0x1e */
-		op_rrra,			/* 0x1f */
-		op_slab,			/* 0x20 */
-		op_slac,			/* 0x21 */
-		op_slad,			/* 0x22 */
-		op_slae,			/* 0x23 */
-		op_slah,			/* 0x24 */
-		op_slal,			/* 0x25 */
-		op_slahl,			/* 0x26 */
-		op_slaa,			/* 0x27 */
-		op_srab,			/* 0x28 */
-		op_srac,			/* 0x29 */
-		op_srad,			/* 0x2a */
-		op_srae,			/* 0x2b */
-		op_srah,			/* 0x2c */
-		op_sral,			/* 0x2d */
-		op_srahl,			/* 0x2e */
-		op_sraa,			/* 0x2f */
-		UNDOC(op_undoc_sllb),		/* 0x30 */
-		UNDOC(op_undoc_sllc),		/* 0x31 */
-		UNDOC(op_undoc_slld),		/* 0x32 */
-		UNDOC(op_undoc_slle),		/* 0x33 */
-		UNDOC(op_undoc_sllh),		/* 0x34 */
-		UNDOC(op_undoc_slll),		/* 0x35 */
-		UNDOC(op_undoc_sllhl),		/* 0x36 */
-		op_undoc_slla,			/* 0x37 */
-		op_srlb,			/* 0x38 */
-		op_srlc,			/* 0x39 */
-		op_srld,			/* 0x3a */
-		op_srle,			/* 0x3b */
-		op_srlh,			/* 0x3c */
-		op_srll,			/* 0x3d */
-		op_srlhl,			/* 0x3e */
-		op_srla,			/* 0x3f */
-		op_tb0b,			/* 0x40 */
-		op_tb0c,			/* 0x41 */
-		op_tb0d,			/* 0x42 */
-		op_tb0e,			/* 0x43 */
-		op_tb0h,			/* 0x44 */
-		op_tb0l,			/* 0x45 */
-		op_tb0hl,			/* 0x46 */
-		op_tb0a,			/* 0x47 */
-		op_tb1b,			/* 0x48 */
-		op_tb1c,			/* 0x49 */
-		op_tb1d,			/* 0x4a */
-		op_tb1e,			/* 0x4b */
-		op_tb1h,			/* 0x4c */
-		op_tb1l,			/* 0x4d */
-		op_tb1hl,			/* 0x4e */
-		op_tb1a,			/* 0x4f */
-		op_tb2b,			/* 0x50 */
-		op_tb2c,			/* 0x51 */
-		op_tb2d,			/* 0x52 */
-		op_tb2e,			/* 0x53 */
-		op_tb2h,			/* 0x54 */
-		op_tb2l,			/* 0x55 */
-		op_tb2hl,			/* 0x56 */
-		op_tb2a,			/* 0x57 */
-		op_tb3b,			/* 0x58 */
-		op_tb3c,			/* 0x59 */
-		op_tb3d,			/* 0x5a */
-		op_tb3e,			/* 0x5b */
-		op_tb3h,			/* 0x5c */
-		op_tb3l,			/* 0x5d */
-		op_tb3hl,			/* 0x5e */
-		op_tb3a,			/* 0x5f */
-		op_tb4b,			/* 0x60 */
-		op_tb4c,			/* 0x61 */
-		op_tb4d,			/* 0x62 */
-		op_tb4e,			/* 0x63 */
-		op_tb4h,			/* 0x64 */
-		op_tb4l,			/* 0x65 */
-		op_tb4hl,			/* 0x66 */
-		op_tb4a,			/* 0x67 */
-		op_tb5b,			/* 0x68 */
-		op_tb5c,			/* 0x69 */
-		op_tb5d,			/* 0x6a */
-		op_tb5e,			/* 0x6b */
-		op_tb5h,			/* 0x6c */
-		op_tb5l,			/* 0x6d */
-		op_tb5hl,			/* 0x6e */
-		op_tb5a,			/* 0x6f */
-		op_tb6b,			/* 0x70 */
-		op_tb6c,			/* 0x71 */
-		op_tb6d,			/* 0x72 */
-		op_tb6e,			/* 0x73 */
-		op_tb6h,			/* 0x74 */
-		op_tb6l,			/* 0x75 */
-		op_tb6hl,			/* 0x76 */
-		op_tb6a,			/* 0x77 */
-		op_tb7b,			/* 0x78 */
-		op_tb7c,			/* 0x79 */
-		op_tb7d,			/* 0x7a */
-		op_tb7e,			/* 0x7b */
-		op_tb7h,			/* 0x7c */
-		op_tb7l,			/* 0x7d */
-		op_tb7hl,			/* 0x7e */
-		op_tb7a,			/* 0x7f */
-		op_rb0b,			/* 0x80 */
-		op_rb0c,			/* 0x81 */
-		op_rb0d,			/* 0x82 */
-		op_rb0e,			/* 0x83 */
-		op_rb0h,			/* 0x84 */
-		op_rb0l,			/* 0x85 */
-		op_rb0hl,			/* 0x86 */
-		op_rb0a,			/* 0x87 */
-		op_rb1b,			/* 0x88 */
-		op_rb1c,			/* 0x89 */
-		op_rb1d,			/* 0x8a */
-		op_rb1e,			/* 0x8b */
-		op_rb1h,			/* 0x8c */
-		op_rb1l,			/* 0x8d */
-		op_rb1hl,			/* 0x8e */
-		op_rb1a,			/* 0x8f */
-		op_rb2b,			/* 0x90 */
-		op_rb2c,			/* 0x91 */
-		op_rb2d,			/* 0x92 */
-		op_rb2e,			/* 0x93 */
-		op_rb2h,			/* 0x94 */
-		op_rb2l,			/* 0x95 */
-		op_rb2hl,			/* 0x96 */
-		op_rb2a,			/* 0x97 */
-		op_rb3b,			/* 0x98 */
-		op_rb3c,			/* 0x99 */
-		op_rb3d,			/* 0x9a */
-		op_rb3e,			/* 0x9b */
-		op_rb3h,			/* 0x9c */
-		op_rb3l,			/* 0x9d */
-		op_rb3hl,			/* 0x9e */
-		op_rb3a,			/* 0x9f */
-		op_rb4b,			/* 0xa0 */
-		op_rb4c,			/* 0xa1 */
-		op_rb4d,			/* 0xa2 */
-		op_rb4e,			/* 0xa3 */
-		op_rb4h,			/* 0xa4 */
-		op_rb4l,			/* 0xa5 */
-		op_rb4hl,			/* 0xa6 */
-		op_rb4a,			/* 0xa7 */
-		op_rb5b,			/* 0xa8 */
-		op_rb5c,			/* 0xa9 */
-		op_rb5d,			/* 0xaa */
-		op_rb5e,			/* 0xab */
-		op_rb5h,			/* 0xac */
-		op_rb5l,			/* 0xad */
-		op_rb5hl,			/* 0xae */
-		op_rb5a,			/* 0xaf */
-		op_rb6b,			/* 0xb0 */
-		op_rb6c,			/* 0xb1 */
-		op_rb6d,			/* 0xb2 */
-		op_rb6e,			/* 0xb3 */
-		op_rb6h,			/* 0xb4 */
-		op_rb6l,			/* 0xb5 */
-		op_rb6hl,			/* 0xb6 */
-		op_rb6a,			/* 0xb7 */
-		op_rb7b,			/* 0xb8 */
-		op_rb7c,			/* 0xb9 */
-		op_rb7d,			/* 0xba */
-		op_rb7e,			/* 0xbb */
-		op_rb7h,			/* 0xbc */
-		op_rb7l,			/* 0xbd */
-		op_rb7hl,			/* 0xbe */
-		op_rb7a,			/* 0xbf */
-		op_sb0b,			/* 0xc0 */
-		op_sb0c,			/* 0xc1 */
-		op_sb0d,			/* 0xc2 */
-		op_sb0e,			/* 0xc3 */
-		op_sb0h,			/* 0xc4 */
-		op_sb0l,			/* 0xc5 */
-		op_sb0hl,			/* 0xc6 */
-		op_sb0a,			/* 0xc7 */
-		op_sb1b,			/* 0xc8 */
-		op_sb1c,			/* 0xc9 */
-		op_sb1d,			/* 0xca */
-		op_sb1e,			/* 0xcb */
-		op_sb1h,			/* 0xcc */
-		op_sb1l,			/* 0xcd */
-		op_sb1hl,			/* 0xce */
-		op_sb1a,			/* 0xcf */
-		op_sb2b,			/* 0xd0 */
-		op_sb2c,			/* 0xd1 */
-		op_sb2d,			/* 0xd2 */
-		op_sb2e,			/* 0xd3 */
-		op_sb2h,			/* 0xd4 */
-		op_sb2l,			/* 0xd5 */
-		op_sb2hl,			/* 0xd6 */
-		op_sb2a,			/* 0xd7 */
-		op_sb3b,			/* 0xd8 */
-		op_sb3c,			/* 0xd9 */
-		op_sb3d,			/* 0xda */
-		op_sb3e,			/* 0xdb */
-		op_sb3h,			/* 0xdc */
-		op_sb3l,			/* 0xdd */
-		op_sb3hl,			/* 0xde */
-		op_sb3a,			/* 0xdf */
-		op_sb4b,			/* 0xe0 */
-		op_sb4c,			/* 0xe1 */
-		op_sb4d,			/* 0xe2 */
-		op_sb4e,			/* 0xe3 */
-		op_sb4h,			/* 0xe4 */
-		op_sb4l,			/* 0xe5 */
-		op_sb4hl,			/* 0xe6 */
-		op_sb4a,			/* 0xe7 */
-		op_sb5b,			/* 0xe8 */
-		op_sb5c,			/* 0xe9 */
-		op_sb5d,			/* 0xea */
-		op_sb5e,			/* 0xeb */
-		op_sb5h,			/* 0xec */
-		op_sb5l,			/* 0xed */
-		op_sb5hl,			/* 0xee */
-		op_sb5a,			/* 0xef */
-		op_sb6b,			/* 0xf0 */
-		op_sb6c,			/* 0xf1 */
-		op_sb6d,			/* 0xf2 */
-		op_sb6e,			/* 0xf3 */
-		op_sb6h,			/* 0xf4 */
-		op_sb6l,			/* 0xf5 */
-		op_sb6hl,			/* 0xf6 */
-		op_sb6a,			/* 0xf7 */
-		op_sb7b,			/* 0xf8 */
-		op_sb7c,			/* 0xf9 */
-		op_sb7d,			/* 0xfa */
-		op_sb7e,			/* 0xfb */
-		op_sb7h,			/* 0xfc */
-		op_sb7l,			/* 0xfd */
-		op_sb7hl,			/* 0xfe */
-		op_sb7a				/* 0xff */
-	};
-
-#ifdef BUS_8080
-	/* M1 opcode fetch */
-	cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
-	m1_step = 1;
-#endif
-#ifdef FRONTPANEL
-	if (F_flag) {
-		/* update frontpanel */
-		fp_clock++;
-		fp_sampleLightGroup(0, 0);
-	}
-#endif
-
-	R++;				/* increment refresh register */
-
-	t = (*op_cb[memrdr(PC++)])();	/* execute next opcode */
-
-	return (t);
-}
-
-/*
- *	This function traps undocumented opcodes following the
- *	initial 0xcb of a multi byte opcode.
- */
-static int trap_cb(void)
-{
-	cpu_error = OPTRAP2;
-	cpu_state = STOPPED;
-	return (0);
-}
-
-static int op_srla(void)		/* SRL A */
+INSTR(0x3f, op_srla)			/* SRL A */
 {
 	(A & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A >>= 1;
@@ -411,10 +23,10 @@ static int op_srla(void)		/* SRL A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srlb(void)		/* SRL B */
+INSTR(0x38, op_srlb)			/* SRL B */
 {
 	(B & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	B >>= 1;
@@ -427,10 +39,10 @@ static int op_srlb(void)		/* SRL B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srlc(void)		/* SRL C */
+INSTR(0x39, op_srlc)			/* SRL C */
 {
 	(C & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	C >>= 1;
@@ -443,10 +55,10 @@ static int op_srlc(void)		/* SRL C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srld(void)		/* SRL D */
+INSTR(0x3a, op_srld)			/* SRL D */
 {
 	(D & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	D >>= 1;
@@ -459,10 +71,10 @@ static int op_srld(void)		/* SRL D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srle(void)		/* SRL E */
+INSTR(0x3b, op_srle)			/* SRL E */
 {
 	(E & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	E >>= 1;
@@ -475,10 +87,10 @@ static int op_srle(void)		/* SRL E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srlh(void)		/* SRL H */
+INSTR(0x3c, op_srlh)			/* SRL H */
 {
 	(H & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H >>= 1;
@@ -491,10 +103,10 @@ static int op_srlh(void)		/* SRL H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srll(void)		/* SRL L */
+INSTR(0x3d, op_srll)			/* SRL L */
 {
 	(L & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	L >>= 1;
@@ -507,10 +119,10 @@ static int op_srll(void)		/* SRL L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srlhl(void)		/* SRL (HL) */
+INSTR(0x3e, op_srlhl)			/* SRL (HL) */
 {
 	register BYTE P;
 	WORD addr;
@@ -529,10 +141,10 @@ static int op_srlhl(void)		/* SRL (HL) */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_slaa(void)		/* SLA A */
+INSTR(0x27, op_slaa)			/* SLA A */
 {
 	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A <<= 1;
@@ -545,10 +157,10 @@ static int op_slaa(void)		/* SLA A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_slab(void)		/* SLA B */
+INSTR(0x20, op_slab)			/* SLA B */
 {
 	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	B <<= 1;
@@ -561,10 +173,10 @@ static int op_slab(void)		/* SLA B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_slac(void)		/* SLA C */
+INSTR(0x21, op_slac)			/* SLA C */
 {
 	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	C <<= 1;
@@ -577,10 +189,10 @@ static int op_slac(void)		/* SLA C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_slad(void)		/* SLA D */
+INSTR(0x22, op_slad)			/* SLA D */
 {
 	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	D <<= 1;
@@ -593,10 +205,10 @@ static int op_slad(void)		/* SLA D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_slae(void)		/* SLA E */
+INSTR(0x23, op_slae)			/* SLA E */
 {
 	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	E <<= 1;
@@ -609,10 +221,10 @@ static int op_slae(void)		/* SLA E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_slah(void)		/* SLA H */
+INSTR(0x24, op_slah)			/* SLA H */
 {
 	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H <<= 1;
@@ -625,10 +237,10 @@ static int op_slah(void)		/* SLA H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_slal(void)		/* SLA L */
+INSTR(0x25, op_slal)			/* SLA L */
 {
 	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	L <<= 1;
@@ -641,10 +253,10 @@ static int op_slal(void)		/* SLA L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_slahl(void)		/* SLA (HL) */
+INSTR(0x26, op_slahl)			/* SLA (HL) */
 {
 	register BYTE P;
 	WORD addr;
@@ -663,10 +275,10 @@ static int op_slahl(void)		/* SLA (HL) */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_rlra(void)		/* RL A */
+INSTR(0x17, op_rlra)			/* RL A */
 {
 	register int old_c_flag;
 
@@ -683,10 +295,10 @@ static int op_rlra(void)		/* RL A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlb(void)			/* RL B */
+INSTR(0x10, op_rlb)			/* RL B */
 {
 	register int old_c_flag;
 
@@ -703,10 +315,10 @@ static int op_rlb(void)			/* RL B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlc(void)			/* RL C */
+INSTR(0x11, op_rlc)			/* RL C */
 {
 	register int old_c_flag;
 
@@ -723,10 +335,10 @@ static int op_rlc(void)			/* RL C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rld(void)			/* RL D */
+INSTR(0x12, op_rld)			/* RL D */
 {
 	register int old_c_flag;
 
@@ -743,10 +355,10 @@ static int op_rld(void)			/* RL D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rle(void)			/* RL E */
+INSTR(0x13, op_rle)			/* RL E */
 {
 	register int old_c_flag;
 
@@ -763,10 +375,10 @@ static int op_rle(void)			/* RL E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlh(void)			/* RL H */
+INSTR(0x14, op_rlh)			/* RL H */
 {
 	register int old_c_flag;
 
@@ -783,10 +395,10 @@ static int op_rlh(void)			/* RL H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rll(void)			/* RL L */
+INSTR(0x15, op_rll)			/* RL L */
 {
 	register int old_c_flag;
 
@@ -803,10 +415,10 @@ static int op_rll(void)			/* RL L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlhl(void)		/* RL (HL) */
+INSTR(0x16, op_rlhl)			/* RL (HL) */
 {
 	register BYTE P;
 	WORD addr;
@@ -828,10 +440,10 @@ static int op_rlhl(void)		/* RL (HL) */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_rrra(void)		/* RR A */
+INSTR(0x1f, op_rrra)			/* RR A */
 {
 	register int old_c_flag;
 
@@ -848,10 +460,10 @@ static int op_rrra(void)		/* RR A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrb(void)			/* RR B */
+INSTR(0x18, op_rrb)			/* RR B */
 {
 	register int old_c_flag;
 
@@ -868,10 +480,10 @@ static int op_rrb(void)			/* RR B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrc(void)			/* RR C */
+INSTR(0x19, op_rrc)			/* RR C */
 {
 	register int old_c_flag;
 
@@ -888,10 +500,10 @@ static int op_rrc(void)			/* RR C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrd(void)			/* RR D */
+INSTR(0x1a, op_rrd)			/* RR D */
 {
 	register int old_c_flag;
 
@@ -908,10 +520,10 @@ static int op_rrd(void)			/* RR D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rre(void)			/* RR E */
+INSTR(0x1b, op_rre)			/* RR E */
 {
 	register int old_c_flag;
 
@@ -928,10 +540,10 @@ static int op_rre(void)			/* RR E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrh(void)			/* RR H */
+INSTR(0x1c, op_rrh)			/* RR H */
 {
 	register int old_c_flag;
 
@@ -948,10 +560,10 @@ static int op_rrh(void)			/* RR H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrl(void)			/* RR L */
+INSTR(0x1d, op_rrl)			/* RR L */
 {
 	register int old_c_flag;
 
@@ -968,10 +580,10 @@ static int op_rrl(void)			/* RR L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrhl(void)		/* RR (HL) */
+INSTR(0x1e, op_rrhl)			/* RR (HL) */
 {
 	register BYTE P;
 	WORD addr;
@@ -993,10 +605,10 @@ static int op_rrhl(void)		/* RR (HL) */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_rrcra(void)		/* RRC A */
+INSTR(0x0f, op_rrcra)			/* RRC A */
 {
 	register int i;
 
@@ -1013,10 +625,10 @@ static int op_rrcra(void)		/* RRC A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrcb(void)		/* RRC B */
+INSTR(0x08, op_rrcb)			/* RRC B */
 {
 	register int i;
 
@@ -1033,10 +645,10 @@ static int op_rrcb(void)		/* RRC B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrcc(void)		/* RRC C */
+INSTR(0x09, op_rrcc)			/* RRC C */
 {
 	register int i;
 
@@ -1053,10 +665,10 @@ static int op_rrcc(void)		/* RRC C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrcd(void)		/* RRC D */
+INSTR(0x0a, op_rrcd)			/* RRC D */
 {
 	register int i;
 
@@ -1073,10 +685,10 @@ static int op_rrcd(void)		/* RRC D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrce(void)		/* RRC E */
+INSTR(0x0b, op_rrce)			/* RRC E */
 {
 	register int i;
 
@@ -1093,10 +705,10 @@ static int op_rrce(void)		/* RRC E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrch(void)		/* RRC H */
+INSTR(0x0c, op_rrch)			/* RRC H */
 {
 	register int i;
 
@@ -1113,10 +725,10 @@ static int op_rrch(void)		/* RRC H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrcl(void)		/* RRC L */
+INSTR(0x0d, op_rrcl)			/* RRC L */
 {
 	register int i;
 
@@ -1133,10 +745,10 @@ static int op_rrcl(void)		/* RRC L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rrchl(void)		/* RRC (HL) */
+INSTR(0x0e, op_rrchl)			/* RRC (HL) */
 {
 	register BYTE P;
 	WORD addr;
@@ -1158,10 +770,10 @@ static int op_rrchl(void)		/* RRC (HL) */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_rlcra(void)		/* RLC A */
+INSTR(0x07, op_rlcra)			/* RLC A */
 {
 	register int i;
 
@@ -1178,10 +790,10 @@ static int op_rlcra(void)		/* RLC A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlcb(void)		/* RLC B */
+INSTR(0x00, op_rlcb)			/* RLC B */
 {
 	register int i;
 
@@ -1198,10 +810,10 @@ static int op_rlcb(void)		/* RLC B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlcc(void)		/* RLC C */
+INSTR(0x01, op_rlcc)			/* RLC C */
 {
 	register int i;
 
@@ -1218,10 +830,10 @@ static int op_rlcc(void)		/* RLC C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlcd(void)		/* RLC D */
+INSTR(0x02, op_rlcd)			/* RLC D */
 {
 	register int i;
 
@@ -1238,10 +850,10 @@ static int op_rlcd(void)		/* RLC D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlce(void)		/* RLC E */
+INSTR(0x03, op_rlce)			/* RLC E */
 {
 	register int i;
 
@@ -1258,10 +870,10 @@ static int op_rlce(void)		/* RLC E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlch(void)		/* RLC H */
+INSTR(0x04, op_rlch)			/* RLC H */
 {
 	register int i;
 
@@ -1278,10 +890,10 @@ static int op_rlch(void)		/* RLC H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlcl(void)		/* RLC L */
+INSTR(0x05, op_rlcl)			/* RLC L */
 {
 	register int i;
 
@@ -1298,10 +910,10 @@ static int op_rlcl(void)		/* RLC L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_rlchl(void)		/* RLC (HL) */
+INSTR(0x06, op_rlchl)			/* RLC (HL) */
 {
 	register BYTE P;
 	WORD addr;
@@ -1323,10 +935,10 @@ static int op_rlchl(void)		/* RLC (HL) */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_sraa(void)		/* SRA A */
+INSTR(0x2f, op_sraa)			/* SRA A */
 {
 	register int i;
 
@@ -1343,10 +955,10 @@ static int op_sraa(void)		/* SRA A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srab(void)		/* SRA B */
+INSTR(0x28, op_srab)			/* SRA B */
 {
 	register int i;
 
@@ -1363,10 +975,10 @@ static int op_srab(void)		/* SRA B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srac(void)		/* SRA C */
+INSTR(0x29, op_srac)			/* SRA C */
 {
 	register int i;
 
@@ -1383,10 +995,10 @@ static int op_srac(void)		/* SRA C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srad(void)		/* SRA D */
+INSTR(0x2a, op_srad)			/* SRA D */
 {
 	register int i;
 
@@ -1403,10 +1015,10 @@ static int op_srad(void)		/* SRA D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srae(void)		/* SRA E */
+INSTR(0x2b, op_srae)			/* SRA E */
 {
 	register int i;
 
@@ -1423,10 +1035,10 @@ static int op_srae(void)		/* SRA E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srah(void)		/* SRA H */
+INSTR(0x2c, op_srah)			/* SRA H */
 {
 	register int i;
 
@@ -1443,10 +1055,10 @@ static int op_srah(void)		/* SRA H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_sral(void)		/* SRA L */
+INSTR(0x2d, op_sral)			/* SRA L */
 {
 	register int i;
 
@@ -1463,10 +1075,10 @@ static int op_sral(void)		/* SRA L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_srahl(void)		/* SRA (HL) */
+INSTR(0x2e, op_srahl)			/* SRA (HL) */
 {
 	register BYTE P;
 	WORD addr;
@@ -1487,778 +1099,778 @@ static int op_srahl(void)		/* SRA (HL) */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_sb0a(void)		/* SET 0,A */
+INSTR(0xc7, op_sb0a)			/* SET 0,A */
 {
 	A |= 1;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb1a(void)		/* SET 1,A */
+INSTR(0xcf, op_sb1a)			/* SET 1,A */
 {
 	A |= 2;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb2a(void)		/* SET 2,A */
+INSTR(0xd7, op_sb2a)			/* SET 2,A */
 {
 	A |= 4;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb3a(void)		/* SET 3,A */
+INSTR(0xdf, op_sb3a)			/* SET 3,A */
 {
 	A |= 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb4a(void)		/* SET 4,A */
+INSTR(0xe7, op_sb4a)			/* SET 4,A */
 {
 	A |= 16;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb5a(void)		/* SET 5,A */
+INSTR(0xef, op_sb5a)			/* SET 5,A */
 {
 	A |= 32;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb6a(void)		/* SET 6,A */
+INSTR(0xf7, op_sb6a)			/* SET 6,A */
 {
 	A |= 64;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb7a(void)		/* SET 7,A */
+INSTR(0xff, op_sb7a)			/* SET 7,A */
 {
 	A |= 128;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb0b(void)		/* SET 0,B */
+INSTR(0xc0, op_sb0b)			/* SET 0,B */
 {
 	B |= 1;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb1b(void)		/* SET 1,B */
+INSTR(0xc8, op_sb1b)			/* SET 1,B */
 {
 	B |= 2;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb2b(void)		/* SET 2,B */
+INSTR(0xd0, op_sb2b)			/* SET 2,B */
 {
 	B |= 4;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb3b(void)		/* SET 3,B */
+INSTR(0xd8, op_sb3b)			/* SET 3,B */
 {
 	B |= 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb4b(void)		/* SET 4,B */
+INSTR(0xe0, op_sb4b)			/* SET 4,B */
 {
 	B |= 16;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb5b(void)		/* SET 5,B */
+INSTR(0xe8, op_sb5b)			/* SET 5,B */
 {
 	B |= 32;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb6b(void)		/* SET 6,B */
+INSTR(0xf0, op_sb6b)			/* SET 6,B */
 {
 	B |= 64;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb7b(void)		/* SET 7,B */
+INSTR(0xf8, op_sb7b)			/* SET 7,B */
 {
 	B |= 128;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb0c(void)		/* SET 0,C */
+INSTR(0xc1, op_sb0c)			/* SET 0,C */
 {
 	C |= 1;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb1c(void)		/* SET 1,C */
+INSTR(0xc9, op_sb1c)			/* SET 1,C */
 {
 	C |= 2;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb2c(void)		/* SET 2,C */
+INSTR(0xd1, op_sb2c)			/* SET 2,C */
 {
 	C |= 4;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb3c(void)		/* SET 3,C */
+INSTR(0xd9, op_sb3c)			/* SET 3,C */
 {
 	C |= 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb4c(void)		/* SET 4,C */
+INSTR(0xe1, op_sb4c)			/* SET 4,C */
 {
 	C |= 16;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb5c(void)		/* SET 5,C */
+INSTR(0xe9, op_sb5c)			/* SET 5,C */
 {
 	C |= 32;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb6c(void)		/* SET 6,C */
+INSTR(0xf1, op_sb6c)			/* SET 6,C */
 {
 	C |= 64;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb7c(void)		/* SET 7,C */
+INSTR(0xf9, op_sb7c)			/* SET 7,C */
 {
 	C |= 128;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb0d(void)		/* SET 0,D */
+INSTR(0xc2, op_sb0d)			/* SET 0,D */
 {
 	D |= 1;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb1d(void)		/* SET 1,D */
+INSTR(0xca, op_sb1d)			/* SET 1,D */
 {
 	D |= 2;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb2d(void)		/* SET 2,D */
+INSTR(0xd2, op_sb2d)			/* SET 2,D */
 {
 	D |= 4;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb3d(void)		/* SET 3,D */
+INSTR(0xda, op_sb3d)			/* SET 3,D */
 {
 	D |= 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb4d(void)		/* SET 4,D */
+INSTR(0xe2, op_sb4d)			/* SET 4,D */
 {
 	D |= 16;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb5d(void)		/* SET 5,D */
+INSTR(0xea, op_sb5d)			/* SET 5,D */
 {
 	D |= 32;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb6d(void)		/* SET 6,D */
+INSTR(0xf2, op_sb6d)			/* SET 6,D */
 {
 	D |= 64;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb7d(void)		/* SET 7,D */
+INSTR(0xfa, op_sb7d)			/* SET 7,D */
 {
 	D |= 128;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb0e(void)		/* SET 0,E */
+INSTR(0xc3, op_sb0e)			/* SET 0,E */
 {
 	E |= 1;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb1e(void)		/* SET 1,E */
+INSTR(0xcb, op_sb1e)			/* SET 1,E */
 {
 	E |= 2;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb2e(void)		/* SET 2,E */
+INSTR(0xd3, op_sb2e)			/* SET 2,E */
 {
 	E |= 4;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb3e(void)		/* SET 3,E */
+INSTR(0xdb, op_sb3e)			/* SET 3,E */
 {
 	E |= 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb4e(void)		/* SET 4,E */
+INSTR(0xe3, op_sb4e)			/* SET 4,E */
 {
 	E |= 16;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb5e(void)		/* SET 5,E */
+INSTR(0xeb, op_sb5e)			/* SET 5,E */
 {
 	E |= 32;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb6e(void)		/* SET 6,E */
+INSTR(0xf3, op_sb6e)			/* SET 6,E */
 {
 	E |= 64;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb7e(void)		/* SET 7,E */
+INSTR(0xfb, op_sb7e)			/* SET 7,E */
 {
 	E |= 128;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb0h(void)		/* SET 0,H */
+INSTR(0xc4, op_sb0h)			/* SET 0,H */
 {
 	H |= 1;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb1h(void)		/* SET 1,H */
+INSTR(0xcc, op_sb1h)			/* SET 1,H */
 {
 	H |= 2;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb2h(void)		/* SET 2,H */
+INSTR(0xd4, op_sb2h)			/* SET 2,H */
 {
 	H |= 4;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb3h(void)		/* SET 3,H */
+INSTR(0xdc, op_sb3h)			/* SET 3,H */
 {
 	H |= 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb4h(void)		/* SET 4,H */
+INSTR(0xe4, op_sb4h)			/* SET 4,H */
 {
 	H |= 16;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb5h(void)		/* SET 5,H */
+INSTR(0xec, op_sb5h)			/* SET 5,H */
 {
 	H |= 32;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb6h(void)		/* SET 6,H */
+INSTR(0xf4, op_sb6h)			/* SET 6,H */
 {
 	H |= 64;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb7h(void)		/* SET 7,H */
+INSTR(0xfc, op_sb7h)			/* SET 7,H */
 {
 	H |= 128;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb0l(void)		/* SET 0,L */
+INSTR(0xc5, op_sb0l)			/* SET 0,L */
 {
 	L |= 1;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb1l(void)		/* SET 1,L */
+INSTR(0xcd, op_sb1l)			/* SET 1,L */
 {
 	L |= 2;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb2l(void)		/* SET 2,L */
+INSTR(0xd5, op_sb2l)			/* SET 2,L */
 {
 	L |= 4;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb3l(void)		/* SET 3,L */
+INSTR(0xdd, op_sb3l)			/* SET 3,L */
 {
 	L |= 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb4l(void)		/* SET 4,L */
+INSTR(0xe5, op_sb4l)			/* SET 4,L */
 {
 	L |= 16;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb5l(void)		/* SET 5,L */
+INSTR(0xed, op_sb5l)			/* SET 5,L */
 {
 	L |= 32;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb6l(void)		/* SET 6,L */
+INSTR(0xf5, op_sb6l)			/* SET 6,L */
 {
 	L |= 64;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb7l(void)		/* SET 7,L */
+INSTR(0xfd, op_sb7l)			/* SET 7,L */
 {
 	L |= 128;
-	return (8);
+	STATES(8);
 }
 
-static int op_sb0hl(void)		/* SET 0,(HL) */
+INSTR(0xc6, op_sb0hl)			/* SET 0,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 1);
-	return (15);
+	STATES(15);
 }
 
-static int op_sb1hl(void)		/* SET 1,(HL) */
+INSTR(0xce, op_sb1hl)			/* SET 1,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 2);
-	return (15);
+	STATES(15);
 }
 
-static int op_sb2hl(void)		/* SET 2,(HL) */
+INSTR(0xd6, op_sb2hl)			/* SET 2,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 4);
-	return (15);
+	STATES(15);
 }
 
-static int op_sb3hl(void)		/* SET 3,(HL) */
+INSTR(0xde, op_sb3hl)			/* SET 3,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 8);
-	return (15);
+	STATES(15);
 }
 
-static int op_sb4hl(void)		/* SET 4,(HL) */
+INSTR(0xe6, op_sb4hl)			/* SET 4,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 16);
-	return (15);
+	STATES(15);
 }
 
-static int op_sb5hl(void)		/* SET 5,(HL) */
+INSTR(0xee, op_sb5hl)			/* SET 5,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 32);
-	return (15);
+	STATES(15);
 }
 
-static int op_sb6hl(void)		/* SET 6,(HL) */
+INSTR(0xf6, op_sb6hl)			/* SET 6,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 64);
-	return (15);
+	STATES(15);
 }
 
-static int op_sb7hl(void)		/* SET 7,(HL) */
+INSTR(0xfe, op_sb7hl)			/* SET 7,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) | 128);
-	return (15);
+	STATES(15);
 }
 
-static int op_rb0a(void)		/* RES 0,A */
+INSTR(0x87, op_rb0a)			/* RES 0,A */
 {
 	A &= ~1;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb1a(void)		/* RES 1,A */
+INSTR(0x8f, op_rb1a)			/* RES 1,A */
 {
 	A &= ~2;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb2a(void)		/* RES 2,A */
+INSTR(0x97, op_rb2a)			/* RES 2,A */
 {
 	A &= ~4;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb3a(void)		/* RES 3,A */
+INSTR(0x9f, op_rb3a)			/* RES 3,A */
 {
 	A &= ~8;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb4a(void)		/* RES 4,A */
+INSTR(0xa7, op_rb4a)			/* RES 4,A */
 {
 	A &= ~16;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb5a(void)		/* RES 5,A */
+INSTR(0xaf, op_rb5a)			/* RES 5,A */
 {
 	A &= ~32;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb6a(void)		/* RES 6,A */
+INSTR(0xb7, op_rb6a)			/* RES 6,A */
 {
 	A &= ~64;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb7a(void)		/* RES 7,A */
+INSTR(0xbf, op_rb7a)			/* RES 7,A */
 {
 	A &= ~128;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb0b(void)		/* RES 0,B */
+INSTR(0x80, op_rb0b)			/* RES 0,B */
 {
 	B &= ~1;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb1b(void)		/* RES 1,B */
+INSTR(0x88, op_rb1b)			/* RES 1,B */
 {
 	B &= ~2;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb2b(void)		/* RES 2,B */
+INSTR(0x90, op_rb2b)			/* RES 2,B */
 {
 	B &= ~4;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb3b(void)		/* RES 3,B */
+INSTR(0x98, op_rb3b)			/* RES 3,B */
 {
 	B &= ~8;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb4b(void)		/* RES 4,B */
+INSTR(0xa0, op_rb4b)			/* RES 4,B */
 {
 	B &= ~16;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb5b(void)		/* RES 5,B */
+INSTR(0xa8, op_rb5b)			/* RES 5,B */
 {
 	B &= ~32;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb6b(void)		/* RES 6,B */
+INSTR(0xb0, op_rb6b)			/* RES 6,B */
 {
 	B &= ~64;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb7b(void)		/* RES 7,B */
+INSTR(0xb8, op_rb7b)			/* RES 7,B */
 {
 	B &= ~128;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb0c(void)		/* RES 0,C */
+INSTR(0x81, op_rb0c)			/* RES 0,C */
 {
 	C &= ~1;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb1c(void)		/* RES 1,C */
+INSTR(0x89, op_rb1c)			/* RES 1,C */
 {
 	C &= ~2;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb2c(void)		/* RES 2,C */
+INSTR(0x91, op_rb2c)			/* RES 2,C */
 {
 	C &= ~4;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb3c(void)		/* RES 3,C */
+INSTR(0x99, op_rb3c)			/* RES 3,C */
 {
 	C &= ~8;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb4c(void)		/* RES 4,C */
+INSTR(0xa1, op_rb4c)			/* RES 4,C */
 {
 	C &= ~16;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb5c(void)		/* RES 5,C */
+INSTR(0xa9, op_rb5c)			/* RES 5,C */
 {
 	C &= ~32;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb6c(void)		/* RES 6,C */
+INSTR(0xb1, op_rb6c)			/* RES 6,C */
 {
 	C &= ~64;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb7c(void)		/* RES 7,C */
+INSTR(0xb9, op_rb7c)			/* RES 7,C */
 {
 	C &= ~128;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb0d(void)		/* RES 0,D */
+INSTR(0x82, op_rb0d)			/* RES 0,D */
 {
 	D &= ~1;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb1d(void)		/* RES 1,D */
+INSTR(0x8a, op_rb1d)			/* RES 1,D */
 {
 	D &= ~2;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb2d(void)		/* RES 2,D */
+INSTR(0x92, op_rb2d)			/* RES 2,D */
 {
 	D &= ~4;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb3d(void)		/* RES 3,D */
+INSTR(0x9a, op_rb3d)			/* RES 3,D */
 {
 	D &= ~8;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb4d(void)		/* RES 4,D */
+INSTR(0xa2, op_rb4d)			/* RES 4,D */
 {
 	D &= ~16;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb5d(void)		/* RES 5,D */
+INSTR(0xaa, op_rb5d)			/* RES 5,D */
 {
 	D &= ~32;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb6d(void)		/* RES 6,D */
+INSTR(0xb2, op_rb6d)			/* RES 6,D */
 {
 	D &= ~64;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb7d(void)		/* RES 7,D */
+INSTR(0xba, op_rb7d)			/* RES 7,D */
 {
 	D &= ~128;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb0e(void)		/* RES 0,E */
+INSTR(0x83, op_rb0e)			/* RES 0,E */
 {
 	E &= ~1;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb1e(void)		/* RES 1,E */
+INSTR(0x8b, op_rb1e)			/* RES 1,E */
 {
 	E &= ~2;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb2e(void)		/* RES 2,E */
+INSTR(0x93, op_rb2e)			/* RES 2,E */
 {
 	E &= ~4;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb3e(void)		/* RES 3,E */
+INSTR(0x9b, op_rb3e)			/* RES 3,E */
 {
 	E &= ~8;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb4e(void)		/* RES 4,E */
+INSTR(0xa3, op_rb4e)			/* RES 4,E */
 {
 	E &= ~16;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb5e(void)		/* RES 5,E */
+INSTR(0xab, op_rb5e)			/* RES 5,E */
 {
 	E &= ~32;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb6e(void)		/* RES 6,E */
+INSTR(0xb3, op_rb6e)			/* RES 6,E */
 {
 	E &= ~64;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb7e(void)		/* RES 7,E */
+INSTR(0xbb, op_rb7e)			/* RES 7,E */
 {
 	E &= ~128;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb0h(void)		/* RES 0,H */
+INSTR(0x84, op_rb0h)			/* RES 0,H */
 {
 	H &= ~1;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb1h(void)		/* RES 1,H */
+INSTR(0x8c, op_rb1h)			/* RES 1,H */
 {
 	H &= ~2;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb2h(void)		/* RES 2,H */
+INSTR(0x94, op_rb2h)			/* RES 2,H */
 {
 	H &= ~4;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb3h(void)		/* RES 3,H */
+INSTR(0x9c, op_rb3h)			/* RES 3,H */
 {
 	H &= ~8;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb4h(void)		/* RES 4,H */
+INSTR(0xa4, op_rb4h)			/* RES 4,H */
 {
 	H &= ~16;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb5h(void)		/* RES 5,H */
+INSTR(0xac, op_rb5h)			/* RES 5,H */
 {
 	H &= ~32;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb6h(void)		/* RES 6,H */
+INSTR(0xb4, op_rb6h)			/* RES 6,H */
 {
 	H &= ~64;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb7h(void)		/* RES 7,H */
+INSTR(0xbc, op_rb7h)			/* RES 7,H */
 {
 	H &= ~128;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb0l(void)		/* RES 0,L */
+INSTR(0x85, op_rb0l)			/* RES 0,L */
 {
 	L &= ~1;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb1l(void)		/* RES 1,L */
+INSTR(0x8d, op_rb1l)			/* RES 1,L */
 {
 	L &= ~2;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb2l(void)		/* RES 2,L */
+INSTR(0x95, op_rb2l)			/* RES 2,L */
 {
 	L &= ~4;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb3l(void)		/* RES 3,L */
+INSTR(0x9d, op_rb3l)			/* RES 3,L */
 {
 	L &= ~8;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb4l(void)		/* RES 4,L */
+INSTR(0xa5, op_rb4l)			/* RES 4,L */
 {
 	L &= ~16;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb5l(void)		/* RES 5,L */
+INSTR(0xad, op_rb5l)			/* RES 5,L */
 {
 	L &= ~32;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb6l(void)		/* RES 6,L */
+INSTR(0xb5, op_rb6l)			/* RES 6,L */
 {
 	L &= ~64;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb7l(void)		/* RES 7,L */
+INSTR(0xbd, op_rb7l)			/* RES 7,L */
 {
 	L &= ~128;
-	return (8);
+	STATES(8);
 }
 
-static int op_rb0hl(void)		/* RES 0,(HL) */
+INSTR(0x86, op_rb0hl)			/* RES 0,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~1);
-	return (15);
+	STATES(15);
 }
 
-static int op_rb1hl(void)		/* RES 1,(HL) */
+INSTR(0x8e, op_rb1hl)			/* RES 1,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~2);
-	return (15);
+	STATES(15);
 }
 
-static int op_rb2hl(void)		/* RES 2,(HL) */
+INSTR(0x96, op_rb2hl)			/* RES 2,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~4);
-	return (15);
+	STATES(15);
 }
 
-static int op_rb3hl(void)		/* RES 3,(HL) */
+INSTR(0x9e, op_rb3hl)			/* RES 3,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~8);
-	return (15);
+	STATES(15);
 }
 
-static int op_rb4hl(void)		/* RES 4,(HL) */
+INSTR(0xa6, op_rb4hl)			/* RES 4,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~16);
-	return (15);
+	STATES(15);
 }
 
-static int op_rb5hl(void)		/* RES 5,(HL) */
+INSTR(0xae, op_rb5hl)			/* RES 5,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~32);
-	return (15);
+	STATES(15);
 }
 
-static int op_rb6hl(void)		/* RES 6,(HL) */
+INSTR(0xb6, op_rb6hl)			/* RES 6,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~64);
-	return (15);
+	STATES(15);
 }
 
-static int op_rb7hl(void)		/* RES 7,(HL) */
+INSTR(0xbe, op_rb7hl)			/* RES 7,(HL) */
 {
 	memwrt((H << 8) + L, memrdr((H << 8) + L) & ~128);
-	return (15);
+	STATES(15);
 }
 
-static int op_tb0a(void)		/* BIT 0,A */
+INSTR(0x47, op_tb0a)			/* BIT 0,A */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2268,10 +1880,10 @@ static int op_tb0a(void)		/* BIT 0,A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb1a(void)		/* BIT 1,A */
+INSTR(0x4f, op_tb1a)			/* BIT 1,A */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2281,10 +1893,10 @@ static int op_tb1a(void)		/* BIT 1,A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb2a(void)		/* BIT 2,A */
+INSTR(0x57, op_tb2a)			/* BIT 2,A */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2294,10 +1906,10 @@ static int op_tb2a(void)		/* BIT 2,A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb3a(void)		/* BIT 3,A */
+INSTR(0x5f, op_tb3a)			/* BIT 3,A */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2307,10 +1919,10 @@ static int op_tb3a(void)		/* BIT 3,A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb4a(void)		/* BIT 4,A */
+INSTR(0x67, op_tb4a)			/* BIT 4,A */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2320,10 +1932,10 @@ static int op_tb4a(void)		/* BIT 4,A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb5a(void)		/* BIT 5,A */
+INSTR(0x6f, op_tb5a)			/* BIT 5,A */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2333,10 +1945,10 @@ static int op_tb5a(void)		/* BIT 5,A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb6a(void)		/* BIT 6,A */
+INSTR(0x77, op_tb6a)			/* BIT 6,A */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2346,10 +1958,10 @@ static int op_tb6a(void)		/* BIT 6,A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb7a(void)		/* BIT 7,A */
+INSTR(0x7f, op_tb7a)			/* BIT 7,A */
 {
 	F &= ~N_FLAG;
 	F |= H_FLAG;
@@ -2365,10 +1977,10 @@ static int op_tb7a(void)		/* BIT 7,A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb0b(void)		/* BIT 0,B */
+INSTR(0x40, op_tb0b)			/* BIT 0,B */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2378,10 +1990,10 @@ static int op_tb0b(void)		/* BIT 0,B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb1b(void)		/* BIT 1,B */
+INSTR(0x48, op_tb1b)			/* BIT 1,B */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2391,10 +2003,10 @@ static int op_tb1b(void)		/* BIT 1,B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb2b(void)		/* BIT 2,B */
+INSTR(0x50, op_tb2b)			/* BIT 2,B */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2404,10 +2016,10 @@ static int op_tb2b(void)		/* BIT 2,B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb3b(void)		/* BIT 3,B */
+INSTR(0x58, op_tb3b)			/* BIT 3,B */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2417,10 +2029,10 @@ static int op_tb3b(void)		/* BIT 3,B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb4b(void)		/* BIT 4,B */
+INSTR(0x60, op_tb4b)			/* BIT 4,B */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2430,10 +2042,10 @@ static int op_tb4b(void)		/* BIT 4,B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb5b(void)		/* BIT 5,B */
+INSTR(0x68, op_tb5b)			/* BIT 5,B */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2443,10 +2055,10 @@ static int op_tb5b(void)		/* BIT 5,B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb6b(void)		/* BIT 6,B */
+INSTR(0x70, op_tb6b)			/* BIT 6,B */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2456,10 +2068,10 @@ static int op_tb6b(void)		/* BIT 6,B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb7b(void)		/* BIT 7,B */
+INSTR(0x78, op_tb7b)			/* BIT 7,B */
 {
 	F &= ~N_FLAG;
 	F |= H_FLAG;
@@ -2475,10 +2087,10 @@ static int op_tb7b(void)		/* BIT 7,B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb0c(void)		/* BIT 0,C */
+INSTR(0x41, op_tb0c)			/* BIT 0,C */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2488,10 +2100,10 @@ static int op_tb0c(void)		/* BIT 0,C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb1c(void)		/* BIT 1,C */
+INSTR(0x49, op_tb1c)			/* BIT 1,C */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2501,10 +2113,10 @@ static int op_tb1c(void)		/* BIT 1,C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb2c(void)		/* BIT 2,C */
+INSTR(0x51, op_tb2c)			/* BIT 2,C */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2514,10 +2126,10 @@ static int op_tb2c(void)		/* BIT 2,C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb3c(void)		/* BIT 3,C */
+INSTR(0x59, op_tb3c)			/* BIT 3,C */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2527,10 +2139,10 @@ static int op_tb3c(void)		/* BIT 3,C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb4c(void)		/* BIT 4,C */
+INSTR(0x61, op_tb4c)			/* BIT 4,C */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2540,10 +2152,10 @@ static int op_tb4c(void)		/* BIT 4,C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb5c(void)		/* BIT 5,C */
+INSTR(0x69, op_tb5c)			/* BIT 5,C */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2553,10 +2165,10 @@ static int op_tb5c(void)		/* BIT 5,C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb6c(void)		/* BIT 6,C */
+INSTR(0x71, op_tb6c)			/* BIT 6,C */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2566,10 +2178,10 @@ static int op_tb6c(void)		/* BIT 6,C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb7c(void)		/* BIT 7,C */
+INSTR(0x79, op_tb7c)			/* BIT 7,C */
 {
 	F &= ~N_FLAG;
 	F |= H_FLAG;
@@ -2585,10 +2197,10 @@ static int op_tb7c(void)		/* BIT 7,C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb0d(void)		/* BIT 0,D */
+INSTR(0x42, op_tb0d)			/* BIT 0,D */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2598,10 +2210,10 @@ static int op_tb0d(void)		/* BIT 0,D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb1d(void)		/* BIT 1,D */
+INSTR(0x4a, op_tb1d)			/* BIT 1,D */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2611,10 +2223,10 @@ static int op_tb1d(void)		/* BIT 1,D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb2d(void)		/* BIT 2,D */
+INSTR(0x52, op_tb2d)			/* BIT 2,D */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2624,10 +2236,10 @@ static int op_tb2d(void)		/* BIT 2,D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb3d(void)		/* BIT 3,D */
+INSTR(0x5a, op_tb3d)			/* BIT 3,D */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2637,10 +2249,10 @@ static int op_tb3d(void)		/* BIT 3,D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb4d(void)		/* BIT 4,D */
+INSTR(0x62, op_tb4d)			/* BIT 4,D */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2650,10 +2262,10 @@ static int op_tb4d(void)		/* BIT 4,D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb5d(void)		/* BIT 5,D */
+INSTR(0x6a, op_tb5d)			/* BIT 5,D */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2663,10 +2275,10 @@ static int op_tb5d(void)		/* BIT 5,D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb6d(void)		/* BIT 6,D */
+INSTR(0x72, op_tb6d)			/* BIT 6,D */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2676,10 +2288,10 @@ static int op_tb6d(void)		/* BIT 6,D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb7d(void)		/* BIT 7,D */
+INSTR(0x7a, op_tb7d)			/* BIT 7,D */
 {
 	F &= ~N_FLAG;
 	F |= H_FLAG;
@@ -2695,10 +2307,10 @@ static int op_tb7d(void)		/* BIT 7,D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb0e(void)		/* BIT 0,E */
+INSTR(0x43, op_tb0e)			/* BIT 0,E */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2708,10 +2320,10 @@ static int op_tb0e(void)		/* BIT 0,E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb1e(void)		/* BIT 1,E */
+INSTR(0x4b, op_tb1e)			/* BIT 1,E */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2721,10 +2333,10 @@ static int op_tb1e(void)		/* BIT 1,E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb2e(void)		/* BIT 2,E */
+INSTR(0x53, op_tb2e)			/* BIT 2,E */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2734,10 +2346,10 @@ static int op_tb2e(void)		/* BIT 2,E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb3e(void)		/* BIT 3,E */
+INSTR(0x5b, op_tb3e)			/* BIT 3,E */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2747,10 +2359,10 @@ static int op_tb3e(void)		/* BIT 3,E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb4e(void)		/* BIT 4,E */
+INSTR(0x63, op_tb4e)			/* BIT 4,E */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2760,10 +2372,10 @@ static int op_tb4e(void)		/* BIT 4,E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb5e(void)		/* BIT 5,E */
+INSTR(0x6b, op_tb5e)			/* BIT 5,E */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2773,10 +2385,10 @@ static int op_tb5e(void)		/* BIT 5,E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb6e(void)		/* BIT 6,E */
+INSTR(0x73, op_tb6e)			/* BIT 6,E */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2786,10 +2398,10 @@ static int op_tb6e(void)		/* BIT 6,E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb7e(void)		/* BIT 7,E */
+INSTR(0x7b, op_tb7e)			/* BIT 7,E */
 {
 	F &= ~N_FLAG;
 	F |= H_FLAG;
@@ -2805,10 +2417,10 @@ static int op_tb7e(void)		/* BIT 7,E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb0h(void)		/* BIT 0,H */
+INSTR(0x44, op_tb0h)			/* BIT 0,H */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2818,10 +2430,10 @@ static int op_tb0h(void)		/* BIT 0,H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb1h(void)		/* BIT 1,H */
+INSTR(0x4c, op_tb1h)			/* BIT 1,H */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2831,10 +2443,10 @@ static int op_tb1h(void)		/* BIT 1,H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb2h(void)		/* BIT 2,H */
+INSTR(0x54, op_tb2h)			/* BIT 2,H */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2844,10 +2456,10 @@ static int op_tb2h(void)		/* BIT 2,H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb3h(void)		/* BIT 3,H */
+INSTR(0x5c, op_tb3h)			/* BIT 3,H */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2857,10 +2469,10 @@ static int op_tb3h(void)		/* BIT 3,H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb4h(void)		/* BIT 4,H */
+INSTR(0x64, op_tb4h)			/* BIT 4,H */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2870,10 +2482,10 @@ static int op_tb4h(void)		/* BIT 4,H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb5h(void)		/* BIT 5,H */
+INSTR(0x6c, op_tb5h)			/* BIT 5,H */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2883,10 +2495,10 @@ static int op_tb5h(void)		/* BIT 5,H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb6h(void)		/* BIT 6,H */
+INSTR(0x74, op_tb6h)			/* BIT 6,H */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2896,10 +2508,10 @@ static int op_tb6h(void)		/* BIT 6,H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb7h(void)		/* BIT 7,H */
+INSTR(0x7c, op_tb7h)			/* BIT 7,H */
 {
 	F &= ~N_FLAG;
 	F |= H_FLAG;
@@ -2915,10 +2527,10 @@ static int op_tb7h(void)		/* BIT 7,H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb0l(void)		/* BIT 0,L */
+INSTR(0x45, op_tb0l)			/* BIT 0,L */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2928,10 +2540,10 @@ static int op_tb0l(void)		/* BIT 0,L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb1l(void)		/* BIT 1,L */
+INSTR(0x4d, op_tb1l)			/* BIT 1,L */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2941,10 +2553,10 @@ static int op_tb1l(void)		/* BIT 1,L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb2l(void)		/* BIT 2,L */
+INSTR(0x55, op_tb2l)			/* BIT 2,L */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2954,10 +2566,10 @@ static int op_tb2l(void)		/* BIT 2,L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb3l(void)		/* BIT 3,L */
+INSTR(0x5d, op_tb3l)			/* BIT 3,L */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2967,10 +2579,10 @@ static int op_tb3l(void)		/* BIT 3,L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb4l(void)		/* BIT 4,L */
+INSTR(0x65, op_tb4l)			/* BIT 4,L */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2980,10 +2592,10 @@ static int op_tb4l(void)		/* BIT 4,L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb5l(void)		/* BIT 5,L */
+INSTR(0x6d, op_tb5l)			/* BIT 5,L */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -2993,10 +2605,10 @@ static int op_tb5l(void)		/* BIT 5,L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb6l(void)		/* BIT 6,L */
+INSTR(0x75, op_tb6l)			/* BIT 6,L */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -3006,10 +2618,10 @@ static int op_tb6l(void)		/* BIT 6,L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb7l(void)		/* BIT 7,L */
+INSTR(0x7d, op_tb7l)			/* BIT 7,L */
 {
 	F &= ~N_FLAG;
 	F |= H_FLAG;
@@ -3025,10 +2637,10 @@ static int op_tb7l(void)		/* BIT 7,L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_tb0hl(void)		/* BIT 0,(HL) */
+INSTR(0x46, op_tb0hl)			/* BIT 0,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -3039,10 +2651,10 @@ static int op_tb0hl(void)		/* BIT 0,(HL) */
 	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_tb1hl(void)		/* BIT 1,(HL) */
+INSTR(0x4e, op_tb1hl)			/* BIT 1,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -3053,10 +2665,10 @@ static int op_tb1hl(void)		/* BIT 1,(HL) */
 	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_tb2hl(void)		/* BIT 2,(HL) */
+INSTR(0x56, op_tb2hl)			/* BIT 2,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -3067,10 +2679,10 @@ static int op_tb2hl(void)		/* BIT 2,(HL) */
 	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_tb3hl(void)		/* BIT 3,(HL) */
+INSTR(0x5e, op_tb3hl)			/* BIT 3,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -3081,10 +2693,10 @@ static int op_tb3hl(void)		/* BIT 3,(HL) */
 	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_tb4hl(void)		/* BIT 4,(HL) */
+INSTR(0x66, op_tb4hl)			/* BIT 4,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -3095,10 +2707,10 @@ static int op_tb4hl(void)		/* BIT 4,(HL) */
 	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_tb5hl(void)		/* BIT 5,(HL) */
+INSTR(0x6e, op_tb5hl)			/* BIT 5,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -3109,10 +2721,10 @@ static int op_tb5hl(void)		/* BIT 5,(HL) */
 	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_tb6hl(void)		/* BIT 6,(HL) */
+INSTR(0x76, op_tb6hl)			/* BIT 6,(HL) */
 {
 	F &= ~(N_FLAG | S_FLAG);
 	F |= H_FLAG;
@@ -3123,10 +2735,10 @@ static int op_tb6hl(void)		/* BIT 6,(HL) */
 	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_tb7hl(void)		/* BIT 7,(HL) */
+INSTR(0x7e, op_tb7hl)			/* BIT 7,(HL) */
 {
 	F &= ~N_FLAG;
 	F |= H_FLAG;
@@ -3142,7 +2754,7 @@ static int op_tb7hl(void)		/* BIT 7,(HL) */
 	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
 /**********************************************************************/
@@ -3156,7 +2768,7 @@ static int op_tb7hl(void)		/* BIT 7,(HL) */
  * documentation, it is in the Z280 one, including an
  * example to tell Z80 and Z280 apart.
  */
-static int op_undoc_slla(void)		/* SLL A */
+INSTR(0x37, op_undoc_slla)		/* SLL A */
 {
 	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A << 1 | 1;
@@ -3169,15 +2781,16 @@ static int op_undoc_slla(void)		/* SLL A */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
 #ifdef UNDOC_INST
 
-static int op_undoc_sllb(void)		/* SLL B */
+INSTR(0x30, op_undoc_sllb)		/* SLL B */
 {
-	if (u_flag)
-		return (trap_cb());
+	if (u_flag) {
+		STATES(trap_cb());
+	}
 
 	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	B = B << 1 | 1;
@@ -3190,13 +2803,14 @@ static int op_undoc_sllb(void)		/* SLL B */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_sllc(void)		/* SLL C */
+INSTR(0x31, op_undoc_sllc)		/* SLL C */
 {
-	if (u_flag)
-		return (trap_cb());
+	if (u_flag) {
+		STATES(trap_cb());
+	}
 
 	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	C = C << 1 | 1;
@@ -3209,13 +2823,14 @@ static int op_undoc_sllc(void)		/* SLL C */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_slld(void)		/* SLL D */
+INSTR(0x32, op_undoc_slld)		/* SLL D */
 {
-	if (u_flag)
-		return (trap_cb());
+	if (u_flag) {
+		STATES(trap_cb());
+	}
 
 	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	D = D << 1 | 1;
@@ -3228,13 +2843,14 @@ static int op_undoc_slld(void)		/* SLL D */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_slle(void)		/* SLL E */
+INSTR(0x33, op_undoc_slle)		/* SLL E */
 {
-	if (u_flag)
-		return (trap_cb());
+	if (u_flag) {
+		STATES(trap_cb());
+	}
 
 	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	E = E << 1 | 1;
@@ -3247,13 +2863,14 @@ static int op_undoc_slle(void)		/* SLL E */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_sllh(void)		/* SLL H */
+INSTR(0x34, op_undoc_sllh)		/* SLL H */
 {
-	if (u_flag)
-		return (trap_cb());
+	if (u_flag) {
+		STATES(trap_cb());
+	}
 
 	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H = H << 1 | 1;
@@ -3266,13 +2883,14 @@ static int op_undoc_sllh(void)		/* SLL H */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_slll(void)		/* SLL L */
+INSTR(0x35, op_undoc_slll)		/* SLL L */
 {
-	if (u_flag)
-		return (trap_cb());
+	if (u_flag) {
+		STATES(trap_cb());
+	}
 
 	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	L = L << 1 | 1;
@@ -3285,16 +2903,17 @@ static int op_undoc_slll(void)		/* SLL L */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_sllhl(void)		/* SLL (HL) */
+INSTR(0x36, op_undoc_sllhl)		/* SLL (HL) */
 {
 	register BYTE P;
 	WORD addr;
 
-	if (u_flag)
-		return (trap_cb());
+	if (u_flag) {
+		STATES(trap_cb());
+	}
 
 	addr = (H << 8) + L;
 	P = memrdr(addr);
@@ -3310,9 +2929,7 @@ static int op_undoc_sllhl(void)		/* SLL (HL) */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-#endif
-
-#endif
+#endif /* UNDOC_INST */

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -6,394 +6,32 @@
  */
 
 /*
- *	Like the function "cpu_z80()" this one emulates multi byte opcodes
- *	starting with 0xdd
+ *	This module contains the implementation of all Z80 instructions
+ *	beginning with the prefix 0xdd and a dispatcher for the
+ *	prefix 0xdd 0xcb
  */
 
-#include "sim.h"
-#include "simglb.h"
-#include "config.h"
-#ifdef FRONTPANEL
-#include "frontpanel.h"
-#endif
-#include "memsim.h"
-
-#ifndef EXCLUDE_Z80
-
-#ifdef UNDOC_INST
-#define UNDOC(f) f
-#else
-#define UNDOC(f) trap_dd
-#endif
-
-static int trap_dd(void);
-static int op_popix(void), op_pusix(void);
-static int op_jpix(void);
-static int op_exspx(void);
-static int op_ldspx(void);
-static int op_ldixnn(void), op_ldixinn(void), op_ldinx(void);
-static int op_adaxd(void), op_acaxd(void), op_suaxd(void), op_scaxd(void);
-static int op_andxd(void), op_xorxd(void), op_orxd(void), op_cpxd(void);
-static int op_decxd(void), op_incxd(void);
-static int op_addxb(void), op_addxd(void), op_addxs(void), op_addxx(void);
-static int op_incix(void), op_decix(void);
-static int op_ldaxd(void), op_ldbxd(void), op_ldcxd(void);
-static int op_lddxd(void), op_ldexd(void);
-static int op_ldhxd(void), op_ldlxd(void);
-static int op_ldxda(void), op_ldxdb(void), op_ldxdc(void);
-static int op_ldxdd(void), op_ldxde(void);
-static int op_ldxdh(void), op_ldxdl(void), op_ldxdn(void);
-extern int op_ddcb_handle(void);
-
-#ifdef UNDOC_INST
-static int op_undoc_ldaixl(void), op_undoc_ldaixh(void);
-static int op_undoc_ldbixl(void), op_undoc_ldbixh(void);
-static int op_undoc_ldcixl(void), op_undoc_ldcixh(void);
-static int op_undoc_lddixl(void), op_undoc_lddixh(void);
-static int op_undoc_ldeixl(void), op_undoc_ldeixh(void);
-static int op_undoc_ldixha(void), op_undoc_ldixla(void);
-static int op_undoc_ldixhb(void), op_undoc_ldixlb(void);
-static int op_undoc_ldixhc(void), op_undoc_ldixlc(void);
-static int op_undoc_ldixhd(void), op_undoc_ldixld(void);
-static int op_undoc_ldixhe(void), op_undoc_ldixle(void);
-static int op_undoc_ldixhixh(void), op_undoc_ldixlixh(void);
-static int op_undoc_ldixhixl(void), op_undoc_ldixlixl(void);
-static int op_undoc_ldixhn(void), op_undoc_ldixln(void);
-static int op_undoc_cpixl(void), op_undoc_cpixh(void);
-static int op_undoc_adaixl(void), op_undoc_adaixh(void);
-static int op_undoc_acaixl(void), op_undoc_acaixh(void);
-static int op_undoc_suaixl(void), op_undoc_suaixh(void);
-static int op_undoc_scaixl(void), op_undoc_scaixh(void);
-static int op_undoc_oraixl(void), op_undoc_oraixh(void);
-static int op_undoc_andixl(void), op_undoc_andixh(void);
-static int op_undoc_xorixl(void), op_undoc_xorixh(void);
-static int op_undoc_incixl(void), op_undoc_incixh(void);
-static int op_undoc_decixl(void), op_undoc_decixh(void);
-#endif
-
-int op_dd_handle(void)
-{
-	register int t;
-
-	static int (*op_dd[256])(void) = {
-		trap_dd,			/* 0x00 */
-		trap_dd,			/* 0x01 */
-		trap_dd,			/* 0x02 */
-		trap_dd,			/* 0x03 */
-		trap_dd,			/* 0x04 */
-		trap_dd,			/* 0x05 */
-		trap_dd,			/* 0x06 */
-		trap_dd,			/* 0x07 */
-		trap_dd,			/* 0x08 */
-		op_addxb,			/* 0x09 */
-		trap_dd,			/* 0x0a */
-		trap_dd,			/* 0x0b */
-		trap_dd,			/* 0x0c */
-		trap_dd,			/* 0x0d */
-		trap_dd,			/* 0x0e */
-		trap_dd,			/* 0x0f */
-		trap_dd,			/* 0x10 */
-		trap_dd,			/* 0x11 */
-		trap_dd,			/* 0x12 */
-		trap_dd,			/* 0x13 */
-		trap_dd,			/* 0x14 */
-		trap_dd,			/* 0x15 */
-		trap_dd,			/* 0x16 */
-		trap_dd,			/* 0x17 */
-		trap_dd,			/* 0x18 */
-		op_addxd,			/* 0x19 */
-		trap_dd,			/* 0x1a */
-		trap_dd,			/* 0x1b */
-		trap_dd,			/* 0x1c */
-		trap_dd,			/* 0x1d */
-		trap_dd,			/* 0x1e */
-		trap_dd,			/* 0x1f */
-		trap_dd,			/* 0x20 */
-		op_ldixnn,			/* 0x21 */
-		op_ldinx,			/* 0x22 */
-		op_incix,			/* 0x23 */
-		UNDOC(op_undoc_incixh),		/* 0x24 */
-		UNDOC(op_undoc_decixh),		/* 0x25 */
-		UNDOC(op_undoc_ldixhn),		/* 0x26 */
-		trap_dd,			/* 0x27 */
-		trap_dd,			/* 0x28 */
-		op_addxx,			/* 0x29 */
-		op_ldixinn,			/* 0x2a */
-		op_decix,			/* 0x2b */
-		UNDOC(op_undoc_incixl),		/* 0x2c */
-		UNDOC(op_undoc_decixl),		/* 0x2d */
-		UNDOC(op_undoc_ldixln),		/* 0x2e */
-		trap_dd,			/* 0x2f */
-		trap_dd,			/* 0x30 */
-		trap_dd,			/* 0x31 */
-		trap_dd,			/* 0x32 */
-		trap_dd,			/* 0x33 */
-		op_incxd,			/* 0x34 */
-		op_decxd,			/* 0x35 */
-		op_ldxdn,			/* 0x36 */
-		trap_dd,			/* 0x37 */
-		trap_dd,			/* 0x38 */
-		op_addxs,			/* 0x39 */
-		trap_dd,			/* 0x3a */
-		trap_dd,			/* 0x3b */
-		trap_dd,			/* 0x3c */
-		trap_dd,			/* 0x3d */
-		trap_dd,			/* 0x3e */
-		trap_dd,			/* 0x3f */
-		trap_dd,			/* 0x40 */
-		trap_dd,			/* 0x41 */
-		trap_dd,			/* 0x42 */
-		trap_dd,			/* 0x43 */
-		UNDOC(op_undoc_ldbixh),		/* 0x44 */
-		UNDOC(op_undoc_ldbixl),		/* 0x45 */
-		op_ldbxd,			/* 0x46 */
-		trap_dd,			/* 0x47 */
-		trap_dd,			/* 0x48 */
-		trap_dd,			/* 0x49 */
-		trap_dd,			/* 0x4a */
-		trap_dd,			/* 0x4b */
-		UNDOC(op_undoc_ldcixh),		/* 0x4c */
-		UNDOC(op_undoc_ldcixl),		/* 0x4d */
-		op_ldcxd,			/* 0x4e */
-		trap_dd,			/* 0x4f */
-		trap_dd,			/* 0x50 */
-		trap_dd,			/* 0x51 */
-		trap_dd,			/* 0x52 */
-		trap_dd,			/* 0x53 */
-		UNDOC(op_undoc_lddixh),		/* 0x54 */
-		UNDOC(op_undoc_lddixl),		/* 0x55 */
-		op_lddxd,			/* 0x56 */
-		trap_dd,			/* 0x57 */
-		trap_dd,			/* 0x58 */
-		trap_dd,			/* 0x59 */
-		trap_dd,			/* 0x5a */
-		trap_dd,			/* 0x5b */
-		UNDOC(op_undoc_ldeixh),		/* 0x5c */
-		UNDOC(op_undoc_ldeixl),		/* 0x5d */
-		op_ldexd,			/* 0x5e */
-		trap_dd,			/* 0x5f */
-		UNDOC(op_undoc_ldixhb),		/* 0x60 */
-		UNDOC(op_undoc_ldixhc),		/* 0x61 */
-		UNDOC(op_undoc_ldixhd),		/* 0x62 */
-		UNDOC(op_undoc_ldixhe),		/* 0x63 */
-		UNDOC(op_undoc_ldixhixh),	/* 0x64 */
-		UNDOC(op_undoc_ldixhixl),	/* 0x65 */
-		op_ldhxd,			/* 0x66 */
-		UNDOC(op_undoc_ldixha),		/* 0x67 */
-		UNDOC(op_undoc_ldixlb),		/* 0x68 */
-		UNDOC(op_undoc_ldixlc),		/* 0x69 */
-		UNDOC(op_undoc_ldixld),		/* 0x6a */
-		UNDOC(op_undoc_ldixle),		/* 0x6b */
-		UNDOC(op_undoc_ldixlixh),	/* 0x6c */
-		UNDOC(op_undoc_ldixlixl),	/* 0x6d */
-		op_ldlxd,			/* 0x6e */
-		UNDOC(op_undoc_ldixla),		/* 0x6f */
-		op_ldxdb,			/* 0x70 */
-		op_ldxdc,			/* 0x71 */
-		op_ldxdd,			/* 0x72 */
-		op_ldxde,			/* 0x73 */
-		op_ldxdh,			/* 0x74 */
-		op_ldxdl,			/* 0x75 */
-		trap_dd,			/* 0x76 */
-		op_ldxda,			/* 0x77 */
-		trap_dd,			/* 0x78 */
-		trap_dd,			/* 0x79 */
-		trap_dd,			/* 0x7a */
-		trap_dd,			/* 0x7b */
-		UNDOC(op_undoc_ldaixh),		/* 0x7c */
-		UNDOC(op_undoc_ldaixl),		/* 0x7d */
-		op_ldaxd,			/* 0x7e */
-		trap_dd,			/* 0x7f */
-		trap_dd,			/* 0x80 */
-		trap_dd,			/* 0x81 */
-		trap_dd,			/* 0x82 */
-		trap_dd,			/* 0x83 */
-		UNDOC(op_undoc_adaixh),		/* 0x84 */
-		UNDOC(op_undoc_adaixl),		/* 0x85 */
-		op_adaxd,			/* 0x86 */
-		trap_dd,			/* 0x87 */
-		trap_dd,			/* 0x88 */
-		trap_dd,			/* 0x89 */
-		trap_dd,			/* 0x8a */
-		trap_dd,			/* 0x8b */
-		UNDOC(op_undoc_acaixh),		/* 0x8c */
-		UNDOC(op_undoc_acaixl),		/* 0x8d */
-		op_acaxd,			/* 0x8e */
-		trap_dd,			/* 0x8f */
-		trap_dd,			/* 0x90 */
-		trap_dd,			/* 0x91 */
-		trap_dd,			/* 0x92 */
-		trap_dd,			/* 0x93 */
-		UNDOC(op_undoc_suaixh),		/* 0x94 */
-		UNDOC(op_undoc_suaixl),		/* 0x95 */
-		op_suaxd,			/* 0x96 */
-		trap_dd,			/* 0x97 */
-		trap_dd,			/* 0x98 */
-		trap_dd,			/* 0x99 */
-		trap_dd,			/* 0x9a */
-		trap_dd,			/* 0x9b */
-		UNDOC(op_undoc_scaixh),		/* 0x9c */
-		UNDOC(op_undoc_scaixl),		/* 0x9d */
-		op_scaxd,			/* 0x9e */
-		trap_dd,			/* 0x9f */
-		trap_dd,			/* 0xa0 */
-		trap_dd,			/* 0xa1 */
-		trap_dd,			/* 0xa2 */
-		trap_dd,			/* 0xa3 */
-		UNDOC(op_undoc_andixh),		/* 0xa4 */
-		UNDOC(op_undoc_andixl),		/* 0xa5 */
-		op_andxd,			/* 0xa6 */
-		trap_dd,			/* 0xa7 */
-		trap_dd,			/* 0xa8 */
-		trap_dd,			/* 0xa9 */
-		trap_dd,			/* 0xaa */
-		trap_dd,			/* 0xab */
-		UNDOC(op_undoc_xorixh),		/* 0xac */
-		UNDOC(op_undoc_xorixl),		/* 0xad */
-		op_xorxd,			/* 0xae */
-		trap_dd,			/* 0xaf */
-		trap_dd,			/* 0xb0 */
-		trap_dd,			/* 0xb1 */
-		trap_dd,			/* 0xb2 */
-		trap_dd,			/* 0xb3 */
-		UNDOC(op_undoc_oraixh),		/* 0xb4 */
-		UNDOC(op_undoc_oraixl),		/* 0xb5 */
-		op_orxd,			/* 0xb6 */
-		trap_dd,			/* 0xb7 */
-		trap_dd,			/* 0xb8 */
-		trap_dd,			/* 0xb9 */
-		trap_dd,			/* 0xba */
-		trap_dd,			/* 0xbb */
-		UNDOC(op_undoc_cpixh),		/* 0xbc */
-		UNDOC(op_undoc_cpixl),		/* 0xbd */
-		op_cpxd,			/* 0xbe */
-		trap_dd,			/* 0xbf */
-		trap_dd,			/* 0xc0 */
-		trap_dd,			/* 0xc1 */
-		trap_dd,			/* 0xc2 */
-		trap_dd,			/* 0xc3 */
-		trap_dd,			/* 0xc4 */
-		trap_dd,			/* 0xc5 */
-		trap_dd,			/* 0xc6 */
-		trap_dd,			/* 0xc7 */
-		trap_dd,			/* 0xc8 */
-		trap_dd,			/* 0xc9 */
-		trap_dd,			/* 0xca */
-		op_ddcb_handle,			/* 0xcb */
-		trap_dd,			/* 0xcc */
-		trap_dd,			/* 0xcd */
-		trap_dd,			/* 0xce */
-		trap_dd,			/* 0xcf */
-		trap_dd,			/* 0xd0 */
-		trap_dd,			/* 0xd1 */
-		trap_dd,			/* 0xd2 */
-		trap_dd,			/* 0xd3 */
-		trap_dd,			/* 0xd4 */
-		trap_dd,			/* 0xd5 */
-		trap_dd,			/* 0xd6 */
-		trap_dd,			/* 0xd7 */
-		trap_dd,			/* 0xd8 */
-		trap_dd,			/* 0xd9 */
-		trap_dd,			/* 0xda */
-		trap_dd,			/* 0xdb */
-		trap_dd,			/* 0xdc */
-		trap_dd,			/* 0xdd */
-		trap_dd,			/* 0xde */
-		trap_dd,			/* 0xdf */
-		trap_dd,			/* 0xe0 */
-		op_popix,			/* 0xe1 */
-		trap_dd,			/* 0xe2 */
-		op_exspx,			/* 0xe3 */
-		trap_dd,			/* 0xe4 */
-		op_pusix,			/* 0xe5 */
-		trap_dd,			/* 0xe6 */
-		trap_dd,			/* 0xe7 */
-		trap_dd,			/* 0xe8 */
-		op_jpix,			/* 0xe9 */
-		trap_dd,			/* 0xea */
-		trap_dd,			/* 0xeb */
-		trap_dd,			/* 0xec */
-		trap_dd,			/* 0xed */
-		trap_dd,			/* 0xee */
-		trap_dd,			/* 0xef */
-		trap_dd,			/* 0xf0 */
-		trap_dd,			/* 0xf1 */
-		trap_dd,			/* 0xf2 */
-		trap_dd,			/* 0xf3 */
-		trap_dd,			/* 0xf4 */
-		trap_dd,			/* 0xf5 */
-		trap_dd,			/* 0xf6 */
-		trap_dd,			/* 0xf7 */
-		trap_dd,			/* 0xf8 */
-		op_ldspx,			/* 0xf9 */
-		trap_dd,			/* 0xfa */
-		trap_dd,			/* 0xfb */
-		trap_dd,			/* 0xfc */
-		trap_dd,			/* 0xfd */
-		trap_dd,			/* 0xfe */
-		trap_dd				/* 0xff */
-	};
-
-#ifdef BUS_8080
-	/* M1 opcode fetch */
-	cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
-	m1_step = 1;
-#endif
-#ifdef FRONTPANEL
-	if (F_flag) {
-		/* update frontpanel */
-		fp_clock++;
-		fp_sampleLightGroup(0, 0);
-	}
-#endif
-
-	R++;				/* increment refresh register */
-
-	t = (*op_dd[memrdr(PC++)])();	/* execute next opcode */
-
-	return (t);
-}
-
-/*
- *	This function traps undocumented opcodes following the
- *	initial 0xdd of a multi byte opcode.
- */
-static int trap_dd(void)
-{
-#ifdef UNDOC_INST
-	if (!u_flag) {
-		/* Treat 0xdd prefix as NOP on non IX-instructions */
-		PC--;
-		R--;
-		return (4);
-	}
-#endif
-	cpu_error = OPTRAP2;
-	cpu_state = STOPPED;
-	return (0);
-}
-
-static int op_popix(void)		/* POP IX */
+INSTR(0xe1, op_popix)			/* POP IX */
 {
 	IX = memrdr(SP++);
 	IX += memrdr(SP++) << 8;
-	return (14);
+	STATES(14);
 }
 
-static int op_pusix(void)		/* PUSH IX */
+INSTR(0xe5, op_pusix)			/* PUSH IX */
 {
 	memwrt(--SP, IX >> 8);
 	memwrt(--SP, IX);
-	return (15);
+	STATES(15);
 }
 
-static int op_jpix(void)		/* JP (IX) */
+INSTR(0xe9, op_jpix)			/* JP (IX) */
 {
 	PC = IX;
-	return (8);
+	STATES(8);
 }
 
-static int op_exspx(void)		/* EX (SP),IX */
+INSTR(0xe3, op_exspx)			/* EX (SP),IX */
 {
 	register WORD i;
 
@@ -404,23 +42,23 @@ static int op_exspx(void)		/* EX (SP),IX */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (23);
+	STATES(23);
 }
 
-static int op_ldspx(void)		/* LD SP,IX */
+INSTR(0xf9, op_ldspx)			/* LD SP,IX */
 {
 	SP = IX;
-	return (10);
+	STATES(10);
 }
 
-static int op_ldixnn(void)		/* LD IX,nn */
+INSTR(0x21, op_ldixnn)			/* LD IX,nn */
 {
 	IX = memrdr(PC++);
 	IX += memrdr(PC++) << 8;
-	return (14);
+	STATES(14);
 }
 
-static int op_ldixinn(void)		/* LD IX,(nn) */
+INSTR(0x2a, op_ldixinn)			/* LD IX,(nn) */
 {
 	register WORD i;
 
@@ -431,10 +69,10 @@ static int op_ldixinn(void)		/* LD IX,(nn) */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_ldinx(void)		/* LD (nn),IX */
+INSTR(0x22, op_ldinx)			/* LD (nn),IX */
 {
 	register WORD i;
 
@@ -445,10 +83,10 @@ static int op_ldinx(void)		/* LD (nn),IX */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_adaxd(void)		/* ADD A,(IX+d) */
+INSTR(0x86, op_adaxd)			/* ADD A,(IX+d) */
 {
 	register int i;
 	register BYTE P;
@@ -469,10 +107,10 @@ static int op_adaxd(void)		/* ADD A,(IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_acaxd(void)		/* ADC A,(IX+d) */
+INSTR(0x8e, op_acaxd)			/* ADC A,(IX+d) */
 {
 	register int i, carry;
 	register BYTE P;
@@ -494,10 +132,10 @@ static int op_acaxd(void)		/* ADC A,(IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_suaxd(void)		/* SUB A,(IX+d) */
+INSTR(0x96, op_suaxd)			/* SUB A,(IX+d) */
 {
 	register int i;
 	register BYTE P;
@@ -518,10 +156,10 @@ static int op_suaxd(void)		/* SUB A,(IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_scaxd(void)		/* SBC A,(IX+d) */
+INSTR(0x9e, op_scaxd)			/* SBC A,(IX+d) */
 {
 	register int i, carry;
 	register BYTE P;
@@ -543,10 +181,10 @@ static int op_scaxd(void)		/* SBC A,(IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_andxd(void)		/* AND (IX+d) */
+INSTR(0xa6, op_andxd)			/* AND (IX+d) */
 {
 	WORD addr;
 
@@ -563,10 +201,10 @@ static int op_andxd(void)		/* AND (IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_xorxd(void)		/* XOR (IX+d) */
+INSTR(0xae, op_xorxd)			/* XOR (IX+d) */
 {
 	WORD addr;
 
@@ -582,10 +220,10 @@ static int op_xorxd(void)		/* XOR (IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_orxd(void)		/* OR (IX+d) */
+INSTR(0xb6, op_orxd)			/* OR (IX+d) */
 {
 	WORD addr;
 
@@ -601,10 +239,10 @@ static int op_orxd(void)		/* OR (IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_cpxd(void)		/* CP (IX+d) */
+INSTR(0xbe, op_cpxd)			/* CP (IX+d) */
 {
 	register int i;
 	register BYTE P;
@@ -625,10 +263,10 @@ static int op_cpxd(void)		/* CP (IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_incxd(void)		/* INC (IX+d) */
+INSTR(0x34, op_incxd)			/* INC (IX+d) */
 {
 	register BYTE P;
 	WORD addr;
@@ -648,10 +286,10 @@ static int op_incxd(void)		/* INC (IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (23);
+	STATES(23);
 }
 
-static int op_decxd(void)		/* DEC (IX+d) */
+INSTR(0x35, op_decxd)			/* DEC (IX+d) */
 {
 	register BYTE P;
 	WORD addr;
@@ -671,10 +309,10 @@ static int op_decxd(void)		/* DEC (IX+d) */
 	WZ = addr;
 	modF = 1;
 #endif
-	return (23);
+	STATES(23);
 }
 
-static int op_addxb(void)		/* ADD IX,BC */
+INSTR(0x09, op_addxb)			/* ADD IX,BC */
 {
 	register int carry;
 	BYTE ixl = IX & 0xff;
@@ -696,10 +334,10 @@ static int op_addxb(void)		/* ADD IX,BC */
 	(ixh & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_addxd(void)		/* ADD IX,DE */
+INSTR(0x19, op_addxd)			/* ADD IX,DE */
 {
 	register int carry;
 	BYTE ixl = IX & 0xff;
@@ -721,10 +359,10 @@ static int op_addxd(void)		/* ADD IX,DE */
 	(ixh & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_addxs(void)		/* ADD IX,SP */
+INSTR(0x39, op_addxs)			/* ADD IX,SP */
 {
 	register int carry;
 	BYTE ixl = IX & 0xff;
@@ -748,10 +386,10 @@ static int op_addxs(void)		/* ADD IX,SP */
 	(ixh & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_addxx(void)		/* ADD IX,IX */
+INSTR(0x29, op_addxx)			/* ADD IX,IX */
 {
 	register int carry;
 	BYTE ixl = IX & 0xff;
@@ -773,22 +411,22 @@ static int op_addxx(void)		/* ADD IX,IX */
 	(ixh & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_incix(void)		/* INC IX */
+INSTR(0x23, op_incix)			/* INC IX */
 {
 	IX++;
-	return (10);
+	STATES(10);
 }
 
-static int op_decix(void)		/* DEC IX */
+INSTR(0x2b, op_decix)			/* DEC IX */
 {
 	IX--;
-	return (10);
+	STATES(10);
 }
 
-static int op_ldaxd(void)		/* LD A,(IX+d) */
+INSTR(0x7e, op_ldaxd)			/* LD A,(IX+d) */
 {
 	WORD addr;
 
@@ -797,10 +435,10 @@ static int op_ldaxd(void)		/* LD A,(IX+d) */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldbxd(void)		/* LD B,(IX+d) */
+INSTR(0x46, op_ldbxd)			/* LD B,(IX+d) */
 {
 	WORD addr;
 
@@ -809,10 +447,10 @@ static int op_ldbxd(void)		/* LD B,(IX+d) */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldcxd(void)		/* LD C,(IX+d) */
+INSTR(0x4e, op_ldcxd)			/* LD C,(IX+d) */
 {
 	WORD addr;
 
@@ -821,10 +459,10 @@ static int op_ldcxd(void)		/* LD C,(IX+d) */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_lddxd(void)		/* LD D,(IX+d) */
+INSTR(0x56, op_lddxd)			/* LD D,(IX+d) */
 {
 	WORD addr;
 
@@ -833,10 +471,10 @@ static int op_lddxd(void)		/* LD D,(IX+d) */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldexd(void)		/* LD E,(IX+d) */
+INSTR(0x5e, op_ldexd)			/* LD E,(IX+d) */
 {
 	WORD addr;
 
@@ -845,10 +483,10 @@ static int op_ldexd(void)		/* LD E,(IX+d) */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldhxd(void)		/* LD H,(IX+d) */
+INSTR(0x66, op_ldhxd)			/* LD H,(IX+d) */
 {
 	WORD addr;
 
@@ -857,10 +495,10 @@ static int op_ldhxd(void)		/* LD H,(IX+d) */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldlxd(void)		/* LD L,(IX+d) */
+INSTR(0x6e, op_ldlxd)			/* LD L,(IX+d) */
 {
 	WORD addr;
 
@@ -869,10 +507,10 @@ static int op_ldlxd(void)		/* LD L,(IX+d) */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldxda(void)		/* LD (IX+d),A */
+INSTR(0x77, op_ldxda)			/* LD (IX+d),A */
 {
 	WORD addr;
 
@@ -881,10 +519,10 @@ static int op_ldxda(void)		/* LD (IX+d),A */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldxdb(void)		/* LD (IX+d),B */
+INSTR(0x70, op_ldxdb)			/* LD (IX+d),B */
 {
 	WORD addr;
 
@@ -893,10 +531,10 @@ static int op_ldxdb(void)		/* LD (IX+d),B */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldxdc(void)		/* LD (IX+d),C */
+INSTR(0x71, op_ldxdc)			/* LD (IX+d),C */
 {
 	WORD addr;
 
@@ -905,10 +543,10 @@ static int op_ldxdc(void)		/* LD (IX+d),C */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldxdd(void)		/* LD (IX+d),D */
+INSTR(0x72, op_ldxdd)			/* LD (IX+d),D */
 {
 	WORD addr;
 
@@ -917,10 +555,10 @@ static int op_ldxdd(void)		/* LD (IX+d),D */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldxde(void)		/* LD (IX+d),E */
+INSTR(0x73, op_ldxde)			/* LD (IX+d),E */
 {
 	WORD addr;
 
@@ -929,10 +567,10 @@ static int op_ldxde(void)		/* LD (IX+d),E */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldxdh(void)		/* LD (IX+d),H */
+INSTR(0x74, op_ldxdh)			/* LD (IX+d),H */
 {
 	WORD addr;
 
@@ -941,10 +579,10 @@ static int op_ldxdh(void)		/* LD (IX+d),H */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldxdl(void)		/* LD (IX+d),L */
+INSTR(0x75, op_ldxdl)			/* LD (IX+d),L */
 {
 	WORD addr;
 
@@ -953,10 +591,10 @@ static int op_ldxdl(void)		/* LD (IX+d),L */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
 
-static int op_ldxdn(void)		/* LD (IX+d),n */
+INSTR(0x36, op_ldxdn)			/* LD (IX+d),n */
 {
 	WORD addr;
 
@@ -965,8 +603,314 @@ static int op_ldxdn(void)		/* LD (IX+d),n */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (19);
+	STATES(19);
 }
+
+INSTR(0xcb, op_ddcb_handle)		/* 0xdd 0xcb prefix */
+{
+#ifndef FAST_INSTR
+
+#ifdef UNDOC_INST
+#define UNDOC(f) f
+#ifdef UNDOC_IALL
+#define UNDOCA(f) f
+#else
+#define UNDOCA(f) trap_ddcb
+#endif
+#else
+#define UNDOC(f) trap_ddcb
+#define UNDOCA(f) trap_ddcb
+#endif
+
+	static int (*op_ddcb[256])(int) = {
+		UNDOCA(op_undoc_rlcixdb),	/* 0x00 */
+		UNDOCA(op_undoc_rlcixdc),	/* 0x01 */
+		UNDOCA(op_undoc_rlcixdd),	/* 0x02 */
+		UNDOCA(op_undoc_rlcixde),	/* 0x03 */
+		UNDOCA(op_undoc_rlcixdh),	/* 0x04 */
+		UNDOCA(op_undoc_rlcixdl),	/* 0x05 */
+		op_rlcixd,			/* 0x06 */
+		UNDOCA(op_undoc_rlcixda),	/* 0x07 */
+		UNDOCA(op_undoc_rrcixdb),	/* 0x08 */
+		UNDOCA(op_undoc_rrcixdc),	/* 0x09 */
+		UNDOCA(op_undoc_rrcixdd),	/* 0x0a */
+		UNDOCA(op_undoc_rrcixde),	/* 0x0b */
+		UNDOCA(op_undoc_rrcixdh),	/* 0x0c */
+		UNDOCA(op_undoc_rrcixdl),	/* 0x0d */
+		op_rrcixd,			/* 0x0e */
+		UNDOCA(op_undoc_rrcixda),	/* 0x0f */
+		UNDOCA(op_undoc_rlixdb),	/* 0x10 */
+		UNDOCA(op_undoc_rlixdc),	/* 0x11 */
+		UNDOCA(op_undoc_rlixdd),	/* 0x12 */
+		UNDOCA(op_undoc_rlixde),	/* 0x13 */
+		UNDOCA(op_undoc_rlixdh),	/* 0x14 */
+		UNDOCA(op_undoc_rlixdl),	/* 0x15 */
+		op_rlixd,			/* 0x16 */
+		UNDOCA(op_undoc_rlixda),	/* 0x17 */
+		UNDOCA(op_undoc_rrixdb),	/* 0x18 */
+		UNDOCA(op_undoc_rrixdc),	/* 0x19 */
+		UNDOCA(op_undoc_rrixdd),	/* 0x1a */
+		UNDOCA(op_undoc_rrixde),	/* 0x1b */
+		UNDOCA(op_undoc_rrixdh),	/* 0x1c */
+		UNDOCA(op_undoc_rrixdl),	/* 0x1d */
+		op_rrixd,			/* 0x1e */
+		UNDOCA(op_undoc_rrixda),	/* 0x1f */
+		UNDOCA(op_undoc_slaixdb),	/* 0x20 */
+		UNDOCA(op_undoc_slaixdc),	/* 0x21 */
+		UNDOCA(op_undoc_slaixdd),	/* 0x22 */
+		UNDOCA(op_undoc_slaixde),	/* 0x23 */
+		UNDOCA(op_undoc_slaixdh),	/* 0x24 */
+		UNDOCA(op_undoc_slaixdl),	/* 0x25 */
+		op_slaixd,			/* 0x26 */
+		UNDOCA(op_undoc_slaixda),	/* 0x27 */
+		UNDOCA(op_undoc_sraixdb),	/* 0x28 */
+		UNDOCA(op_undoc_sraixdc),	/* 0x29 */
+		UNDOCA(op_undoc_sraixdd),	/* 0x2a */
+		UNDOCA(op_undoc_sraixde),	/* 0x2b */
+		UNDOCA(op_undoc_sraixdh),	/* 0x2c */
+		UNDOCA(op_undoc_sraixdl),	/* 0x2d */
+		op_sraixd,			/* 0x2e */
+		UNDOCA(op_undoc_sraixda),	/* 0x2f */
+		UNDOCA(op_undoc_sllixdb),	/* 0x30 */
+		UNDOCA(op_undoc_sllixdc),	/* 0x31 */
+		UNDOCA(op_undoc_sllixdd),	/* 0x32 */
+		UNDOCA(op_undoc_sllixde),	/* 0x33 */
+		UNDOCA(op_undoc_sllixdh),	/* 0x34 */
+		UNDOCA(op_undoc_sllixdl),	/* 0x35 */
+		UNDOC(op_undoc_sllixd),		/* 0x36 */
+		UNDOCA(op_undoc_sllixda),	/* 0x37 */
+		UNDOCA(op_undoc_srlixdb),	/* 0x38 */
+		UNDOCA(op_undoc_srlixdc),	/* 0x39 */
+		UNDOCA(op_undoc_srlixdd),	/* 0x3a */
+		UNDOCA(op_undoc_srlixde),	/* 0x3b */
+		UNDOCA(op_undoc_srlixdh),	/* 0x3c */
+		UNDOCA(op_undoc_srlixdl),	/* 0x3d */
+		op_srlixd,			/* 0x3e */
+		UNDOCA(op_undoc_srlixda),	/* 0x3f */
+		UNDOCA(op_undoc_tb0ixd),	/* 0x40 */
+		UNDOCA(op_undoc_tb0ixd),	/* 0x41 */
+		UNDOCA(op_undoc_tb0ixd),	/* 0x42 */
+		UNDOCA(op_undoc_tb0ixd),	/* 0x43 */
+		UNDOCA(op_undoc_tb0ixd),	/* 0x44 */
+		UNDOCA(op_undoc_tb0ixd),	/* 0x45 */
+		op_tb0ixd,			/* 0x46 */
+		UNDOCA(op_undoc_tb0ixd),	/* 0x47 */
+		UNDOCA(op_undoc_tb1ixd),	/* 0x48 */
+		UNDOCA(op_undoc_tb1ixd),	/* 0x49 */
+		UNDOCA(op_undoc_tb1ixd),	/* 0x4a */
+		UNDOCA(op_undoc_tb1ixd),	/* 0x4b */
+		UNDOCA(op_undoc_tb1ixd),	/* 0x4c */
+		UNDOCA(op_undoc_tb1ixd),	/* 0x4d */
+		op_tb1ixd,			/* 0x4e */
+		UNDOCA(op_undoc_tb1ixd),	/* 0x4f */
+		UNDOCA(op_undoc_tb2ixd),	/* 0x50 */
+		UNDOCA(op_undoc_tb2ixd),	/* 0x51 */
+		UNDOCA(op_undoc_tb2ixd),	/* 0x52 */
+		UNDOCA(op_undoc_tb2ixd),	/* 0x53 */
+		UNDOCA(op_undoc_tb2ixd),	/* 0x54 */
+		UNDOCA(op_undoc_tb2ixd),	/* 0x55 */
+		op_tb2ixd,			/* 0x56 */
+		UNDOCA(op_undoc_tb2ixd),	/* 0x57 */
+		UNDOCA(op_undoc_tb3ixd),	/* 0x58 */
+		UNDOCA(op_undoc_tb3ixd),	/* 0x59 */
+		UNDOCA(op_undoc_tb3ixd),	/* 0x5a */
+		UNDOCA(op_undoc_tb3ixd),	/* 0x5b */
+		UNDOCA(op_undoc_tb3ixd),	/* 0x5c */
+		UNDOCA(op_undoc_tb3ixd),	/* 0x5d */
+		op_tb3ixd,			/* 0x5e */
+		UNDOCA(op_undoc_tb3ixd),	/* 0x5f */
+		UNDOCA(op_undoc_tb4ixd),	/* 0x60 */
+		UNDOCA(op_undoc_tb4ixd),	/* 0x61 */
+		UNDOCA(op_undoc_tb4ixd),	/* 0x62 */
+		UNDOCA(op_undoc_tb4ixd),	/* 0x63 */
+		UNDOCA(op_undoc_tb4ixd),	/* 0x64 */
+		UNDOCA(op_undoc_tb4ixd),	/* 0x65 */
+		op_tb4ixd,			/* 0x66 */
+		UNDOCA(op_undoc_tb4ixd),	/* 0x67 */
+		UNDOCA(op_undoc_tb5ixd),	/* 0x68 */
+		UNDOCA(op_undoc_tb5ixd),	/* 0x69 */
+		UNDOCA(op_undoc_tb5ixd),	/* 0x6a */
+		UNDOCA(op_undoc_tb5ixd),	/* 0x6b */
+		UNDOCA(op_undoc_tb5ixd),	/* 0x6c */
+		UNDOCA(op_undoc_tb5ixd),	/* 0x6d */
+		op_tb5ixd,			/* 0x6e */
+		UNDOCA(op_undoc_tb5ixd),	/* 0x6f */
+		UNDOCA(op_undoc_tb6ixd),	/* 0x70 */
+		UNDOCA(op_undoc_tb6ixd),	/* 0x71 */
+		UNDOCA(op_undoc_tb6ixd),	/* 0x72 */
+		UNDOCA(op_undoc_tb6ixd),	/* 0x73 */
+		UNDOCA(op_undoc_tb6ixd),	/* 0x74 */
+		UNDOCA(op_undoc_tb6ixd),	/* 0x75 */
+		op_tb6ixd,			/* 0x76 */
+		UNDOCA(op_undoc_tb6ixd),	/* 0x77 */
+		UNDOCA(op_undoc_tb7ixd),	/* 0x78 */
+		UNDOCA(op_undoc_tb7ixd),	/* 0x79 */
+		UNDOCA(op_undoc_tb7ixd),	/* 0x7a */
+		UNDOCA(op_undoc_tb7ixd),	/* 0x7b */
+		UNDOCA(op_undoc_tb7ixd),	/* 0x7c */
+		UNDOCA(op_undoc_tb7ixd),	/* 0x7d */
+		op_tb7ixd,			/* 0x7e */
+		UNDOCA(op_undoc_tb7ixd),	/* 0x7f */
+		UNDOCA(op_undoc_rb0ixdb),	/* 0x80 */
+		UNDOCA(op_undoc_rb0ixdc),	/* 0x81 */
+		UNDOCA(op_undoc_rb0ixdd),	/* 0x82 */
+		UNDOCA(op_undoc_rb0ixde),	/* 0x83 */
+		UNDOCA(op_undoc_rb0ixdh),	/* 0x84 */
+		UNDOCA(op_undoc_rb0ixdl),	/* 0x85 */
+		op_rb0ixd,			/* 0x86 */
+		UNDOCA(op_undoc_rb0ixda),	/* 0x87 */
+		UNDOCA(op_undoc_rb1ixdb),	/* 0x88 */
+		UNDOCA(op_undoc_rb1ixdc),	/* 0x89 */
+		UNDOCA(op_undoc_rb1ixdd),	/* 0x8a */
+		UNDOCA(op_undoc_rb1ixde),	/* 0x8b */
+		UNDOCA(op_undoc_rb1ixdh),	/* 0x8c */
+		UNDOCA(op_undoc_rb1ixdl),	/* 0x8d */
+		op_rb1ixd,			/* 0x8e */
+		UNDOCA(op_undoc_rb1ixda),	/* 0x8f */
+		UNDOCA(op_undoc_rb2ixdb),	/* 0x90 */
+		UNDOCA(op_undoc_rb2ixdc),	/* 0x91 */
+		UNDOCA(op_undoc_rb2ixdd),	/* 0x92 */
+		UNDOCA(op_undoc_rb2ixde),	/* 0x93 */
+		UNDOCA(op_undoc_rb2ixdh),	/* 0x94 */
+		UNDOCA(op_undoc_rb2ixdl),	/* 0x95 */
+		op_rb2ixd,			/* 0x96 */
+		UNDOCA(op_undoc_rb2ixda),	/* 0x97 */
+		UNDOCA(op_undoc_rb3ixdb),	/* 0x98 */
+		UNDOCA(op_undoc_rb3ixdc),	/* 0x99 */
+		UNDOCA(op_undoc_rb3ixdd),	/* 0x9a */
+		UNDOCA(op_undoc_rb3ixde),	/* 0x9b */
+		UNDOCA(op_undoc_rb3ixdh),	/* 0x9c */
+		UNDOCA(op_undoc_rb3ixdl),	/* 0x9d */
+		op_rb3ixd,			/* 0x9e */
+		UNDOCA(op_undoc_rb3ixda),	/* 0x9f */
+		UNDOCA(op_undoc_rb4ixdb),	/* 0xa0 */
+		UNDOCA(op_undoc_rb4ixdc),	/* 0xa1 */
+		UNDOCA(op_undoc_rb4ixdd),	/* 0xa2 */
+		UNDOCA(op_undoc_rb4ixde),	/* 0xa3 */
+		UNDOCA(op_undoc_rb4ixdh),	/* 0xa4 */
+		UNDOCA(op_undoc_rb4ixdl),	/* 0xa5 */
+		op_rb4ixd,			/* 0xa6 */
+		UNDOCA(op_undoc_rb4ixda),	/* 0xa7 */
+		UNDOCA(op_undoc_rb5ixdb),	/* 0xa8 */
+		UNDOCA(op_undoc_rb5ixdc),	/* 0xa9 */
+		UNDOCA(op_undoc_rb5ixdd),	/* 0xaa */
+		UNDOCA(op_undoc_rb5ixde),	/* 0xab */
+		UNDOCA(op_undoc_rb5ixdh),	/* 0xac */
+		UNDOCA(op_undoc_rb5ixdl),	/* 0xad */
+		op_rb5ixd,			/* 0xae */
+		UNDOCA(op_undoc_rb5ixda),	/* 0xaf */
+		UNDOCA(op_undoc_rb6ixdb),	/* 0xb0 */
+		UNDOCA(op_undoc_rb6ixdc),	/* 0xb1 */
+		UNDOCA(op_undoc_rb6ixdd),	/* 0xb2 */
+		UNDOCA(op_undoc_rb6ixde),	/* 0xb3 */
+		UNDOCA(op_undoc_rb6ixdh),	/* 0xb4 */
+		UNDOCA(op_undoc_rb6ixdl),	/* 0xb5 */
+		op_rb6ixd,			/* 0xb6 */
+		UNDOCA(op_undoc_rb6ixda),	/* 0xb7 */
+		UNDOCA(op_undoc_rb7ixdb),	/* 0xb8 */
+		UNDOCA(op_undoc_rb7ixdc),	/* 0xb9 */
+		UNDOCA(op_undoc_rb7ixdd),	/* 0xba */
+		UNDOCA(op_undoc_rb7ixde),	/* 0xbb */
+		UNDOCA(op_undoc_rb7ixdh),	/* 0xbc */
+		UNDOCA(op_undoc_rb7ixdl),	/* 0xbd */
+		op_rb7ixd,			/* 0xbe */
+		UNDOCA(op_undoc_rb7ixda),	/* 0xbf */
+		UNDOCA(op_undoc_sb0ixdb),	/* 0xc0 */
+		UNDOCA(op_undoc_sb0ixdc),	/* 0xc1 */
+		UNDOCA(op_undoc_sb0ixdd),	/* 0xc2 */
+		UNDOCA(op_undoc_sb0ixde),	/* 0xc3 */
+		UNDOCA(op_undoc_sb0ixdh),	/* 0xc4 */
+		UNDOCA(op_undoc_sb0ixdl),	/* 0xc5 */
+		op_sb0ixd,			/* 0xc6 */
+		UNDOCA(op_undoc_sb0ixda),	/* 0xc7 */
+		UNDOCA(op_undoc_sb1ixdb),	/* 0xc8 */
+		UNDOCA(op_undoc_sb1ixdc),	/* 0xc9 */
+		UNDOCA(op_undoc_sb1ixdd),	/* 0xca */
+		UNDOCA(op_undoc_sb1ixde),	/* 0xcb */
+		UNDOCA(op_undoc_sb1ixdh),	/* 0xcc */
+		UNDOCA(op_undoc_sb1ixdl),	/* 0xcd */
+		op_sb1ixd,			/* 0xce */
+		UNDOCA(op_undoc_sb1ixda),	/* 0xcf */
+		UNDOCA(op_undoc_sb2ixdb),	/* 0xd0 */
+		UNDOCA(op_undoc_sb2ixdc),	/* 0xd1 */
+		UNDOCA(op_undoc_sb2ixdd),	/* 0xd2 */
+		UNDOCA(op_undoc_sb2ixde),	/* 0xd3 */
+		UNDOCA(op_undoc_sb2ixdh),	/* 0xd4 */
+		UNDOCA(op_undoc_sb2ixdl),	/* 0xd5 */
+		op_sb2ixd,			/* 0xd6 */
+		UNDOCA(op_undoc_sb2ixda),	/* 0xd7 */
+		UNDOCA(op_undoc_sb3ixdb),	/* 0xd8 */
+		UNDOCA(op_undoc_sb3ixdc),	/* 0xd9 */
+		UNDOCA(op_undoc_sb3ixdd),	/* 0xda */
+		UNDOCA(op_undoc_sb3ixde),	/* 0xdb */
+		UNDOCA(op_undoc_sb3ixdh),	/* 0xdc */
+		UNDOCA(op_undoc_sb3ixdl),	/* 0xdd */
+		op_sb3ixd,			/* 0xde */
+		UNDOCA(op_undoc_sb3ixda),	/* 0xdf */
+		UNDOCA(op_undoc_sb4ixdb),	/* 0xe0 */
+		UNDOCA(op_undoc_sb4ixdc),	/* 0xe1 */
+		UNDOCA(op_undoc_sb4ixdd),	/* 0xe2 */
+		UNDOCA(op_undoc_sb4ixde),	/* 0xe3 */
+		UNDOCA(op_undoc_sb4ixdh),	/* 0xe4 */
+		UNDOCA(op_undoc_sb4ixdl),	/* 0xe5 */
+		op_sb4ixd,			/* 0xe6 */
+		UNDOCA(op_undoc_sb4ixda),	/* 0xe7 */
+		UNDOCA(op_undoc_sb5ixdb),	/* 0xe8 */
+		UNDOCA(op_undoc_sb5ixdc),	/* 0xe9 */
+		UNDOCA(op_undoc_sb5ixdd),	/* 0xea */
+		UNDOCA(op_undoc_sb5ixde),	/* 0xeb */
+		UNDOCA(op_undoc_sb5ixdh),	/* 0xec */
+		UNDOCA(op_undoc_sb5ixdl),	/* 0xed */
+		op_sb5ixd,			/* 0xee */
+		UNDOCA(op_undoc_sb5ixda),	/* 0xef */
+		UNDOCA(op_undoc_sb6ixdb),	/* 0xf0 */
+		UNDOCA(op_undoc_sb6ixdc),	/* 0xf1 */
+		UNDOCA(op_undoc_sb6ixdd),	/* 0xf2 */
+		UNDOCA(op_undoc_sb6ixde),	/* 0xf3 */
+		UNDOCA(op_undoc_sb6ixdh),	/* 0xf4 */
+		UNDOCA(op_undoc_sb6ixdl),	/* 0xf5 */
+		op_sb6ixd,			/* 0xf6 */
+		UNDOCA(op_undoc_sb6ixda),	/* 0xf7 */
+		UNDOCA(op_undoc_sb7ixdb),	/* 0xf8 */
+		UNDOCA(op_undoc_sb7ixdc),	/* 0xf9 */
+		UNDOCA(op_undoc_sb7ixdd),	/* 0xfa */
+		UNDOCA(op_undoc_sb7ixde),	/* 0xfb */
+		UNDOCA(op_undoc_sb7ixdh),	/* 0xfc */
+		UNDOCA(op_undoc_sb7ixdl),	/* 0xfd */
+		op_sb7ixd,			/* 0xfe */
+		UNDOCA(op_undoc_sb7ixda)	/* 0xff */
+	};
+
+#undef UNDOC
+#undef UNDOCA
+
+	register int t;
+
+#endif /* !FAST_INSTR */
+
+	register int data;
+
+	data = (signed char) memrdr(PC++);
+
+#ifndef FAST_INSTR
+	t = (*op_ddcb[memrdr(PC++)])(data); /* execute next opcode */
+#else
+	switch (memrdr(PC++)) {		/* execute next opcode */
+
+#include "simz80-ddcb.c"
+
+	default:
+		t = trap_ddcb(data);
+		break;
+	}
+#endif
+
+	STATES(t);
+}
+
+#ifndef FAST_INSTR
+#include "simz80-ddcb.c"
+#endif
 
 /**********************************************************************/
 /**********************************************************************/
@@ -976,245 +920,272 @@ static int op_ldxdn(void)		/* LD (IX+d),n */
 
 #ifdef UNDOC_INST
 
-static int op_undoc_ldaixl(void)	/* LD A,IXL */
+INSTR(0x7d, op_undoc_ldaixl)		/* LD A,IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	A = IX & 0xff;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldaixh(void)	/* LD A,IXH */
+INSTR(0x7c, op_undoc_ldaixh)		/* LD A,IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	A = IX >> 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldbixl(void)	/* LD B,IXL */
+INSTR(0x45, op_undoc_ldbixl)		/* LD B,IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	B = IX & 0xff;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldbixh(void)	/* LD B,IXH */
+INSTR(0x44, op_undoc_ldbixh)		/* LD B,IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	B = IX >> 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldcixl(void)	/* LD C,IXL */
+INSTR(0x4d, op_undoc_ldcixl)		/* LD C,IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	C = IX & 0xff;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldcixh(void)	/* LD C,IXH */
+INSTR(0x4c, op_undoc_ldcixh)		/* LD C,IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	C = IX >> 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_lddixl(void)	/* LD D,IXL */
+INSTR(0x55, op_undoc_lddixl)		/* LD D,IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	D = IX & 0xff;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_lddixh(void)	/* LD D,IXH */
+INSTR(0x54, op_undoc_lddixh)		/* LD D,IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	D = IX >> 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldeixl(void)	/* LD E,IXL */
+INSTR(0x5d, op_undoc_ldeixl)		/* LD E,IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	E = IX & 0xff;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldeixh(void)	/* LD E,IXH */
+INSTR(0x5c, op_undoc_ldeixh)		/* LD E,IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	E = IX >> 8;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixla(void)	/* LD IXL,A */
+INSTR(0x6f, op_undoc_ldixla)		/* LD IXL,A */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0xff00) | A;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixha(void)	/* LD IXH,A */
+INSTR(0x67, op_undoc_ldixha)		/* LD IXH,A */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0x00ff) | (A << 8);
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixlb(void)	/* LD IXL,B */
+INSTR(0x68, op_undoc_ldixlb)		/* LD IXL,B */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0xff00) | B;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixhb(void)	/* LD IXH,B */
+INSTR(0x60, op_undoc_ldixhb)		/* LD IXH,B */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0x00ff) | (B << 8);
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixlc(void)	/* LD IXL,C */
+INSTR(0x69, op_undoc_ldixlc)		/* LD IXL,C */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0xff00) | C;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixhc(void)	/* LD IXH,C */
+INSTR(0x61, op_undoc_ldixhc)		/* LD IXH,C */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0x00ff) | (C << 8);
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixld(void)	/* LD IXL,D */
+INSTR(0x6a, op_undoc_ldixld)		/* LD IXL,D */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0xff00) | D;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixhd(void)	/* LD IXH,D */
+INSTR(0x62, op_undoc_ldixhd)		/* LD IXH,D */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0x00ff) | (D << 8);
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixle(void)	/* LD IXL,E */
+INSTR(0x6b, op_undoc_ldixle)		/* LD IXL,E */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0xff00) | E;
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixhe(void)	/* LD IXH,E */
+INSTR(0x63, op_undoc_ldixhe)		/* LD IXH,E */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0x00ff) | (E << 8);
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixlixh(void)	/* LD IXL,IXH */
+INSTR(0x6c, op_undoc_ldixlixh)		/* LD IXL,IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0xff00) | (IX >> 8);
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixhixh(void)	/* LD IXH,IXH */
+INSTR(0x64, op_undoc_ldixhixh)		/* LD IXH,IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixlixl(void)	/* LD IXL,IXL */
+INSTR(0x6d, op_undoc_ldixlixl)		/* LD IXL,IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixhixl(void)	/* LD IXH,IXL */
+INSTR(0x65, op_undoc_ldixhixl)		/* LD IXH,IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0x00ff) | (IX << 8);
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_ldixhn(void)	/* LD IXH,n */
+INSTR(0x26, op_undoc_ldixhn)		/* LD IXH,n */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0x00ff) | (memrdr(PC++) << 8);
-	return (11);
+	STATES(11);
 }
 
-static int op_undoc_ldixln(void)	/* LD IXL,n */
+INSTR(0x2e, op_undoc_ldixln)		/* LD IXL,n */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	IX = (IX & 0xff00) | memrdr(PC++);
-	return (11);
+	STATES(11);
 }
 
-static int op_undoc_cpixl(void)		/* CP IXL */
+INSTR(0xbd, op_undoc_cpixl)		/* CP IXL */
 {
 	register int i;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX & 0xff;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1229,16 +1200,17 @@ static int op_undoc_cpixl(void)		/* CP IXL */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_cpixh(void)		/* CP IXH */
+INSTR(0xbc, op_undoc_cpixh)		/* CP IXH */
 {
 	register int i;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX >> 8;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1253,16 +1225,17 @@ static int op_undoc_cpixh(void)		/* CP IXH */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_adaixl(void)	/* ADD A,IXL */
+INSTR(0x85, op_undoc_adaixl)		/* ADD A,IXL */
 {
 	register int i;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX & 0xff;
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1277,16 +1250,17 @@ static int op_undoc_adaixl(void)	/* ADD A,IXL */
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_adaixh(void)	/* ADD A,IXH */
+INSTR(0x84, op_undoc_adaixh)		/* ADD A,IXH */
 {
 	register int i;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX >> 8;
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1301,16 +1275,17 @@ static int op_undoc_adaixh(void)	/* ADD A,IXH */
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_acaixl(void)	/* ADC A,IXL */
+INSTR(0x8d, op_undoc_acaixl)		/* ADC A,IXL */
 {
 	register int i, carry;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
 	P = IX & 0xff;
@@ -1326,16 +1301,17 @@ static int op_undoc_acaixl(void)	/* ADC A,IXL */
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_acaixh(void)	/* ADC A,IXH */
+INSTR(0x8c, op_undoc_acaixh)		/* ADC A,IXH */
 {
 	register int i, carry;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
 	P = IX >> 8;
@@ -1351,16 +1327,17 @@ static int op_undoc_acaixh(void)	/* ADC A,IXH */
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_suaixl(void)	/* SUB A,IXL */
+INSTR(0x95, op_undoc_suaixl)		/* SUB A,IXL */
 {
 	register int i;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX & 0xff;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1375,16 +1352,17 @@ static int op_undoc_suaixl(void)	/* SUB A,IXL */
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_suaixh(void)	/* SUB A,IXH */
+INSTR(0x94, op_undoc_suaixh)		/* SUB A,IXH */
 {
 	register int i;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX >> 8;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1399,16 +1377,17 @@ static int op_undoc_suaixh(void)	/* SUB A,IXH */
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_scaixl(void)	/* SBC A,IXL */
+INSTR(0x9d, op_undoc_scaixl)		/* SBC A,IXL */
 {
 	register int i, carry;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
 	P = IX & 0xff;
@@ -1424,16 +1403,17 @@ static int op_undoc_scaixl(void)	/* SBC A,IXL */
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_scaixh(void)	/* SBC A,IXH */
+INSTR(0x9c, op_undoc_scaixh)		/* SBC A,IXH */
 {
 	register int i, carry;
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	carry = (F & C_FLAG) ? 1 : 0;
 	P = IX >> 8;
@@ -1449,13 +1429,14 @@ static int op_undoc_scaixh(void)	/* SBC A,IXH */
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_oraixl(void)	/* OR IXL */
+INSTR(0xb5, op_undoc_oraixl)		/* OR IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	A |= IX & 0xff;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
@@ -1467,13 +1448,14 @@ static int op_undoc_oraixl(void)	/* OR IXL */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_oraixh(void)	/* OR IXH */
+INSTR(0xb4, op_undoc_oraixh)		/* OR IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	A |= IX >> 8;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
@@ -1485,13 +1467,14 @@ static int op_undoc_oraixh(void)	/* OR IXH */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_xorixl(void)	/* XOR IXL */
+INSTR(0xad, op_undoc_xorixl)		/* XOR IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	A ^= IX & 0xff;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
@@ -1503,13 +1486,14 @@ static int op_undoc_xorixl(void)	/* XOR IXL */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_xorixh(void)	/* XOR IXH */
+INSTR(0xac, op_undoc_xorixh)		/* XOR IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	A ^= IX >> 8;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
@@ -1521,13 +1505,14 @@ static int op_undoc_xorixh(void)	/* XOR IXH */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_andixl(void)	/* AND IXL */
+INSTR(0xa5, op_undoc_andixl)		/* AND IXL */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	A &= IX & 0xff;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
@@ -1540,13 +1525,14 @@ static int op_undoc_andixl(void)	/* AND IXL */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_andixh(void)	/* AND IXH */
+INSTR(0xa4, op_undoc_andixh)		/* AND IXH */
 {
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	A &= IX >> 8;
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
@@ -1559,15 +1545,16 @@ static int op_undoc_andixh(void)	/* AND IXH */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_incixl(void)	/* INC IXL */
+INSTR(0x2c, op_undoc_incixl)		/* INC IXL */
 {
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX & 0xff;
 	P++;
@@ -1582,15 +1569,16 @@ static int op_undoc_incixl(void)	/* INC IXL */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_incixh(void)	/* INC IXH */
+INSTR(0x24, op_undoc_incixh)		/* INC IXH */
 {
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX >> 8;
 	P++;
@@ -1605,15 +1593,16 @@ static int op_undoc_incixh(void)	/* INC IXH */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_decixl(void)	/* DEC IXL */
+INSTR(0x2d, op_undoc_decixl)		/* DEC IXL */
 {
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX & 0xff;
 	P--;
@@ -1628,15 +1617,16 @@ static int op_undoc_decixl(void)	/* DEC IXL */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_undoc_decixh(void)	/* DEC IXH */
+INSTR(0x25, op_undoc_decixh)		/* DEC IXH */
 {
 	register BYTE P;
 
-	if (u_flag)
-		return (trap_dd());
+	if (u_flag) {
+		STATES(trap_dd());
+	}
 
 	P = IX >> 8;
 	P--;
@@ -1651,9 +1641,7 @@ static int op_undoc_decixh(void)	/* DEC IXH */
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-#endif
-
-#endif
+#endif /* UNDOC_INST */

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -6,370 +6,29 @@
  */
 
 /*
- *	Like the function "cpu_z80()" this one emulates multi byte opcodes
- *	starting with 0xed
+ *	This module contains the implementation of all Z80 instructions
+ *	beginning with the prefix 0xed
  */
 
-#include <stdio.h>
-#include "sim.h"
-#include "simglb.h"
-#include "config.h"
-#ifdef FRONTPANEL
-#include "frontpanel.h"
-#endif
-#include "memsim.h"
-
-#ifndef EXCLUDE_Z80
-
-#ifdef UNDOC_INST
-#define UNDOC(f) f
-#else
-#define UNDOC(f) trap_ed
-#endif
-
-static int trap_ed(void);
-static int op_im0(void), op_im1(void), op_im2(void);
-static int op_reti(void), op_retn(void);
-static int op_neg(void);
-static int op_inaic(void), op_inbic(void), op_incic(void);
-static int op_indic(void), op_ineic(void);
-static int op_inhic(void), op_inlic(void);
-static int op_outca(void), op_outcb(void), op_outcc(void);
-static int op_outcd(void), op_outce(void);
-static int op_outch(void), op_outcl(void);
-static int op_ini(void), op_inir(void), op_ind(void), op_indr(void);
-static int op_outi(void), op_otir(void), op_outd(void), op_otdr(void);
-static int op_ldai(void), op_ldar(void), op_ldia(void), op_ldra(void);
-static int op_ldbcinn(void), op_lddeinn(void);
-static int op_ldhlinn(void), op_ldspinn(void);
-static int op_ldinbc(void), op_ldinde(void), op_ldinhl(void), op_ldinsp(void);
-static int op_adchb(void), op_adchd(void), op_adchh(void), op_adchs(void);
-static int op_sbchb(void), op_sbchd(void), op_sbchh(void), op_sbchs(void);
-static int op_ldi(void), op_ldir(void), op_ldd(void), op_lddr(void);
-static int op_cpi(void), op_cpir(void), op_cpdop(void), op_cpdr(void);
-static int op_oprld(void), op_oprrd(void);
-
-#ifdef UNDOC_INST
-static int op_undoc_outc0(void), op_undoc_infic(void);
-static int op_undoc_nop(void);
-static int op_undoc_im0(void), op_undoc_im1(void), op_undoc_im2(void);
-static int op_undoc_reti(void), op_undoc_retn(void);
-static int op_undoc_neg(void);
-#endif
-
-int op_ed_handle(void)
-{
-	register int t;
-
-	static int (*op_ed[256])(void) = {
-		UNDOC(op_undoc_nop),		/* 0x00 */
-		UNDOC(op_undoc_nop),		/* 0x01 */
-		UNDOC(op_undoc_nop),		/* 0x02 */
-		UNDOC(op_undoc_nop),		/* 0x03 */
-		UNDOC(op_undoc_nop),		/* 0x04 */
-		UNDOC(op_undoc_nop),		/* 0x05 */
-		UNDOC(op_undoc_nop),		/* 0x06 */
-		UNDOC(op_undoc_nop),		/* 0x07 */
-		UNDOC(op_undoc_nop),		/* 0x08 */
-		UNDOC(op_undoc_nop),		/* 0x09 */
-		UNDOC(op_undoc_nop),		/* 0x0a */
-		UNDOC(op_undoc_nop),		/* 0x0b */
-		UNDOC(op_undoc_nop),		/* 0x0c */
-		UNDOC(op_undoc_nop),		/* 0x0d */
-		UNDOC(op_undoc_nop),		/* 0x0e */
-		UNDOC(op_undoc_nop),		/* 0x0f */
-		UNDOC(op_undoc_nop),		/* 0x10 */
-		UNDOC(op_undoc_nop),		/* 0x11 */
-		UNDOC(op_undoc_nop),		/* 0x12 */
-		UNDOC(op_undoc_nop),		/* 0x13 */
-		UNDOC(op_undoc_nop),		/* 0x14 */
-		UNDOC(op_undoc_nop),		/* 0x15 */
-		UNDOC(op_undoc_nop),		/* 0x16 */
-		UNDOC(op_undoc_nop),		/* 0x17 */
-		UNDOC(op_undoc_nop),		/* 0x18 */
-		UNDOC(op_undoc_nop),		/* 0x19 */
-		UNDOC(op_undoc_nop),		/* 0x1a */
-		UNDOC(op_undoc_nop),		/* 0x1b */
-		UNDOC(op_undoc_nop),		/* 0x1c */
-		UNDOC(op_undoc_nop),		/* 0x1d */
-		UNDOC(op_undoc_nop),		/* 0x1e */
-		UNDOC(op_undoc_nop),		/* 0x1f */
-		UNDOC(op_undoc_nop),		/* 0x20 */
-		UNDOC(op_undoc_nop),		/* 0x21 */
-		UNDOC(op_undoc_nop),		/* 0x22 */
-		UNDOC(op_undoc_nop),		/* 0x23 */
-		UNDOC(op_undoc_nop),		/* 0x24 */
-		UNDOC(op_undoc_nop),		/* 0x25 */
-		UNDOC(op_undoc_nop),		/* 0x26 */
-		UNDOC(op_undoc_nop),		/* 0x27 */
-		UNDOC(op_undoc_nop),		/* 0x28 */
-		UNDOC(op_undoc_nop),		/* 0x29 */
-		UNDOC(op_undoc_nop),		/* 0x2a */
-		UNDOC(op_undoc_nop),		/* 0x2b */
-		UNDOC(op_undoc_nop),		/* 0x2c */
-		UNDOC(op_undoc_nop),		/* 0x2d */
-		UNDOC(op_undoc_nop),		/* 0x2e */
-		UNDOC(op_undoc_nop),		/* 0x2f */
-		UNDOC(op_undoc_nop),		/* 0x30 */
-		UNDOC(op_undoc_nop),		/* 0x31 */
-		UNDOC(op_undoc_nop),		/* 0x32 */
-		UNDOC(op_undoc_nop),		/* 0x33 */
-		UNDOC(op_undoc_nop),		/* 0x34 */
-		UNDOC(op_undoc_nop),		/* 0x35 */
-		UNDOC(op_undoc_nop),		/* 0x36 */
-		UNDOC(op_undoc_nop),		/* 0x37 */
-		UNDOC(op_undoc_nop),		/* 0x38 */
-		UNDOC(op_undoc_nop),		/* 0x39 */
-		UNDOC(op_undoc_nop),		/* 0x3a */
-		UNDOC(op_undoc_nop),		/* 0x3b */
-		UNDOC(op_undoc_nop),		/* 0x3c */
-		UNDOC(op_undoc_nop),		/* 0x3d */
-		UNDOC(op_undoc_nop),		/* 0x3e */
-		UNDOC(op_undoc_nop),		/* 0x3f */
-		op_inbic,			/* 0x40 */
-		op_outcb,			/* 0x41 */
-		op_sbchb,			/* 0x42 */
-		op_ldinbc,			/* 0x43 */
-		op_neg,				/* 0x44 */
-		op_retn,			/* 0x45 */
-		op_im0,				/* 0x46 */
-		op_ldia,			/* 0x47 */
-		op_incic,			/* 0x48 */
-		op_outcc,			/* 0x49 */
-		op_adchb,			/* 0x4a */
-		op_ldbcinn,			/* 0x4b */
-		UNDOC(op_undoc_neg),		/* 0x4c */
-		op_reti,			/* 0x4d */
-		UNDOC(op_undoc_im0),		/* 0x4e */
-		op_ldra,			/* 0x4f */
-		op_indic,			/* 0x50 */
-		op_outcd,			/* 0x51 */
-		op_sbchd,			/* 0x52 */
-		op_ldinde,			/* 0x53 */
-		UNDOC(op_undoc_neg),		/* 0x54 */
-		UNDOC(op_undoc_retn),		/* 0x55 */
-		op_im1,				/* 0x56 */
-		op_ldai,			/* 0x57 */
-		op_ineic,			/* 0x58 */
-		op_outce,			/* 0x59 */
-		op_adchd,			/* 0x5a */
-		op_lddeinn,			/* 0x5b */
-		UNDOC(op_undoc_neg),		/* 0x5c */
-		UNDOC(op_undoc_reti),		/* 0x5d */
-		op_im2,				/* 0x5e */
-		op_ldar,			/* 0x5f */
-		op_inhic,			/* 0x60 */
-		op_outch,			/* 0x61 */
-		op_sbchh,			/* 0x62 */
-		op_ldinhl,			/* 0x63 */
-		UNDOC(op_undoc_neg),		/* 0x64 */
-		UNDOC(op_undoc_retn),		/* 0x65 */
-		UNDOC(op_undoc_im0),		/* 0x66 */
-		op_oprrd,			/* 0x67 */
-		op_inlic,			/* 0x68 */
-		op_outcl,			/* 0x69 */
-		op_adchh,			/* 0x6a */
-		op_ldhlinn,			/* 0x6b */
-		UNDOC(op_undoc_neg),		/* 0x6c */
-		UNDOC(op_undoc_reti),		/* 0x6d */
-		UNDOC(op_undoc_im0),		/* 0x6e */
-		op_oprld,			/* 0x6f */
-		UNDOC(op_undoc_infic),		/* 0x70 */
-		UNDOC(op_undoc_outc0),		/* 0x71 */
-		op_sbchs,			/* 0x72 */
-		op_ldinsp,			/* 0x73 */
-		UNDOC(op_undoc_neg),		/* 0x74 */
-		UNDOC(op_undoc_retn),		/* 0x75 */
-		UNDOC(op_undoc_im1),		/* 0x76 */
-		UNDOC(op_undoc_nop),		/* 0x77 */
-		op_inaic,			/* 0x78 */
-		op_outca,			/* 0x79 */
-		op_adchs,			/* 0x7a */
-		op_ldspinn,			/* 0x7b */
-		UNDOC(op_undoc_neg),		/* 0x7c */
-		UNDOC(op_undoc_reti),		/* 0x7d */
-		UNDOC(op_undoc_im2),		/* 0x7e */
-		UNDOC(op_undoc_nop),		/* 0x7f */
-		UNDOC(op_undoc_nop),		/* 0x80 */
-		UNDOC(op_undoc_nop),		/* 0x81 */
-		UNDOC(op_undoc_nop),		/* 0x82 */
-		UNDOC(op_undoc_nop),		/* 0x83 */
-		UNDOC(op_undoc_nop),		/* 0x84 */
-		UNDOC(op_undoc_nop),		/* 0x85 */
-		UNDOC(op_undoc_nop),		/* 0x86 */
-		UNDOC(op_undoc_nop),		/* 0x87 */
-		UNDOC(op_undoc_nop),		/* 0x88 */
-		UNDOC(op_undoc_nop),		/* 0x89 */
-		UNDOC(op_undoc_nop),		/* 0x8a */
-		UNDOC(op_undoc_nop),		/* 0x8b */
-		UNDOC(op_undoc_nop),		/* 0x8c */
-		UNDOC(op_undoc_nop),		/* 0x8d */
-		UNDOC(op_undoc_nop),		/* 0x8e */
-		UNDOC(op_undoc_nop),		/* 0x8f */
-		UNDOC(op_undoc_nop),		/* 0x90 */
-		UNDOC(op_undoc_nop),		/* 0x91 */
-		UNDOC(op_undoc_nop),		/* 0x92 */
-		UNDOC(op_undoc_nop),		/* 0x93 */
-		UNDOC(op_undoc_nop),		/* 0x94 */
-		UNDOC(op_undoc_nop),		/* 0x95 */
-		UNDOC(op_undoc_nop),		/* 0x96 */
-		UNDOC(op_undoc_nop),		/* 0x97 */
-		UNDOC(op_undoc_nop),		/* 0x98 */
-		UNDOC(op_undoc_nop),		/* 0x99 */
-		UNDOC(op_undoc_nop),		/* 0x9a */
-		UNDOC(op_undoc_nop),		/* 0x9b */
-		UNDOC(op_undoc_nop),		/* 0x9c */
-		UNDOC(op_undoc_nop),		/* 0x9d */
-		UNDOC(op_undoc_nop),		/* 0x9e */
-		UNDOC(op_undoc_nop),		/* 0x9f */
-		op_ldi,				/* 0xa0 */
-		op_cpi,				/* 0xa1 */
-		op_ini,				/* 0xa2 */
-		op_outi,			/* 0xa3 */
-		UNDOC(op_undoc_nop),		/* 0xa4 */
-		UNDOC(op_undoc_nop),		/* 0xa5 */
-		UNDOC(op_undoc_nop),		/* 0xa6 */
-		UNDOC(op_undoc_nop),		/* 0xa7 */
-		op_ldd,				/* 0xa8 */
-		op_cpdop,			/* 0xa9 */
-		op_ind,				/* 0xaa */
-		op_outd,			/* 0xab */
-		UNDOC(op_undoc_nop),		/* 0xac */
-		UNDOC(op_undoc_nop),		/* 0xad */
-		UNDOC(op_undoc_nop),		/* 0xae */
-		UNDOC(op_undoc_nop),		/* 0xaf */
-		op_ldir,			/* 0xb0 */
-		op_cpir,			/* 0xb1 */
-		op_inir,			/* 0xb2 */
-		op_otir,			/* 0xb3 */
-		UNDOC(op_undoc_nop),		/* 0xb4 */
-		UNDOC(op_undoc_nop),		/* 0xb5 */
-		UNDOC(op_undoc_nop),		/* 0xb6 */
-		UNDOC(op_undoc_nop),		/* 0xb7 */
-		op_lddr,			/* 0xb8 */
-		op_cpdr,			/* 0xb9 */
-		op_indr,			/* 0xba */
-		op_otdr,			/* 0xbb */
-		UNDOC(op_undoc_nop),		/* 0xbc */
-		UNDOC(op_undoc_nop),		/* 0xbd */
-		UNDOC(op_undoc_nop),		/* 0xbe */
-		UNDOC(op_undoc_nop),		/* 0xbf */
-		UNDOC(op_undoc_nop),		/* 0xc0 */
-		UNDOC(op_undoc_nop),		/* 0xc1 */
-		UNDOC(op_undoc_nop),		/* 0xc2 */
-		UNDOC(op_undoc_nop),		/* 0xc3 */
-		UNDOC(op_undoc_nop),		/* 0xc4 */
-		UNDOC(op_undoc_nop),		/* 0xc5 */
-		UNDOC(op_undoc_nop),		/* 0xc6 */
-		UNDOC(op_undoc_nop),		/* 0xc7 */
-		UNDOC(op_undoc_nop),		/* 0xc8 */
-		UNDOC(op_undoc_nop),		/* 0xc9 */
-		UNDOC(op_undoc_nop),		/* 0xca */
-		UNDOC(op_undoc_nop),		/* 0xcb */
-		UNDOC(op_undoc_nop),		/* 0xcc */
-		UNDOC(op_undoc_nop),		/* 0xcd */
-		UNDOC(op_undoc_nop),		/* 0xce */
-		UNDOC(op_undoc_nop),		/* 0xcf */
-		UNDOC(op_undoc_nop),		/* 0xd0 */
-		UNDOC(op_undoc_nop),		/* 0xd1 */
-		UNDOC(op_undoc_nop),		/* 0xd2 */
-		UNDOC(op_undoc_nop),		/* 0xd3 */
-		UNDOC(op_undoc_nop),		/* 0xd4 */
-		UNDOC(op_undoc_nop),		/* 0xd5 */
-		UNDOC(op_undoc_nop),		/* 0xd6 */
-		UNDOC(op_undoc_nop),		/* 0xd7 */
-		UNDOC(op_undoc_nop),		/* 0xd8 */
-		UNDOC(op_undoc_nop),		/* 0xd9 */
-		UNDOC(op_undoc_nop),		/* 0xda */
-		UNDOC(op_undoc_nop),		/* 0xdb */
-		UNDOC(op_undoc_nop),		/* 0xdc */
-		UNDOC(op_undoc_nop),		/* 0xdd */
-		UNDOC(op_undoc_nop),		/* 0xde */
-		UNDOC(op_undoc_nop),		/* 0xdf */
-		UNDOC(op_undoc_nop),		/* 0xe0 */
-		UNDOC(op_undoc_nop),		/* 0xe1 */
-		UNDOC(op_undoc_nop),		/* 0xe2 */
-		UNDOC(op_undoc_nop),		/* 0xe3 */
-		UNDOC(op_undoc_nop),		/* 0xe4 */
-		UNDOC(op_undoc_nop),		/* 0xe5 */
-		UNDOC(op_undoc_nop),		/* 0xe6 */
-		UNDOC(op_undoc_nop),		/* 0xe7 */
-		UNDOC(op_undoc_nop),		/* 0xe8 */
-		UNDOC(op_undoc_nop),		/* 0xe9 */
-		UNDOC(op_undoc_nop),		/* 0xea */
-		UNDOC(op_undoc_nop),		/* 0xeb */
-		UNDOC(op_undoc_nop),		/* 0xec */
-		UNDOC(op_undoc_nop),		/* 0xed */
-		UNDOC(op_undoc_nop),		/* 0xee */
-		UNDOC(op_undoc_nop),		/* 0xef */
-		UNDOC(op_undoc_nop),		/* 0xf0 */
-		UNDOC(op_undoc_nop),		/* 0xf1 */
-		UNDOC(op_undoc_nop),		/* 0xf2 */
-		UNDOC(op_undoc_nop),		/* 0xf3 */
-		UNDOC(op_undoc_nop),		/* 0xf4 */
-		UNDOC(op_undoc_nop),		/* 0xf5 */
-		UNDOC(op_undoc_nop),		/* 0xf6 */
-		UNDOC(op_undoc_nop),		/* 0xf7 */
-		UNDOC(op_undoc_nop),		/* 0xf8 */
-		UNDOC(op_undoc_nop),		/* 0xf9 */
-		UNDOC(op_undoc_nop),		/* 0xfa */
-		UNDOC(op_undoc_nop),		/* 0xfb */
-		UNDOC(op_undoc_nop),		/* 0xfc */
-		UNDOC(op_undoc_nop),		/* 0xfd */
-		UNDOC(op_undoc_nop),		/* 0xfe */
-		UNDOC(op_undoc_nop)		/* 0xff */
-	};
-
-#ifdef BUS_8080
-	/* M1 opcode fetch */
-	cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
-	m1_step = 1;
-#endif
-#ifdef FRONTPANEL
-	if (F_flag) {
-		/* update frontpanel */
-		fp_clock++;
-		fp_sampleLightGroup(0, 0);
-	}
-#endif
-
-	R++;				/* increment refresh register */
-
-	t = (*op_ed[memrdr(PC++)])();	/* execute next opcode */
-
-	return (t);
-}
-
-/*
- *	This function traps undocumented opcodes following the
- *	initial 0xed of a multi byte opcode.
- */
-static int trap_ed(void)
-{
-	cpu_error = OPTRAP2;
-	cpu_state = STOPPED;
-	return (0);
-}
-
-static int op_im0(void)			/* IM 0 */
+INSTR(0x46, op_im0)			/* IM 0 */
 {
 	int_mode = 0;
-	return (8);
+	STATES(8);
 }
 
-static int op_im1(void)			/* IM 1 */
+INSTR(0x56, op_im1)			/* IM 1 */
 {
 	int_mode = 1;
-	return (8);
+	STATES(8);
 }
 
-static int op_im2(void)			/* IM 2 */
+INSTR(0x5e, op_im2)			/* IM 2 */
 {
 	int_mode = 2;
-	return (8);
+	STATES(8);
 }
 
-static int op_reti(void)		/* RETI */
+INSTR(0x4d, op_reti)			/* RETI */
 {
 	register WORD i;
 
@@ -379,10 +38,10 @@ static int op_reti(void)		/* RETI */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (14);
+	STATES(14);
 }
 
-static int op_retn(void)		/* RETN */
+INSTR(0x45, op_retn)			/* RETN */
 {
 	register WORD i;
 
@@ -394,10 +53,10 @@ static int op_retn(void)		/* RETN */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (14);
+	STATES(14);
 }
 
-static int op_neg(void)			/* NEG */
+INSTR(0x44, op_neg)			/* NEG */
 {
 	(A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	(A == 0x80) ? (F |= P_FLAG) : (F &= ~P_FLAG);
@@ -411,10 +70,10 @@ static int op_neg(void)			/* NEG */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (8);
+	STATES(8);
 }
 
-static int op_inaic(void)		/* IN A,(C) */
+INSTR(0x78, op_inaic)			/* IN A,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
@@ -431,10 +90,10 @@ static int op_inaic(void)		/* IN A,(C) */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_inbic(void)		/* IN B,(C) */
+INSTR(0x40, op_inbic)			/* IN B,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
@@ -451,10 +110,10 @@ static int op_inbic(void)		/* IN B,(C) */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_incic(void)		/* IN C,(C) */
+INSTR(0x48, op_incic)			/* IN C,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
@@ -471,10 +130,10 @@ static int op_incic(void)		/* IN C,(C) */
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_indic(void)		/* IN D,(C) */
+INSTR(0x50, op_indic)			/* IN D,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
@@ -491,10 +150,10 @@ static int op_indic(void)		/* IN D,(C) */
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_ineic(void)		/* IN E,(C) */
+INSTR(0x58, op_ineic)			/* IN E,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
@@ -511,10 +170,10 @@ static int op_ineic(void)		/* IN E,(C) */
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_inhic(void)		/* IN H,(C) */
+INSTR(0x60, op_inhic)			/* IN H,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
@@ -531,10 +190,10 @@ static int op_inhic(void)		/* IN H,(C) */
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_inlic(void)		/* IN L,(C) */
+INSTR(0x68, op_inlic)			/* IN L,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 
@@ -551,10 +210,10 @@ static int op_inlic(void)		/* IN L,(C) */
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_outca(void)		/* OUT (C),A */
+INSTR(0x79, op_outca)			/* OUT (C),A */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 
@@ -562,10 +221,10 @@ static int op_outca(void)		/* OUT (C),A */
 #ifdef UNDOC_FLAGS
 	WZ = ((B << 8) + C) + 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_outcb(void)		/* OUT (C),B */
+INSTR(0x41, op_outcb)			/* OUT (C),B */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 
@@ -573,10 +232,10 @@ static int op_outcb(void)		/* OUT (C),B */
 #ifdef UNDOC_FLAGS
 	WZ = ((B << 8) + C) + 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_outcc(void)		/* OUT (C),C */
+INSTR(0x49, op_outcc)			/* OUT (C),C */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 
@@ -584,10 +243,10 @@ static int op_outcc(void)		/* OUT (C),C */
 #ifdef UNDOC_FLAGS
 	WZ = ((B << 8) + C) + 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_outcd(void)		/* OUT (C),D */
+INSTR(0x51, op_outcd)			/* OUT (C),D */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 
@@ -595,10 +254,10 @@ static int op_outcd(void)		/* OUT (C),D */
 #ifdef UNDOC_FLAGS
 	WZ = ((B << 8) + C) + 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_outce(void)		/* OUT (C),E */
+INSTR(0x59, op_outce)			/* OUT (C),E */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 
@@ -606,10 +265,10 @@ static int op_outce(void)		/* OUT (C),E */
 #ifdef UNDOC_FLAGS
 	WZ = ((B << 8) + C) + 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_outch(void)		/* OUT (C),H */
+INSTR(0x61, op_outch)			/* OUT (C),H */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 
@@ -617,10 +276,10 @@ static int op_outch(void)		/* OUT (C),H */
 #ifdef UNDOC_FLAGS
 	WZ = ((B << 8) + C) + 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_outcl(void)		/* OUT (C),L */
+INSTR(0x69, op_outcl)			/* OUT (C),L */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 
@@ -628,10 +287,10 @@ static int op_outcl(void)		/* OUT (C),L */
 #ifdef UNDOC_FLAGS
 	WZ = ((B << 8) + C) + 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_ini(void)			/* INI */
+INSTR(0xa2, op_ini)			/* INI */
 {
 	extern BYTE io_in(BYTE, BYTE);
 	BYTE data;
@@ -661,19 +320,22 @@ static int op_ini(void)			/* INI */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (16);
+	STATES(16);
 }
 
-#ifdef WANT_FASTB
-static int op_inir(void)		/* INIR */
+#ifdef FAST_BLOCK
+INSTR(0xb2, op_inir)			/* INIR */
 {
 	extern BYTE io_in(BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-	register int t = -21;
+#ifndef FAST_INSTR
+	register int t;
+#endif
 
 	addr = (H << 8) + L;
 	R -= 2;
+	t = -21;
 	do {
 		data = io_in(C, B);
 		B--;
@@ -699,17 +361,46 @@ static int op_inir(void)		/* INIR */
 	WZ = ((1 << 8) + C) + 1;
 	modF = 1;
 #endif
-	return (t + 16);
+	STATES(t + 16);
 }
-#else
-static int op_inir(void)		/* INIR */
+#else /* !FAST_BLOCK */
+INSTR(0xb2, op_inir)			/* INIR */
 {
-	register int t = 16;
-
+#ifndef FAST_INSTR
 	op_ini();
+#else /* FAST_INSTR */
+	extern BYTE io_in(BYTE, BYTE);
+	BYTE data;
+
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) + 1;
+#endif
+	data = io_in(C, B);
+	B--;
+	memwrt((H << 8) + L, data);
+	L++;
+	if (!L)
+		H++;
+#if 0
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	WORD k = (WORD) ((C + 1) & 0xff) + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#endif
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+#endif /* FAST_INSTR */
+
 	if (!(F & Z_FLAG)) {
 		PC -= 2;
-		t += 5;
 #ifdef UNDOC_FLAGS
 		register int i;
 		WZ = PC + 1;
@@ -729,12 +420,13 @@ static int op_inir(void)		/* INIR */
 			i = parity[B & 0x07];
 		(((F & P_FLAG) == 0) ^ i) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #endif
+		STATES(21);
 	}
-	return (t);
+	STATES(16);
 }
-#endif
+#endif /* !FAST_BLOCK */
 
-static int op_ind(void)			/* IND */
+INSTR(0xaa, op_ind)			/* IND */
 {
 	extern BYTE io_in(BYTE, BYTE);
 	BYTE data;
@@ -764,19 +456,22 @@ static int op_ind(void)			/* IND */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (16);
+	STATES(16);
 }
 
-#ifdef WANT_FASTB
-static int op_indr(void)		/* INDR */
+#ifdef FAST_BLOCK
+INSTR(0xba, op_indr)			/* INDR */
 {
 	extern BYTE io_in(BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-	register int t = -21;
+#ifndef FAST_INSTR
+	register int t;
+#endif
 
 	addr = (H << 8) + L;
 	R -= 2;
+	t = -21;
 	do {
 		data = io_in(C, B);
 		memwrt(addr--, data);
@@ -802,17 +497,46 @@ static int op_indr(void)		/* INDR */
 	WZ = ((1 << 8) + C) - 1;
 	modF = 1;
 #endif
-	return (t + 16);
+	STATES(t + 16);
 }
-#else
-static int op_indr(void)		/* INDR */
+#else /* !FAST_BLOCK */
+INSTR(0xba, op_indr)			/* INDR */
 {
-	register int t = 16;
-
+#ifndef FAST_INSTR
 	op_ind();
+#else /* FAST_INSTR */
+	extern BYTE io_in(BYTE, BYTE);
+	BYTE data;
+
+#ifdef UNDOC_FLAGS
+	WZ = ((B << 8) + C) - 1;
+#endif
+	data = io_in(C, B);
+	B--;
+	memwrt((H << 8) + L, data);
+	L--;
+	if (L == 0xff)
+		H--;
+#if 0
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	WORD k = (WORD) ((C - 1) & 0xff) + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#endif
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+#endif /* FAST_INSTR */
+
 	if (!(F & Z_FLAG)) {
 		PC -= 2;
-		t += 5;
 #ifdef UNDOC_FLAGS
 		register int i;
 		WZ = PC + 1;
@@ -832,12 +556,13 @@ static int op_indr(void)		/* INDR */
 			i = parity[B & 0x07];
 		(((F & P_FLAG) == 0) ^ i) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #endif
+		STATES(21);
 	}
-	return (t);
+	STATES(16);
 }
-#endif
+#endif /* !FAST_BLOCK */
 
-static int op_outi(void)		/* OUTI */
+INSTR(0xa3, op_outi)			/* OUTI */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 	BYTE data;
@@ -865,19 +590,22 @@ static int op_outi(void)		/* OUTI */
 	WZ = ((B << 8) + C) + 1;
 	modF = 1;
 #endif
-	return (16);
+	STATES(16);
 }
 
-#ifdef WANT_FASTB
-static int op_otir(void)		/* OTIR */
+#ifdef FAST_BLOCK
+INSTR(0xb3, op_otir)			/* OTIR */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-	register int t = -21;
+#ifndef FAST_INSTR
+	register int t;
+#endif
 
 	addr = (H << 8) + L;
 	R -= 2;
+	t = -21;
 	do {
 		B--;
 		data = memrdr(addr++);
@@ -903,17 +631,44 @@ static int op_otir(void)		/* OTIR */
 	WZ = (WORD) C + (WORD) 1;
 	modF = 1;
 #endif
-	return (t + 16);
+	STATES(t + 16);
 }
-#else
-static int op_otir(void)		/* OTIR */
+#else /* !FAST_BLOCK */
+INSTR(0xb3, op_otir)			/* OTIR */
 {
-	register int t = 16;
-
+#ifndef FAST_INSTR
 	op_outi();
+#else /* FAST_INSTR */
+	extern void io_out(BYTE, BYTE, BYTE);
+	BYTE data;
+
+	data = memrdr((H << 8) + L);
+	B--;
+	io_out(C, B, data);
+	L++;
+	if (!L)
+		H++;
+#if 0
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	WORD k = (WORD) L + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#endif
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	WZ = ((B << 8) + C) + 1;
+	modF = 1;
+#endif
+#endif /* FAST_INSTR */
+
 	if (!(F & Z_FLAG)) {
 		PC -= 2;
-		t += 5;
 #ifdef UNDOC_FLAGS
 		register int i;
 		WZ = PC + 1;
@@ -933,12 +688,13 @@ static int op_otir(void)		/* OTIR */
 			i = parity[B & 0x07];
 		(((F & P_FLAG) == 0) ^ i) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #endif
+		STATES(21);
 	}
-	return (t);
+	STATES(16);
 }
-#endif
+#endif /* !FAST_BLOCK */
 
-static int op_outd(void)		/* OUTD */
+INSTR(0xab, op_outd)			/* OUTD */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 	BYTE data;
@@ -966,19 +722,22 @@ static int op_outd(void)		/* OUTD */
 	WZ = ((B << 8) + C) - 1;
 	modF = 1;
 #endif
-	return (16);
+	STATES(16);
 }
 
-#ifdef WANT_FASTB
-static int op_otdr(void)		/* OTDR */
+#ifdef FAST_BLOCK
+INSTR(0xbb, op_otdr)			/* OTDR */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-	register int t = -21;
+#ifndef FAST_INSTR
+	register int t;
+#endif
 
 	addr = (H << 8) + L;
 	R -= 2;
+	t = -21;
 	do {
 		B--;
 		data = memrdr(addr--);
@@ -1004,17 +763,44 @@ static int op_otdr(void)		/* OTDR */
 	WZ = (WORD) C - (WORD) 1;
 	modF = 1;
 #endif
-	return (t + 16);
+	STATES(t + 16);
 }
-#else
-static int op_otdr(void)		/* OTDR */
+#else /* !FAST_BLOCK */
+INSTR(0xbb, op_otdr)			/* OTDR */
 {
-	register int t = 16;
-
+#ifndef FAST_INSTR
 	op_outd();
+#else /* FAST_INSTR */
+	extern void io_out(BYTE, BYTE, BYTE);
+	BYTE data;
+
+	data = memrdr((H << 8) + L);
+	B--;
+	io_out(C, B, data);
+	L--;
+	if (L == 0xff)
+		H--;
+#if 0
+	F |= N_FLAG; /* As documented in the "Z80 CPU User Manual" */
+#else
+	/* S,H,P,N,C flags according to "The Undocumented Z80 Documented" */
+	WORD k = (WORD) L + (WORD) data;
+	(k > 255) ? (F |= (H_FLAG | C_FLAG)) : (F &= ~(H_FLAG | C_FLAG));
+	(parity[(k & 0x07) ^ B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
+	(data & 128) ? (F |= N_FLAG) : (F &= ~N_FLAG);
+	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#endif
+	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+#ifdef UNDOC_FLAGS
+	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	WZ = ((B << 8) + C) - 1;
+	modF = 1;
+#endif
+#endif /* FAST_INSTR */
+
 	if (!(F & Z_FLAG)) {
 		PC -= 2;
-		t += 5;
 #ifdef UNDOC_FLAGS
 		register int i;
 		WZ = PC + 1;
@@ -1034,12 +820,13 @@ static int op_otdr(void)		/* OTDR */
 			i = parity[B & 0x07];
 		(((F & P_FLAG) == 0) ^ i) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #endif
+		STATES(21);
 	}
-	return (t);
+	STATES(16);
 }
-#endif
+#endif /* !FAST_BLOCK */
 
-static int op_ldai(void)		/* LD A,I */
+INSTR(0x57, op_ldai)			/* LD A,I */
 {
 	A = I;
 	F &= ~(N_FLAG | H_FLAG);
@@ -1051,10 +838,10 @@ static int op_ldai(void)		/* LD A,I */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (9);
+	STATES(9);
 }
 
-static int op_ldar(void)		/* LD A,R */
+INSTR(0x5f, op_ldar)			/* LD A,R */
 {
 	A = (R_ & 0x80) | (R & 0x7f);
 	F &= ~(N_FLAG | H_FLAG);
@@ -1066,22 +853,22 @@ static int op_ldar(void)		/* LD A,R */
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (9);
+	STATES(9);
 }
 
-static int op_ldia(void)		/* LD I,A */
+INSTR(0x47, op_ldia)			/* LD I,A */
 {
 	I = A;
-	return (9);
+	STATES(9);
 }
 
-static int op_ldra(void)		/* LD R,A */
+INSTR(0x4f, op_ldra)			/* LD R,A */
 {
 	R_ = R = A;
-	return (9);
+	STATES(9);
 }
 
-static int op_ldbcinn(void)		/* LD BC,(nn) */
+INSTR(0x4b, op_ldbcinn)			/* LD BC,(nn) */
 {
 	register WORD i;
 
@@ -1092,10 +879,10 @@ static int op_ldbcinn(void)		/* LD BC,(nn) */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_lddeinn(void)		/* LD DE,(nn) */
+INSTR(0x5b, op_lddeinn)			/* LD DE,(nn) */
 {
 	register WORD i;
 
@@ -1106,10 +893,10 @@ static int op_lddeinn(void)		/* LD DE,(nn) */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_ldhlinn(void)		/* LD HL,(nn) */
+INSTR(0x6b, op_ldhlinn)			/* LD HL,(nn) */
 {
 	register WORD i;
 
@@ -1120,10 +907,10 @@ static int op_ldhlinn(void)		/* LD HL,(nn) */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_ldspinn(void)		/* LD SP,(nn) */
+INSTR(0x7b, op_ldspinn)			/* LD SP,(nn) */
 {
 	register WORD i;
 
@@ -1134,10 +921,10 @@ static int op_ldspinn(void)		/* LD SP,(nn) */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_ldinbc(void)		/* LD (nn),BC */
+INSTR(0x43, op_ldinbc)			/* LD (nn),BC */
 {
 	register WORD i;
 
@@ -1148,10 +935,10 @@ static int op_ldinbc(void)		/* LD (nn),BC */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_ldinde(void)		/* LD (nn),DE */
+INSTR(0x53, op_ldinde)			/* LD (nn),DE */
 {
 	register WORD i;
 
@@ -1162,10 +949,10 @@ static int op_ldinde(void)		/* LD (nn),DE */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_ldinhl(void)		/* LD (nn),HL */
+INSTR(0x63, op_ldinhl2)			/* LD (nn),HL */
 {
 	register WORD i;
 
@@ -1176,10 +963,10 @@ static int op_ldinhl(void)		/* LD (nn),HL */
 #ifdef UNDOC_FLAGS
 	WZ = i;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_ldinsp(void)		/* LD (nn),SP */
+INSTR(0x73, op_ldinsp)			/* LD (nn),SP */
 {
 	register WORD addr;
 	WORD i;
@@ -1192,10 +979,10 @@ static int op_ldinsp(void)		/* LD (nn),SP */
 #ifdef UNDOC_FLAGS
 	WZ = addr;
 #endif
-	return (20);
+	STATES(20);
 }
 
-static int op_adchb(void)		/* ADC HL,BC */
+INSTR(0x4a, op_adchb)			/* ADC HL,BC */
 {
 	int carry, i;
 	WORD hl, bc;
@@ -1223,10 +1010,10 @@ static int op_adchb(void)		/* ADC HL,BC */
 	WZ = hl + 1;
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_adchd(void)		/* ADC HL,DE */
+INSTR(0x5a, op_adchd)			/* ADC HL,DE */
 {
 	int carry, i;
 	WORD hl, de;
@@ -1254,10 +1041,10 @@ static int op_adchd(void)		/* ADC HL,DE */
 	WZ = hl + 1;
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_adchh(void)		/* ADC HL,HL */
+INSTR(0x6a, op_adchh)			/* ADC HL,HL */
 {
 	int carry, i;
 	WORD hl;
@@ -1283,10 +1070,10 @@ static int op_adchh(void)		/* ADC HL,HL */
 	WZ = hl + 1;
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_adchs(void)		/* ADC HL,SP */
+INSTR(0x7a, op_adchs)			/* ADC HL,SP */
 {
 	int carry, i;
 	WORD hl, sp;
@@ -1314,10 +1101,10 @@ static int op_adchs(void)		/* ADC HL,SP */
 	WZ = hl + 1;
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_sbchb(void)		/* SBC HL,BC */
+INSTR(0x42, op_sbchb)			/* SBC HL,BC */
 {
 	int carry, i;
 	WORD hl, bc;
@@ -1345,10 +1132,10 @@ static int op_sbchb(void)		/* SBC HL,BC */
 	WZ = hl + 1;
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_sbchd(void)		/* SBC HL,DE */
+INSTR(0x52, op_sbchd)			/* SBC HL,DE */
 {
 	int carry, i;
 	WORD hl, de;
@@ -1376,10 +1163,10 @@ static int op_sbchd(void)		/* SBC HL,DE */
 	WZ = hl + 1;
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_sbchh(void)		/* SBC HL,HL */
+INSTR(0x62, op_sbchh)			/* SBC HL,HL */
 {
 	int carry, i;
 	WORD hl;
@@ -1405,10 +1192,10 @@ static int op_sbchh(void)		/* SBC HL,HL */
 	WZ = hl + 1;
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_sbchs(void)		/* SBC HL,SP */
+INSTR(0x72, op_sbchs)			/* SBC HL,SP */
 {
 	int carry, i;
 	WORD hl, sp;
@@ -1436,10 +1223,10 @@ static int op_sbchs(void)		/* SBC HL,SP */
 	WZ = hl + 1;
 	modF = 1;
 #endif
-	return (15);
+	STATES(15);
 }
 
-static int op_ldi(void)			/* LDI */
+INSTR(0xa0, op_ldi)			/* LDI */
 {
 	register BYTE tmp;
 
@@ -1462,21 +1249,24 @@ static int op_ldi(void)			/* LDI */
 	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (16);
+	STATES(16);
 }
 
-#ifdef WANT_FASTB
-static int op_ldir(void)		/* LDIR */
+#ifdef FAST_BLOCK
+INSTR(0xb0, op_ldir)			/* LDIR */
 {
-	register int t = -21;
 	register WORD i;
 	register WORD s, d;
 	BYTE tmp;
+#ifndef FAST_INSTR
+	register int t;
+#endif
 
 	i = (B << 8) + C;
 	d = (D << 8) + E;
 	s = (H << 8) + L;
 	R -= 2;
+	t = -21;
 #ifdef UNDOC_FLAGS
 	if (i == 1)
 		WZ = PC - 1;
@@ -1499,28 +1289,51 @@ static int op_ldir(void)		/* LDIR */
 	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (t + 16);
+	STATES(t + 16);
 }
-#else
-static int op_ldir(void)		/* LDIR */
+#else /* !FAST_BLOCK */
+INSTR(0xb0, op_ldir)			/* LDIR */
 {
-	register int t = 16;
-
+#ifndef FAST_INSTR
 	op_ldi();
+#else /* FAST_INSTR */
+	register BYTE tmp;
+
+	tmp = memrdr((H << 8) + L);
+	memwrt((D << 8) + E, tmp);
+	E++;
+	if (!E)
+		D++;
+	L++;
+	if (!L)
+		H++;
+	C--;
+	if (C == 0xff)
+		B--;
+	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	F &= ~(N_FLAG | H_FLAG);
+#ifdef UNDOC_FLAGS
+	tmp += A;
+	(tmp & 2) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+#endif /* FAST_INSTR */
+	
 	if (F & P_FLAG) {
 		PC -= 2;
-		t += 5;
 #ifdef UNDOC_FLAGS
 		WZ = PC + 1;
 		(PC & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 		(PC & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
+		STATES(21);
 	}
-	return (t);
+	STATES(16);
 }
-#endif
+#endif /* !FAST_BLOCK */
 
-static int op_ldd(void)			/* LDD */
+INSTR(0xa8, op_ldd)			/* LDD */
 {
 	register BYTE tmp;
 
@@ -1543,21 +1356,24 @@ static int op_ldd(void)			/* LDD */
 	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (16);
+	STATES(16);
 }
 
-#ifdef WANT_FASTB
-static int op_lddr(void)		/* LDDR */
+#ifdef FAST_BLOCK
+INSTR(0xb8, op_lddr)			/* LDDR */
 {
-	register int t = -21;
 	register WORD i;
 	register WORD s, d;
 	BYTE tmp;
+#ifndef FAST_INSTR
+	register int t;
+#endif
 
 	i = (B << 8) + C;
 	d = (D << 8) + E;
 	s = (H << 8) + L;
 	R -= 2;
+	t = -21;
 #ifdef UNDOC_FLAGS
 	if (i == 1)
 		WZ = PC - 1;
@@ -1580,29 +1396,51 @@ static int op_lddr(void)		/* LDDR */
 	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (t + 16);
+	STATES(t + 16);
 }
-#else
-static int op_lddr(void)		/* LDDR */
+#else /* !FAST_BLOCK */
+INSTR(0xb8, op_lddr)			/* LDDR */
 {
-	register int t;
-
+#ifndef FAST_INSTR
 	op_ldd();
+#else /* FAST_INSTR */
+	register BYTE tmp;
+
+	tmp = memrdr((H << 8) + L);
+	memwrt((D << 8) + E, tmp);
+	E--;
+	if (E == 0xff)
+		D--;
+	L--;
+	if (L == 0xff)
+		H--;
+	C--;
+	if (C == 0xff)
+		B--;
+	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	F &= ~(N_FLAG | H_FLAG);
+#ifdef UNDOC_FLAGS
+	tmp += A;
+	(tmp & 2) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+#endif /* FAST_INSTR */
+
 	if (F & P_FLAG) {
-		t = 21;
 		PC -= 2;
 #ifdef UNDOC_FLAGS
 		WZ = PC + 1;
 		(PC & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 		(PC & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-	} else
-		t = 16;
-	return (t);
+		STATES(21);
+	}
+	STATES(16);
 }
-#endif
+#endif /* !FAST_BLOCK */
 
-static int op_cpi(void)			/* CPI */
+INSTR(0xa1, op_cpi)			/* CPI */
 {
 	register BYTE i;
 
@@ -1627,21 +1465,24 @@ static int op_cpi(void)			/* CPI */
 	WZ++;
 	modF = 1;
 #endif
-	return (16);
+	STATES(16);
 }
 
-#ifdef WANT_FASTB
-static int op_cpir(void)		/* CPIR */
+#ifdef FAST_BLOCK
+INSTR(0xb1, op_cpir)			/* CPIR */
 {
-	register int t = -21;
 	register WORD s;
 	register BYTE d;
 	register WORD i;
 	BYTE tmp;
+#ifndef FAST_INSTR
+	register int t;
+#endif
 
 	i = (B << 8) + C;
 	s = (H << 8) + L;
 	R -= 2;
+	t = -21;
 	do {
 		tmp = memrdr(s++);
 		((tmp & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1670,28 +1511,53 @@ static int op_cpir(void)		/* CPIR */
 	(d & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (t + 16);
+	STATES(t + 16);
 }
-#else
-static int op_cpir(void)		/* CPIR */
+#else /* !FAST_BLOCK */
+INSTR(0xb1, op_cpir)			/* CPIR */
 {
-	register int t = 16;
-
+#ifndef FAST_INSTR
 	op_cpi();
+#else /* FAST_INSTR */
+	register BYTE i;
+
+	i = memrdr(((H << 8) + L));
+	((i & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	i = A - i;
+	L++;
+	if (!L)
+		H++;
+	C--;
+	if (C == 0xff)
+		B--;
+	F |= N_FLAG;
+	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	if (F & H_FLAG)
+		i--;
+	(i & 2) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	WZ++;
+	modF = 1;
+#endif
+#endif /* FAST_INSTR */
+
 	if ((F & (P_FLAG | Z_FLAG)) == P_FLAG) {
 		PC -= 2;
-		t += 5;
 #ifdef UNDOC_FLAGS
 		WZ = PC + 1;
 		(PC & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 		(PC & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
+		STATES(21);
 	}
-	return (t);
+	STATES(16);
 }
-#endif
+#endif /* !FAST_BLOCK */
 
-static int op_cpdop(void)		/* CPD */
+INSTR(0xa9, op_cpdop)			/* CPD */
 {
 	register BYTE i;
 
@@ -1716,21 +1582,24 @@ static int op_cpdop(void)		/* CPD */
 	WZ--;
 	modF = 1;
 #endif
-	return (16);
+	STATES(16);
 }
 
-#ifdef WANT_FASTB
-static int op_cpdr(void)		/* CPDR */
+#ifdef FAST_BLOCK
+INSTR(0xb9, op_cpdr)			/* CPDR */
 {
 	register WORD s;
 	register BYTE d;
 	register WORD i;
-	register BYTE tmp;
-	register int t = -21;
+	BYTE tmp;
+#ifndef FAST_INSTR
+	register int t;
+#endif
 
 	i = (B << 8) + C;
 	s = (H << 8) + L;
 	R -= 2;
+	t = -21;
 	do {
 		tmp = memrdr(s--);
 		((tmp & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
@@ -1759,28 +1628,53 @@ static int op_cpdr(void)		/* CPDR */
 	(d & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (t + 16);
+	STATES(t + 16);
 }
-#else
-static int op_cpdr(void)		/* CPDR */
+#else /* !FAST_BLOCK */
+INSTR(0xb9, op_cpdr)			/* CPDR */
 {
-	register int t = 16;
-
+#ifndef FAST_INSTR
 	op_cpdop();
+#else /* FAST_INSTR */
+	register BYTE i;
+
+	i = memrdr(((H << 8) + L));
+	((i & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	i = A - i;
+	L--;
+	if (L == 0xff)
+		H--;
+	C--;
+	if (C == 0xff)
+		B--;
+	F |= N_FLAG;
+	(B | C) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	if (F & H_FLAG)
+		i--;
+	(i & 2) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	WZ--;
+	modF = 1;
+#endif
+#endif /* FAST_INSTR */
+
 	if ((F & (P_FLAG | Z_FLAG)) == P_FLAG) {
 		PC -= 2;
-		t += 5;
 #ifdef UNDOC_FLAGS
 		WZ = PC + 1;
 		(PC & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 		(PC & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
+		STATES(21);
 	}
-	return (t);
+	STATES(16);
 }
-#endif
+#endif /* !FAST_BLOCK */
 
-static int op_oprld(void)		/* RLD (HL) */
+INSTR(0x6f, op_oprld)			/* RLD (HL) */
 {
 	register BYTE i, j;
 	register WORD addr;
@@ -1801,10 +1695,10 @@ static int op_oprld(void)		/* RLD (HL) */
 	WZ = addr + 1;
 	modF = 1;
 #endif
-	return (18);
+	STATES(18);
 }
 
-static int op_oprrd(void)		/* RRD (HL) */
+INSTR(0x67, op_oprrd)			/* RRD (HL) */
 {
 	register BYTE i, j;
 	register WORD addr;
@@ -1825,7 +1719,7 @@ static int op_oprrd(void)		/* RRD (HL) */
 	WZ = addr + 1;
 	modF = 1;
 #endif
-	return (18);
+	STATES(18);
 }
 
 /**********************************************************************/
@@ -1836,27 +1730,29 @@ static int op_oprrd(void)		/* RRD (HL) */
 
 #ifdef UNDOC_INST
 
-static int op_undoc_outc0(void)		/* OUT (C),0 */
+INSTR(0x71, op_undoc_outc0)		/* OUT (C),0 */
 {
 	extern void io_out(BYTE, BYTE, BYTE);
 
-	if (u_flag)
-		return (trap_ed());
+	if (u_flag) {
+		STATES(trap_ed());
+	}
 
 	io_out(C, B, 0); /* NMOS, CMOS outputs 0xff */
 #ifdef UNDOC_FLAGS
 	WZ = ((B << 8) + C) + 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
-static int op_undoc_infic(void)		/* IN F,(C) */
+INSTR(0x70, op_undoc_infic)		/* IN F,(C) */
 {
 	extern BYTE io_in(BYTE, BYTE);
 	BYTE tmp;
 
-	if (u_flag)
-		return (trap_ed());
+	if (u_flag) {
+		STATES(trap_ed());
+	}
 
 #ifdef UNDOC_FLAGS
 	WZ = ((B << 8) + C) + 1;
@@ -1871,65 +1767,184 @@ static int op_undoc_infic(void)		/* IN F,(C) */
 	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-	return (12);
+	STATES(12);
 }
 
+#ifdef UNDOC_IALL
+
+#ifndef FAST_INSTR
 static int op_undoc_nop(void)		/* NOP */
+#else
+case 0x00: case 0x01: case 0x02: case 0x03: /* NOP */
+case 0x04: case 0x05: case 0x06: case 0x07: /* NOP */
+case 0x08: case 0x09: case 0x0a: case 0x0b: /* NOP */
+case 0x0c: case 0x0d: case 0x0e: case 0x0f: /* NOP */
+case 0x10: case 0x11: case 0x12: case 0x13: /* NOP */
+case 0x14: case 0x15: case 0x16: case 0x17: /* NOP */
+case 0x18: case 0x19: case 0x1a: case 0x1b: /* NOP */
+case 0x1c: case 0x1d: case 0x1e: case 0x1f: /* NOP */
+case 0x20: case 0x21: case 0x22: case 0x23: /* NOP */
+case 0x24: case 0x25: case 0x26: case 0x27: /* NOP */
+case 0x28: case 0x29: case 0x2a: case 0x2b: /* NOP */
+case 0x2c: case 0x2d: case 0x2e: case 0x2f: /* NOP */
+case 0x30: case 0x31: case 0x32: case 0x33: /* NOP */
+case 0x34: case 0x35: case 0x36: case 0x37: /* NOP */
+case 0x38: case 0x39: case 0x3a: case 0x3b: /* NOP */
+case 0x3c: case 0x3d: case 0x3e: case 0x3f: /* NOP */
+				 case 0x77: /* NOP */
+				 case 0x7f: /* NOP */
+case 0x80: case 0x81: case 0x82: case 0x83: /* NOP */
+case 0x84: case 0x85: case 0x86: case 0x87: /* NOP */
+case 0x88: case 0x89: case 0x8a: case 0x8b: /* NOP */
+case 0x8c: case 0x8d: case 0x8e: case 0x8f: /* NOP */
+case 0x90: case 0x91: case 0x92: case 0x93: /* NOP */
+case 0x94: case 0x95: case 0x96: case 0x97: /* NOP */
+case 0x98: case 0x99: case 0x9a: case 0x9b: /* NOP */
+case 0x9c: case 0x9d: case 0x9e: case 0x9f: /* NOP */
+case 0xa4: case 0xa5: case 0xa6: case 0xa7: /* NOP */
+case 0xac: case 0xad: case 0xae: case 0xaf: /* NOP */
+case 0xb4: case 0xb5: case 0xb6: case 0xb7: /* NOP */
+case 0xbc: case 0xbd: case 0xbe: case 0xbf: /* NOP */
+case 0xc0: case 0xc1: case 0xc2: case 0xc3: /* NOP */
+case 0xc4: case 0xc5: case 0xc6: case 0xc7: /* NOP */
+case 0xc8: case 0xc9: case 0xca: case 0xcb: /* NOP */
+case 0xcc: case 0xcd: case 0xce: case 0xcf: /* NOP */
+case 0xd0: case 0xd1: case 0xd2: case 0xd3: /* NOP */
+case 0xd4: case 0xd5: case 0xd6: case 0xd7: /* NOP */
+case 0xd8: case 0xd9: case 0xda: case 0xdb: /* NOP */
+case 0xdc: case 0xdd: case 0xde: case 0xdf: /* NOP */
+case 0xe0: case 0xe1: case 0xe2: case 0xe3: /* NOP */
+case 0xe4: case 0xe5: case 0xe6: case 0xe7: /* NOP */
+case 0xe8: case 0xe9: case 0xea: case 0xeb: /* NOP */
+case 0xec: case 0xed: case 0xee: case 0xef: /* NOP */
+case 0xf0: case 0xf1: case 0xf2: case 0xf3: /* NOP */
+case 0xf4: case 0xf5: case 0xf6: case 0xf7: /* NOP */
+case 0xf8: case 0xf9: case 0xfa: case 0xfb: /* NOP */
+case 0xfc: case 0xfd: case 0xfe: case 0xff: /* NOP */
+#endif
 {
-	if (u_flag)
-		return (trap_ed());
+	if (u_flag) {
+		STATES(trap_ed());
+	}
 
-	return (8);
+	STATES(8);
 }
 
+#ifndef FAST_INSTR
 static int op_undoc_im0(void)		/* IM 0 */
+#else
+case 0x4e:				/* IM 0 */
+case 0x66:				/* IM 0 */
+case 0x6e:				/* IM 0 */
+#endif
 {
-	if (u_flag)
-		return (trap_ed());
+	if (u_flag) {
+		STATES(trap_ed());
+	}
 
-	return (op_im0());
+	int_mode = 0;
+	STATES(8);
 }
 
-static int op_undoc_im1(void)		/* IM 1 */
+INSTR(0x76, op_undoc_im1)		/* IM 1 */
 {
-	if (u_flag)
-		return (trap_ed());
+	if (u_flag) {
+		STATES(trap_ed());
+	}
 
-	return (op_im1());
+	int_mode = 1;
+	STATES(8);
 }
 
-static int op_undoc_im2(void)		/* IM 2 */
+INSTR(0x7e, op_undoc_im2)		/* IM 2 */
 {
-	if (u_flag)
-		return (trap_ed());
+	if (u_flag) {
+		STATES(trap_ed());
+	}
 
-	return (op_im2());
+	int_mode = 2;
+	STATES(8);
 }
 
+#ifndef FAST_INSTR
 static int op_undoc_reti(void)		/* RETI */
+#else
+case 0x5d:				/* RETI */
+case 0x6d:				/* RETI */
+case 0x7d:				/* RETI */
+#endif
 {
-	if (u_flag)
-		return (trap_ed());
+	if (u_flag) {
+		STATES(trap_ed());
+	}
 
-	return (op_reti());
+	register WORD i;
+
+	i = memrdr(SP++);
+	i += memrdr(SP++) << 8;
+	PC = i;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(14);
 }
 
+#ifndef FAST_INSTR
 static int op_undoc_retn(void)		/* RETN */
+#else
+case 0x55:				/* RETN */
+case 0x65:				/* RETN */
+case 0x75:				/* RETN */
+#endif
 {
-	if (u_flag)
-		return (trap_ed());
+	if (u_flag) {
+		STATES(trap_ed());
+	}
 
-	return (op_retn());
+	register WORD i;
+
+	i = memrdr(SP++);
+	i += memrdr(SP++) << 8;
+	PC = i;
+	if (IFF & 2)
+		IFF |= 1;
+#ifdef UNDOC_FLAGS
+	WZ = i;
+#endif
+	STATES(14);
 }
 
+#ifndef FAST_INSTR
 static int op_undoc_neg(void)		/* NEG */
+#else
+case 0x4c:				/* NEG */
+case 0x54:				/* NEG */
+case 0x5c:				/* NEG */
+case 0x64:				/* NEG */
+case 0x6c:				/* NEG */
+case 0x74:				/* NEG */
+case 0x7c:				/* NEG */
+#endif
 {
-	if (u_flag)
-		return (trap_ed());
+	if (u_flag) {
+		STATES(trap_ed());
+	}
 
-	return (op_neg());
+	(A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
+	(A == 0x80) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+	(0 - ((signed char) A & 0xf) < 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	A = 0 - A;
+	F |= N_FLAG;
+	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
+	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
+#ifdef UNDOC_FLAGS
+	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	modF = 1;
+#endif
+	STATES(8);
 }
 
-#endif
+#endif /* UNDOC_IALL */
 
-#endif
+#endif /* UNDOC_INST */

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -5,6 +5,13 @@
  * Copyright (C) 2024 by Thomas Eberhardt
  */
 
+/*
+ *	This module contains the main Z80 instruction loop ( cpu_z80() )
+ *	which handles interrupt requests, DMA bus requests and dispatches
+ *	all single byte instructions. It also containes the trap handlers
+ *	for undocumented instructions.
+ */
+
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
@@ -18,6 +25,15 @@
 #ifdef WANT_GUI
 extern void check_gui_break(void);
 #endif
+
+static int trap_cb(void), trap_dd(void), trap_ddcb(int);
+static int trap_ed(void), trap_fd(void), trap_fdcb(int);
+
+#ifndef FAST_INSTR
+
+#define INSTR(opcode, func)	static int func(void)
+#define INSTRD(opcode, func)	static int func(int data)
+#define STATES(states)		return (states)
 
 static int op_nop(void), op_halt(void), op_scf(void);
 static int op_ccf(void), op_cpl(void), op_daa(void);
@@ -100,8 +116,392 @@ static int op_retpe(void), op_retpo(void), op_retm(void), op_retp(void);
 static int op_jrz(void), op_jrnz(void), op_jrc(void), op_jrnc(void);
 static int op_rst00(void), op_rst08(void), op_rst10(void), op_rst18(void);
 static int op_rst20(void), op_rst28(void), op_rst30(void), op_rst38(void);
-extern int op_cb_handle(void), op_dd_handle(void);
-extern int op_ed_handle(void), op_fd_handle(void);
+static int op_cb_handle(void), op_dd_handle(void);
+static int op_ed_handle(void), op_fd_handle(void);
+
+/* ------------------------------ op_cb_handle ----------------------------- */
+
+static int op_srla(void), op_srlb(void), op_srlc(void);
+static int op_srld(void), op_srle(void);
+static int op_srlh(void), op_srll(void), op_srlhl(void);
+static int op_slaa(void), op_slab(void), op_slac(void);
+static int op_slad(void), op_slae(void);
+static int op_slah(void), op_slal(void), op_slahl(void);
+static int op_rlra(void), op_rlb(void), op_rlc(void);
+static int op_rld(void), op_rle(void);
+static int op_rlh(void), op_rll(void), op_rlhl(void);
+static int op_rrra(void), op_rrb(void), op_rrc(void);
+static int op_rrd(void), op_rre(void);
+static int op_rrh(void), op_rrl(void), op_rrhl(void);
+static int op_rrcra(void), op_rrcb(void), op_rrcc(void);
+static int op_rrcd(void), op_rrce(void);
+static int op_rrch(void), op_rrcl(void), op_rrchl(void);
+static int op_rlcra(void), op_rlcb(void), op_rlcc(void);
+static int op_rlcd(void), op_rlce(void);
+static int op_rlch(void), op_rlcl(void), op_rlchl(void);
+static int op_sraa(void), op_srab(void), op_srac(void);
+static int op_srad(void), op_srae(void);
+static int op_srah(void), op_sral(void), op_srahl(void);
+static int op_sb0a(void), op_sb1a(void), op_sb2a(void), op_sb3a(void);
+static int op_sb4a(void), op_sb5a(void), op_sb6a(void), op_sb7a(void);
+static int op_sb0b(void), op_sb1b(void), op_sb2b(void), op_sb3b(void);
+static int op_sb4b(void), op_sb5b(void), op_sb6b(void), op_sb7b(void);
+static int op_sb0c(void), op_sb1c(void), op_sb2c(void), op_sb3c(void);
+static int op_sb4c(void), op_sb5c(void), op_sb6c(void), op_sb7c(void);
+static int op_sb0d(void), op_sb1d(void), op_sb2d(void), op_sb3d(void);
+static int op_sb4d(void), op_sb5d(void), op_sb6d(void), op_sb7d(void);
+static int op_sb0e(void), op_sb1e(void), op_sb2e(void), op_sb3e(void);
+static int op_sb4e(void), op_sb5e(void), op_sb6e(void), op_sb7e(void);
+static int op_sb0h(void), op_sb1h(void), op_sb2h(void), op_sb3h(void);
+static int op_sb4h(void), op_sb5h(void), op_sb6h(void), op_sb7h(void);
+static int op_sb0l(void), op_sb1l(void), op_sb2l(void), op_sb3l(void);
+static int op_sb4l(void), op_sb5l(void), op_sb6l(void), op_sb7l(void);
+static int op_sb0hl(void), op_sb1hl(void), op_sb2hl(void), op_sb3hl(void);
+static int op_sb4hl(void), op_sb5hl(void), op_sb6hl(void), op_sb7hl(void);
+static int op_rb0a(void), op_rb1a(void), op_rb2a(void), op_rb3a(void);
+static int op_rb4a(void), op_rb5a(void), op_rb6a(void), op_rb7a(void);
+static int op_rb0b(void), op_rb1b(void), op_rb2b(void), op_rb3b(void);
+static int op_rb4b(void), op_rb5b(void), op_rb6b(void), op_rb7b(void);
+static int op_rb0c(void), op_rb1c(void), op_rb2c(void), op_rb3c(void);
+static int op_rb4c(void), op_rb5c(void), op_rb6c(void), op_rb7c(void);
+static int op_rb0d(void), op_rb1d(void), op_rb2d(void), op_rb3d(void);
+static int op_rb4d(void), op_rb5d(void), op_rb6d(void), op_rb7d(void);
+static int op_rb0e(void), op_rb1e(void), op_rb2e(void), op_rb3e(void);
+static int op_rb4e(void), op_rb5e(void), op_rb6e(void), op_rb7e(void);
+static int op_rb0h(void), op_rb1h(void), op_rb2h(void), op_rb3h(void);
+static int op_rb4h(void), op_rb5h(void), op_rb6h(void), op_rb7h(void);
+static int op_rb0l(void), op_rb1l(void), op_rb2l(void), op_rb3l(void);
+static int op_rb4l(void), op_rb5l(void), op_rb6l(void), op_rb7l(void);
+static int op_rb0hl(void), op_rb1hl(void), op_rb2hl(void), op_rb3hl(void);
+static int op_rb4hl(void), op_rb5hl(void), op_rb6hl(void), op_rb7hl(void);
+static int op_tb0a(void), op_tb1a(void), op_tb2a(void), op_tb3a(void);
+static int op_tb4a(void), op_tb5a(void), op_tb6a(void), op_tb7a(void);
+static int op_tb0b(void), op_tb1b(void), op_tb2b(void), op_tb3b(void);
+static int op_tb4b(void), op_tb5b(void), op_tb6b(void), op_tb7b(void);
+static int op_tb0c(void), op_tb1c(void), op_tb2c(void), op_tb3c(void);
+static int op_tb4c(void), op_tb5c(void), op_tb6c(void), op_tb7c(void);
+static int op_tb0d(void), op_tb1d(void), op_tb2d(void), op_tb3d(void);
+static int op_tb4d(void), op_tb5d(void), op_tb6d(void), op_tb7d(void);
+static int op_tb0e(void), op_tb1e(void), op_tb2e(void), op_tb3e(void);
+static int op_tb4e(void), op_tb5e(void), op_tb6e(void), op_tb7e(void);
+static int op_tb0h(void), op_tb1h(void), op_tb2h(void), op_tb3h(void);
+static int op_tb4h(void), op_tb5h(void), op_tb6h(void), op_tb7h(void);
+static int op_tb0l(void), op_tb1l(void), op_tb2l(void), op_tb3l(void);
+static int op_tb4l(void), op_tb5l(void), op_tb6l(void), op_tb7l(void);
+static int op_tb0hl(void), op_tb1hl(void), op_tb2hl(void), op_tb3hl(void);
+static int op_tb4hl(void), op_tb5hl(void), op_tb6hl(void), op_tb7hl(void);
+
+static int op_undoc_slla(void);
+#ifdef UNDOC_INST
+static int op_undoc_sllb(void), op_undoc_sllc(void), op_undoc_slld(void);
+static int op_undoc_slle(void), op_undoc_sllh(void), op_undoc_slll(void);
+static int op_undoc_sllhl(void);
+#endif
+
+/* ------------------------------ op_dd_handle ----------------------------- */
+
+static int op_popix(void), op_pusix(void);
+static int op_jpix(void);
+static int op_exspx(void);
+static int op_ldspx(void);
+static int op_ldixnn(void), op_ldixinn(void), op_ldinx(void);
+static int op_adaxd(void), op_acaxd(void), op_suaxd(void), op_scaxd(void);
+static int op_andxd(void), op_xorxd(void), op_orxd(void), op_cpxd(void);
+static int op_decxd(void), op_incxd(void);
+static int op_addxb(void), op_addxd(void), op_addxs(void), op_addxx(void);
+static int op_incix(void), op_decix(void);
+static int op_ldaxd(void), op_ldbxd(void), op_ldcxd(void);
+static int op_lddxd(void), op_ldexd(void);
+static int op_ldhxd(void), op_ldlxd(void);
+static int op_ldxda(void), op_ldxdb(void), op_ldxdc(void);
+static int op_ldxdd(void), op_ldxde(void);
+static int op_ldxdh(void), op_ldxdl(void), op_ldxdn(void);
+static int op_ddcb_handle(void);
+
+#ifdef UNDOC_INST
+static int op_undoc_ldaixl(void), op_undoc_ldaixh(void);
+static int op_undoc_ldbixl(void), op_undoc_ldbixh(void);
+static int op_undoc_ldcixl(void), op_undoc_ldcixh(void);
+static int op_undoc_lddixl(void), op_undoc_lddixh(void);
+static int op_undoc_ldeixl(void), op_undoc_ldeixh(void);
+static int op_undoc_ldixha(void), op_undoc_ldixla(void);
+static int op_undoc_ldixhb(void), op_undoc_ldixlb(void);
+static int op_undoc_ldixhc(void), op_undoc_ldixlc(void);
+static int op_undoc_ldixhd(void), op_undoc_ldixld(void);
+static int op_undoc_ldixhe(void), op_undoc_ldixle(void);
+static int op_undoc_ldixhixh(void), op_undoc_ldixlixh(void);
+static int op_undoc_ldixhixl(void), op_undoc_ldixlixl(void);
+static int op_undoc_ldixhn(void), op_undoc_ldixln(void);
+static int op_undoc_cpixl(void), op_undoc_cpixh(void);
+static int op_undoc_adaixl(void), op_undoc_adaixh(void);
+static int op_undoc_acaixl(void), op_undoc_acaixh(void);
+static int op_undoc_suaixl(void), op_undoc_suaixh(void);
+static int op_undoc_scaixl(void), op_undoc_scaixh(void);
+static int op_undoc_oraixl(void), op_undoc_oraixh(void);
+static int op_undoc_andixl(void), op_undoc_andixh(void);
+static int op_undoc_xorixl(void), op_undoc_xorixh(void);
+static int op_undoc_incixl(void), op_undoc_incixh(void);
+static int op_undoc_decixl(void), op_undoc_decixh(void);
+#endif
+
+/* ----------------------------- op_ddcb_handle ---------------------------- */
+
+static int op_tb0ixd(int), op_tb1ixd(int), op_tb2ixd(int), op_tb3ixd(int);
+static int op_tb4ixd(int), op_tb5ixd(int), op_tb6ixd(int), op_tb7ixd(int);
+static int op_rb0ixd(int), op_rb1ixd(int), op_rb2ixd(int), op_rb3ixd(int);
+static int op_rb4ixd(int), op_rb5ixd(int), op_rb6ixd(int), op_rb7ixd(int);
+static int op_sb0ixd(int), op_sb1ixd(int), op_sb2ixd(int), op_sb3ixd(int);
+static int op_sb4ixd(int), op_sb5ixd(int), op_sb6ixd(int), op_sb7ixd(int);
+static int op_rlcixd(int), op_rrcixd(int), op_rlixd(int), op_rrixd(int);
+static int op_slaixd(int), op_sraixd(int), op_srlixd(int);
+
+#ifdef UNDOC_INST
+static int op_undoc_sllixd(int);
+#ifdef UNDOC_IALL
+static int op_undoc_tb0ixd(int), op_undoc_tb1ixd(int), op_undoc_tb2ixd(int);
+static int op_undoc_tb3ixd(int), op_undoc_tb4ixd(int), op_undoc_tb5ixd(int);
+static int op_undoc_tb6ixd(int), op_undoc_tb7ixd(int);
+static int op_undoc_rb0ixda(int), op_undoc_rb1ixda(int), op_undoc_rb2ixda(int);
+static int op_undoc_rb3ixda(int), op_undoc_rb4ixda(int), op_undoc_rb5ixda(int);
+static int op_undoc_rb6ixda(int), op_undoc_rb7ixda(int);
+static int op_undoc_rb0ixdb(int), op_undoc_rb1ixdb(int), op_undoc_rb2ixdb(int);
+static int op_undoc_rb3ixdb(int), op_undoc_rb4ixdb(int), op_undoc_rb5ixdb(int);
+static int op_undoc_rb6ixdb(int), op_undoc_rb7ixdb(int);
+static int op_undoc_rb0ixdc(int), op_undoc_rb1ixdc(int), op_undoc_rb2ixdc(int);
+static int op_undoc_rb3ixdc(int), op_undoc_rb4ixdc(int), op_undoc_rb5ixdc(int);
+static int op_undoc_rb6ixdc(int), op_undoc_rb7ixdc(int);
+static int op_undoc_rb0ixdd(int), op_undoc_rb1ixdd(int), op_undoc_rb2ixdd(int);
+static int op_undoc_rb3ixdd(int), op_undoc_rb4ixdd(int), op_undoc_rb5ixdd(int);
+static int op_undoc_rb6ixdd(int), op_undoc_rb7ixdd(int);
+static int op_undoc_rb0ixde(int), op_undoc_rb1ixde(int), op_undoc_rb2ixde(int);
+static int op_undoc_rb3ixde(int), op_undoc_rb4ixde(int), op_undoc_rb5ixde(int);
+static int op_undoc_rb6ixde(int), op_undoc_rb7ixde(int);
+static int op_undoc_rb0ixdh(int), op_undoc_rb1ixdh(int), op_undoc_rb2ixdh(int);
+static int op_undoc_rb3ixdh(int), op_undoc_rb4ixdh(int), op_undoc_rb5ixdh(int);
+static int op_undoc_rb6ixdh(int), op_undoc_rb7ixdh(int);
+static int op_undoc_rb0ixdl(int), op_undoc_rb1ixdl(int), op_undoc_rb2ixdl(int);
+static int op_undoc_rb3ixdl(int), op_undoc_rb4ixdl(int), op_undoc_rb5ixdl(int);
+static int op_undoc_rb6ixdl(int), op_undoc_rb7ixdl(int);
+static int op_undoc_sb0ixda(int), op_undoc_sb1ixda(int), op_undoc_sb2ixda(int);
+static int op_undoc_sb3ixda(int), op_undoc_sb4ixda(int), op_undoc_sb5ixda(int);
+static int op_undoc_sb6ixda(int), op_undoc_sb7ixda(int);
+static int op_undoc_sb0ixdb(int), op_undoc_sb1ixdb(int), op_undoc_sb2ixdb(int);
+static int op_undoc_sb3ixdb(int), op_undoc_sb4ixdb(int), op_undoc_sb5ixdb(int);
+static int op_undoc_sb6ixdb(int), op_undoc_sb7ixdb(int);
+static int op_undoc_sb0ixdc(int), op_undoc_sb1ixdc(int), op_undoc_sb2ixdc(int);
+static int op_undoc_sb3ixdc(int), op_undoc_sb4ixdc(int), op_undoc_sb5ixdc(int);
+static int op_undoc_sb6ixdc(int), op_undoc_sb7ixdc(int);
+static int op_undoc_sb0ixdd(int), op_undoc_sb1ixdd(int), op_undoc_sb2ixdd(int);
+static int op_undoc_sb3ixdd(int), op_undoc_sb4ixdd(int), op_undoc_sb5ixdd(int);
+static int op_undoc_sb6ixdd(int), op_undoc_sb7ixdd(int);
+static int op_undoc_sb0ixde(int), op_undoc_sb1ixde(int), op_undoc_sb2ixde(int);
+static int op_undoc_sb3ixde(int), op_undoc_sb4ixde(int), op_undoc_sb5ixde(int);
+static int op_undoc_sb6ixde(int), op_undoc_sb7ixde(int);
+static int op_undoc_sb0ixdh(int), op_undoc_sb1ixdh(int), op_undoc_sb2ixdh(int);
+static int op_undoc_sb3ixdh(int), op_undoc_sb4ixdh(int), op_undoc_sb5ixdh(int);
+static int op_undoc_sb6ixdh(int), op_undoc_sb7ixdh(int);
+static int op_undoc_sb0ixdl(int), op_undoc_sb1ixdl(int), op_undoc_sb2ixdl(int);
+static int op_undoc_sb3ixdl(int), op_undoc_sb4ixdl(int), op_undoc_sb5ixdl(int);
+static int op_undoc_sb6ixdl(int), op_undoc_sb7ixdl(int);
+static int op_undoc_rlcixda(int), op_undoc_rlcixdb(int), op_undoc_rlcixdc(int);
+static int op_undoc_rlcixdd(int), op_undoc_rlcixde(int), op_undoc_rlcixdh(int);
+static int op_undoc_rlcixdl(int);
+static int op_undoc_rrcixda(int), op_undoc_rrcixdb(int), op_undoc_rrcixdc(int);
+static int op_undoc_rrcixdd(int), op_undoc_rrcixde(int), op_undoc_rrcixdh(int);
+static int op_undoc_rrcixdl(int);
+static int op_undoc_rlixda(int), op_undoc_rlixdb(int), op_undoc_rlixdc(int);
+static int op_undoc_rlixdd(int), op_undoc_rlixde(int), op_undoc_rlixdh(int);
+static int op_undoc_rlixdl(int);
+static int op_undoc_rrixda(int), op_undoc_rrixdb(int), op_undoc_rrixdc(int);
+static int op_undoc_rrixdd(int), op_undoc_rrixde(int), op_undoc_rrixdh(int);
+static int op_undoc_rrixdl(int);
+static int op_undoc_slaixda(int), op_undoc_slaixdb(int), op_undoc_slaixdc(int);
+static int op_undoc_slaixdd(int), op_undoc_slaixde(int), op_undoc_slaixdh(int);
+static int op_undoc_slaixdl(int);
+static int op_undoc_sraixda(int), op_undoc_sraixdb(int), op_undoc_sraixdc(int);
+static int op_undoc_sraixdd(int), op_undoc_sraixde(int), op_undoc_sraixdh(int);
+static int op_undoc_sraixdl(int);
+static int op_undoc_sllixda(int), op_undoc_sllixdb(int), op_undoc_sllixdc(int);
+static int op_undoc_sllixdd(int), op_undoc_sllixde(int), op_undoc_sllixdh(int);
+static int op_undoc_sllixdl(int);
+static int op_undoc_srlixda(int), op_undoc_srlixdb(int), op_undoc_srlixdc(int);
+static int op_undoc_srlixdd(int), op_undoc_srlixde(int), op_undoc_srlixdh(int);
+static int op_undoc_srlixdl(int);
+#endif /* UNDOC_IALL */
+#endif /* UNDOC_INST */
+
+/* ------------------------------ op_ed_handle ----------------------------- */
+
+static int op_im0(void), op_im1(void), op_im2(void);
+static int op_reti(void), op_retn(void);
+static int op_neg(void);
+static int op_inaic(void), op_inbic(void), op_incic(void);
+static int op_indic(void), op_ineic(void);
+static int op_inhic(void), op_inlic(void);
+static int op_outca(void), op_outcb(void), op_outcc(void);
+static int op_outcd(void), op_outce(void);
+static int op_outch(void), op_outcl(void);
+static int op_ini(void), op_inir(void), op_ind(void), op_indr(void);
+static int op_outi(void), op_otir(void), op_outd(void), op_otdr(void);
+static int op_ldai(void), op_ldar(void), op_ldia(void), op_ldra(void);
+static int op_ldbcinn(void), op_lddeinn(void);
+static int op_ldhlinn(void), op_ldspinn(void);
+static int op_ldinbc(void), op_ldinde(void), op_ldinhl2(void), op_ldinsp(void);
+static int op_adchb(void), op_adchd(void), op_adchh(void), op_adchs(void);
+static int op_sbchb(void), op_sbchd(void), op_sbchh(void), op_sbchs(void);
+static int op_ldi(void), op_ldir(void), op_ldd(void), op_lddr(void);
+static int op_cpi(void), op_cpir(void), op_cpdop(void), op_cpdr(void);
+static int op_oprld(void), op_oprrd(void);
+
+#ifdef UNDOC_INST
+static int op_undoc_outc0(void), op_undoc_infic(void);
+#ifdef UNDOC_IALL
+static int op_undoc_nop(void);
+static int op_undoc_im0(void), op_undoc_im1(void), op_undoc_im2(void);
+static int op_undoc_reti(void), op_undoc_retn(void);
+static int op_undoc_neg(void);
+#endif
+#endif
+
+/* ------------------------------ op_fd_handle ----------------------------- */
+
+static int op_popiy(void), op_pusiy(void);
+static int op_jpiy(void);
+static int op_exspy(void);
+static int op_ldspy(void);
+static int op_ldiynn(void), op_ldiyinn(void), op_ldiny(void);
+static int op_adayd(void), op_acayd(void), op_suayd(void), op_scayd(void);
+static int op_andyd(void), op_xoryd(void), op_oryd(void), op_cpyd(void);
+static int op_decyd(void), op_incyd(void);
+static int op_addyb(void), op_addyd(void), op_addys(void), op_addyy(void);
+static int op_inciy(void), op_deciy(void);
+static int op_ldayd(void), op_ldbyd(void), op_ldcyd(void);
+static int op_lddyd(void), op_ldeyd(void);
+static int op_ldhyd(void), op_ldlyd(void);
+static int op_ldyda(void), op_ldydb(void), op_ldydc(void);
+static int op_ldydd(void), op_ldyde(void);
+static int op_ldydh(void), op_ldydl(void), op_ldydn(void);
+static int op_fdcb_handle(void);
+
+#ifdef UNDOC_INST
+static int op_undoc_ldaiyl(void), op_undoc_ldaiyh(void);
+static int op_undoc_ldbiyl(void), op_undoc_ldbiyh(void);
+static int op_undoc_ldciyl(void), op_undoc_ldciyh(void);
+static int op_undoc_lddiyl(void), op_undoc_lddiyh(void);
+static int op_undoc_ldeiyl(void), op_undoc_ldeiyh(void);
+static int op_undoc_ldiyha(void), op_undoc_ldiyla(void);
+static int op_undoc_ldiyhb(void), op_undoc_ldiylb(void);
+static int op_undoc_ldiyhc(void), op_undoc_ldiylc(void);
+static int op_undoc_ldiyhd(void), op_undoc_ldiyld(void);
+static int op_undoc_ldiyhe(void), op_undoc_ldiyle(void);
+static int op_undoc_ldiyhiyh(void), op_undoc_ldiyliyh(void);
+static int op_undoc_ldiyhiyl(void), op_undoc_ldiyliyl(void);
+static int op_undoc_ldiyhn(void), op_undoc_ldiyln(void);
+static int op_undoc_cpiyl(void), op_undoc_cpiyh(void);
+static int op_undoc_adaiyl(void), op_undoc_adaiyh(void);
+static int op_undoc_acaiyl(void), op_undoc_acaiyh(void);
+static int op_undoc_suaiyl(void), op_undoc_suaiyh(void);
+static int op_undoc_scaiyl(void), op_undoc_scaiyh(void);
+static int op_undoc_oraiyl(void), op_undoc_oraiyh(void);
+static int op_undoc_andiyl(void), op_undoc_andiyh(void);
+static int op_undoc_xoriyl(void), op_undoc_xoriyh(void);
+static int op_undoc_inciyl(void), op_undoc_inciyh(void);
+static int op_undoc_deciyl(void), op_undoc_deciyh(void);
+#endif
+
+/* ----------------------------- op_fdcb_handle ---------------------------- */
+
+static int op_tb0iyd(int), op_tb1iyd(int), op_tb2iyd(int), op_tb3iyd(int);
+static int op_tb4iyd(int), op_tb5iyd(int), op_tb6iyd(int), op_tb7iyd(int);
+static int op_rb0iyd(int), op_rb1iyd(int), op_rb2iyd(int), op_rb3iyd(int);
+static int op_rb4iyd(int), op_rb5iyd(int), op_rb6iyd(int), op_rb7iyd(int);
+static int op_sb0iyd(int), op_sb1iyd(int), op_sb2iyd(int), op_sb3iyd(int);
+static int op_sb4iyd(int), op_sb5iyd(int), op_sb6iyd(int), op_sb7iyd(int);
+static int op_rlciyd(int), op_rrciyd(int), op_rliyd(int), op_rriyd(int);
+static int op_slaiyd(int), op_sraiyd(int), op_srliyd(int);
+
+#ifdef UNDOC_INST
+static int op_undoc_slliyd(int);
+#ifdef UNDOC_IALL
+static int op_undoc_tb0iyd(int), op_undoc_tb1iyd(int), op_undoc_tb2iyd(int);
+static int op_undoc_tb3iyd(int), op_undoc_tb4iyd(int), op_undoc_tb5iyd(int);
+static int op_undoc_tb6iyd(int), op_undoc_tb7iyd(int);
+static int op_undoc_rb0iyda(int), op_undoc_rb1iyda(int), op_undoc_rb2iyda(int);
+static int op_undoc_rb3iyda(int), op_undoc_rb4iyda(int), op_undoc_rb5iyda(int);
+static int op_undoc_rb6iyda(int), op_undoc_rb7iyda(int);
+static int op_undoc_rb0iydb(int), op_undoc_rb1iydb(int), op_undoc_rb2iydb(int);
+static int op_undoc_rb3iydb(int), op_undoc_rb4iydb(int), op_undoc_rb5iydb(int);
+static int op_undoc_rb6iydb(int), op_undoc_rb7iydb(int);
+static int op_undoc_rb0iydc(int), op_undoc_rb1iydc(int), op_undoc_rb2iydc(int);
+static int op_undoc_rb3iydc(int), op_undoc_rb4iydc(int), op_undoc_rb5iydc(int);
+static int op_undoc_rb6iydc(int), op_undoc_rb7iydc(int);
+static int op_undoc_rb0iydd(int), op_undoc_rb1iydd(int), op_undoc_rb2iydd(int);
+static int op_undoc_rb3iydd(int), op_undoc_rb4iydd(int), op_undoc_rb5iydd(int);
+static int op_undoc_rb6iydd(int), op_undoc_rb7iydd(int);
+static int op_undoc_rb0iyde(int), op_undoc_rb1iyde(int), op_undoc_rb2iyde(int);
+static int op_undoc_rb3iyde(int), op_undoc_rb4iyde(int), op_undoc_rb5iyde(int);
+static int op_undoc_rb6iyde(int), op_undoc_rb7iyde(int);
+static int op_undoc_rb0iydh(int), op_undoc_rb1iydh(int), op_undoc_rb2iydh(int);
+static int op_undoc_rb3iydh(int), op_undoc_rb4iydh(int), op_undoc_rb5iydh(int);
+static int op_undoc_rb6iydh(int), op_undoc_rb7iydh(int);
+static int op_undoc_rb0iydl(int), op_undoc_rb1iydl(int), op_undoc_rb2iydl(int);
+static int op_undoc_rb3iydl(int), op_undoc_rb4iydl(int), op_undoc_rb5iydl(int);
+static int op_undoc_rb6iydl(int), op_undoc_rb7iydl(int);
+static int op_undoc_sb0iyda(int), op_undoc_sb1iyda(int), op_undoc_sb2iyda(int);
+static int op_undoc_sb3iyda(int), op_undoc_sb4iyda(int), op_undoc_sb5iyda(int);
+static int op_undoc_sb6iyda(int), op_undoc_sb7iyda(int);
+static int op_undoc_sb0iydb(int), op_undoc_sb1iydb(int), op_undoc_sb2iydb(int);
+static int op_undoc_sb3iydb(int), op_undoc_sb4iydb(int), op_undoc_sb5iydb(int);
+static int op_undoc_sb6iydb(int), op_undoc_sb7iydb(int);
+static int op_undoc_sb0iydc(int), op_undoc_sb1iydc(int), op_undoc_sb2iydc(int);
+static int op_undoc_sb3iydc(int), op_undoc_sb4iydc(int), op_undoc_sb5iydc(int);
+static int op_undoc_sb6iydc(int), op_undoc_sb7iydc(int);
+static int op_undoc_sb0iydd(int), op_undoc_sb1iydd(int), op_undoc_sb2iydd(int);
+static int op_undoc_sb3iydd(int), op_undoc_sb4iydd(int), op_undoc_sb5iydd(int);
+static int op_undoc_sb6iydd(int), op_undoc_sb7iydd(int);
+static int op_undoc_sb0iyde(int), op_undoc_sb1iyde(int), op_undoc_sb2iyde(int);
+static int op_undoc_sb3iyde(int), op_undoc_sb4iyde(int), op_undoc_sb5iyde(int);
+static int op_undoc_sb6iyde(int), op_undoc_sb7iyde(int);
+static int op_undoc_sb0iydh(int), op_undoc_sb1iydh(int), op_undoc_sb2iydh(int);
+static int op_undoc_sb3iydh(int), op_undoc_sb4iydh(int), op_undoc_sb5iydh(int);
+static int op_undoc_sb6iydh(int), op_undoc_sb7iydh(int);
+static int op_undoc_sb0iydl(int), op_undoc_sb1iydl(int), op_undoc_sb2iydl(int);
+static int op_undoc_sb3iydl(int), op_undoc_sb4iydl(int), op_undoc_sb5iydl(int);
+static int op_undoc_sb6iydl(int), op_undoc_sb7iydl(int);
+static int op_undoc_rlciyda(int), op_undoc_rlciydb(int), op_undoc_rlciydc(int);
+static int op_undoc_rlciydd(int), op_undoc_rlciyde(int), op_undoc_rlciydh(int);
+static int op_undoc_rlciydl(int);
+static int op_undoc_rrciyda(int), op_undoc_rrciydb(int), op_undoc_rrciydc(int);
+static int op_undoc_rrciydd(int), op_undoc_rrciyde(int), op_undoc_rrciydh(int);
+static int op_undoc_rrciydl(int);
+static int op_undoc_rliyda(int), op_undoc_rliydb(int), op_undoc_rliydc(int);
+static int op_undoc_rliydd(int), op_undoc_rliyde(int), op_undoc_rliydh(int);
+static int op_undoc_rliydl(int);
+static int op_undoc_rriyda(int), op_undoc_rriydb(int), op_undoc_rriydc(int);
+static int op_undoc_rriydd(int), op_undoc_rriyde(int), op_undoc_rriydh(int);
+static int op_undoc_rriydl(int);
+static int op_undoc_slaiyda(int), op_undoc_slaiydb(int), op_undoc_slaiydc(int);
+static int op_undoc_slaiydd(int), op_undoc_slaiyde(int), op_undoc_slaiydh(int);
+static int op_undoc_slaiydl(int);
+static int op_undoc_sraiyda(int), op_undoc_sraiydb(int), op_undoc_sraiydc(int);
+static int op_undoc_sraiydd(int), op_undoc_sraiyde(int), op_undoc_sraiydh(int);
+static int op_undoc_sraiydl(int);
+static int op_undoc_slliyda(int), op_undoc_slliydb(int), op_undoc_slliydc(int);
+static int op_undoc_slliydd(int), op_undoc_slliyde(int), op_undoc_slliydh(int);
+static int op_undoc_slliydl(int);
+static int op_undoc_srliyda(int), op_undoc_srliydb(int), op_undoc_srliydc(int);
+static int op_undoc_srliydd(int), op_undoc_srliyde(int), op_undoc_srliydh(int);
+static int op_undoc_srliydl(int);
+#endif /* UNDOC_IALL */
+#endif /* UNDOC_INST */
+
+#else /* FAST_INSTR */
+
+#define INSTR(opcode, func)	case opcode:
+#define INSTRD(opcode, func)	case opcode:
+#define STATES(states)		t = states; break
+
+#endif /* FAST_INSTR */
 
 /*
  *	This function builds the Z80 central processing unit.
@@ -114,6 +514,7 @@ void cpu_z80(void)
 {
 	extern unsigned long long get_clock_us(void);
 
+#ifndef FAST_INSTR
 	static int (*op_sim[256])(void) = {
 		op_nop,				/* 0x00 */
 		op_ldbcnn,			/* 0x01 */
@@ -372,10 +773,11 @@ void cpu_z80(void)
 		op_cpn,				/* 0xfe */
 		op_rst38			/* 0xff */
 	};
+#endif /* !FAST_INSTR */
 
 	Tstates_t T_max;
 	unsigned long long t1, t2;
-	int tdiff;
+	int tdiff, t;
 	WORD p;
 
 	T_max = T + tmax;
@@ -581,7 +983,20 @@ leave:
 #endif
 
 		int_protection = 0;
-		T += (*op_sim[memrdr(PC++)])(); /* execute next opcode */
+
+#ifndef FAST_INSTR
+		t = (*op_sim[memrdr(PC++)])();	/* execute next opcode */
+#else
+		switch (memrdr(PC++)) {		/* execute next opcode */
+
+#include "simz80-00.c"
+
+		default:
+			t = 0;		/* silence compiler */
+			break;
+		}
+#endif
+		T += t;
 
 		if (f_flag) {		/* adjust CPU speed */
 			if (T >= T_max && !cpu_needed) {
@@ -623,3325 +1038,94 @@ leave:
 #endif
 }
 
-static int op_nop(void)			/* NOP */
-{
-	return (4);
-}
-
-static int op_halt(void)		/* HALT */
-{
-#ifdef BUS_8080
-	cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
-#endif
-
-#ifdef FRONTPANEL
-	if (!F_flag) {
-#endif
-		if (IFF == 0) {
-			/* without a frontpanel DI + HALT stops the machine */
-			cpu_error = OPHALT;
-			cpu_state = STOPPED;
-		} else {
-			/* else wait for INT, NMI or user interrupt */
-			while ((int_int == 0) && (int_nmi == 0) &&
-			       (cpu_state == CONTIN_RUN)) {
-				SLEEP_MS(1);
-				R += 99;
-			}
-		}
-#ifdef BUS_8080
-		if (int_int)
-			cpu_bus = CPU_INTA | CPU_WO | CPU_HLTA | CPU_M1;
-#endif
-
-		busy_loop_cnt = 0;
-
-#ifdef FRONTPANEL
-	} else {
-		fp_led_address = 0xffff;
-		fp_led_data = 0xff;
-
-		if (IFF == 0) {
-			/* INT disabled, wait for NMI,
-			   frontpanel reset or user interrupt */
-			while ((int_nmi == 0) && !(cpu_state & RESET)) {
-				fp_clock++;
-				fp_sampleData();
-				SLEEP_MS(1);
-				R += 99;
-				if (cpu_error != NONE)
-					break;
-			}
-		} else {
-			/* else wait for INT, NMI,
-			   frontpanel reset or user interrupt */
-			while ((int_int == 0) && (int_nmi == 0) &&
-			       !(cpu_state & RESET)) {
-				fp_clock++;
-				fp_sampleData();
-				SLEEP_MS(1);
-				R += 99;
-				if (cpu_error != NONE)
-					break;
-			}
-			if (int_int) {
-				cpu_bus = CPU_INTA | CPU_WO |
-					  CPU_HLTA | CPU_M1;
-				fp_clock++;
-				fp_sampleLightGroup(0, 0);
-			}
-		}
-	}
-#endif
-
-	return (4);
-}
-
-static int op_scf(void)			/* SCF */
-{
-	F |= C_FLAG;
-	F &= ~(N_FLAG | H_FLAG);
-#ifdef UNDOC_FLAGS
-	/* This is Zilog/Mostek NMOS Z80 behaviour */
-	(A & 32) ? (F |= Y_FLAG) : (pmodF ? (F &= ~Y_FLAG) : 0);
-	(A & 8) ? (F |= X_FLAG) : (pmodF ? (F &= ~X_FLAG) : 0);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_ccf(void)			/* CCF */
-{
-	if (F & C_FLAG) {
-		F |= H_FLAG;
-		F &= ~C_FLAG;
-	} else {
-		F &= ~H_FLAG;
-		F |= C_FLAG;
-	}
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	/* This is Zilog/Mostek NMOS Z80 behaviour */
-	(A & 32) ? (F |= Y_FLAG) : (pmodF ? (F &= ~Y_FLAG) : 0);
-	(A & 8) ? (F |= X_FLAG) : (pmodF ? (F &= ~X_FLAG) : 0);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_cpl(void)			/* CPL */
-{
-	A = ~A;
-	F |= H_FLAG | N_FLAG;
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-/*
- * This is my original implementation of the DAA instruction.
- * It implements the instruction as described in Z80 data sheets
- * and books, but it won't pass the ex.com instruction exerciser.
- * Below is a contributed implementation active, that also passes
- * the tests done by ex.com.
- */
-#if 0
-static int op_daa(void)			/* DAA */
-{
-	if (F & N_FLAG) {		/* subtractions */
-		if (((A & 0x0f) > 9) || (F & H_FLAG)) {
-			(((A & 0x0f) - 6) < 0) ? (F |= H_FLAG)
-					       : (F &= ~H_FLAG);
-			A -= 6;
-		}
-		if (((A & 0xf0) > 0x90) || (F & C_FLAG)) {
-			if (((A & 0xf0) - 0x60) < 0)
-				F |= C_FLAG;
-			A -= 0x60;
-		}
-	} else {			/* additions */
-		if (((A & 0x0f) > 9) || (F & H_FLAG)) {
-			(((A & 0x0f) + 6) > 0x0f) ? (F |= H_FLAG)
-						  : (F &= ~H_FLAG);
-			A += 6;
-		}
-		if (((A & 0xf0) > 0x90) || (F & C_FLAG)) {
-			if (((A & 0xf0) + 0x60) > 0xf0)
-				F |= C_FLAG;
-			A += 0x60;
-		}
-	}
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
+#ifndef FAST_INSTR
+#include "simz80-00.c"
 #endif
 
 /*
- * This implementation was contributed by Mark Garlanger,
- * see http://heathkit.garlanger.com/
- * It passes the instruction exerciser test from ex.com
- * and is correct.
+ *	This function traps undocumented opcodes following the
+ *	initial 0xcb of a multi byte opcode.
  */
-static int op_daa(void)			/* DAA */
+static int trap_cb(void)
 {
-	int tmp_a = A;
-	int low_nibble = A & 0x0f;
-	int carry = (F & C_FLAG);
+	cpu_error = OPTRAP2;
+	cpu_state = STOPPED;
+	return (0);
+}
 
-	if (F & N_FLAG) {		/* subtraction */
-		int adjustment = (carry || (tmp_a > 0x99)) ? 0x160 : 0x00;
-
-		if ((F & H_FLAG) || (low_nibble > 9)) {
-			if (low_nibble > 5) {
-				F &= ~H_FLAG;
-			}
-			tmp_a = (tmp_a - 6) & 0xff;
-		}
-		tmp_a -= adjustment;
-	} else {			/* addition */
-		if ((low_nibble > 9) || (F & H_FLAG)) {
-			(low_nibble > 9) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-			tmp_a += 6;
-		}
-		if (((tmp_a & 0x1f0) > 0x90) || carry) {
-			tmp_a += 0x60;
-		}
+/*
+ *	This function traps undocumented opcodes following the
+ *	initial 0xdd of a multi byte opcode.
+ */
+static int trap_dd(void)
+{
+#ifdef UNDOC_INST
+	if (!u_flag) {
+		/* Treat 0xdd prefix as NOP on non IX-instructions */
+		PC--;
+		R--;
+		return (4);
 	}
-
-	(carry || (tmp_a & 0x100)) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = (tmp_a & 0xff);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_ei(void)			/* EI */
-{
-	IFF = 3;
-	int_protection = 1;		/* protect next instruction */
-	return (4);
-}
-
-static int op_di(void)			/* DI */
-{
-	IFF = 0;
-	return (4);
-}
-
-static int op_in(void)			/* IN A,(n) */
-{
-	extern BYTE io_in(BYTE, BYTE);
-	BYTE addr;
-
-	addr = memrdr(PC++);
-#ifdef UNDOC_FLAGS
-	WZ = (A << 8) + ((addr + 1) & 0xff);
-#endif
-	A = io_in(addr, A);
-	return (11);
-}
-
-static int op_out(void)			/* OUT (n),A */
-{
-	extern void io_out(BYTE, BYTE, BYTE);
-	BYTE addr;
-
-	addr = memrdr(PC++);
-	io_out(addr, A, A);
-#ifdef UNDOC_FLAGS
-	WZ = (A << 8) + ((addr + 1) & 0xff);
-#endif
-	return (11);
-}
-
-static int op_ldan(void)		/* LD A,n */
-{
-	A = memrdr(PC++);
-	return (7);
-}
-
-static int op_ldbn(void)		/* LD B,n */
-{
-	B = memrdr(PC++);
-	return (7);
-}
-
-static int op_ldcn(void)		/* LD C,n */
-{
-	C = memrdr(PC++);
-	return (7);
-}
-
-static int op_lddn(void)		/* LD D,n */
-{
-	D = memrdr(PC++);
-	return (7);
-}
-
-static int op_lden(void)		/* LD E,n */
-{
-	E = memrdr(PC++);
-	return (7);
-}
-
-static int op_ldhn(void)		/* LD H,n */
-{
-	H = memrdr(PC++);
-	return (7);
-}
-
-static int op_ldln(void)		/* LD L,n */
-{
-	L = memrdr(PC++);
-	return (7);
-}
-
-static int op_ldabc(void)		/* LD A,(BC) */
-{
-	register WORD i;
-
-	i = (B << 8) + C;
-	A = memrdr(i);
-#ifdef UNDOC_FLAGS
-	WZ = i + 1;
-#endif
-	return (7);
-}
-
-static int op_ldade(void)		/* LD A,(DE) */
-{
-	register WORD i;
-
-	i = (D << 8) + E;
-	A = memrdr(i);
-#ifdef UNDOC_FLAGS
-	WZ = i + 1;
-#endif
-	return (7);
-}
-
-static int op_ldann(void)		/* LD A,(nn) */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	A = memrdr(i);
-#ifdef UNDOC_FLAGS
-	WZ = i + 1;
-#endif
-	return (13);
-}
-
-static int op_ldbca(void)		/* LD (BC),A */
-{
-	memwrt((B << 8) + C, A);
-#ifdef UNDOC_FLAGS
-	WZ = (A << 8) + ((C + 1) & 0xff);
-#endif
-	return (7);
-}
-
-static int op_lddea(void)		/* LD (DE),A */
-{
-	memwrt((D << 8) + E, A);
-#ifdef UNDOC_FLAGS
-	WZ = (A << 8) + ((E + 1) & 0xff);
-#endif
-	return (7);
-}
-
-static int op_ldnna(void)		/* LD (nn),A */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	memwrt(i, A);
-#ifdef UNDOC_FLAGS
-	WZ = (A << 8) + ((i + 1) & 0xff);
-#endif
-	return (13);
-}
-
-static int op_ldhla(void)		/* LD (HL),A */
-{
-	memwrt((H << 8) + L, A);
-	return (7);
-}
-
-static int op_ldhlb(void)		/* LD (HL),B */
-{
-	memwrt((H << 8) + L, B);
-	return (7);
-}
-
-static int op_ldhlc(void)		/* LD (HL),C */
-{
-	memwrt((H << 8) + L, C);
-	return (7);
-}
-
-static int op_ldhld(void)		/* LD (HL),D */
-{
-	memwrt((H << 8) + L, D);
-	return (7);
-}
-
-static int op_ldhle(void)		/* LD (HL),E */
-{
-	memwrt((H << 8) + L, E);
-	return (7);
-}
-
-static int op_ldhlh(void)		/* LD (HL),H */
-{
-	memwrt((H << 8) + L, H);
-	return (7);
-}
-
-static int op_ldhll(void)		/* LD (HL),L */
-{
-	memwrt((H << 8) + L, L);
-	return (7);
-}
-
-static int op_ldhl1(void)		/* LD (HL),n */
-{
-	memwrt((H << 8) + L, memrdr(PC++));
-	return (10);
-}
-
-static int op_ldaa(void)		/* LD A,A */
-{
-	return (4);
-}
-
-static int op_ldab(void)		/* LD A,B */
-{
-	A = B;
-	return (4);
-}
-
-static int op_ldac(void)		/* LD A,C */
-{
-	A = C;
-	return (4);
-}
-
-static int op_ldad(void)		/* LD A,D */
-{
-	A = D;
-	return (4);
-}
-
-static int op_ldae(void)		/* LD A,E */
-{
-	A = E;
-	return (4);
-}
-
-static int op_ldah(void)		/* LD A,H */
-{
-	A = H;
-	return (4);
-}
-
-static int op_ldal(void)		/* LD A,L */
-{
-	A = L;
-	return (4);
-}
-
-static int op_ldahl(void)		/* LD A,(HL) */
-{
-	A = memrdr((H << 8) + L);
-	return (7);
-}
-
-static int op_ldba(void)		/* LD B,A */
-{
-	B = A;
-	return (4);
-}
-
-static int op_ldbb(void)		/* LD B,B */
-{
-	return (4);
-}
-
-static int op_ldbc(void)		/* LD B,C */
-{
-	B = C;
-	return (4);
-}
-
-static int op_ldbd(void)		/* LD B,D */
-{
-	B = D;
-	return (4);
-}
-
-static int op_ldbe(void)		/* LD B,E */
-{
-	B = E;
-	return (4);
-}
-
-static int op_ldbh(void)		/* LD B,H */
-{
-	B = H;
-	return (4);
-}
-
-static int op_ldbl(void)		/* LD B,L */
-{
-	B = L;
-	return (4);
-}
-
-static int op_ldbhl(void)		/* LD B,(HL) */
-{
-	B = memrdr((H << 8) + L);
-	return (7);
-}
-
-static int op_ldca(void)		/* LD C,A */
-{
-	C = A;
-	return (4);
-}
-
-static int op_ldcb(void)		/* LD C,B */
-{
-	C = B;
-	return (4);
-}
-
-static int op_ldcc(void)		/* LD C,C */
-{
-	return (4);
-}
-
-static int op_ldcd(void)		/* LD C,D */
-{
-	C = D;
-	return (4);
-}
-
-static int op_ldce(void)		/* LD C,E */
-{
-	C = E;
-	return (4);
-}
-
-static int op_ldch(void)		/* LD C,H */
-{
-	C = H;
-	return (4);
-}
-
-static int op_ldcl(void)		/* LD C,L */
-{
-	C = L;
-	return (4);
-}
-
-static int op_ldchl(void)		/* LD C,(HL) */
-{
-	C = memrdr((H << 8) + L);
-	return (7);
-}
-
-static int op_ldda(void)		/* LD D,A */
-{
-	D = A;
-	return (4);
-}
-
-static int op_lddb(void)		/* LD D,B */
-{
-	D = B;
-	return (4);
-}
-
-static int op_lddc(void)		/* LD D,C */
-{
-	D = C;
-	return (4);
-}
-
-static int op_lddd(void)		/* LD D,D */
-{
-	return (4);
-}
-
-static int op_ldde(void)		/* LD D,E */
-{
-	D = E;
-	return (4);
-}
-
-static int op_lddh(void)		/* LD D,H */
-{
-	D = H;
-	return (4);
-}
-
-static int op_lddl(void)		/* LD D,L */
-{
-	D = L;
-	return (4);
-}
-
-static int op_lddhl(void)		/* LD D,(HL) */
-{
-	D = memrdr((H << 8) + L);
-	return (7);
-}
-
-static int op_ldea(void)		/* LD E,A */
-{
-	E = A;
-	return (4);
-}
-
-static int op_ldeb(void)		/* LD E,B */
-{
-	E = B;
-	return (4);
-}
-
-static int op_ldec(void)		/* LD E,C */
-{
-	E = C;
-	return (4);
-}
-
-static int op_lded(void)		/* LD E,D */
-{
-	E = D;
-	return (4);
-}
-
-static int op_ldee(void)		/* LD E,E */
-{
-	return (4);
-}
-
-static int op_ldeh(void)		/* LD E,H */
-{
-	E = H;
-	return (4);
-}
-
-static int op_ldel(void)		/* LD E,L */
-{
-	E = L;
-	return (4);
-}
-
-static int op_ldehl(void)		/* LD E,(HL) */
-{
-	E = memrdr((H << 8) + L);
-	return (7);
-}
-
-static int op_ldha(void)		/* LD H,A */
-{
-	H = A;
-	return (4);
-}
-
-static int op_ldhb(void)		/* LD H,B */
-{
-	H = B;
-	return (4);
-}
-
-static int op_ldhc(void)		/* LD H,C */
-{
-	H = C;
-	return (4);
-}
-
-static int op_ldhd(void)		/* LD H,D */
-{
-	H = D;
-	return (4);
-}
-
-static int op_ldhe(void)		/* LD H,E */
-{
-	H = E;
-	return (4);
-}
-
-static int op_ldhh(void)		/* LD H,H */
-{
-	return (4);
-}
-
-static int op_ldhl(void)		/* LD H,L */
-{
-	H = L;
-	return (4);
-}
-
-static int op_ldhhl(void)		/* LD H,(HL) */
-{
-	H = memrdr((H << 8) + L);
-	return (7);
-}
-
-static int op_ldla(void)		/* LD L,A */
-{
-	L = A;
-	return (4);
-}
-
-static int op_ldlb(void)		/* LD L,B */
-{
-	L = B;
-	return (4);
-}
-
-static int op_ldlc(void)		/* LD L,C */
-{
-	L = C;
-	return (4);
-}
-
-static int op_ldld(void)		/* LD L,D */
-{
-	L = D;
-	return (4);
-}
-
-static int op_ldle(void)		/* LD L,E */
-{
-	L = E;
-	return (4);
-}
-
-static int op_ldlh(void)		/* LD L,H */
-{
-	L = H;
-	return (4);
-}
-
-static int op_ldll(void)		/* LD L,L */
-{
-	return (4);
-}
-
-static int op_ldlhl(void)		/* LD L,(HL) */
-{
-	L = memrdr((H << 8) + L);
-	return (7);
-}
-
-static int op_ldbcnn(void)		/* LD BC,nn */
-{
-	C = memrdr(PC++);
-	B = memrdr(PC++);
-	return (10);
-}
-
-static int op_lddenn(void)		/* LD DE,nn */
-{
-	E = memrdr(PC++);
-	D = memrdr(PC++);
-	return (10);
-}
-
-static int op_ldhlnn(void)		/* LD HL,nn */
-{
-	L = memrdr(PC++);
-	H = memrdr(PC++);
-	return (10);
-}
-
-static int op_ldspnn(void)		/* LD SP,nn */
-{
-	SP = memrdr(PC++);
-	SP += memrdr(PC++) << 8;
-	return (10);
-}
-
-static int op_ldsphl(void)		/* LD SP,HL */
-{
-	SP = (H << 8) + L;
-	return (6);
-}
-
-static int op_ldhlin(void)		/* LD HL,(nn) */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	L = memrdr(i++);
-	H = memrdr(i);
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (16);
-}
-
-static int op_ldinhl(void)		/* LD (nn),HL */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	memwrt(i++, L);
-	memwrt(i, H);
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (16);
-}
-
-static int op_incbc(void)		/* INC BC */
-{
-	C++;
-	if (!C)
-		B++;
-	return (6);
-}
-
-static int op_incde(void)		/* INC DE */
-{
-	E++;
-	if (!E)
-		D++;
-	return (6);
-}
-
-static int op_inchl(void)		/* INC HL */
-{
-	L++;
-	if (!L)
-		H++;
-	return (6);
-}
-
-static int op_incsp(void)		/* INC SP */
-{
-	SP++;
-	return (6);
-}
-
-static int op_decbc(void)		/* DEC BC */
-{
-	C--;
-	if (C == 0xff)
-		B--;
-	return (6);
-}
-
-static int op_decde(void)		/* DEC DE */
-{
-	E--;
-	if (E == 0xff)
-		D--;
-	return (6);
-}
-
-static int op_dechl(void)		/* DEC HL */
-{
-	L--;
-	if (L == 0xff)
-		H--;
-	return (6);
-}
-
-static int op_decsp(void)		/* DEC SP */
-{
-	SP--;
-	return (6);
-}
-
-static int op_adhlbc(void)		/* ADD HL,BC */
-{
-	register int carry;
-
-#ifdef UNDOC_FLAGS
-	WZ = ((H << 8) + L) + 1;
 #endif
-	carry = (L + C > 255) ? 1 : 0;
-	L += C;
-	((H & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(H + B + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	H += B + carry;
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (11);
-}
-
-static int op_adhlde(void)		/* ADD HL,DE */
-{
-	register int carry;
-
-#ifdef UNDOC_FLAGS
-	WZ = ((H << 8) + L) + 1;
-#endif
-	carry = (L + E > 255) ? 1 : 0;
-	L += E;
-	((H & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(H + D + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	H += D + carry;
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (11);
-}
-
-static int op_adhlhl(void)		/* ADD HL,HL */
-{
-	register int carry;
-
-#ifdef UNDOC_FLAGS
-	WZ = ((H << 8) + L) + 1;
-#endif
-	carry = (L << 1 > 255) ? 1 : 0;
-	L <<= 1;
-	((H & 0xf) + (H & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(H + H + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	H += H + carry;
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (11);
-}
-
-static int op_adhlsp(void)		/* ADD HL,SP */
-{
-	register int carry;
-
-	BYTE spl = SP & 0xff;
-	BYTE sph = SP >> 8;
-
-#ifdef UNDOC_FLAGS
-	WZ = ((H << 8) + L) + 1;
-#endif
-	carry = (L + spl > 255) ? 1 : 0;
-	L += spl;
-	((H & 0xf) + (sph & 0xf) + carry > 0xf) ? (F |= H_FLAG)
-						: (F &= ~H_FLAG);
-	(H + sph + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	H += sph + carry;
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (11);
-}
-
-static int op_anda(void)		/* AND A */
-{
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_andb(void)		/* AND B */
-{
-	A &= B;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_andc(void)		/* AND C */
-{
-	A &= C;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_andd(void)		/* AND D */
-{
-	A &= D;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_ande(void)		/* AND E */
-{
-	A &= E;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_andh(void)		/* AND H */
-{
-	A &= H;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_andl(void)		/* AND L */
-{
-	A &= L;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_andhl(void)		/* AND (HL) */
-{
-	A &= memrdr((H << 8) + L);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_andn(void)		/* AND n */
-{
-	A &= memrdr(PC++);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_ora(void)			/* OR A */
-{
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_orb(void)			/* OR B */
-{
-	A |= B;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_orc(void)			/* OR C */
-{
-	A |= C;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_ord(void)			/* OR D */
-{
-	A |= D;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_ore(void)			/* OR E */
-{
-	A |= E;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_orh(void)			/* OR H */
-{
-	A |= H;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_orl(void)			/* OR L */
-{
-	A |= L;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_orhl(void)		/* OR (HL) */
-{
-	A |= memrdr((H << 8) + L);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_orn(void)			/* OR n */
-{
-	A |= memrdr(PC++);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_xora(void)		/* XOR A */
-{
-	A = 0;
-	F &= ~(S_FLAG | H_FLAG | N_FLAG | C_FLAG);
-	F |= Z_FLAG | P_FLAG;
-#ifdef UNDOC_FLAGS
-	F &= ~(Y_FLAG | X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_xorb(void)		/* XOR B */
-{
-	A ^= B;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_xorc(void)		/* XOR C */
-{
-	A ^= C;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_xord(void)		/* XOR D */
-{
-	A ^= D;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_xore(void)		/* XOR E */
-{
-	A ^= E;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_xorh(void)		/* XOR H */
-{
-	A ^= H;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_xorl(void)		/* XOR L */
-{
-	A ^= L;
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_xorhl(void)		/* XOR (HL) */
-{
-	A ^= memrdr((H << 8) + L);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_xorn(void)		/* XOR n */
-{
-	A ^= memrdr(PC++);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
+	cpu_error = OPTRAP2;
+	cpu_state = STOPPED;
+	return (0);
 }
 
-static int op_adda(void)		/* ADD A,A */
+/*
+ *	This function traps undocumented opcodes following the
+ *	initial 0xdd 0xcb of a 4 byte opcode.
+ */
+static int trap_ddcb(int data)
 {
-	register int i;
+	UNUSED(data);
 
-	((A & 0xf) + (A & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	((A << 1) > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) A;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_addb(void)		/* ADD A,B */
-{
-	register int i;
-
-	((A & 0xf) + (B & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + B > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) B;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_addc(void)		/* ADD A,C */
-{
-	register int i;
-
-	((A & 0xf) + (C & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + C > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) C;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_addd(void)		/* ADD A,D */
-{
-	register int i;
-
-	((A & 0xf) + (D & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + D > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) D;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_adde(void)		/* ADD A,E */
-{
-	register int i;
-
-	((A & 0xf) + (E & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + E > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) E;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_addh(void)		/* ADD A,H */
-{
-	register int i;
-
-	((A & 0xf) + (H & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + H > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) H;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_addl(void)		/* ADD A,L */
-{
-	register int i;
-
-	((A & 0xf) + (L & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + L > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) L;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_addhl(void)		/* ADD A,(HL) */
-{
-	register int i;
-	register BYTE P;
-
-	P = memrdr((H << 8) + L);
-	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_addn(void)		/* ADD A,n */
-{
-	register int i;
-	register BYTE P;
-
-	P = memrdr(PC++);
-	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_adca(void)		/* ADC A,A */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((A & 0xf) + (A & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	((A << 1) + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) A + carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_adcb(void)		/* ADC A,B */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((A & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + B + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) B + carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_adcc(void)		/* ADC A,C */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((A & 0xf) + (C & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + C + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) C + carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_adcd(void)		/* ADC A,D */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((A & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + D + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) D + carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_adce(void)		/* ADC A,E */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((A & 0xf) + (E & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + E + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) E + carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_adch(void)		/* ADC A,H */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((A & 0xf) + (H & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + H + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) H + carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_adcl(void)		/* ADC A,L */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((A & 0xf) + (L & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + L + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) L + carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_adchl(void)		/* ADC A,(HL) */
-{
-	register int i, carry;
-	register BYTE P;
-
-	P = memrdr((H << 8) + L);
-	carry = (F & C_FLAG) ? 1 : 0;
-	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_adcn(void)		/* ADC A,n */
-{
-	register int i, carry;
-	register BYTE P;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	P = memrdr(PC++);
-	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_suba(void)		/* SUB A,A */
-{
-	A = 0;
-	F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
-	F |= Z_FLAG | N_FLAG;
-#ifdef UNDOC_FLAGS
-	F &= ~(Y_FLAG | X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_subb(void)		/* SUB A,B */
-{
-	register int i;
-
-	((B & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(B > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) B;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_subc(void)		/* SUB A,C */
-{
-	register int i;
-
-	((C & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(C > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) C;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_subd(void)		/* SUB A,D */
-{
-	register int i;
-
-	((D & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(D > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) D;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_sube(void)		/* SUB A,E */
-{
-	register int i;
-
-	((E & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(E > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) E;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_subh(void)		/* SUB A,H */
-{
-	register int i;
-
-	((H & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(H > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) H;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_subl(void)		/* SUB A,L */
-{
-	register int i;
-
-	((L & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(L > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) L;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
+	cpu_error = OPTRAP4;
+	cpu_state = STOPPED;
+	return (0);
 }
 
-static int op_subhl(void)		/* SUB A,(HL) */
+/*
+ *	This function traps undocumented opcodes following the
+ *	initial 0xed of a multi byte opcode.
+ */
+static int trap_ed(void)
 {
-	register int i;
-	register BYTE P;
-
-	P = memrdr((H << 8) + L);
-	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_subn(void)		/* SUB A,n */
-{
-	register int i;
-	register BYTE P;
-
-	P = memrdr(PC++);
-	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
+	cpu_error = OPTRAP2;
+	cpu_state = STOPPED;
+	return (0);
 }
 
-static int op_sbca(void)		/* SBC A,A */
+/*
+ *	This function traps undocumented opcodes following the
+ *	initial 0xfd of a multi byte opcode.
+ */
+static int trap_fd(void)
 {
-	if (F & C_FLAG) {
-		A = 255;
-		F |= S_FLAG | H_FLAG | N_FLAG | C_FLAG;
-		F &= ~(Z_FLAG | P_FLAG);
-#ifdef UNDOC_FLAGS
-		F |= Y_FLAG | X_FLAG;
-		modF = 1;
-#endif
-	} else {
-		A = 0;
-		F |= Z_FLAG | N_FLAG;
-		F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
-#ifdef UNDOC_FLAGS
-		F &= ~(Y_FLAG | X_FLAG);
-		modF = 1;
-#endif
+#ifdef UNDOC_INST
+	if (!u_flag) {
+		/* Treat 0xfd prefix as NOP on non IY-instructions */
+		PC--;
+		R--;
+		return (4);
 	}
-	return (4);
-}
-
-static int op_sbcb(void)		/* SBC A,B */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((B & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(B + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) B - carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_sbcc(void)		/* SBC A,C */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((C & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(C + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) C - carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_sbcd(void)		/* SBC A,D */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((D & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(D + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) D - carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_sbce(void)		/* SBC A,E */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((E & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(E + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) E - carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_sbch(void)		/* SBC A,H */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((H & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(H + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) H - carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_sbcl(void)		/* SBC A,L */
-{
-	register int i, carry;
-
-	carry = (F & C_FLAG) ? 1 : 0;
-	((L & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(L + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) L - carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_sbchl(void)		/* SBC A,(HL) */
-{
-	register int i, carry;
-	register BYTE P;
-
-	P = memrdr((H << 8) + L);
-	carry = (F & C_FLAG) ? 1 : 0;
-	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_sbcn(void)		/* SBC A,n */
-{
-	register int i, carry;
-	register BYTE P;
-
-	P = memrdr(PC++);
-	carry = (F & C_FLAG) ? 1 : 0;
-	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_cpa(void)			/* CP A */
-{
-	F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
-	F |= Z_FLAG | N_FLAG;
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_cpb(void)			/* CP B */
-{
-	register int i;
-
-	((B & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(B > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) B;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_cpc(void)			/* CP C */
-{
-	register int i;
-
-	((C & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(C > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) C;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_cpd(void)			/* CP D */
-{
-	register int i;
-
-	((D & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(D > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) D;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_cpe(void)			/* CP E */
-{
-	register int i;
-
-	((E & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(E > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) E;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_cph(void)			/* CP H */
-{
-	register int i;
-
-	((H & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(H > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) H;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_cplr(void)		/* CP L */
-{
-	register int i;
-
-	((L & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(L > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) L;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_cphl(void)		/* CP (HL) */
-{
-	register int i;
-	register BYTE P;
-
-	P = memrdr((H << 8) + L);
-	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_cpn(void)			/* CP n */
-{
-	register int i;
-	register BYTE P;
-
-	P = memrdr(PC++);
-	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
-	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (7);
-}
-
-static int op_inca(void)		/* INC A */
-{
-	A++;
-	((A & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_incb(void)		/* INC B */
-{
-	B++;
-	((B & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(B == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_incc(void)		/* INC C */
-{
-	C++;
-	((C & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(C == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_incd(void)		/* INC D */
-{
-	D++;
-	((D & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(D == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_ince(void)		/* INC E */
-{
-	E++;
-	((E & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(E == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_inch(void)		/* INC H */
-{
-	H++;
-	((H & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(H == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_incl(void)		/* INC L */
-{
-	L++;
-	((L & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(L == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_incihl(void)		/* INC (HL) */
-{
-	register BYTE P;
-	WORD addr;
-
-	addr = (H << 8) + L;
-	P = memrdr(addr);
-	P++;
-	memwrt(addr, P);
-	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(P == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
-#ifdef UNDOC_FLAGS
-	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (11);
-}
-
-static int op_deca(void)		/* DEC A */
-{
-	A--;
-	((A & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(A == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_decb(void)		/* DEC B */
-{
-	B--;
-	((B & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(B == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_decc(void)		/* DEC C */
-{
-	C--;
-	((C & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(C == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_decd(void)		/* DEC D */
-{
-	D--;
-	((D & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(D == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_dece(void)		/* DEC E */
-{
-	E--;
-	((E & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(E == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_dech(void)		/* DEC H */
-{
-	H--;
-	((H & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(H == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_decl(void)		/* DEC L */
-{
-	L--;
-	((L & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(L == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_decihl(void)		/* DEC (HL) */
-{
-	register BYTE P;
-	WORD addr;
-
-	addr = (H << 8) + L;
-	P = memrdr(addr);
-	P--;
-	memwrt(addr, P);
-	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-	(P == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
-	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
-#ifdef UNDOC_FLAGS
-	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (11);
-}
-
-static int op_rlca(void)		/* RLCA */
-{
-	register int i;
-
-	i = (A & 128) ? 1 : 0;
-	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	F &= ~(H_FLAG | N_FLAG);
-	A <<= 1;
-	A |= i;
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_rrca(void)		/* RRCA */
-{
-	register int i;
-
-	i = A & 1;
-	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	F &= ~(H_FLAG | N_FLAG);
-	A >>= 1;
-	if (i) A |= 128;
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_rla(void)			/* RLA */
-{
-	register int old_c_flag;
-
-	old_c_flag = F & C_FLAG;
-	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	F &= ~(H_FLAG | N_FLAG);
-	A <<= 1;
-	if (old_c_flag) A |= 1;
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_rra(void)			/* RRA */
-{
-	register int i, old_c_flag;
-
-	old_c_flag = F & C_FLAG;
-	i = A & 1;
-	(i) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	F &= ~(H_FLAG | N_FLAG);
-	A >>= 1;
-	if (old_c_flag) A |= 128;
-#ifdef UNDOC_FLAGS
-	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
-	modF = 1;
-#endif
-	return (4);
-}
-
-static int op_exdehl(void)		/* EX DE,HL */
-{
-	register BYTE i;
-
-	i = D;
-	D = H;
-	H = i;
-	i = E;
-	E = L;
-	L = i;
-	return (4);
-}
-
-static int op_exafaf(void)		/* EX AF,AF' */
-{
-	register BYTE i;
-
-	i = A;
-	A = A_;
-	A_ = i;
-	i = F;
-	F = F_;
-	F_ = i;
-	return (4);
-}
-
-static int op_exx(void)			/* EXX */
-{
-	register BYTE i;
-
-	i = B;
-	B = B_;
-	B_ = i;
-	i = C;
-	C = C_;
-	C_ = i;
-	i = D;
-	D = D_;
-	D_ = i;
-	i = E;
-	E = E_;
-	E_ = i;
-	i = H;
-	H = H_;
-	H_ = i;
-	i = L;
-	L = L_;
-	L_ = i;
-	return (4);
-}
-
-static int op_exsphl(void)		/* EX (SP),HL */
-{
-	register BYTE i;
-
-	i = memrdr(SP);
-	memwrt(SP, L);
-	L = i;
-	i = memrdr(SP + 1);
-	memwrt(SP + 1, H);
-	H = i;
-#ifdef UNDOC_FLAGS
-	WZ = (H << 8) + L;
-#endif
-	return (19);
-}
-
-static int op_pushaf(void)		/* PUSH AF */
-{
-	memwrt(--SP, A);
-	memwrt(--SP, F);
-	return (11);
-}
-
-static int op_pushbc(void)		/* PUSH BC */
-{
-	memwrt(--SP, B);
-	memwrt(--SP, C);
-	return (11);
-}
-
-static int op_pushde(void)		/* PUSH DE */
-{
-	memwrt(--SP, D);
-	memwrt(--SP, E);
-	return (11);
-}
-
-static int op_pushhl(void)		/* PUSH HL */
-{
-	memwrt(--SP, H);
-	memwrt(--SP, L);
-	return (11);
-}
-
-static int op_popaf(void)		/* POP AF */
-{
-	F = memrdr(SP++);
-	A = memrdr(SP++);
-	return (10);
-}
-
-static int op_popbc(void)		/* POP BC */
-{
-	C = memrdr(SP++);
-	B = memrdr(SP++);
-	return (10);
-}
-
-static int op_popde(void)		/* POP DE */
-{
-	E = memrdr(SP++);
-	D = memrdr(SP++);
-	return (10);
-}
-
-static int op_pophl(void)		/* POP HL */
-{
-	L = memrdr(SP++);
-	H = memrdr(SP++);
-	return (10);
-}
-
-static int op_jp(void)			/* JP */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC) << 8;
-	PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_jphl(void)		/* JP (HL) */
-{
-	PC = (H << 8) + L;
-	return (4);
-}
-
-static int op_jr(void)			/* JR */
-{
-	register int d;
-
-	d = (signed char) memrdr(PC++);
-	PC += d;
-#ifdef UNDOC_FLAGS
-	WZ = PC;
-#endif
-	return (12);
-}
-
-static int op_djnz(void)		/* DJNZ */
-{
-	register int d;
-	register int t = 8;
-
-	d = (signed char) memrdr(PC++);
-	if (--B) {
-		PC += d;
-		t += 5;
-#ifdef UNDOC_FLAGS
-		WZ = PC;
-#endif
-	}
-	return (t);
-}
-
-static int op_call(void)		/* CALL */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (17);
-}
-
-static int op_ret(void)			/* RET */
-{
-	register WORD i;
-
-	i = memrdr(SP++);
-	i += memrdr(SP++) << 8;
-	PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_jpz(void)			/* JP Z,nn */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (F & Z_FLAG)
-		PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_jpnz(void)		/* JP NZ,nn */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (!(F & Z_FLAG))
-		PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_jpc(void)			/* JP C,nn */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (F & C_FLAG)
-		PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_jpnc(void)		/* JP NC,nn */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (!(F & C_FLAG))
-		PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_jppe(void)		/* JP PE,nn */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (F & P_FLAG)
-		PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_jppo(void)		/* JP PO,nn */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (!(F & P_FLAG))
-		PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_jpm(void)			/* JP M,nn */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (F & S_FLAG)
-		PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_jpp(void)			/* JP P,nn */
-{
-	register WORD i;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (!(F & S_FLAG))
-		PC = i;
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (10);
-}
-
-static int op_calz(void)		/* CALL Z,nn */
-{
-	register WORD i;
-	register int t = 10;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (F & Z_FLAG) {
-		memwrt(--SP, PC >> 8);
-		memwrt(--SP, PC);
-		PC = i;
-		t += 7;
-	}
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (t);
-}
-
-static int op_calnz(void)		/* CALL NZ,nn */
-{
-	register WORD i;
-	register int t = 10;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (!(F & Z_FLAG)) {
-		memwrt(--SP, PC >> 8);
-		memwrt(--SP, PC);
-		PC = i;
-		t += 7;
-	}
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (t);
-}
-
-static int op_calc(void)		/* CALL C,nn */
-{
-	register WORD i;
-	register int t = 10;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (F & C_FLAG) {
-		memwrt(--SP, PC >> 8);
-		memwrt(--SP, PC);
-		PC = i;
-		t += 7;
-	}
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (t);
-}
-
-static int op_calnc(void)		/* CALL NC,nn */
-{
-	register WORD i;
-	register int t = 10;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (!(F & C_FLAG)) {
-		memwrt(--SP, PC >> 8);
-		memwrt(--SP, PC);
-		PC = i;
-		t += 7;
-	}
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (t);
-}
-
-static int op_calpe(void)		/* CALL PE,nn */
-{
-	register WORD i;
-	register int t = 10;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (F & P_FLAG) {
-		memwrt(--SP, PC >> 8);
-		memwrt(--SP, PC);
-		PC = i;
-		t += 7;
-	}
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (t);
-}
-
-static int op_calpo(void)		/* CALL PO,nn */
-{
-	register WORD i;
-	register int t = 10;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (!(F & P_FLAG)) {
-		memwrt(--SP, PC >> 8);
-		memwrt(--SP, PC);
-		PC = i;
-		t += 7;
-	}
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (t);
-}
-
-static int op_calm(void)		/* CALL M,nn */
-{
-	register WORD i;
-	register int t = 10;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (F & S_FLAG) {
-		memwrt(--SP, PC >> 8);
-		memwrt(--SP, PC);
-		PC = i;
-		t += 7;
-	}
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (t);
-}
-
-static int op_calp(void)		/* CALL P,nn */
-{
-	register WORD i;
-	register int t = 10;
-
-	i = memrdr(PC++);
-	i += memrdr(PC++) << 8;
-	if (!(F & S_FLAG)) {
-		memwrt(--SP, PC >> 8);
-		memwrt(--SP, PC);
-		PC = i;
-		t += 7;
-	}
-#ifdef UNDOC_FLAGS
-	WZ = i;
-#endif
-	return (t);
-}
-
-static int op_retz(void)		/* RET Z */
-{
-	register WORD i;
-	register int t = 5;
-
-	if (F & Z_FLAG) {
-		i = memrdr(SP++);
-		i += memrdr(SP++) << 8;
-		PC = i;
-		t += 6;
-#ifdef UNDOC_FLAGS
-		WZ = i;
-#endif
-	}
-	return (t);
-}
-
-static int op_retnz(void)		/* RET NZ */
-{
-	register WORD i;
-	register int t = 5;
-
-	if (!(F & Z_FLAG)) {
-		i = memrdr(SP++);
-		i += memrdr(SP++) << 8;
-		PC = i;
-		t += 6;
-#ifdef UNDOC_FLAGS
-		WZ = i;
-#endif
-	}
-	return (t);
-}
-
-static int op_retc(void)		/* RET C */
-{
-	register WORD i;
-	register int t = 5;
-
-	if (F & C_FLAG) {
-		i = memrdr(SP++);
-		i += memrdr(SP++) << 8;
-		PC = i;
-		t += 6;
-#ifdef UNDOC_FLAGS
-		WZ = i;
-#endif
-	}
-	return (t);
-}
-
-static int op_retnc(void)		/* RET NC */
-{
-	register WORD i;
-	register int t = 5;
-
-	if (!(F & C_FLAG)) {
-		i = memrdr(SP++);
-		i += memrdr(SP++) << 8;
-		PC = i;
-		t += 6;
-#ifdef UNDOC_FLAGS
-		WZ = i;
-#endif
-	}
-	return (t);
-}
-
-static int op_retpe(void)		/* RET PE */
-{
-	register WORD i;
-	register int t = 5;
-
-	if (F & P_FLAG) {
-		i = memrdr(SP++);
-		i += memrdr(SP++) << 8;
-		PC = i;
-		t += 6;
-#ifdef UNDOC_FLAGS
-		WZ = i;
-#endif
-	}
-	return (t);
-}
-
-static int op_retpo(void)		/* RET PO */
-{
-	register WORD i;
-	register int t = 5;
-
-	if (!(F & P_FLAG)) {
-		i = memrdr(SP++);
-		i += memrdr(SP++) << 8;
-		PC = i;
-		t += 6;
-#ifdef UNDOC_FLAGS
-		WZ = i;
-#endif
-	}
-	return (t);
-}
-
-static int op_retm(void)		/* RET M */
-{
-	register WORD i;
-	register int t = 5;
-
-	if (F & S_FLAG) {
-		i = memrdr(SP++);
-		i += memrdr(SP++) << 8;
-		PC = i;
-		t += 6;
-#ifdef UNDOC_FLAGS
-		WZ = i;
-#endif
-	}
-	return (t);
-}
-
-static int op_retp(void)		/* RET P */
-{
-	register WORD i;
-	register int t = 5;
-
-	if (!(F & S_FLAG)) {
-		i = memrdr(SP++);
-		i += memrdr(SP++) << 8;
-		PC = i;
-		t += 6;
-#ifdef UNDOC_FLAGS
-		WZ = i;
-#endif
-	}
-	return (t);
-}
-
-static int op_jrz(void)			/* JR Z,n */
-{
-	register int d;
-	register int t = 7;
-
-	d = (signed char) memrdr(PC++);
-	if (F & Z_FLAG) {
-		PC += d;
-		t += 5;
-#ifdef UNDOC_FLAGS
-		WZ = PC;
-#endif
-	}
-	return (t);
-}
-
-static int op_jrnz(void)		/* JR NZ,n */
-{
-	register int d;
-	register int t = 7;
-
-	d = (signed char) memrdr(PC++);
-	if (!(F & Z_FLAG)) {
-		PC += d;
-		t += 5;
-#ifdef UNDOC_FLAGS
-		WZ = PC;
-#endif
-	}
-	return (t);
-}
-
-static int op_jrc(void)			/* JR C,n */
-{
-	register int d;
-	register int t = 7;
-
-	d = (signed char) memrdr(PC++);
-	if (F & C_FLAG) {
-		PC += d;
-		t += 5;
-#ifdef UNDOC_FLAGS
-		WZ = PC;
-#endif
-	}
-	return (t);
-}
-
-static int op_jrnc(void)		/* JR NC,n */
-{
-	register int d;
-	register int t = 7;
-
-	d = (signed char) memrdr(PC++);
-	if (!(F & C_FLAG)) {
-		PC += d;
-		t += 5;
-#ifdef UNDOC_FLAGS
-		WZ = PC;
-#endif
-	}
-	return (t);
-}
-
-static int op_rst00(void)		/* RST 00 */
-{
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = 0;
-#ifdef UNDOC_FLAGS
-	WZ = PC;
-#endif
-	return (11);
-}
-
-static int op_rst08(void)		/* RST 08 */
-{
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = 0x08;
-#ifdef UNDOC_FLAGS
-	WZ = PC;
-#endif
-	return (11);
-}
-
-static int op_rst10(void)		/* RST 10 */
-{
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = 0x10;
-#ifdef UNDOC_FLAGS
-	WZ = PC;
-#endif
-	return (11);
-}
-
-static int op_rst18(void)		/* RST 18 */
-{
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = 0x18;
-#ifdef UNDOC_FLAGS
-	WZ = PC;
 #endif
-	return (11);
+	cpu_error = OPTRAP2;
+	cpu_state = STOPPED;
+	return (0);
 }
 
-static int op_rst20(void)		/* RST 20 */
+/*
+ *	This function traps undocumented opcodes following the
+ *	initial 0xfd 0xcb of a 4 byte opcode.
+ */
+static int trap_fdcb(int data)
 {
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = 0x20;
-#ifdef UNDOC_FLAGS
-	WZ = PC;
-#endif
-	return (11);
-}
-
-static int op_rst28(void)		/* RST 28 */
-{
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = 0x28;
-#ifdef UNDOC_FLAGS
-	WZ = PC;
-#endif
-	return (11);
-}
+	UNUSED(data);
 
-static int op_rst30(void)		/* RST 30 */
-{
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = 0x30;
-#ifdef UNDOC_FLAGS
-	WZ = PC;
-#endif
-	return (11);
-}
-
-static int op_rst38(void)		/* RST 38 */
-{
-	memwrt(--SP, PC >> 8);
-	memwrt(--SP, PC);
-	PC = 0x38;
-#ifdef UNDOC_FLAGS
-	WZ = PC;
-#endif
-	return (11);
+	cpu_error = OPTRAP4;
+	cpu_state = STOPPED;
+	return (0);
 }
 
-#endif
+#endif /* !EXCLUDE_Z80 */

--- a/z80sim/srcsim/Makefile
+++ b/z80sim/srcsim/Makefile
@@ -77,8 +77,7 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
-	simz80-fd.c simz80-fdcb.c
+	simmain.c simz80.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -16,10 +16,10 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 /*#define UNDOC_INST*/	/* compile undocumented instructions */
-#define UNDOC_FLAGS	/* compile undocumented flags */
-/*#define FAST_INSTR*/	/* faster instructions, but less debuggable */
-/*#define WANT_FASTB*/	/* much faster but not accurate Z80 block instr. */
-/*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
+/*#define UNDOC_IALL*/	/* compile rarely used undoc'd Z80 instructions */
+/*#define UNDOC_FLAGS*/	/* compile undocumented Z80 flags */
+/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 
 #define WANT_ICE	/* attach ICE to headless machine */
 #define WANT_TIM	/* count t-states */

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -17,10 +17,10 @@
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 #define UNDOC_INST	/* compile undocumented instructions */
-#define UNDOC_FLAGS	/* compile undocumented flags */
-#define FAST_INSTR	/* faster instructions, but less debuggable */
-#define WANT_FASTB	/* much faster but not accurate Z80 block instr. */
-/*#define CORE_LOG*/	/* don't use LOG() logging in core simulator */
+#define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
+#define UNDOC_FLAGS	/* compile undocumented Z80 flags */
+#define FAST_INSTR	/* faster instr. & smaller size, but less debuggable */
+#define FAST_BLOCK	/* much faster but not accurate Z80 block instr. */
 
 #define WANT_ICE	/* attach ICE to headless machine */
 /*#define WANT_TIM*/	/* count t-states */

--- a/z80sim/z80test/z80sim.patch
+++ b/z80sim/z80test/z80sim.patch
@@ -1,34 +1,36 @@
 diff --git a/z80sim/srcsim/iosim.c b/z80sim/srcsim/iosim.c
-index 983d881..fc54d88 100644
+index c60ec2f..8b778a9 100644
 --- a/z80sim/srcsim/iosim.c
 +++ b/z80sim/srcsim/iosim.c
-@@ -29,7 +29,7 @@
-  */
+@@ -30,6 +30,7 @@
  static BYTE io_trap_in(void);
  static void io_trap_out(BYTE);
--static BYTE p000_in(void), p001_in(void);
-+static BYTE p000_in(void), p001_in(void), p254_in(void);
- static void p001_out(BYTE);
+ static BYTE p000_in(void), p001_in(void), p255_in(void);
++static BYTE p254_in(void);
+ static void p001_out(BYTE), p255_out(BYTE);
  
- /*
-@@ -70,6 +70,7 @@ void init_io(void)
+ static BYTE sio_last;	/* last byte read from sio */
+@@ -73,6 +74,7 @@ void init_io(void)
  		port_in[i] = io_trap_in;
  		port_out[i] = io_trap_out;
  	}
-+	port_in[254] = p254_in;
++	port_in[254] = p254_in; /* for z80test */
+ 	port_in[255] = p255_in; /* for frontpanel */
+ 	port_out[255] = p255_out;
+ }
+@@ -192,6 +194,15 @@ static BYTE p001_in(void)
+ 	}
  }
  
- /*
-@@ -185,3 +186,12 @@ static void p001_out(BYTE data)
- 	putchar((int) data);
- 	fflush(stdout);
- }
-+
 +/*
 + *	I/O function port 254 read:
-+ *	Return 0xbf as ZX Spectrum
++ *	Return 0xbf as ZX Spectrum (used by z80test)
 + */
 +static BYTE p254_in(void)
 +{
 +	return ((BYTE) 0xbf);
 +}
++
+ /*
+  *	I/O function port 255 read:
+  *	used by frontpanel machines


### PR DESCRIPTION
[Got unfortunately really large, couldn't be helped]

Same as done to the 8080 simulator.

Renamed WANT_FASTB to FAST_BLOCK.

Also new define UNDOC_IALL. When disabled only compiles in the more useful/used IXL, IXH, IYL, IYH, basic SLL, OUT (C),0, and IN F,(C) instructions. [Still runs exz80all, but not z80test without UNDOC_IALL]

So with UNDOC_INST, UNDOC_IALL, UNDOC_FLAGS, FAST_INSTR, FAST_BLOCK, EXCLUDE_Z80, and EXCLUDE_I8080 full configurability for small SOC usage.

Updated z80test patch for z80sim. Didn't apply anymore.