### PR TITLE
implemented flag tables for the Z80 like the 8080

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -39,7 +39,8 @@
 #define UNDOC_INST	/* compile undocumented instructions */
 #define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
 #define UNDOC_FLAGS	/* compile undocumented Z80 flags */
-/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define INSTR_SWTCH*/	/* big switch instead of functions, less debuggable */
+/*#define FLAG_TABLES*/	/* use table lookups for flags */
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -16,7 +16,8 @@
 #define UNDOC_INST	/* compile undocumented instructions */
 #define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
 #define UNDOC_FLAGS	/* compile undocumented Z80 flags */
-#define FAST_INSTR	/* faster instr. & smaller size, but less debuggable */
+#define INSTR_SWTCH	/* big switch instead of functions, less debuggable */
+#define FLAG_TABLES	/* use table lookups for flags */
 #define FAST_BLOCK	/* much faster but not accurate Z80 block instr. */
 
 /*#define WANT_ICE*/	/* attach ICE to machine */

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -40,7 +40,8 @@
 #define UNDOC_INST	/* compile undocumented instructions */
 #define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
 #define UNDOC_FLAGS	/* compile undocumented Z80 flags */
-/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define INSTR_SWTCH*/	/* big switch instead of functions, less debuggable */
+/*#define FLAG_TABLES*/	/* use table lookups for flags */
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -40,7 +40,8 @@
 #define UNDOC_INST	/* compile undocumented instructions */
 #define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
 #define UNDOC_FLAGS	/* compile undocumented Z80 flags */
-/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define INSTR_SWTCH*/	/* big switch instead of functions, less debuggable */
+/*#define FLAG_TABLES*/	/* use table lookups for flags */
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -25,7 +25,8 @@
 #define UNDOC_INST	/* compile undocumented instructions */
 #define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
 #define UNDOC_FLAGS	/* compile undocumented Z80 flags */
-/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define INSTR_SWTCH*/	/* big switch instead of functions, less debuggable */
+/*#define FLAG_TABLES*/	/* use table lookups for flags */
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 #define EXCLUDE_I8080	/* this was a Z80 machine */
 

--- a/picosim/sim.h
+++ b/picosim/sim.h
@@ -17,7 +17,8 @@
 #define UNDOC_INST	/* compile undocumented instructions */
 #define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
 #define UNDOC_FLAGS	/* compile undocumented Z80 flags */
-#define FAST_INSTR	/* faster instr. & smaller size, but less debuggable */
+#define INSTR_SWTCH	/* big switch instead of functions, less debuggable */
+#define FLAG_TABLES	/* use table lookups for flags */
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 #define BAREMETAL	/* set up the simulator core for bare metal use */
 

--- a/z80core/sim8080-00.c
+++ b/z80core/sim8080-00.c
@@ -6,8 +6,7 @@
  */
 
 /*
- *	This module contains the implementation of all
- *	8080 instructions
+ *	This module contains the implementation of all 8080 instructions
  */
 
 INSTR(0x00, op_nop)			/* NOP */
@@ -114,7 +113,7 @@ INSTR(0x27, op_daa)			/* DAA */
 	if (tmp_a & 0x100)
 		(F |= C_FLAG);
 	A = tmp_a & 0xff;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -826,7 +825,7 @@ INSTR(0xa7, op_anaa)			/* ANA A */
 #else
 	(A & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 #endif
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -845,7 +844,7 @@ INSTR(0xa0, op_anab)			/* ANA B */
 	((A | B) & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 #endif
 	A &= B;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -864,7 +863,7 @@ INSTR(0xa1, op_anac)			/* ANA C */
 	((A | C) & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 #endif
 	A &= C;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -883,7 +882,7 @@ INSTR(0xa2, op_anad)			/* ANA D */
 	((A | D) & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 #endif
 	A &= D;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -902,7 +901,7 @@ INSTR(0xa3, op_anae)			/* ANA E */
 	((A | E) & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 #endif
 	A &= E;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -921,7 +920,7 @@ INSTR(0xa4, op_anah)			/* ANA H */
 	((A | H) & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 #endif
 	A &= H;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -940,7 +939,7 @@ INSTR(0xa5, op_anal)			/* ANA L */
 	((A | L) & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 #endif
 	A &= L;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -962,7 +961,7 @@ INSTR(0xa6, op_anam)			/* ANA M */
 	((A | P) & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 #endif
 	A &= P;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -984,7 +983,7 @@ INSTR(0xe6, op_anin)			/* ANI n */
 	((A | P) & 8) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 #endif
 	A &= P;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -997,7 +996,7 @@ INSTR(0xe6, op_anin)			/* ANI n */
 
 INSTR(0xb7, op_oraa)			/* ORA A */
 {
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1011,7 +1010,7 @@ INSTR(0xb7, op_oraa)			/* ORA A */
 INSTR(0xb0, op_orab)			/* ORA B */
 {
 	A |= B;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1025,7 +1024,7 @@ INSTR(0xb0, op_orab)			/* ORA B */
 INSTR(0xb1, op_orac)			/* ORA C */
 {
 	A |= C;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1039,7 +1038,7 @@ INSTR(0xb1, op_orac)			/* ORA C */
 INSTR(0xb2, op_orad)			/* ORA D */
 {
 	A |= D;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1053,7 +1052,7 @@ INSTR(0xb2, op_orad)			/* ORA D */
 INSTR(0xb3, op_orae)			/* ORA E */
 {
 	A |= E;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1067,7 +1066,7 @@ INSTR(0xb3, op_orae)			/* ORA E */
 INSTR(0xb4, op_orah)			/* ORA H */
 {
 	A |= H;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1081,7 +1080,7 @@ INSTR(0xb4, op_orah)			/* ORA H */
 INSTR(0xb5, op_oral)			/* ORA L */
 {
 	A |= L;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1095,7 +1094,7 @@ INSTR(0xb5, op_oral)			/* ORA L */
 INSTR(0xb6, op_oram)			/* ORA M */
 {
 	A |= memrdr((H << 8) + L);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1109,7 +1108,7 @@ INSTR(0xb6, op_oram)			/* ORA M */
 INSTR(0xf6, op_orin)			/* ORI n */
 {
 	A |= memrdr(PC++);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1131,7 +1130,7 @@ INSTR(0xaf, op_xraa)			/* XRA A */
 INSTR(0xa8, op_xrab)			/* XRA B */
 {
 	A ^= B;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1145,7 +1144,7 @@ INSTR(0xa8, op_xrab)			/* XRA B */
 INSTR(0xa9, op_xrac)			/* XRA C */
 {
 	A ^= C;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1159,7 +1158,7 @@ INSTR(0xa9, op_xrac)			/* XRA C */
 INSTR(0xaa, op_xrad)			/* XRA D */
 {
 	A ^= D;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1173,7 +1172,7 @@ INSTR(0xaa, op_xrad)			/* XRA D */
 INSTR(0xab, op_xrae)			/* XRA E */
 {
 	A ^= E;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1187,7 +1186,7 @@ INSTR(0xab, op_xrae)			/* XRA E */
 INSTR(0xac, op_xrah)			/* XRA H */
 {
 	A ^= H;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1201,7 +1200,7 @@ INSTR(0xac, op_xrah)			/* XRA H */
 INSTR(0xad, op_xral)			/* XRA L */
 {
 	A ^= L;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1215,7 +1214,7 @@ INSTR(0xad, op_xral)			/* XRA L */
 INSTR(0xae, op_xram)			/* XRA M */
 {
 	A ^= memrdr((H << 8) + L);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1229,7 +1228,7 @@ INSTR(0xae, op_xram)			/* XRA M */
 INSTR(0xee, op_xrin)			/* XRI n */
 {
 	A ^= memrdr(PC++);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1245,7 +1244,7 @@ INSTR(0x87, op_adda)			/* ADD A */
 	((A & 0xf) + (A & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	((A << 1) > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A << 1;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1260,7 +1259,7 @@ INSTR(0x80, op_addb)			/* ADD B */
 	((A & 0xf) + (B & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + B > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + B;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1275,7 +1274,7 @@ INSTR(0x81, op_addc)			/* ADD C */
 	((A & 0xf) + (C & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + C > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + C;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1290,7 +1289,7 @@ INSTR(0x82, op_addd)			/* ADD D */
 	((A & 0xf) + (D & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + D > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + D;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1305,7 +1304,7 @@ INSTR(0x83, op_adde)			/* ADD E */
 	((A & 0xf) + (E & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + E > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + E;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1320,7 +1319,7 @@ INSTR(0x84, op_addh)			/* ADD H */
 	((A & 0xf) + (H & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + H > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + H;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1335,7 +1334,7 @@ INSTR(0x85, op_addl)			/* ADD L */
 	((A & 0xf) + (L & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + L > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + L;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1353,7 +1352,7 @@ INSTR(0x86, op_addm)			/* ADD M */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + P;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1371,7 +1370,7 @@ INSTR(0xc6, op_adin)			/* ADI n */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + P;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1389,7 +1388,7 @@ INSTR(0x8f, op_adca)			/* ADC A */
 	((A & 0xf) + (A & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	((A << 1) + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = (A << 1) + carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1407,7 +1406,7 @@ INSTR(0x88, op_adcb)			/* ADC B */
 	((A & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + B + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + B + carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1425,7 +1424,7 @@ INSTR(0x89, op_adcc)			/* ADC C */
 	((A & 0xf) + (C & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + C + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + C + carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1443,7 +1442,7 @@ INSTR(0x8a, op_adcd)			/* ADC D */
 	((A & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + D + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + D + carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1461,7 +1460,7 @@ INSTR(0x8b, op_adce)			/* ADC E */
 	((A & 0xf) + (E & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + E + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + E + carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1479,7 +1478,7 @@ INSTR(0x8c, op_adch)			/* ADC H */
 	((A & 0xf) + (H & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + H + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + H + carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1497,7 +1496,7 @@ INSTR(0x8d, op_adcl)			/* ADC L */
 	((A & 0xf) + (L & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + L + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + L + carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1517,7 +1516,7 @@ INSTR(0x8e, op_adcm)			/* ADC M */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + P + carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1537,7 +1536,7 @@ INSTR(0xce, op_acin)			/* ACI n */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A + P + carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1560,7 +1559,7 @@ INSTR(0x90, op_subb)			/* SUB B */
 	((B & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(B > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - B;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1575,7 +1574,7 @@ INSTR(0x91, op_subc)			/* SUB C */
 	((C & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(C > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - C;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1590,7 +1589,7 @@ INSTR(0x92, op_subd)			/* SUB D */
 	((D & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(D > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - D;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1605,7 +1604,7 @@ INSTR(0x93, op_sube)			/* SUB E */
 	((E & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(E > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - E;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1620,7 +1619,7 @@ INSTR(0x94, op_subh)			/* SUB H */
 	((H & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(H > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - H;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1635,7 +1634,7 @@ INSTR(0x95, op_subl)			/* SUB L */
 	((L & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(L > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - L;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1653,7 +1652,7 @@ INSTR(0x96, op_subm)			/* SUB M */
 	((P & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - P;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1671,7 +1670,7 @@ INSTR(0xd6, op_suin)			/* SUI n */
 	((P & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - P;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1703,7 +1702,7 @@ INSTR(0x98, op_sbbb)			/* SBB B */
 	((B & 0xf) + carry > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(B + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - B - carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1721,7 +1720,7 @@ INSTR(0x99, op_sbbc)			/* SBB C */
 	((C & 0xf) + carry > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(C + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - C - carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1739,7 +1738,7 @@ INSTR(0x9a, op_sbbd)			/* SBB D */
 	((D & 0xf) + carry > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(D + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - D - carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1757,7 +1756,7 @@ INSTR(0x9b, op_sbbe)			/* SBB E */
 	((E & 0xf) + carry > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(E + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - E - carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1775,7 +1774,7 @@ INSTR(0x9c, op_sbbh)			/* SBB H */
 	((H & 0xf) + carry > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(H + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - H - carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1793,7 +1792,7 @@ INSTR(0x9d, op_sbbl)			/* SBB L */
 	((L & 0xf) + carry > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(L + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - L - carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1813,7 +1812,7 @@ INSTR(0x9e, op_sbbm)			/* SBB M */
 	((P & 0xf) + carry > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - P - carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1833,7 +1832,7 @@ INSTR(0xde, op_sbin)			/* SBI n */
 	((P & 0xf) + carry > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A - P - carry;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1857,7 +1856,7 @@ INSTR(0xb8, op_cmpb)			/* CMP B */
 	((B & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(B > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = A - B;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1874,7 +1873,7 @@ INSTR(0xb9, op_cmpc)			/* CMP C */
 	((C & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(C > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = A - C;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1891,7 +1890,7 @@ INSTR(0xba, op_cmpd)			/* CMP D */
 	((D & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(D > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = A - D;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1908,7 +1907,7 @@ INSTR(0xbb, op_cmpe)			/* CMP E */
 	((E & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(E > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = A - E;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1925,7 +1924,7 @@ INSTR(0xbc, op_cmph)			/* CMP H */
 	((H & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(H > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = A - H;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1942,7 +1941,7 @@ INSTR(0xbd, op_cmpl)			/* CMP L */
 	((L & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(L > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = A - L;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1961,7 +1960,7 @@ INSTR(0xbe, op_cmpm)			/* CMP M */
 	((P & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = A - P;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1980,7 +1979,7 @@ INSTR(0xfe, op_cpin)			/* CPI n */
 	((P & 0xf) > (A & 0xf)) ? (F &= ~H_FLAG) : (F |= H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	i = A - P;
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[i]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1994,7 +1993,7 @@ INSTR(0x3c, op_inra)			/* INR A */
 {
 	A++;
 	((A & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2008,7 +2007,7 @@ INSTR(0x04, op_inrb)			/* INR B */
 {
 	B++;
 	((B & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2022,7 +2021,7 @@ INSTR(0x0c, op_inrc)			/* INR C */
 {
 	C++;
 	((C & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2036,7 +2035,7 @@ INSTR(0x14, op_inrd)			/* INR D */
 {
 	D++;
 	((D & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2050,7 +2049,7 @@ INSTR(0x1c, op_inre)			/* INR E */
 {
 	E++;
 	((E & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2064,7 +2063,7 @@ INSTR(0x24, op_inrh)			/* INR H */
 {
 	H++;
 	((H & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2078,7 +2077,7 @@ INSTR(0x2c, op_inrl)			/* INR L */
 {
 	L++;
 	((L & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2098,7 +2097,7 @@ INSTR(0x34, op_inrm)			/* INR M */
 	P++;
 	memwrt(addr, P);
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2112,7 +2111,7 @@ INSTR(0x3d, op_dcra)			/* DCR A */
 {
 	A--;
 	((A & 0xf) == 0xf) ? (F &= ~H_FLAG) : (F |= H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2126,7 +2125,7 @@ INSTR(0x05, op_dcrb)			/* DCR B */
 {
 	B--;
 	((B & 0xf) == 0xf) ? (F &= ~H_FLAG) : (F |= H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2140,7 +2139,7 @@ INSTR(0x0d, op_dcrc)			/* DCR C */
 {
 	C--;
 	((C & 0xf) == 0xf) ? (F &= ~H_FLAG) : (F |= H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2154,7 +2153,7 @@ INSTR(0x15, op_dcrd)			/* DCR D */
 {
 	D--;
 	((D & 0xf) == 0xf) ? (F &= ~H_FLAG) : (F |= H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2168,7 +2167,7 @@ INSTR(0x1d, op_dcre)			/* DCR E */
 {
 	E--;
 	((E & 0xf) == 0xf) ? (F &= ~H_FLAG) : (F |= H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2182,7 +2181,7 @@ INSTR(0x25, op_dcrh)			/* DCR H */
 {
 	H--;
 	((H & 0xf) == 0xf) ? (F &= ~H_FLAG) : (F |= H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2196,7 +2195,7 @@ INSTR(0x2d, op_dcrl)			/* DCR L */
 {
 	L--;
 	((L & 0xf) == 0xf) ? (F &= ~H_FLAG) : (F |= H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2216,7 +2215,7 @@ INSTR(0x35, op_dcrm)			/* DCR M */
 	P--;
 	memwrt(addr, P);
 	((P & 0xf) == 0xf) ? (F &= ~H_FLAG) : (F |= H_FLAG);
-#ifndef FAST_INSTR
+#ifndef FLAG_TABLES
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2883,7 +2882,7 @@ INSTR(0xff, op_rst7)			/* RST 7 */
 
 #ifdef UNDOC_INST
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_nop(void)		/* NOP */
 #else
 case 0x08:				/* NOP */
@@ -2916,7 +2915,7 @@ INSTR(0xcb, op_undoc_jmp)		/* JMP nn */
 	STATES(10);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_call(void)		/* CALL nn */
 #else
 case 0xdd:				/* CALL nn */

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -28,7 +28,7 @@ extern void check_gui_break(void);
 
 static int trap_undoc(void);
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 
 static int op_nop(void), op_hlt(void), op_stc(void);
 static int op_cmc(void), op_cma(void), op_daa(void), op_ei(void), op_di(void);
@@ -109,12 +109,12 @@ static int op_undoc_call(void);
 #define INSTR(opcode, func)	static int func(void)
 #define STATES(states)		return (states)
 
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 
 #define INSTR(opcode, func)	case opcode:
 #define STATES(states)		t = states; break
 
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 
 /*
  * Function to update address bus LED's during execution of
@@ -142,7 +142,7 @@ void cpu_8080(void)
 {
 	extern unsigned long long get_clock_us(void);
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 
 #ifdef UNDOC_INST
 #define UNDOC(f) f
@@ -411,7 +411,7 @@ void cpu_8080(void)
 
 #undef UNDOC
 
-#endif /* !FAST_INSTR */
+#endif /* !INSTR_SWTCH */
 
 	Tstates_t T_max;
 	unsigned long long t1, t2;
@@ -577,7 +577,7 @@ leave:
 
 		int_protection = 0;
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 		t = (*op_sim[memrdr(PC++)])();	/* execute next opcode */
 #else
 		switch (memrdr(PC++)) {		/* execute next opcode */
@@ -631,7 +631,7 @@ leave:
 #endif
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 #include "sim8080-00.c"
 #endif
 

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -31,6 +31,18 @@
 #if defined(EXCLUDE_Z80) && DEF_CPU != I8080
 #error "DEF_CPU=Z80 and no Z80 simulation included"
 #endif
+#if defined(EXCLUDE_Z80) && defined(UNDOC_IALL)
+#error "UNDOC_IALL makes only sense without EXCLUDE_Z80"
+#endif
+#if defined(EXCLUDE_Z80) && defined(UNDOC_FLAGS)
+#error "UNDOC_FLAGS makes only sense without EXCLUDE_Z80"
+#endif
+#if defined(EXCLUDE_Z80) && defined(FAST_BLOCK)
+#error "FAST_BLOCK makes only sense without EXCLUDE_Z80"
+#endif
+#if defined(UNDOC_IALL) && !defined(UNDOC_INST)
+#error "UNDOC_IALL makes only sense together with UNDOC_INST"
+#endif
 
 				/* bit definitions of CPU flags */
 #define S_FLAG		128	/* sign flag */
@@ -42,8 +54,15 @@
 #define N_FLAG		2	/* add/subtract flag */
 #define C_FLAG		1	/* carry flag */
 
-#ifdef FAST_INSTR
+#ifdef FLAG_TABLES
+#ifndef EXCLUDE_Z80
+#define SZ_FLAGS	(S_FLAG | Z_FLAG)
+#endif
 #define SZP_FLAGS	(S_FLAG | Z_FLAG | P_FLAG)
+#ifdef UNDOC_FLAGS
+#define SZYX_FLAGS	(S_FLAG | Z_FLAG | Y_FLAG | X_FLAG)
+#define SZYXP_FLAGS	(S_FLAG | Z_FLAG | Y_FLAG | X_FLAG | P_FLAG)
+#endif
 #endif
 
 				/* bit definitions for CPU bus status */

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -147,7 +147,7 @@ char conffn[MAX_LFN];		/* configuration file (option -c) */
 char rompath[MAX_LFN];		/* path for boot ROM files */
 #endif
 
-#if !defined(FAST_INSTR) || !defined(EXCLUDE_Z80)
+#if !defined(FLAG_TABLES) || !defined(EXCLUDE_Z80)
 /*
  *	Precompiled table to get parity as fast as possible
  */
@@ -217,18 +217,62 @@ const char parity[256] = {
 	1 /* 11111000 */, 0 /* 11111001 */, 0 /* 11111010 */, 1 /* 11111011 */,
 	0 /* 11111100 */, 1 /* 11111101 */, 1 /* 11111110 */, 0 /* 11111111 */
 };
-#endif /* !FAST_INSTR && !EXCLUDE_Z80 */
+#endif /* !FLAG_TABLES || !EXCLUDE_Z80 */
 
-#ifdef FAST_INSTR
-/*
- *	Precomputed table for fast sign, zero and parity flag calculation
- */
+#ifdef FLAG_TABLES
+
 #define _ 0
 #define S S_FLAG
 #define Z Z_FLAG
+#define Y Y_FLAG
+#define X X_FLAG
 #define P P_FLAG
+
+#ifndef EXCLUDE_Z80
+/*
+ *	Precomputed table for fast sign, zero flag calculation
+ */
+const BYTE sz_flags[256] = {
+/*00*/	Z,	_,	_,	_,	_,	_,	_,	_,
+/*08*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*10*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*18*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*20*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*28*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*30*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*38*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*40*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*48*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*50*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*58*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*60*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*68*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*70*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*78*/	_,	_,	_,	_,	_,	_,	_,	_,
+/*80*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*88*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*90*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*98*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*a0*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*a8*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*b0*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*b8*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*c0*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*c8*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*d0*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*d8*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*e0*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*e8*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*f0*/	S,	S,	S,	S,	S,	S,	S,	S,
+/*f8*/	S,	S,	S,	S,	S,	S,	S,	S
+};
+#endif
+
+/*
+ *	Precomputed table for fast sign, zero and parity flag calculation
+ */
 const BYTE szp_flags[256] = {
-/*00*/	Z | P,	_,	_,	P,	_,	P,	P,	_,
+/*00*/	Z|P,	_,	_,	P,	_,	P,	P,	_,
 /*08*/	_,	P,	P,	_,	P,	_,	_,	P,
 /*10*/	_,	P,	P,	_,	P,	_,	_,	P,
 /*18*/	P,	_,	_,	P,	_,	P,	P,	_,
@@ -244,25 +288,109 @@ const BYTE szp_flags[256] = {
 /*68*/	_,	P,	P,	_,	P,	_,	_,	P,
 /*70*/	_,	P,	P,	_,	P,	_,	_,	P,
 /*78*/	P,	_,	_,	P,	_,	P,	P,	_,
-/*80*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
-/*88*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
-/*90*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
-/*98*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
-/*a0*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
-/*a8*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
-/*b0*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
-/*b8*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
-/*c0*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
-/*c8*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
-/*d0*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
-/*d8*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
-/*e0*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P,
-/*e8*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
-/*f0*/	S | P,	S,	S,	S | P,	S,	S | P,	S | P,	S,
-/*f8*/	S,	S | P,	S | P,	S,	S | P,	S,	S,	S | P
+/*80*/	S,	S|P,	S|P,	S,	S|P,	S,	S,	S|P,
+/*88*/	S|P,	S,	S,	S|P,	S,	S|P,	S|P,	S,
+/*90*/	S|P,	S,	S,	S|P,	S,	S|P,	S|P,	S,
+/*98*/	S,	S|P,	S|P,	S,	S|P,	S,	S,	S|P,
+/*a0*/	S|P,	S,	S,	S|P,	S,	S|P,	S|P,	S,
+/*a8*/	S,	S|P,	S|P,	S,	S|P,	S,	S,	S|P,
+/*b0*/	S,	S|P,	S|P,	S,	S|P,	S,	S,	S|P,
+/*b8*/	S|P,	S,	S,	S|P,	S,	S|P,	S|P,	S,
+/*c0*/	S|P,	S,	S,	S|P,	S,	S|P,	S|P,	S,
+/*c8*/	S,	S|P,	S|P,	S,	S|P,	S,	S,	S|P,
+/*d0*/	S,	S|P,	S|P,	S,	S|P,	S,	S,	S|P,
+/*d8*/	S|P,	S,	S,	S|P,	S,	S|P,	S|P,	S,
+/*e0*/	S,	S|P,	S|P,	S,	S|P,	S,	S,	S|P,
+/*e8*/	S|P,	S,	S,	S|P,	S,	S|P,	S|P,	S,
+/*f0*/	S|P,	S,	S,	S|P,	S,	S|P,	S|P,	S,
+/*f8*/	S,	S|P,	S|P,	S,	S|P,	S,	S,	S|P
 };
+
+#ifdef UNDOC_FLAGS
+
+/*
+ *	Precomputed table for fast sign, zero, Y, and X flag calculation
+ */
+const BYTE szyx_flags[256] = {
+/*00*/	Z,       _,       _,       _,       _,       _,       _,       _,
+/*08*/	X,       X,       X,       X,       X,       X,       X,       X,
+/*10*/	_,       _,       _,       _,       _,       _,       _,       _,
+/*18*/	X,       X,       X,       X,       X,       X,       X,       X,
+/*20*/	Y,       Y,       Y,       Y,       Y,       Y,       Y,       Y,
+/*28*/	Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,
+/*30*/	Y,       Y,       Y,       Y,       Y,       Y,       Y,       Y,
+/*38*/	Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,
+/*40*/	_,       _,       _,       _,       _,       _,       _,       _,
+/*48*/	X,       X,       X,       X,       X,       X,       X,       X,
+/*50*/	_,       _,       _,       _,       _,       _,       _,       _,
+/*58*/	X,       X,       X,       X,       X,       X,       X,       X,
+/*60*/	Y,       Y,       Y,       Y,       Y,       Y,       Y,       Y,
+/*68*/	Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,
+/*70*/	Y,       Y,       Y,       Y,       Y,       Y,       Y,       Y,
+/*78*/	Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,     Y|X,
+/*80*/	S,       S,       S,       S,       S,       S,       S,       S,
+/*88*/	S|X,     S|X,     S|X,     S|X,     S|X,     S|X,     S|X,     S|X,
+/*90*/	S,       S,       S,       S,       S,       S,       S,       S,
+/*98*/	S|X,     S|X,     S|X,     S|X,     S|X,     S|X,     S|X,     S|X,
+/*a0*/	S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,
+/*a8*/	S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,
+/*b0*/	S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,
+/*b8*/	S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,
+/*c0*/	S,       S,       S,       S,       S,       S,       S,       S,
+/*c8*/	S|X,     S|X,     S|X,     S|X,     S|X,     S|X,     S|X,     S|X,
+/*d0*/	S,       S,       S,       S,       S,       S,       S,       S,
+/*d8*/	S|X,     S|X,     S|X,     S|X,     S|X,     S|X,     S|X,     S|X,
+/*e0*/	S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,
+/*e8*/	S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,
+/*f0*/	S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,     S|Y,
+/*f8*/	S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X,   S|Y|X
+};
+
+/*
+ *	Precomputed table for fast sign, zero, Y, X, & parity flag calculation
+ */
+const BYTE szyxp_flags[256] = {
+/*00*/	Z|P,     _,       _,       P,       _,       P,       P,       _,
+/*08*/	X,       X|P,     X|P,     X,       X|P,     X,       X,       X|P,
+/*10*/	_,       P,       P,       _,       P,       _,       _,       P,
+/*18*/	X|P,     X,       X,       X|P,     X,       X|P,     X|P,     X,
+/*20*/	Y,       Y|P,     Y|P,     Y,       Y|P,     Y,       Y,       Y|P,
+/*28*/	Y|X|P,   Y|X,     Y|X,     Y|X|P,   Y|X,     Y|X|P,   Y|X|P,   Y|X,
+/*30*/	Y|P,     Y,       Y,       Y|P,     Y,       Y|P,     Y|P,     Y,
+/*38*/	Y|X,     Y|X|P,   Y|X|P,   Y|X,     Y|X|P,   Y|X,     Y|X,     Y|X|P,
+/*40*/	_,       P,       P,       _,       P,       _,       _,       P,
+/*48*/	X|P,     X,       X,       X|P,     X,       X|P,     X|P,     X,
+/*50*/	P,       _,       _,       P,       _,       P,       P,       _,
+/*58*/	X,       X|P,     X|P,     X,       X|P,     X,       X,       X|P,
+/*60*/	Y|P,     Y,       Y,       Y|P,     Y,       Y|P,     Y|P,     Y,
+/*68*/	Y|X,     Y|X|P,   Y|X|P,   Y|X,     Y|X|P,   Y|X,     Y|X,     Y|X|P,
+/*70*/	Y,       Y|P,     Y|P,     Y,       Y|P,     Y,       Y,       Y|P,
+/*78*/	Y|X|P,   Y|X,     Y|X,     Y|X|P,   Y|X,     Y|X|P,   Y|X|P,   Y|X,
+/*80*/	S,       S|P,     S|P,     S,       S|P,     S,       S,       S|P,
+/*88*/	S|X|P,   S|X,     S|X,     S|X|P,   S|X,     S|X|P,   S|X|P,   S|X,
+/*90*/	S|P,     S,       S,       S|P,     S,       S|P,     S|P,     S,
+/*98*/	S|X,     S|X|P,   S|X|P,   S|X,     S|X|P,   S|X,     S|X,     S|X|P,
+/*a0*/	S|Y|P,   S|Y,     S|Y,     S|Y|P,   S|Y,     S|Y|P,   S|Y|P,   S|Y,
+/*a8*/	S|Y|X,   S|Y|X|P, S|Y|X|P, S|Y|X,   S|Y|X|P, S|Y|X,   S|Y|X,   S|Y|X|P,
+/*b0*/	S|Y,     S|Y|P,   S|Y|P,   S|Y,     S|Y|P,   S|Y,     S|Y,     S|Y|P,
+/*b8*/	S|Y|X|P, S|Y|X,   S|Y|X,   S|Y|X|P, S|Y|X,   S|Y|X|P, S|Y|X|P, S|Y|X,
+/*c0*/	S|P,     S,       S,       S|P,     S,       S|P,     S|P,     S,
+/*c8*/	S|X,     S|X|P,   S|X|P,   S|X,     S|X|P,   S|X,     S|X,     S|X|P,
+/*d0*/	S,       S|P,     S|P,     S,       S|P,     S,       S,       S|P,
+/*d8*/	S|X|P,   S|X,     S|X,     S|X|P,   S|X,     S|X|P,   S|X|P,   S|X,
+/*e0*/	S|Y,     S|Y|P,   S|Y|P,   S|Y,     S|Y|P,   S|Y,     S|Y,     S|Y|P,
+/*e8*/	S|Y|X|P, S|Y|X,   S|Y|X,   S|Y|X|P, S|Y|X,   S|Y|X|P, S|Y|X|P, S|Y|X,
+/*f0*/	S|Y|P,   S|Y,     S|Y,     S|Y|P,   S|Y,     S|Y|P,   S|Y|P,   S|Y,
+/*f8*/	S|Y|X,   S|Y|X|P, S|Y|X|P, S|Y|X,   S|Y|X|P, S|Y|X,   S|Y|X,   S|Y|X|P
+};
+
+#endif /* UNDOC_FLAGS */
+
 #undef _
 #undef S
 #undef Z
+#undef Y
+#undef X
 #undef P
-#endif /* FAST_INSTR */
+
+#endif /* FLAG_TABLES */

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -114,11 +114,18 @@ extern char	conffn[];
 extern char	rompath[];
 #endif
 
-#if !defined(FAST_INSTR) || !defined(EXCLUDE_Z80)
+#if !defined(FLAG_TABLES) || !defined(EXCLUDE_Z80)
 extern const char parity[];
 #endif
-#ifdef FAST_INSTR
+#ifdef FLAG_TABLES
+#ifndef EXCLUDE_Z80
+extern const BYTE sz_flags[];
+#endif
 extern const BYTE szp_flags[];
+#ifdef UNDOC_FLAGS
+extern const BYTE szyx_flags[];
+extern const BYTE szyxp_flags[];
+#endif
 #endif
 
 #endif

--- a/z80core/simz80-00.c
+++ b/z80core/simz80-00.c
@@ -162,12 +162,22 @@ INSTR(0x27, op_daa)			/* DAA */
 			A += 0x60;
 		}
 	}
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /*FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -208,12 +218,22 @@ INSTR(0x27, op_daa)			/* DAA */
 
 	(carry || (tmp_a & 0x100)) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = (tmp_a & 0xff);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -957,14 +977,24 @@ INSTR(0x39, op_adhlsp)			/* ADD HL,SP */
 
 INSTR(0xa7, op_anda)			/* AND A */
 {
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -973,14 +1003,24 @@ INSTR(0xa7, op_anda)			/* AND A */
 INSTR(0xa0, op_andb)			/* AND B */
 {
 	A &= B;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -989,14 +1029,24 @@ INSTR(0xa0, op_andb)			/* AND B */
 INSTR(0xa1, op_andc)			/* AND C */
 {
 	A &= C;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1005,14 +1055,24 @@ INSTR(0xa1, op_andc)			/* AND C */
 INSTR(0xa2, op_andd)			/* AND D */
 {
 	A &= D;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1021,14 +1081,24 @@ INSTR(0xa2, op_andd)			/* AND D */
 INSTR(0xa3, op_ande)			/* AND E */
 {
 	A &= E;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1037,14 +1107,24 @@ INSTR(0xa3, op_ande)			/* AND E */
 INSTR(0xa4, op_andh)			/* AND H */
 {
 	A &= H;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1053,14 +1133,24 @@ INSTR(0xa4, op_andh)			/* AND H */
 INSTR(0xa5, op_andl)			/* AND L */
 {
 	A &= L;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1069,14 +1159,24 @@ INSTR(0xa5, op_andl)			/* AND L */
 INSTR(0xa6, op_andhl)			/* AND (HL) */
 {
 	A &= memrdr((H << 8) + L);
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1085,14 +1185,24 @@ INSTR(0xa6, op_andhl)			/* AND (HL) */
 INSTR(0xe6, op_andn)			/* AND n */
 {
 	A &= memrdr(PC++);
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1100,13 +1210,23 @@ INSTR(0xe6, op_andn)			/* AND n */
 
 INSTR(0xb7, op_ora)			/* OR A */
 {
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1115,13 +1235,23 @@ INSTR(0xb7, op_ora)			/* OR A */
 INSTR(0xb0, op_orb)			/* OR B */
 {
 	A |= B;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1130,13 +1260,23 @@ INSTR(0xb0, op_orb)			/* OR B */
 INSTR(0xb1, op_orc)			/* OR C */
 {
 	A |= C;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1145,13 +1285,23 @@ INSTR(0xb1, op_orc)			/* OR C */
 INSTR(0xb2, op_ord)			/* OR D */
 {
 	A |= D;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1160,13 +1310,23 @@ INSTR(0xb2, op_ord)			/* OR D */
 INSTR(0xb3, op_ore)			/* OR E */
 {
 	A |= E;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1175,13 +1335,23 @@ INSTR(0xb3, op_ore)			/* OR E */
 INSTR(0xb4, op_orh)			/* OR H */
 {
 	A |= H;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1190,13 +1360,23 @@ INSTR(0xb4, op_orh)			/* OR H */
 INSTR(0xb5, op_orl)			/* OR L */
 {
 	A |= L;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1205,13 +1385,23 @@ INSTR(0xb5, op_orl)			/* OR L */
 INSTR(0xb6, op_orhl)			/* OR (HL) */
 {
 	A |= memrdr((H << 8) + L);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1220,13 +1410,23 @@ INSTR(0xb6, op_orhl)			/* OR (HL) */
 INSTR(0xf6, op_orn)			/* OR n */
 {
 	A |= memrdr(PC++);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1247,13 +1447,23 @@ INSTR(0xaf, op_xora)			/* XOR A */
 INSTR(0xa8, op_xorb)			/* XOR B */
 {
 	A ^= B;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1262,13 +1472,23 @@ INSTR(0xa8, op_xorb)			/* XOR B */
 INSTR(0xa9, op_xorc)			/* XOR C */
 {
 	A ^= C;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1277,13 +1497,23 @@ INSTR(0xa9, op_xorc)			/* XOR C */
 INSTR(0xaa, op_xord)			/* XOR D */
 {
 	A ^= D;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1292,13 +1522,23 @@ INSTR(0xaa, op_xord)			/* XOR D */
 INSTR(0xab, op_xore)			/* XOR E */
 {
 	A ^= E;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1307,13 +1547,23 @@ INSTR(0xab, op_xore)			/* XOR E */
 INSTR(0xac, op_xorh)			/* XOR H */
 {
 	A ^= H;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1322,13 +1572,23 @@ INSTR(0xac, op_xorh)			/* XOR H */
 INSTR(0xad, op_xorl)			/* XOR L */
 {
 	A ^= L;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1337,13 +1597,23 @@ INSTR(0xad, op_xorl)			/* XOR L */
 INSTR(0xae, op_xorhl)			/* XOR (HL) */
 {
 	A ^= memrdr((H << 8) + L);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1352,13 +1622,23 @@ INSTR(0xae, op_xorhl)			/* XOR (HL) */
 INSTR(0xee, op_xorn)			/* XOR n */
 {
 	A ^= memrdr(PC++);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1371,13 +1651,23 @@ INSTR(0x87, op_adda)			/* ADD A,A */
 	((A & 0xf) + (A & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	((A << 1) > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) A;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1390,13 +1680,23 @@ INSTR(0x80, op_addb)			/* ADD A,B */
 	((A & 0xf) + (B & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + B > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) B;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1409,13 +1709,23 @@ INSTR(0x81, op_addc)			/* ADD A,C */
 	((A & 0xf) + (C & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + C > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) C;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1428,13 +1738,23 @@ INSTR(0x82, op_addd)			/* ADD A,D */
 	((A & 0xf) + (D & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + D > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) D;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1447,13 +1767,23 @@ INSTR(0x83, op_adde)			/* ADD A,E */
 	((A & 0xf) + (E & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + E > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) E;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1466,13 +1796,23 @@ INSTR(0x84, op_addh)			/* ADD A,H */
 	((A & 0xf) + (H & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + H > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) H;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1485,13 +1825,23 @@ INSTR(0x85, op_addl)			/* ADD A,L */
 	((A & 0xf) + (L & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + L > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) L;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1506,13 +1856,23 @@ INSTR(0x86, op_addhl)			/* ADD A,(HL) */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1527,13 +1887,23 @@ INSTR(0xc6, op_addn)			/* ADD A,n */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1547,13 +1917,23 @@ INSTR(0x8f, op_adca)			/* ADC A,A */
 	((A & 0xf) + (A & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	((A << 1) + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) A + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1567,13 +1947,23 @@ INSTR(0x88, op_adcb)			/* ADC A,B */
 	((A & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + B + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) B + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1587,13 +1977,23 @@ INSTR(0x89, op_adcc)			/* ADC A,C */
 	((A & 0xf) + (C & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + C + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) C + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1607,13 +2007,23 @@ INSTR(0x8a, op_adcd)			/* ADC A,D */
 	((A & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + D + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) D + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1627,13 +2037,23 @@ INSTR(0x8b, op_adce)			/* ADC A,E */
 	((A & 0xf) + (E & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + E + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) E + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1647,13 +2067,23 @@ INSTR(0x8c, op_adch)			/* ADC A,H */
 	((A & 0xf) + (H & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + H + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) H + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1667,13 +2097,23 @@ INSTR(0x8d, op_adcl)			/* ADC A,L */
 	((A & 0xf) + (L & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + L + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) L + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1689,13 +2129,23 @@ INSTR(0x8e, op_adchl)			/* ADC A,(HL) */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1711,13 +2161,23 @@ INSTR(0xce, op_adcn)			/* ADC A,n */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1742,13 +2202,23 @@ INSTR(0x90, op_subb)			/* SUB A,B */
 	((B & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(B > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) B;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1761,13 +2231,23 @@ INSTR(0x91, op_subc)			/* SUB A,C */
 	((C & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(C > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) C;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1780,13 +2260,23 @@ INSTR(0x92, op_subd)			/* SUB A,D */
 	((D & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(D > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) D;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1799,13 +2289,23 @@ INSTR(0x93, op_sube)			/* SUB A,E */
 	((E & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(E > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) E;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1818,13 +2318,23 @@ INSTR(0x94, op_subh)			/* SUB A,H */
 	((H & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(H > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) H;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1837,13 +2347,23 @@ INSTR(0x95, op_subl)			/* SUB A,L */
 	((L & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(L > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) L;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1858,13 +2378,23 @@ INSTR(0x96, op_subhl)			/* SUB A,(HL) */
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1879,13 +2409,23 @@ INSTR(0xd6, op_subn)			/* SUB A,n */
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -1899,7 +2439,6 @@ INSTR(0x9f, op_sbca)			/* SBC A,A */
 		F &= ~(Z_FLAG | P_FLAG);
 #ifdef UNDOC_FLAGS
 		F |= Y_FLAG | X_FLAG;
-		modF = 1;
 #endif
 	} else {
 		A = 0;
@@ -1907,9 +2446,11 @@ INSTR(0x9f, op_sbca)			/* SBC A,A */
 		F &= ~(S_FLAG | H_FLAG | P_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 		F &= ~(Y_FLAG | X_FLAG);
-		modF = 1;
 #endif
 	}
+#ifdef UNDOC_FLAGS
+	modF = 1;
+#endif
 	STATES(4);
 }
 
@@ -1921,13 +2462,23 @@ INSTR(0x98, op_sbcb)			/* SBC A,B */
 	((B & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(B + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) B - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1941,13 +2492,23 @@ INSTR(0x99, op_sbcc)			/* SBC A,C */
 	((C & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(C + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) C - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1961,13 +2522,23 @@ INSTR(0x9a, op_sbcd)			/* SBC A,D */
 	((D & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(D + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) D - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -1981,13 +2552,23 @@ INSTR(0x9b, op_sbce)			/* SBC A,E */
 	((E & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(E + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) E - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2001,13 +2582,23 @@ INSTR(0x9c, op_sbch)			/* SBC A,H */
 	((H & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(H + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) H - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2021,13 +2612,23 @@ INSTR(0x9d, op_sbcl)			/* SBC A,L */
 	((L & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(L + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) L - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2043,13 +2644,23 @@ INSTR(0x9e, op_sbchl)			/* SBC A,(HL) */
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -2065,13 +2676,23 @@ INSTR(0xde, op_sbcn)			/* SBC A,n */
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(7);
@@ -2249,13 +2870,23 @@ INSTR(0x3c, op_inca)			/* INC A */
 {
 	A++;
 	((A & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(A == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2265,13 +2896,23 @@ INSTR(0x04, op_incb)			/* INC B */
 {
 	B++;
 	((B & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(B == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[B];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2281,13 +2922,23 @@ INSTR(0x0c, op_incc)			/* INC C */
 {
 	C++;
 	((C & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(C == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[C];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2297,13 +2948,23 @@ INSTR(0x14, op_incd)			/* INC D */
 {
 	D++;
 	((D & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(D == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[D];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2313,13 +2974,23 @@ INSTR(0x1c, op_ince)			/* INC E */
 {
 	E++;
 	((E & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(E == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[E];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2329,13 +3000,23 @@ INSTR(0x24, op_inch)			/* INC H */
 {
 	H++;
 	((H & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(H == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[H];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2345,13 +3026,23 @@ INSTR(0x2c, op_incl)			/* INC L */
 {
 	L++;
 	((L & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(L == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[L];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2367,13 +3058,23 @@ INSTR(0x34, op_incihl)			/* INC (HL) */
 	P++;
 	memwrt(addr, P);
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(P == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(11);
@@ -2383,13 +3084,23 @@ INSTR(0x3d, op_deca)			/* DEC A */
 {
 	A--;
 	((A & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(A == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2399,13 +3110,23 @@ INSTR(0x05, op_decb)			/* DEC B */
 {
 	B--;
 	((B & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(B == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[B];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2415,13 +3136,23 @@ INSTR(0x0d, op_decc)			/* DEC C */
 {
 	C--;
 	((C & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(C == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[C];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2431,13 +3162,23 @@ INSTR(0x15, op_decd)			/* DEC D */
 {
 	D--;
 	((D & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(D == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[D];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2447,13 +3188,23 @@ INSTR(0x1d, op_dece)			/* DEC E */
 {
 	E--;
 	((E & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(E == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[E];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2463,13 +3214,23 @@ INSTR(0x25, op_dech)			/* DEC H */
 {
 	H--;
 	((H & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(H == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[H];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2479,13 +3240,23 @@ INSTR(0x2d, op_decl)			/* DEC L */
 {
 	L--;
 	((L & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(L == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[L];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(4);
@@ -2501,13 +3272,23 @@ INSTR(0x35, op_decihl)			/* DEC (HL) */
 	P--;
 	memwrt(addr, P);
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(P == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(11);
@@ -3313,7 +4094,7 @@ INSTR(0xff, op_rst38)			/* RST 38 */
 
 INSTR(0xcb, op_cb_handle)		/* 0xcb prefix */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 
 #ifdef UNDOC_INST
 #define UNDOC(f) f
@@ -3584,7 +4365,7 @@ INSTR(0xcb, op_cb_handle)		/* 0xcb prefix */
 
 	register int t;
 
-#endif /* !FAST_INSTR */
+#endif /* !INSTR_SWTCH */
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -3601,7 +4382,7 @@ INSTR(0xcb, op_cb_handle)		/* 0xcb prefix */
 
 	R++;				/* increment refresh register */
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	t = (*op_cb[memrdr(PC++)])();	/* execute next opcode */
 #else
 	switch (memrdr(PC++)) {		/* execute next opcode */
@@ -3617,13 +4398,13 @@ INSTR(0xcb, op_cb_handle)		/* 0xcb prefix */
 	STATES(t);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 #include "simz80-cb.c"
 #endif
 
 INSTR(0xdd, op_dd_handle)		/* 0xdd prefix */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 
 #ifdef UNDOC_INST
 #define UNDOC(f) f
@@ -3894,7 +4675,7 @@ INSTR(0xdd, op_dd_handle)		/* 0xdd prefix */
 
 	register int t;
 
-#endif /* !FAST_INSTR */
+#endif /* !INSTR_SWTCH */
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -3911,7 +4692,7 @@ INSTR(0xdd, op_dd_handle)		/* 0xdd prefix */
 
 	R++;				/* increment refresh register */
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	t = (*op_dd[memrdr(PC++)])();	/* execute next opcode */
 #else
 	switch (memrdr(PC++)) {		/* execute next opcode */
@@ -3927,13 +4708,13 @@ INSTR(0xdd, op_dd_handle)		/* 0xdd prefix */
 	STATES(t);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 #include "simz80-dd.c"
 #endif
 
 INSTR(0xed, op_ed_handle)		/* 0xed prefix */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 
 #ifdef UNDOC_INST
 #define UNDOC(f) f
@@ -4211,7 +4992,7 @@ INSTR(0xed, op_ed_handle)		/* 0xed prefix */
 
 	register int t;
 
-#endif /* !FAST_INSTR */
+#endif /* !INSTR_SWTCH */
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -4228,7 +5009,7 @@ INSTR(0xed, op_ed_handle)		/* 0xed prefix */
 
 	R++;				/* increment refresh register */
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	t = (*op_ed[memrdr(PC++)])();	/* execute next opcode */
 #else
 	switch (memrdr(PC++)) {		/* execute next opcode */
@@ -4244,13 +5025,13 @@ INSTR(0xed, op_ed_handle)		/* 0xed prefix */
 	STATES(t);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 #include "simz80-ed.c"
 #endif
 
 INSTR(0xfd, op_fd_handle)		/* 0xfd prefix */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 
 #ifdef UNDOC_INST
 #define UNDOC(f) f
@@ -4521,7 +5302,7 @@ INSTR(0xfd, op_fd_handle)		/* 0xfd prefix */
 
 	register int t;
 
-#endif /* !FAST_INSTR */
+#endif /* !INSTR_SWTCH */
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -4538,7 +5319,7 @@ INSTR(0xfd, op_fd_handle)		/* 0xfd prefix */
 
 	R++;				/* increment refresh register */
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	t = (*op_fd[memrdr(PC++)])();	/* execute next opcode */
 #else
 	switch (memrdr(PC++)) {		/* execute next opcode */
@@ -4554,6 +5335,6 @@ INSTR(0xfd, op_fd_handle)		/* 0xfd prefix */
 	STATES(t);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 #include "simz80-fd.c"
 #endif

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -15,7 +15,7 @@ INSTR(0x3f, op_srla)			/* SRL A */
 	(A & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -23,13 +23,13 @@ INSTR(0x3f, op_srla)			/* SRL A */
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[A];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -41,7 +41,7 @@ INSTR(0x38, op_srlb)			/* SRL B */
 	(B & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	B >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -49,13 +49,13 @@ INSTR(0x38, op_srlb)			/* SRL B */
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[B];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -67,7 +67,7 @@ INSTR(0x39, op_srlc)			/* SRL C */
 	(C & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	C >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -75,13 +75,13 @@ INSTR(0x39, op_srlc)			/* SRL C */
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[C];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -93,7 +93,7 @@ INSTR(0x3a, op_srld)			/* SRL D */
 	(D & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	D >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -101,13 +101,13 @@ INSTR(0x3a, op_srld)			/* SRL D */
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[D];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -119,7 +119,7 @@ INSTR(0x3b, op_srle)			/* SRL E */
 	(E & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	E >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -127,13 +127,13 @@ INSTR(0x3b, op_srle)			/* SRL E */
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[E];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -145,7 +145,7 @@ INSTR(0x3c, op_srlh)			/* SRL H */
 	(H & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -153,13 +153,13 @@ INSTR(0x3c, op_srlh)			/* SRL H */
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[H];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -171,7 +171,7 @@ INSTR(0x3d, op_srll)			/* SRL L */
 	(L & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	L >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -179,13 +179,13 @@ INSTR(0x3d, op_srll)			/* SRL L */
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[L];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -203,7 +203,7 @@ INSTR(0x3e, op_srlhl)			/* SRL (HL) */
 	P >>= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -211,13 +211,13 @@ INSTR(0x3e, op_srlhl)			/* SRL (HL) */
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[P];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -229,7 +229,7 @@ INSTR(0x27, op_slaa)			/* SLA A */
 	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -237,13 +237,13 @@ INSTR(0x27, op_slaa)			/* SLA A */
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[A];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -255,7 +255,7 @@ INSTR(0x20, op_slab)			/* SLA B */
 	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	B <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -263,13 +263,13 @@ INSTR(0x20, op_slab)			/* SLA B */
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[B];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -281,7 +281,7 @@ INSTR(0x21, op_slac)			/* SLA C */
 	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	C <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -289,13 +289,13 @@ INSTR(0x21, op_slac)			/* SLA C */
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[C];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -307,7 +307,7 @@ INSTR(0x22, op_slad)			/* SLA D */
 	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	D <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -315,13 +315,13 @@ INSTR(0x22, op_slad)			/* SLA D */
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[D];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -333,7 +333,7 @@ INSTR(0x23, op_slae)			/* SLA E */
 	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	E <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -341,13 +341,13 @@ INSTR(0x23, op_slae)			/* SLA E */
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[E];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -359,7 +359,7 @@ INSTR(0x24, op_slah)			/* SLA H */
 	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -367,13 +367,13 @@ INSTR(0x24, op_slah)			/* SLA H */
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[H];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -385,7 +385,7 @@ INSTR(0x25, op_slal)			/* SLA L */
 	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	L <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -393,13 +393,13 @@ INSTR(0x25, op_slal)			/* SLA L */
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[L];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -417,7 +417,7 @@ INSTR(0x26, op_slahl)			/* SLA (HL) */
 	P <<= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -425,13 +425,13 @@ INSTR(0x26, op_slahl)			/* SLA (HL) */
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[P];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -447,7 +447,7 @@ INSTR(0x17, op_rlra)			/* RL A */
 	A <<= 1;
 	if (old_c_flag) A |= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -455,13 +455,13 @@ INSTR(0x17, op_rlra)			/* RL A */
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[A];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -477,7 +477,7 @@ INSTR(0x10, op_rlb)			/* RL B */
 	B <<= 1;
 	if (old_c_flag) B |= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -485,13 +485,13 @@ INSTR(0x10, op_rlb)			/* RL B */
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[B];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -507,7 +507,7 @@ INSTR(0x11, op_rlc)			/* RL C */
 	C <<= 1;
 	if (old_c_flag) C |= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -515,13 +515,13 @@ INSTR(0x11, op_rlc)			/* RL C */
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[C];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -537,7 +537,7 @@ INSTR(0x12, op_rld)			/* RL D */
 	D <<= 1;
 	if (old_c_flag) D |= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -545,13 +545,13 @@ INSTR(0x12, op_rld)			/* RL D */
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[D];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -567,7 +567,7 @@ INSTR(0x13, op_rle)			/* RL E */
 	E <<= 1;
 	if (old_c_flag) E |= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -575,13 +575,13 @@ INSTR(0x13, op_rle)			/* RL E */
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[E];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -597,7 +597,7 @@ INSTR(0x14, op_rlh)			/* RL H */
 	H <<= 1;
 	if (old_c_flag) H |= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -605,13 +605,13 @@ INSTR(0x14, op_rlh)			/* RL H */
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[H];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -627,7 +627,7 @@ INSTR(0x15, op_rll)			/* RL L */
 	L <<= 1;
 	if (old_c_flag) L |= 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -635,13 +635,13 @@ INSTR(0x15, op_rll)			/* RL L */
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[L];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -662,7 +662,7 @@ INSTR(0x16, op_rlhl)			/* RL (HL) */
 	if (old_c_flag) P |= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -670,13 +670,13 @@ INSTR(0x16, op_rlhl)			/* RL (HL) */
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[P];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -692,7 +692,7 @@ INSTR(0x1f, op_rrra)			/* RR A */
 	A >>= 1;
 	if (old_c_flag) A |= 128;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -700,13 +700,13 @@ INSTR(0x1f, op_rrra)			/* RR A */
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[A];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -722,7 +722,7 @@ INSTR(0x18, op_rrb)			/* RR B */
 	B >>= 1;
 	if (old_c_flag) B |= 128;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -730,13 +730,13 @@ INSTR(0x18, op_rrb)			/* RR B */
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[B];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -752,7 +752,7 @@ INSTR(0x19, op_rrc)			/* RR C */
 	C >>= 1;
 	if (old_c_flag) C |= 128;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -760,13 +760,13 @@ INSTR(0x19, op_rrc)			/* RR C */
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[C];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -782,7 +782,7 @@ INSTR(0x1a, op_rrd)			/* RR D */
 	D >>= 1;
 	if (old_c_flag) D |= 128;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -790,13 +790,13 @@ INSTR(0x1a, op_rrd)			/* RR D */
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[D];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -812,7 +812,7 @@ INSTR(0x1b, op_rre)			/* RR E */
 	E >>= 1;
 	if (old_c_flag) E |= 128;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -820,13 +820,13 @@ INSTR(0x1b, op_rre)			/* RR E */
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[E];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -842,7 +842,7 @@ INSTR(0x1c, op_rrh)			/* RR H */
 	H >>= 1;
 	if (old_c_flag) H |= 128;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -850,13 +850,13 @@ INSTR(0x1c, op_rrh)			/* RR H */
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[H];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -872,7 +872,7 @@ INSTR(0x1d, op_rrl)			/* RR L */
 	L >>= 1;
 	if (old_c_flag) L |= 128;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -880,13 +880,13 @@ INSTR(0x1d, op_rrl)			/* RR L */
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[L];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -907,7 +907,7 @@ INSTR(0x1e, op_rrhl)			/* RR (HL) */
 	if (old_c_flag) P |= 128;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -915,13 +915,13 @@ INSTR(0x1e, op_rrhl)			/* RR (HL) */
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[P];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -937,7 +937,7 @@ INSTR(0x0f, op_rrcra)			/* RRC A */
 	F &= ~(H_FLAG | N_FLAG);
 	A >>= 1;
 	if (i) A |= 128;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -945,13 +945,13 @@ INSTR(0x0f, op_rrcra)			/* RRC A */
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[A];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -967,7 +967,7 @@ INSTR(0x08, op_rrcb)			/* RRC B */
 	F &= ~(H_FLAG | N_FLAG);
 	B >>= 1;
 	if (i) B |= 128;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -975,13 +975,13 @@ INSTR(0x08, op_rrcb)			/* RRC B */
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[B];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -997,7 +997,7 @@ INSTR(0x09, op_rrcc)			/* RRC C */
 	F &= ~(H_FLAG | N_FLAG);
 	C >>= 1;
 	if (i) C |= 128;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1005,13 +1005,13 @@ INSTR(0x09, op_rrcc)			/* RRC C */
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[C];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1027,7 +1027,7 @@ INSTR(0x0a, op_rrcd)			/* RRC D */
 	F &= ~(H_FLAG | N_FLAG);
 	D >>= 1;
 	if (i) D |= 128;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1035,13 +1035,13 @@ INSTR(0x0a, op_rrcd)			/* RRC D */
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[D];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1057,7 +1057,7 @@ INSTR(0x0b, op_rrce)			/* RRC E */
 	F &= ~(H_FLAG | N_FLAG);
 	E >>= 1;
 	if (i) E |= 128;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1065,13 +1065,13 @@ INSTR(0x0b, op_rrce)			/* RRC E */
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[E];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1087,7 +1087,7 @@ INSTR(0x0c, op_rrch)			/* RRC H */
 	F &= ~(H_FLAG | N_FLAG);
 	H >>= 1;
 	if (i) H |= 128;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1095,13 +1095,13 @@ INSTR(0x0c, op_rrch)			/* RRC H */
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[H];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1117,7 +1117,7 @@ INSTR(0x0d, op_rrcl)			/* RRC L */
 	F &= ~(H_FLAG | N_FLAG);
 	L >>= 1;
 	if (i) L |= 128;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1125,13 +1125,13 @@ INSTR(0x0d, op_rrcl)			/* RRC L */
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[L];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1152,7 +1152,7 @@ INSTR(0x0e, op_rrchl)			/* RRC (HL) */
 	if (i) P |= 128;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1160,13 +1160,13 @@ INSTR(0x0e, op_rrchl)			/* RRC (HL) */
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[P];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1182,7 +1182,7 @@ INSTR(0x07, op_rlcra)			/* RLC A */
 	F &= ~(H_FLAG | N_FLAG);
 	A <<= 1;
 	if (i) A |= 1;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1190,13 +1190,13 @@ INSTR(0x07, op_rlcra)			/* RLC A */
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[A];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1212,7 +1212,7 @@ INSTR(0x00, op_rlcb)			/* RLC B */
 	F &= ~(H_FLAG | N_FLAG);
 	B <<= 1;
 	if (i) B |= 1;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1220,13 +1220,13 @@ INSTR(0x00, op_rlcb)			/* RLC B */
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[B];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1242,7 +1242,7 @@ INSTR(0x01, op_rlcc)			/* RLC C */
 	F &= ~(H_FLAG | N_FLAG);
 	C <<= 1;
 	if (i) C |= 1;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1250,13 +1250,13 @@ INSTR(0x01, op_rlcc)			/* RLC C */
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[C];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1272,7 +1272,7 @@ INSTR(0x02, op_rlcd)			/* RLC D */
 	F &= ~(H_FLAG | N_FLAG);
 	D <<= 1;
 	if (i) D |= 1;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1280,13 +1280,13 @@ INSTR(0x02, op_rlcd)			/* RLC D */
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[D];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1302,7 +1302,7 @@ INSTR(0x03, op_rlce)			/* RLC E */
 	F &= ~(H_FLAG | N_FLAG);
 	E <<= 1;
 	if (i) E |= 1;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1310,13 +1310,13 @@ INSTR(0x03, op_rlce)			/* RLC E */
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[E];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1332,7 +1332,7 @@ INSTR(0x04, op_rlch)			/* RLC H */
 	F &= ~(H_FLAG | N_FLAG);
 	H <<= 1;
 	if (i) H |= 1;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1340,13 +1340,13 @@ INSTR(0x04, op_rlch)			/* RLC H */
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[H];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1362,7 +1362,7 @@ INSTR(0x05, op_rlcl)			/* RLC L */
 	F &= ~(H_FLAG | N_FLAG);
 	L <<= 1;
 	if (i) L |= 1;
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1370,13 +1370,13 @@ INSTR(0x05, op_rlcl)			/* RLC L */
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[L];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1397,7 +1397,7 @@ INSTR(0x06, op_rlchl)			/* RLC (HL) */
 	if (i) P |= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1405,13 +1405,13 @@ INSTR(0x06, op_rlchl)			/* RLC (HL) */
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[P];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1427,7 +1427,7 @@ INSTR(0x2f, op_sraa)			/* SRA A */
 	A >>= 1;
 	A |= i;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1435,13 +1435,13 @@ INSTR(0x2f, op_sraa)			/* SRA A */
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[A];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1457,7 +1457,7 @@ INSTR(0x28, op_srab)			/* SRA B */
 	B >>= 1;
 	B |= i;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1465,13 +1465,13 @@ INSTR(0x28, op_srab)			/* SRA B */
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[B];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1487,7 +1487,7 @@ INSTR(0x29, op_srac)			/* SRA C */
 	C >>= 1;
 	C |= i;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1495,13 +1495,13 @@ INSTR(0x29, op_srac)			/* SRA C */
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[C];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1517,7 +1517,7 @@ INSTR(0x2a, op_srad)			/* SRA D */
 	D >>= 1;
 	D |= i;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1525,13 +1525,13 @@ INSTR(0x2a, op_srad)			/* SRA D */
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[D];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1547,7 +1547,7 @@ INSTR(0x2b, op_srae)			/* SRA E */
 	E >>= 1;
 	E |= i;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1555,13 +1555,13 @@ INSTR(0x2b, op_srae)			/* SRA E */
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[E];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1577,7 +1577,7 @@ INSTR(0x2c, op_srah)			/* SRA H */
 	H >>= 1;
 	H |= i;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1585,13 +1585,13 @@ INSTR(0x2c, op_srah)			/* SRA H */
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[H];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1607,7 +1607,7 @@ INSTR(0x2d, op_sral)			/* SRA L */
 	L >>= 1;
 	L |= i;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1615,13 +1615,13 @@ INSTR(0x2d, op_sral)			/* SRA L */
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[L];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -1641,7 +1641,7 @@ INSTR(0x2e, op_srahl)			/* SRA (HL) */
 	P = (P >> 1) | i;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1649,13 +1649,13 @@ INSTR(0x2e, op_srahl)			/* SRA (HL) */
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[P];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -3333,7 +3333,7 @@ INSTR(0x37, op_undoc_slla)		/* SLL A */
 	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -3341,13 +3341,13 @@ INSTR(0x37, op_undoc_slla)		/* SLL A */
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[A];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -3365,7 +3365,7 @@ INSTR(0x30, op_undoc_sllb)		/* SLL B */
 	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	B = B << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -3373,13 +3373,13 @@ INSTR(0x30, op_undoc_sllb)		/* SLL B */
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[B];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -3395,7 +3395,7 @@ INSTR(0x31, op_undoc_sllc)		/* SLL C */
 	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	C = C << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -3403,13 +3403,13 @@ INSTR(0x31, op_undoc_sllc)		/* SLL C */
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[C];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -3425,7 +3425,7 @@ INSTR(0x32, op_undoc_slld)		/* SLL D */
 	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	D = D << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -3433,13 +3433,13 @@ INSTR(0x32, op_undoc_slld)		/* SLL D */
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[D];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -3455,7 +3455,7 @@ INSTR(0x33, op_undoc_slle)		/* SLL E */
 	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	E = E << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -3463,13 +3463,13 @@ INSTR(0x33, op_undoc_slle)		/* SLL E */
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[E];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -3485,7 +3485,7 @@ INSTR(0x34, op_undoc_sllh)		/* SLL H */
 	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H = H << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -3493,13 +3493,13 @@ INSTR(0x34, op_undoc_sllh)		/* SLL H */
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[H];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -3515,7 +3515,7 @@ INSTR(0x35, op_undoc_slll)		/* SLL L */
 	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	L = L << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -3523,13 +3523,13 @@ INSTR(0x35, op_undoc_slll)		/* SLL L */
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[L];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
@@ -3551,7 +3551,7 @@ INSTR(0x36, op_undoc_sllhl)		/* SLL (HL) */
 	P = (P << 1) | 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
-#ifndef FAST_FLAGS
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -3559,13 +3559,13 @@ INSTR(0x36, op_undoc_sllhl)		/* SLL (HL) */
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 #endif
-#else /* FAST_FLAGS */
+#else /* FLAG_TABLES */
 #ifndef UNDOC_FLAGS
 	F = (F & ~SZP_FLAGS) | szp_flags[P];
 #else
 	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
 #endif
-#endif /* FAST_FLAGS */
+#endif /* FLAG_TABLES */
 #ifdef UNDOC_FLAGS
 	modF = 1;
 #endif

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -15,12 +15,22 @@ INSTR(0x3f, op_srla)			/* SRL A */
 	(A & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -31,12 +41,22 @@ INSTR(0x38, op_srlb)			/* SRL B */
 	(B & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	B >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -47,12 +67,22 @@ INSTR(0x39, op_srlc)			/* SRL C */
 	(C & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	C >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -63,12 +93,22 @@ INSTR(0x3a, op_srld)			/* SRL D */
 	(D & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	D >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -79,12 +119,22 @@ INSTR(0x3b, op_srle)			/* SRL E */
 	(E & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	E >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -95,12 +145,22 @@ INSTR(0x3c, op_srlh)			/* SRL H */
 	(H & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -111,12 +171,22 @@ INSTR(0x3d, op_srll)			/* SRL L */
 	(L & 1) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	L >>= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -133,12 +203,22 @@ INSTR(0x3e, op_srlhl)			/* SRL (HL) */
 	P >>= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(15);
@@ -149,12 +229,22 @@ INSTR(0x27, op_slaa)			/* SLA A */
 	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -165,12 +255,22 @@ INSTR(0x20, op_slab)			/* SLA B */
 	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	B <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -181,12 +281,22 @@ INSTR(0x21, op_slac)			/* SLA C */
 	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	C <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -197,12 +307,22 @@ INSTR(0x22, op_slad)			/* SLA D */
 	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	D <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -213,12 +333,22 @@ INSTR(0x23, op_slae)			/* SLA E */
 	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	E <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -229,12 +359,22 @@ INSTR(0x24, op_slah)			/* SLA H */
 	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -245,12 +385,22 @@ INSTR(0x25, op_slal)			/* SLA L */
 	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	L <<= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -267,12 +417,22 @@ INSTR(0x26, op_slahl)			/* SLA (HL) */
 	P <<= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(15);
@@ -287,12 +447,22 @@ INSTR(0x17, op_rlra)			/* RL A */
 	A <<= 1;
 	if (old_c_flag) A |= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -307,12 +477,22 @@ INSTR(0x10, op_rlb)			/* RL B */
 	B <<= 1;
 	if (old_c_flag) B |= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -327,12 +507,22 @@ INSTR(0x11, op_rlc)			/* RL C */
 	C <<= 1;
 	if (old_c_flag) C |= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -347,12 +537,22 @@ INSTR(0x12, op_rld)			/* RL D */
 	D <<= 1;
 	if (old_c_flag) D |= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -367,12 +567,22 @@ INSTR(0x13, op_rle)			/* RL E */
 	E <<= 1;
 	if (old_c_flag) E |= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -387,12 +597,22 @@ INSTR(0x14, op_rlh)			/* RL H */
 	H <<= 1;
 	if (old_c_flag) H |= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -407,12 +627,22 @@ INSTR(0x15, op_rll)			/* RL L */
 	L <<= 1;
 	if (old_c_flag) L |= 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -432,12 +662,22 @@ INSTR(0x16, op_rlhl)			/* RL (HL) */
 	if (old_c_flag) P |= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(15);
@@ -452,12 +692,22 @@ INSTR(0x1f, op_rrra)			/* RR A */
 	A >>= 1;
 	if (old_c_flag) A |= 128;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -472,12 +722,22 @@ INSTR(0x18, op_rrb)			/* RR B */
 	B >>= 1;
 	if (old_c_flag) B |= 128;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -492,12 +752,22 @@ INSTR(0x19, op_rrc)			/* RR C */
 	C >>= 1;
 	if (old_c_flag) C |= 128;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -512,12 +782,22 @@ INSTR(0x1a, op_rrd)			/* RR D */
 	D >>= 1;
 	if (old_c_flag) D |= 128;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -532,12 +812,22 @@ INSTR(0x1b, op_rre)			/* RR E */
 	E >>= 1;
 	if (old_c_flag) E |= 128;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -552,12 +842,22 @@ INSTR(0x1c, op_rrh)			/* RR H */
 	H >>= 1;
 	if (old_c_flag) H |= 128;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -572,12 +872,22 @@ INSTR(0x1d, op_rrl)			/* RR L */
 	L >>= 1;
 	if (old_c_flag) L |= 128;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -597,12 +907,22 @@ INSTR(0x1e, op_rrhl)			/* RR (HL) */
 	if (old_c_flag) P |= 128;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(15);
@@ -617,12 +937,22 @@ INSTR(0x0f, op_rrcra)			/* RRC A */
 	F &= ~(H_FLAG | N_FLAG);
 	A >>= 1;
 	if (i) A |= 128;
+#ifndef FAST_FLAGS
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -637,12 +967,22 @@ INSTR(0x08, op_rrcb)			/* RRC B */
 	F &= ~(H_FLAG | N_FLAG);
 	B >>= 1;
 	if (i) B |= 128;
+#ifndef FAST_FLAGS
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -657,12 +997,22 @@ INSTR(0x09, op_rrcc)			/* RRC C */
 	F &= ~(H_FLAG | N_FLAG);
 	C >>= 1;
 	if (i) C |= 128;
+#ifndef FAST_FLAGS
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -677,12 +1027,22 @@ INSTR(0x0a, op_rrcd)			/* RRC D */
 	F &= ~(H_FLAG | N_FLAG);
 	D >>= 1;
 	if (i) D |= 128;
+#ifndef FAST_FLAGS
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -697,12 +1057,22 @@ INSTR(0x0b, op_rrce)			/* RRC E */
 	F &= ~(H_FLAG | N_FLAG);
 	E >>= 1;
 	if (i) E |= 128;
+#ifndef FAST_FLAGS
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -717,12 +1087,22 @@ INSTR(0x0c, op_rrch)			/* RRC H */
 	F &= ~(H_FLAG | N_FLAG);
 	H >>= 1;
 	if (i) H |= 128;
+#ifndef FAST_FLAGS
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -737,12 +1117,22 @@ INSTR(0x0d, op_rrcl)			/* RRC L */
 	F &= ~(H_FLAG | N_FLAG);
 	L >>= 1;
 	if (i) L |= 128;
+#ifndef FAST_FLAGS
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -762,12 +1152,22 @@ INSTR(0x0e, op_rrchl)			/* RRC (HL) */
 	if (i) P |= 128;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(15);
@@ -782,12 +1182,22 @@ INSTR(0x07, op_rlcra)			/* RLC A */
 	F &= ~(H_FLAG | N_FLAG);
 	A <<= 1;
 	if (i) A |= 1;
+#ifndef FAST_FLAGS
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -802,12 +1212,22 @@ INSTR(0x00, op_rlcb)			/* RLC B */
 	F &= ~(H_FLAG | N_FLAG);
 	B <<= 1;
 	if (i) B |= 1;
+#ifndef FAST_FLAGS
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -822,12 +1242,22 @@ INSTR(0x01, op_rlcc)			/* RLC C */
 	F &= ~(H_FLAG | N_FLAG);
 	C <<= 1;
 	if (i) C |= 1;
+#ifndef FAST_FLAGS
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -842,12 +1272,22 @@ INSTR(0x02, op_rlcd)			/* RLC D */
 	F &= ~(H_FLAG | N_FLAG);
 	D <<= 1;
 	if (i) D |= 1;
+#ifndef FAST_FLAGS
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -862,12 +1302,22 @@ INSTR(0x03, op_rlce)			/* RLC E */
 	F &= ~(H_FLAG | N_FLAG);
 	E <<= 1;
 	if (i) E |= 1;
+#ifndef FAST_FLAGS
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -882,12 +1332,22 @@ INSTR(0x04, op_rlch)			/* RLC H */
 	F &= ~(H_FLAG | N_FLAG);
 	H <<= 1;
 	if (i) H |= 1;
+#ifndef FAST_FLAGS
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -902,12 +1362,22 @@ INSTR(0x05, op_rlcl)			/* RLC L */
 	F &= ~(H_FLAG | N_FLAG);
 	L <<= 1;
 	if (i) L |= 1;
+#ifndef FAST_FLAGS
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -927,12 +1397,22 @@ INSTR(0x06, op_rlchl)			/* RLC (HL) */
 	if (i) P |= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(15);
@@ -947,12 +1427,22 @@ INSTR(0x2f, op_sraa)			/* SRA A */
 	A >>= 1;
 	A |= i;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -967,12 +1457,22 @@ INSTR(0x28, op_srab)			/* SRA B */
 	B >>= 1;
 	B |= i;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -987,12 +1487,22 @@ INSTR(0x29, op_srac)			/* SRA C */
 	C >>= 1;
 	C |= i;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1007,12 +1517,22 @@ INSTR(0x2a, op_srad)			/* SRA D */
 	D >>= 1;
 	D |= i;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1027,12 +1547,22 @@ INSTR(0x2b, op_srae)			/* SRA E */
 	E >>= 1;
 	E |= i;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1047,12 +1577,22 @@ INSTR(0x2c, op_srah)			/* SRA H */
 	H >>= 1;
 	H |= i;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1067,12 +1607,22 @@ INSTR(0x2d, op_sral)			/* SRA L */
 	L >>= 1;
 	L |= i;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1091,12 +1641,22 @@ INSTR(0x2e, op_srahl)			/* SRA (HL) */
 	P = (P >> 1) | i;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(15);
@@ -2647,8 +3207,8 @@ INSTR(0x46, op_tb0hl)			/* BIT 0,(HL) */
 	(memrdr((H << 8) + L) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	((WZ >> 8) & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(WZ & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(WZ & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
 	STATES(12);
@@ -2661,8 +3221,8 @@ INSTR(0x4e, op_tb1hl)			/* BIT 1,(HL) */
 	(memrdr((H << 8) + L) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	((WZ >> 8) & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(WZ & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(WZ & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
 	STATES(12);
@@ -2675,8 +3235,8 @@ INSTR(0x56, op_tb2hl)			/* BIT 2,(HL) */
 	(memrdr((H << 8) + L) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	((WZ >> 8) & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(WZ & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(WZ & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
 	STATES(12);
@@ -2689,8 +3249,8 @@ INSTR(0x5e, op_tb3hl)			/* BIT 3,(HL) */
 	(memrdr((H << 8) + L) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 				   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	((WZ >> 8) & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(WZ & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(WZ & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
 	STATES(12);
@@ -2703,8 +3263,8 @@ INSTR(0x66, op_tb4hl)			/* BIT 4,(HL) */
 	(memrdr((H << 8) + L) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	((WZ >> 8) & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(WZ & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(WZ & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
 	STATES(12);
@@ -2717,8 +3277,8 @@ INSTR(0x6e, op_tb5hl)			/* BIT 5,(HL) */
 	(memrdr((H << 8) + L) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	((WZ >> 8) & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(WZ & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(WZ & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
 	STATES(12);
@@ -2731,8 +3291,8 @@ INSTR(0x76, op_tb6hl)			/* BIT 6,(HL) */
 	(memrdr((H << 8) + L) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 				    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	((WZ >> 8) & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(WZ & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(WZ & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
 	STATES(12);
@@ -2750,8 +3310,8 @@ INSTR(0x7e, op_tb7hl)			/* BIT 7,(HL) */
 		F &= ~S_FLAG;
 	}
 #ifdef UNDOC_FLAGS
-	((WZ >> 8) & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	((WZ >> 8) & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(WZ & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(WZ & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
 	STATES(12);
@@ -2773,12 +3333,22 @@ INSTR(0x37, op_undoc_slla)		/* SLL A */
 	(A & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = A << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -2795,12 +3365,22 @@ INSTR(0x30, op_undoc_sllb)		/* SLL B */
 	(B & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	B = B << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -2815,12 +3395,22 @@ INSTR(0x31, op_undoc_sllc)		/* SLL C */
 	(C & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	C = C << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -2835,12 +3425,22 @@ INSTR(0x32, op_undoc_slld)		/* SLL D */
 	(D & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	D = D << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -2855,12 +3455,22 @@ INSTR(0x33, op_undoc_slle)		/* SLL E */
 	(E & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	E = E << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -2875,12 +3485,22 @@ INSTR(0x34, op_undoc_sllh)		/* SLL H */
 	(H & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	H = H << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -2895,12 +3515,22 @@ INSTR(0x35, op_undoc_slll)		/* SLL L */
 	(L & 128) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	L = L << 1 | 1;
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -2921,12 +3551,22 @@ INSTR(0x36, op_undoc_sllhl)		/* SLL (HL) */
 	P = (P << 1) | 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FAST_FLAGS
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FAST_FLAGS */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FAST_FLAGS */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(15);

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -97,13 +97,23 @@ INSTR(0x86, op_adaxd)			/* ADD A,(IX+d) */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -122,13 +132,23 @@ INSTR(0x8e, op_acaxd)			/* ADC A,(IX+d) */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -146,13 +166,23 @@ INSTR(0x96, op_suaxd)			/* SUB A,(IX+d) */
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -171,13 +201,23 @@ INSTR(0x9e, op_scaxd)			/* SBC A,(IX+d) */
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -190,14 +230,24 @@ INSTR(0xa6, op_andxd)			/* AND (IX+d) */
 
 	addr = IX + (signed char) memrdr(PC++);
 	A &= memrdr(addr);
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -210,13 +260,23 @@ INSTR(0xae, op_xorxd)			/* XOR (IX+d) */
 
 	addr = IX + (signed char) memrdr(PC++);
 	A ^= memrdr(addr);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -229,13 +289,23 @@ INSTR(0xb6, op_orxd)			/* OR (IX+d) */
 
 	addr = IX + (signed char) memrdr(PC++);
 	A |= memrdr(addr);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -276,13 +346,23 @@ INSTR(0x34, op_incxd)			/* INC (IX+d) */
 	P++;
 	memwrt(addr, P);
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(P == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -299,13 +379,23 @@ INSTR(0x35, op_decxd)			/* DEC (IX+d) */
 	P--;
 	memwrt(addr, P);
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(P == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -608,7 +698,7 @@ INSTR(0x36, op_ldxdn)			/* LD (IX+d),n */
 
 INSTR(0xcb, op_ddcb_handle)		/* 0xdd 0xcb prefix */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 
 #ifdef UNDOC_INST
 #define UNDOC(f) f
@@ -886,13 +976,13 @@ INSTR(0xcb, op_ddcb_handle)		/* 0xdd 0xcb prefix */
 
 	register int t;
 
-#endif /* !FAST_INSTR */
+#endif /* !INSTR_SWTCH */
 
 	register int data;
 
 	data = (signed char) memrdr(PC++);
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	t = (*op_ddcb[memrdr(PC++)])(data); /* execute next opcode */
 #else
 	switch (memrdr(PC++)) {		/* execute next opcode */
@@ -908,7 +998,7 @@ INSTR(0xcb, op_ddcb_handle)		/* 0xdd 0xcb prefix */
 	STATES(t);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 #include "simz80-ddcb.c"
 #endif
 
@@ -1241,13 +1331,23 @@ INSTR(0x85, op_undoc_adaixl)		/* ADD A,IXL */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1266,13 +1366,23 @@ INSTR(0x84, op_undoc_adaixh)		/* ADD A,IXH */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1292,13 +1402,23 @@ INSTR(0x8d, op_undoc_acaixl)		/* ADC A,IXL */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1318,13 +1438,23 @@ INSTR(0x8c, op_undoc_acaixh)		/* ADC A,IXH */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1343,13 +1473,23 @@ INSTR(0x95, op_undoc_suaixl)		/* SUB A,IXL */
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1368,13 +1508,23 @@ INSTR(0x94, op_undoc_suaixh)		/* SUB A,IXH */
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1394,13 +1544,23 @@ INSTR(0x9d, op_undoc_scaixl)		/* SBC A,IXL */
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1420,13 +1580,23 @@ INSTR(0x9c, op_undoc_scaixh)		/* SBC A,IXH */
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1439,13 +1609,23 @@ INSTR(0xb5, op_undoc_oraixl)		/* OR IXL */
 	}
 
 	A |= IX & 0xff;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1458,13 +1638,23 @@ INSTR(0xb4, op_undoc_oraixh)		/* OR IXH */
 	}
 
 	A |= IX >> 8;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1477,13 +1667,23 @@ INSTR(0xad, op_undoc_xorixl)		/* XOR IXL */
 	}
 
 	A ^= IX & 0xff;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1496,13 +1696,23 @@ INSTR(0xac, op_undoc_xorixh)		/* XOR IXH */
 	}
 
 	A ^= IX >> 8;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1515,14 +1725,24 @@ INSTR(0xa5, op_undoc_andixl)		/* AND IXL */
 	}
 
 	A &= IX & 0xff;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1535,14 +1755,24 @@ INSTR(0xa4, op_undoc_andixh)		/* AND IXH */
 	}
 
 	A &= IX >> 8;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1560,13 +1790,23 @@ INSTR(0x2c, op_undoc_incixl)		/* INC IXL */
 	P++;
 	IX = (IX & 0xff00) | P;
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(P == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1584,13 +1824,23 @@ INSTR(0x24, op_undoc_incixh)		/* INC IXH */
 	P++;
 	IX = (IX & 0x00ff) | (P << 8);
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(P == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1608,13 +1858,23 @@ INSTR(0x2d, op_undoc_decixl)		/* DEC IXL */
 	P--;
 	IX = (IX & 0xff00) | P;
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(P == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1632,13 +1892,23 @@ INSTR(0x25, op_undoc_decixh)		/* DEC IXH */
 	P--;
 	IX = (IX & 0x00ff) | (P << 8);
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(P == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);

--- a/z80core/simz80-ddcb.c
+++ b/z80core/simz80-ddcb.c
@@ -20,8 +20,8 @@ INSTRD(0x46, op_tb0ixd)			/* BIT 0,(IX+d) */
 	(memrdr(addr) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -38,8 +38,8 @@ INSTRD(0x4e, op_tb1ixd)			/* BIT 1,(IX+d) */
 	(memrdr(addr) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -56,8 +56,8 @@ INSTRD(0x56, op_tb2ixd)			/* BIT 2,(IX+d) */
 	(memrdr(addr) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -74,8 +74,8 @@ INSTRD(0x5e, op_tb3ixd)			/* BIT 3,(IX+d) */
 	(memrdr(addr) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -92,8 +92,8 @@ INSTRD(0x66, op_tb4ixd)			/* BIT 4,(IX+d) */
 	(memrdr(addr) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -110,8 +110,8 @@ INSTRD(0x6e, op_tb5ixd)			/* BIT 5,(IX+d) */
 	(memrdr(addr) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -128,8 +128,8 @@ INSTRD(0x76, op_tb6ixd)			/* BIT 6,(IX+d) */
 	(memrdr(addr) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -151,8 +151,8 @@ INSTRD(0x7e, op_tb7ixd)			/* BIT 7,(IX+d) */
 		F &= ~S_FLAG;
 	}
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -365,12 +365,22 @@ INSTRD(0x06, op_rlcixd)			/* RLC (IX+d) */
 	if (i) P |= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -391,12 +401,22 @@ INSTRD(0x0e, op_rrcixd)			/* RRC (IX+d) */
 	if (i) P |= 128;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -417,12 +437,22 @@ INSTRD(0x16, op_rlixd)			/* RL (IX+d) */
 	if (old_c_flag) P |= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -443,12 +473,22 @@ INSTRD(0x1e, op_rrixd)			/* RR (IX+d) */
 	if (old_c_flag) P |= 128;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -466,12 +506,22 @@ INSTRD(0x26, op_slaixd)			/* SLA (IX+d) */
 	P <<= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -491,12 +541,22 @@ INSTRD(0x2e, op_sraixd)			/* SRA (IX+d) */
 	P = (P >> 1) | i;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -514,12 +574,22 @@ INSTRD(0x3e, op_srlixd)			/* SRL (IX+d) */
 	P >>= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -549,12 +619,22 @@ INSTRD(0x36, op_undoc_sllixd)		/* SLL (IX+d) */
 	P = (P << 1) | 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -563,7 +643,7 @@ INSTRD(0x36, op_undoc_sllixd)		/* SLL (IX+d) */
 
 #ifdef UNDOC_IALL
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb0ixd(int data)	/* BIT 0,(IX+d) */
 #else
 case 0x40:				/* BIT 0,(IX+d) */
@@ -587,15 +667,15 @@ case 0x47:				/* BIT 0,(IX+d) */
 	(memrdr(addr) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb1ixd(int data)	/* BIT 1,(IX+d) */
 #else
 case 0x48:				/* BIT 1,(IX+d) */
@@ -619,15 +699,15 @@ case 0x4f:				/* BIT 1,(IX+d) */
 	(memrdr(addr) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb2ixd(int data)	/* BIT 2,(IX+d) */
 #else
 case 0x50:				/* BIT 2,(IX+d) */
@@ -651,15 +731,15 @@ case 0x57:				/* BIT 2,(IX+d) */
 	(memrdr(addr) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb3ixd(int data)	/* BIT 3,(IX+d) */
 #else
 case 0x58:				/* BIT 3,(IX+d) */
@@ -683,15 +763,15 @@ case 0x5f:				/* BIT 3,(IX+d) */
 	(memrdr(addr) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb4ixd(int data)	/* BIT 4,(IX+d) */
 #else
 case 0x60:				/* BIT 4,(IX+d) */
@@ -715,15 +795,15 @@ case 0x67:				/* BIT 4,(IX+d) */
 	(memrdr(addr) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb5ixd(int data)	/* BIT 5,(IX+d) */
 #else
 case 0x68:				/* BIT 5,(IX+d) */
@@ -747,15 +827,15 @@ case 0x6f:				/* BIT 5,(IX+d) */
 	(memrdr(addr) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb6ixd(int data)	/* BIT 6,(IX+d) */
 #else
 case 0x70:				/* BIT 6,(IX+d) */
@@ -779,15 +859,15 @@ case 0x77:				/* BIT 6,(IX+d) */
 	(memrdr(addr) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb7ixd(int data)	/* BIT 7,(IX+d) */
 #else
 case 0x78:				/* BIT 7,(IX+d) */
@@ -816,8 +896,8 @@ case 0x7f:				/* BIT 7,(IX+d) */
 		F &= ~S_FLAG;
 	}
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2745,12 +2825,22 @@ INSTRD(0x07, op_undoc_rlcixda)		/* RLC (IX+d),A */
 	if (i) A |= 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2774,12 +2864,22 @@ INSTRD(0x00, op_undoc_rlcixdb)		/* RLC (IX+d),B */
 	if (i) B |= 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2803,12 +2903,22 @@ INSTRD(0x01, op_undoc_rlcixdc)		/* RLC (IX+d),C */
 	if (i) C |= 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2832,12 +2942,22 @@ INSTRD(0x02, op_undoc_rlcixdd)		/* RLC (IX+d),D */
 	if (i) D |= 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2861,12 +2981,22 @@ INSTRD(0x03, op_undoc_rlcixde)		/* RLC (IX+d),E */
 	if (i) E |= 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2890,12 +3020,22 @@ INSTRD(0x04, op_undoc_rlcixdh)		/* RLC (IX+d),H */
 	if (i) H |= 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2919,12 +3059,22 @@ INSTRD(0x05, op_undoc_rlcixdl)		/* RLC (IX+d),L */
 	if (i) L |= 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2948,12 +3098,22 @@ INSTRD(0x0f, op_undoc_rrcixda)		/* RRC (IX+d),A */
 	if (i) A |= 128;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2977,12 +3137,22 @@ INSTRD(0x08, op_undoc_rrcixdb)		/* RRC (IX+d),B */
 	if (i) B |= 128;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3006,12 +3176,22 @@ INSTRD(0x09, op_undoc_rrcixdc)		/* RRC (IX+d),C */
 	if (i) C |= 128;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3035,12 +3215,22 @@ INSTRD(0x0a, op_undoc_rrcixdd)		/* RRC (IX+d),D */
 	if (i) D |= 128;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3064,12 +3254,22 @@ INSTRD(0x0b, op_undoc_rrcixde)		/* RRC (IX+d),E */
 	if (i) E |= 128;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3093,12 +3293,22 @@ INSTRD(0x0c, op_undoc_rrcixdh)		/* RRC (IX+d),H */
 	if (i) H |= 128;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3122,12 +3332,22 @@ INSTRD(0x0d, op_undoc_rrcixdl)		/* RRC (IX+d),L */
 	if (i) L |= 128;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3151,12 +3371,22 @@ INSTRD(0x17, op_undoc_rlixda)		/* RL (IX+d),A */
 	if (old_c_flag) A |= 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3180,12 +3410,22 @@ INSTRD(0x10, op_undoc_rlixdb)		/* RL (IX+d),B */
 	if (old_c_flag) B |= 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3209,12 +3449,22 @@ INSTRD(0x11, op_undoc_rlixdc)		/* RL (IX+d),C */
 	if (old_c_flag) C |= 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3238,12 +3488,22 @@ INSTRD(0x12, op_undoc_rlixdd)		/* RL (IX+d),D */
 	if (old_c_flag) D |= 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3267,12 +3527,22 @@ INSTRD(0x13, op_undoc_rlixde)		/* RL (IX+d),E */
 	if (old_c_flag) E |= 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3296,12 +3566,22 @@ INSTRD(0x14, op_undoc_rlixdh)		/* RL (IX+d),H */
 	if (old_c_flag) H |= 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3325,12 +3605,22 @@ INSTRD(0x15, op_undoc_rlixdl)		/* RL (IX+d),L */
 	if (old_c_flag) L |= 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3354,12 +3644,22 @@ INSTRD(0x1f, op_undoc_rrixda)		/* RR (IX+d),A */
 	if (old_c_flag) A |= 128;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3383,12 +3683,22 @@ INSTRD(0x18, op_undoc_rrixdb)		/* RR (IX+d),B */
 	if (old_c_flag) B |= 128;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3412,12 +3722,22 @@ INSTRD(0x19, op_undoc_rrixdc)		/* RR (IX+d),C */
 	if (old_c_flag) C |= 128;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3441,12 +3761,22 @@ INSTRD(0x1a, op_undoc_rrixdd)		/* RR (IX+d),D */
 	if (old_c_flag) D |= 128;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3470,12 +3800,22 @@ INSTRD(0x1b, op_undoc_rrixde)		/* RR (IX+d),E */
 	if (old_c_flag) E |= 128;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3499,12 +3839,22 @@ INSTRD(0x1c, op_undoc_rrixdh)		/* RR (IX+d),H */
 	if (old_c_flag) H |= 128;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3528,12 +3878,22 @@ INSTRD(0x1d, op_undoc_rrixdl)		/* RR (IX+d),L */
 	if (old_c_flag) L |= 128;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3554,12 +3914,22 @@ INSTRD(0x27, op_undoc_slaixda)		/* SLA (IX+d),A */
 	A <<= 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3580,12 +3950,22 @@ INSTRD(0x20, op_undoc_slaixdb)		/* SLA (IX+d),B */
 	B <<= 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3606,12 +3986,22 @@ INSTRD(0x21, op_undoc_slaixdc)		/* SLA (IX+d),C */
 	C <<= 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3632,12 +4022,22 @@ INSTRD(0x22, op_undoc_slaixdd)		/* SLA (IX+d),D */
 	D <<= 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3658,12 +4058,22 @@ INSTRD(0x23, op_undoc_slaixde)		/* SLA (IX+d),E */
 	E <<= 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3684,12 +4094,22 @@ INSTRD(0x24, op_undoc_slaixdh)		/* SLA (IX+d),H */
 	H <<= 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3710,12 +4130,22 @@ INSTRD(0x25, op_undoc_slaixdl)		/* SLA (IX+d),L */
 	L <<= 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3738,12 +4168,22 @@ INSTRD(0x2f, op_undoc_sraixda)		/* SRA (IX+d),A */
 	A = (A >> 1) | i;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3766,12 +4206,22 @@ INSTRD(0x28, op_undoc_sraixdb)		/* SRA (IX+d),B */
 	B = (B >> 1) | i;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3794,12 +4244,22 @@ INSTRD(0x29, op_undoc_sraixdc)		/* SRA (IX+d),C */
 	C = (C >> 1) | i;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3822,12 +4282,22 @@ INSTRD(0x2a, op_undoc_sraixdd)		/* SRA (IX+d),D */
 	D = (D >> 1) | i;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3850,12 +4320,22 @@ INSTRD(0x2b, op_undoc_sraixde)		/* SRA (IX+d),E */
 	E = (E >> 1) | i;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3878,12 +4358,22 @@ INSTRD(0x2c, op_undoc_sraixdh)		/* SRA (IX+d),H */
 	H = (H >> 1) | i;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3906,12 +4396,22 @@ INSTRD(0x2d, op_undoc_sraixdl)		/* SRA (IX+d),L */
 	L = (L >> 1) | i;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3932,12 +4432,22 @@ INSTRD(0x37, op_undoc_sllixda)		/* SLL (IX+d),A */
 	A = (A << 1) | 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3958,12 +4468,22 @@ INSTRD(0x30, op_undoc_sllixdb)		/* SLL (IX+d),B */
 	B = (B << 1) | 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3984,12 +4504,22 @@ INSTRD(0x31, op_undoc_sllixdc)		/* SLL (IX+d),C */
 	C = (C << 1) | 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4010,12 +4540,22 @@ INSTRD(0x32, op_undoc_sllixdd)		/* SLL (IX+d),D */
 	D = (D << 1) | 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4036,12 +4576,22 @@ INSTRD(0x33, op_undoc_sllixde)		/* SLL (IX+d),E */
 	E = (E << 1) | 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4062,12 +4612,22 @@ INSTRD(0x34, op_undoc_sllixdh)		/* SLL (IX+d),H */
 	H = (H << 1) | 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4088,12 +4648,22 @@ INSTRD(0x35, op_undoc_sllixdl)		/* SLL (IX+d),L */
 	L = (L << 1) | 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4114,12 +4684,22 @@ INSTRD(0x3f, op_undoc_srlixda)		/* SRL (IX+d),A */
 	A >>= 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4140,12 +4720,22 @@ INSTRD(0x38, op_undoc_srlixdb)		/* SRL (IX+d),B */
 	B >>= 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4166,12 +4756,22 @@ INSTRD(0x39, op_undoc_srlixdc)		/* SRL (IX+d),C */
 	C >>= 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4192,12 +4792,22 @@ INSTRD(0x3a, op_undoc_srlixdd)		/* SRL (IX+d),D */
 	D >>= 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4218,12 +4828,22 @@ INSTRD(0x3b, op_undoc_srlixde)		/* SRL (IX+d),E */
 	E >>= 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4244,12 +4864,22 @@ INSTRD(0x3c, op_undoc_srlixdh)		/* SRL (IX+d),H */
 	H >>= 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4270,12 +4900,22 @@ INSTRD(0x3d, op_undoc_srlixdl)		/* SRL (IX+d),L */
 	L >>= 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -63,11 +63,21 @@ INSTR(0x44, op_neg)			/* NEG */
 	(0 - ((signed char) A & 0xf) < 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	A = 0 - A;
 	F |= N_FLAG;
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -82,12 +92,22 @@ INSTR(0x78, op_inaic)			/* IN A,(C) */
 #endif
 	A = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(12);
@@ -102,12 +122,22 @@ INSTR(0x40, op_inbic)			/* IN B,(C) */
 #endif
 	B = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(12);
@@ -122,12 +152,22 @@ INSTR(0x48, op_incic)			/* IN C,(C) */
 #endif
 	C = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(12);
@@ -142,12 +182,22 @@ INSTR(0x50, op_indic)			/* IN D,(C) */
 #endif
 	D = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(12);
@@ -162,12 +212,22 @@ INSTR(0x58, op_ineic)			/* IN E,(C) */
 #endif
 	E = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(12);
@@ -182,12 +242,22 @@ INSTR(0x60, op_inhic)			/* IN H,(C) */
 #endif
 	H = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(12);
@@ -202,12 +272,22 @@ INSTR(0x68, op_inlic)			/* IN L,(C) */
 #endif
 	L = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(12);
@@ -329,7 +409,7 @@ INSTR(0xb2, op_inir)			/* INIR */
 	extern BYTE io_in(BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	register int t;
 #endif
 
@@ -358,7 +438,7 @@ INSTR(0xb2, op_inir)			/* INIR */
 	F |= Z_FLAG;
 #ifdef UNDOC_FLAGS
 	F &= ~(Y_FLAG | X_FLAG);
-	WZ = ((1 << 8) + C) + 1;
+	WZ = (0x0100 + C) + 1;
 	modF = 1;
 #endif
 	STATES(t + 16);
@@ -366,9 +446,9 @@ INSTR(0xb2, op_inir)			/* INIR */
 #else /* !FAST_BLOCK */
 INSTR(0xb2, op_inir)			/* INIR */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	op_ini();
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 	extern BYTE io_in(BYTE, BYTE);
 	BYTE data;
 
@@ -397,7 +477,7 @@ INSTR(0xb2, op_inir)			/* INIR */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 
 	if (!(F & Z_FLAG)) {
 		PC -= 2;
@@ -465,7 +545,7 @@ INSTR(0xba, op_indr)			/* INDR */
 	extern BYTE io_in(BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	register int t;
 #endif
 
@@ -494,7 +574,7 @@ INSTR(0xba, op_indr)			/* INDR */
 	F |= Z_FLAG;
 #ifdef UNDOC_FLAGS
 	F &= ~(Y_FLAG | X_FLAG);
-	WZ = ((1 << 8) + C) - 1;
+	WZ = (0x0100 + C) - 1;
 	modF = 1;
 #endif
 	STATES(t + 16);
@@ -502,9 +582,9 @@ INSTR(0xba, op_indr)			/* INDR */
 #else /* !FAST_BLOCK */
 INSTR(0xba, op_indr)			/* INDR */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	op_ind();
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 	extern BYTE io_in(BYTE, BYTE);
 	BYTE data;
 
@@ -533,7 +613,7 @@ INSTR(0xba, op_indr)			/* INDR */
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 
 	if (!(F & Z_FLAG)) {
 		PC -= 2;
@@ -599,7 +679,7 @@ INSTR(0xb3, op_otir)			/* OTIR */
 	extern void io_out(BYTE, BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	register int t;
 #endif
 
@@ -636,9 +716,9 @@ INSTR(0xb3, op_otir)			/* OTIR */
 #else /* !FAST_BLOCK */
 INSTR(0xb3, op_otir)			/* OTIR */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	op_outi();
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 	extern void io_out(BYTE, BYTE, BYTE);
 	BYTE data;
 
@@ -665,7 +745,7 @@ INSTR(0xb3, op_otir)			/* OTIR */
 	WZ = ((B << 8) + C) + 1;
 	modF = 1;
 #endif
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 
 	if (!(F & Z_FLAG)) {
 		PC -= 2;
@@ -731,7 +811,7 @@ INSTR(0xbb, op_otdr)			/* OTDR */
 	extern void io_out(BYTE, BYTE, BYTE);
 	WORD addr;
 	BYTE data;
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	register int t;
 #endif
 
@@ -768,9 +848,9 @@ INSTR(0xbb, op_otdr)			/* OTDR */
 #else /* !FAST_BLOCK */
 INSTR(0xbb, op_otdr)			/* OTDR */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	op_outd();
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 	extern void io_out(BYTE, BYTE, BYTE);
 	BYTE data;
 
@@ -797,7 +877,7 @@ INSTR(0xbb, op_otdr)			/* OTDR */
 	WZ = ((B << 8) + C) - 1;
 	modF = 1;
 #endif
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 
 	if (!(F & Z_FLAG)) {
 		PC -= 2;
@@ -831,11 +911,21 @@ INSTR(0x57, op_ldai)			/* LD A,I */
 	A = I;
 	F &= ~(N_FLAG | H_FLAG);
 	(IFF & 2) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(9);
@@ -846,11 +936,21 @@ INSTR(0x5f, op_ldar)			/* LD A,R */
 	A = (R_ & 0x80) | (R & 0x7f);
 	F &= ~(N_FLAG | H_FLAG);
 	(IFF & 2) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(9);
@@ -1258,7 +1358,7 @@ INSTR(0xb0, op_ldir)			/* LDIR */
 	register WORD i;
 	register WORD s, d;
 	BYTE tmp;
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	register int t;
 #endif
 
@@ -1294,9 +1394,9 @@ INSTR(0xb0, op_ldir)			/* LDIR */
 #else /* !FAST_BLOCK */
 INSTR(0xb0, op_ldir)			/* LDIR */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	op_ldi();
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 	register BYTE tmp;
 
 	tmp = memrdr((H << 8) + L);
@@ -1318,7 +1418,7 @@ INSTR(0xb0, op_ldir)			/* LDIR */
 	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 	
 	if (F & P_FLAG) {
 		PC -= 2;
@@ -1365,7 +1465,7 @@ INSTR(0xb8, op_lddr)			/* LDDR */
 	register WORD i;
 	register WORD s, d;
 	BYTE tmp;
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	register int t;
 #endif
 
@@ -1401,9 +1501,9 @@ INSTR(0xb8, op_lddr)			/* LDDR */
 #else /* !FAST_BLOCK */
 INSTR(0xb8, op_lddr)			/* LDDR */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	op_ldd();
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 	register BYTE tmp;
 
 	tmp = memrdr((H << 8) + L);
@@ -1425,7 +1525,7 @@ INSTR(0xb8, op_lddr)			/* LDDR */
 	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	modF = 1;
 #endif
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 
 	if (F & P_FLAG) {
 		PC -= 2;
@@ -1475,7 +1575,7 @@ INSTR(0xb1, op_cpir)			/* CPIR */
 	register BYTE d;
 	register WORD i;
 	BYTE tmp;
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	register int t;
 #endif
 
@@ -1516,9 +1616,9 @@ INSTR(0xb1, op_cpir)			/* CPIR */
 #else /* !FAST_BLOCK */
 INSTR(0xb1, op_cpir)			/* CPIR */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	op_cpi();
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 	register BYTE i;
 
 	i = memrdr(((H << 8) + L));
@@ -1542,7 +1642,7 @@ INSTR(0xb1, op_cpir)			/* CPIR */
 	WZ++;
 	modF = 1;
 #endif
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 
 	if ((F & (P_FLAG | Z_FLAG)) == P_FLAG) {
 		PC -= 2;
@@ -1592,7 +1692,7 @@ INSTR(0xb9, op_cpdr)			/* CPDR */
 	register BYTE d;
 	register WORD i;
 	BYTE tmp;
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	register int t;
 #endif
 
@@ -1633,9 +1733,9 @@ INSTR(0xb9, op_cpdr)			/* CPDR */
 #else /* !FAST_BLOCK */
 INSTR(0xb9, op_cpdr)			/* CPDR */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	op_cpdop();
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 	register BYTE i;
 
 	i = memrdr(((H << 8) + L));
@@ -1659,7 +1759,7 @@ INSTR(0xb9, op_cpdr)			/* CPDR */
 	WZ--;
 	modF = 1;
 #endif
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 
 	if ((F & (P_FLAG | Z_FLAG)) == P_FLAG) {
 		PC -= 2;
@@ -1686,6 +1786,7 @@ INSTR(0x6f, op_oprld)			/* RLD (HL) */
 	i = (i << 4) | j;
 	memwrt(addr, i);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -1695,6 +1796,15 @@ INSTR(0x6f, op_oprld)			/* RLD (HL) */
 	WZ = addr + 1;
 	modF = 1;
 #endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+	WZ = addr + 1;
+	modF = 1;
+#endif
+#endif /* FLAG_TABLES */
 	STATES(18);
 }
 
@@ -1710,12 +1820,22 @@ INSTR(0x67, op_oprrd)			/* RRD (HL) */
 	i = (i >> 4) | (j << 4);
 	memwrt(addr, i);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr + 1;
 	modF = 1;
 #endif
@@ -1759,12 +1879,22 @@ INSTR(0x70, op_undoc_infic)		/* IN F,(C) */
 #endif
 	tmp = io_in(C, B);
 	F &= ~(N_FLAG | H_FLAG);
+#ifndef FLAG_TABLES
 	(tmp) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(tmp & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[tmp]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(tmp & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(tmp & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[tmp];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[tmp];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(12);
@@ -1772,7 +1902,7 @@ INSTR(0x70, op_undoc_infic)		/* IN F,(C) */
 
 #ifdef UNDOC_IALL
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_nop(void)		/* NOP */
 #else
 case 0x00: case 0x01: case 0x02: case 0x03: /* NOP */
@@ -1830,7 +1960,7 @@ case 0xfc: case 0xfd: case 0xfe: case 0xff: /* NOP */
 	STATES(8);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_im0(void)		/* IM 0 */
 #else
 case 0x4e:				/* IM 0 */
@@ -1866,7 +1996,7 @@ INSTR(0x7e, op_undoc_im2)		/* IM 2 */
 	STATES(8);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_reti(void)		/* RETI */
 #else
 case 0x5d:				/* RETI */
@@ -1889,7 +2019,7 @@ case 0x7d:				/* RETI */
 	STATES(14);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_retn(void)		/* RETN */
 #else
 case 0x55:				/* RETN */
@@ -1914,7 +2044,7 @@ case 0x75:				/* RETN */
 	STATES(14);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_neg(void)		/* NEG */
 #else
 case 0x4c:				/* NEG */
@@ -1935,11 +2065,21 @@ case 0x7c:				/* NEG */
 	(0 - ((signed char) A & 0xf) < 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	A = 0 - A;
 	F |= N_FLAG;
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -97,13 +97,23 @@ INSTR(0x86, op_adayd)			/* ADD A,(IY+d) */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -122,13 +132,23 @@ INSTR(0x8e, op_acayd)			/* ADC A,(IY+d) */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -146,13 +166,23 @@ INSTR(0x96, op_suayd)			/* SUB A,(IY+d) */
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -171,13 +201,23 @@ INSTR(0x9e, op_scayd)			/* SBC A,(IY+d) */
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -190,14 +230,24 @@ INSTR(0xa6, op_andyd)			/* AND (IY+d) */
 
 	addr = IY + (signed char) memrdr(PC++);
 	A &= memrdr(addr);
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -210,13 +260,23 @@ INSTR(0xae, op_xoryd)			/* XOR (IY+d) */
 
 	addr = IY + (signed char) memrdr(PC++);
 	A ^= memrdr(addr);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -229,13 +289,23 @@ INSTR(0xb6, op_oryd)			/* OR (IY+d) */
 
 	addr = IY + (signed char) memrdr(PC++);
 	A |= memrdr(addr);
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -276,13 +346,23 @@ INSTR(0x34, op_incyd)			/* INC (IY+d) */
 	P++;
 	memwrt(addr, P);
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(P == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -299,13 +379,23 @@ INSTR(0x35, op_decyd)			/* DEC (IY+d) */
 	P--;
 	memwrt(addr, P);
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(P == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -608,7 +698,7 @@ INSTR(0x36, op_ldydn)			/* LD (IY+d),n */
 
 INSTR(0xcb, op_fdcb_handle)		/* 0xfd 0xcb prefix */
 {
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 
 #ifdef UNDOC_INST
 #define UNDOC(f) f
@@ -886,13 +976,13 @@ INSTR(0xcb, op_fdcb_handle)		/* 0xfd 0xcb prefix */
 
 	register int t;
 
-#endif /* !FAST_INSTR */
+#endif /* !INSTR_SWTCH */
 
 	register int data;
 
 	data = (signed char) memrdr(PC++);
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	t = (*op_fdcb[memrdr(PC++)])(data); /* execute next opcode */
 #else
 	switch (memrdr(PC++)) {		/* execute next opcode */
@@ -908,7 +998,7 @@ INSTR(0xcb, op_fdcb_handle)		/* 0xfd 0xcb prefix */
 	STATES(t);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 #include "simz80-fdcb.c"
 #endif
 
@@ -1241,13 +1331,23 @@ INSTR(0x85, op_undoc_adaiyl)		/* ADD A,IYL */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1266,13 +1366,23 @@ INSTR(0x84, op_undoc_adaiyh)		/* ADD A,IYH */
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1292,13 +1402,23 @@ INSTR(0x8d, op_undoc_acaiyl)		/* ADC A,IYL */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1318,13 +1438,23 @@ INSTR(0x8c, op_undoc_acaiyh)		/* ADC A,IYH */
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A + (signed char) P + carry;
+	F &= ~N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1343,13 +1473,23 @@ INSTR(0x95, op_undoc_suaiyl)		/* SUB A,IYL */
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1368,13 +1508,23 @@ INSTR(0x94, op_undoc_suaiyh)		/* SUB A,IYH */
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1394,13 +1544,23 @@ INSTR(0x9d, op_undoc_scaiyl)		/* SBC A,IYL */
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1420,13 +1580,23 @@ INSTR(0x9c, op_undoc_scaiyh)		/* SBC A,IYH */
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	A = i = (signed char) A - (signed char) P - carry;
+	F |= N_FLAG;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(i & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(i & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[A];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1439,13 +1609,23 @@ INSTR(0xb5, op_undoc_oraiyl)		/* OR IYL */
 	}
 
 	A |= IY & 0xff;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1458,13 +1638,23 @@ INSTR(0xb4, op_undoc_oraiyh)		/* OR IYH */
 	}
 
 	A |= IY >> 8;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1477,13 +1667,23 @@ INSTR(0xad, op_undoc_xoriyl)		/* XOR IYL */
 	}
 
 	A ^= IY & 0xff;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1496,13 +1696,23 @@ INSTR(0xac, op_undoc_xoriyh)		/* XOR IYH */
 	}
 
 	A ^= IY >> 8;
+	F &= ~(H_FLAG | N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(H_FLAG | N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1515,14 +1725,24 @@ INSTR(0xa5, op_undoc_andiyl)		/* AND IYL */
 	}
 
 	A &= IY & 0xff;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1535,14 +1755,24 @@ INSTR(0xa4, op_undoc_andiyh)		/* AND IYH */
 	}
 
 	A &= IY >> 8;
+	F |= H_FLAG;
+	F &= ~(N_FLAG | C_FLAG);
+#ifndef FLAG_TABLES
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= H_FLAG;
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
-	F &= ~(N_FLAG | C_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1560,13 +1790,23 @@ INSTR(0x2c, op_undoc_inciyl)		/* INC IYL */
 	P++;
 	IY = (IY & 0xff00) | P;
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(P == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1584,13 +1824,23 @@ INSTR(0x24, op_undoc_inciyh)		/* INC IYH */
 	P++;
 	IY = (IY & 0x00ff) | (P << 8);
 	((P & 0xf) == 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F &= ~N_FLAG;
 	(P == 128) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F &= ~N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1608,13 +1858,23 @@ INSTR(0x2d, op_undoc_deciyl)		/* DEC IYL */
 	P--;
 	IY = (IY & 0xff00) | P;
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(P == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);
@@ -1632,13 +1892,23 @@ INSTR(0x25, op_undoc_deciyh)		/* DEC IYH */
 	P--;
 	IY = (IY & 0x00ff) | (P << 8);
 	((P & 0xf) == 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	F |= N_FLAG;
 	(P == 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
+#ifndef FLAG_TABLES
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
-	F |= N_FLAG;
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZ_FLAGS) | sz_flags[P];
+#else
+	F = (F & ~SZYX_FLAGS) | szyx_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	modF = 1;
 #endif
 	STATES(8);

--- a/z80core/simz80-fdcb.c
+++ b/z80core/simz80-fdcb.c
@@ -20,8 +20,8 @@ INSTRD(0x46, op_tb0iyd)			/* BIT 0,(IY+d) */
 	(memrdr(addr) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -38,8 +38,8 @@ INSTRD(0x4e, op_tb1iyd)			/* BIT 1,(IY+d) */
 	(memrdr(addr) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -56,8 +56,8 @@ INSTRD(0x56, op_tb2iyd)			/* BIT 2,(IY+d) */
 	(memrdr(addr) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -74,8 +74,8 @@ INSTRD(0x5e, op_tb3iyd)			/* BIT 3,(IY+d) */
 	(memrdr(addr) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -92,8 +92,8 @@ INSTRD(0x66, op_tb4iyd)			/* BIT 4,(IY+d) */
 	(memrdr(addr) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -110,8 +110,8 @@ INSTRD(0x6e, op_tb5iyd)			/* BIT 5,(IY+d) */
 	(memrdr(addr) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -128,8 +128,8 @@ INSTRD(0x76, op_tb6iyd)			/* BIT 6,(IY+d) */
 	(memrdr(addr) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -151,8 +151,8 @@ INSTRD(0x7e, op_tb7iyd)			/* BIT 7,(IY+d) */
 		F &= ~S_FLAG;
 	}
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -365,12 +365,22 @@ INSTRD(0x06, op_rlciyd)			/* RLC (IY+d) */
 	if (i) P |= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -391,12 +401,22 @@ INSTRD(0x0e, op_rrciyd)			/* RRC (IY+d) */
 	if (i) P |= 128;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -417,12 +437,22 @@ INSTRD(0x16, op_rliyd)			/* RL (IY+d) */
 	if (old_c_flag) P |= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -443,12 +473,22 @@ INSTRD(0x1e, op_rriyd)			/* RR (IY+d) */
 	if (old_c_flag) P |= 128;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -466,12 +506,22 @@ INSTRD(0x26, op_slaiyd)			/* SLA (IY+d) */
 	P <<= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -491,12 +541,22 @@ INSTRD(0x2e, op_sraiyd)			/* SRA (IY+d) */
 	P = (P >> 1) | i;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -514,12 +574,22 @@ INSTRD(0x3e, op_srliyd)			/* SRL (IY+d) */
 	P >>= 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -549,12 +619,22 @@ INSTRD(0x36, op_undoc_slliyd)		/* SLL (IY+d) */
 	P = (P << 1) | 1;
 	memwrt(addr, P);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(P) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(P & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[P]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(P & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(P & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[P];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[P];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -563,7 +643,7 @@ INSTRD(0x36, op_undoc_slliyd)		/* SLL (IY+d) */
 
 #ifdef UNDOC_IALL
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb0iyd(int data)	/* BIT 0,(IY+d) */
 #else
 case 0x40:				/* BIT 0,(IY+d) */
@@ -578,7 +658,7 @@ case 0x47:				/* BIT 0,(IY+d) */
 	WORD addr;
 
 	if (u_flag) {
-		STATES(trap_ddcb(0));
+		STATES(trap_fdcb(0));
 	}
 
 	addr = IY + data;
@@ -587,15 +667,15 @@ case 0x47:				/* BIT 0,(IY+d) */
 	(memrdr(addr) & 1) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb1iyd(int data)	/* BIT 1,(IY+d) */
 #else
 case 0x48:				/* BIT 1,(IY+d) */
@@ -610,7 +690,7 @@ case 0x4f:				/* BIT 1,(IY+d) */
 	WORD addr;
 
 	if (u_flag) {
-		STATES(trap_ddcb(0));
+		STATES(trap_fdcb(0));
 	}
 
 	addr = IY + data;
@@ -619,15 +699,15 @@ case 0x4f:				/* BIT 1,(IY+d) */
 	(memrdr(addr) & 2) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb2iyd(int data)	/* BIT 2,(IY+d) */
 #else
 case 0x50:				/* BIT 2,(IY+d) */
@@ -642,7 +722,7 @@ case 0x57:				/* BIT 2,(IY+d) */
 	WORD addr;
 
 	if (u_flag) {
-		STATES(trap_ddcb(0));
+		STATES(trap_fdcb(0));
 	}
 
 	addr = IY + data;
@@ -651,15 +731,15 @@ case 0x57:				/* BIT 2,(IY+d) */
 	(memrdr(addr) & 4) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb3iyd(int data)	/* BIT 3,(IY+d) */
 #else
 case 0x58:				/* BIT 3,(IY+d) */
@@ -674,7 +754,7 @@ case 0x5f:				/* BIT 3,(IY+d) */
 	WORD addr;
 
 	if (u_flag) {
-		STATES(trap_ddcb(0));
+		STATES(trap_fdcb(0));
 	}
 
 	addr = IY + data;
@@ -683,15 +763,15 @@ case 0x5f:				/* BIT 3,(IY+d) */
 	(memrdr(addr) & 8) ? (F &= ~(Z_FLAG | P_FLAG))
 			   : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb4iyd(int data)	/* BIT 4,(IY+d) */
 #else
 case 0x60:				/* BIT 4,(IY+d) */
@@ -706,7 +786,7 @@ case 0x67:				/* BIT 4,(IY+d) */
 	WORD addr;
 
 	if (u_flag) {
-		STATES(trap_ddcb(0));
+		STATES(trap_fdcb(0));
 	}
 
 	addr = IY + data;
@@ -715,15 +795,15 @@ case 0x67:				/* BIT 4,(IY+d) */
 	(memrdr(addr) & 16) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb5iyd(int data)	/* BIT 5,(IY+d) */
 #else
 case 0x68:				/* BIT 5,(IY+d) */
@@ -738,7 +818,7 @@ case 0x6f:				/* BIT 5,(IY+d) */
 	WORD addr;
 
 	if (u_flag) {
-		STATES(trap_ddcb(0));
+		STATES(trap_fdcb(0));
 	}
 
 	addr = IY + data;
@@ -747,15 +827,15 @@ case 0x6f:				/* BIT 5,(IY+d) */
 	(memrdr(addr) & 32) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb6iyd(int data)	/* BIT 6,(IY+d) */
 #else
 case 0x70:				/* BIT 6,(IY+d) */
@@ -770,7 +850,7 @@ case 0x77:				/* BIT 6,(IY+d) */
 	WORD addr;
 
 	if (u_flag) {
-		STATES(trap_ddcb(0));
+		STATES(trap_fdcb(0));
 	}
 
 	addr = IY + data;
@@ -779,15 +859,15 @@ case 0x77:				/* BIT 6,(IY+d) */
 	(memrdr(addr) & 64) ? (F &= ~(Z_FLAG | P_FLAG))
 			    : (F |= (Z_FLAG | P_FLAG));
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
 	STATES(20);
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 static int op_undoc_tb7iyd(int data)	/* BIT 7,(IY+d) */
 #else
 case 0x78:				/* BIT 7,(IY+d) */
@@ -802,7 +882,7 @@ case 0x7f:				/* BIT 7,(IY+d) */
 	WORD addr;
 
 	if (u_flag) {
-		STATES(trap_ddcb(0));
+		STATES(trap_fdcb(0));
 	}
 
 	addr = IY + data;
@@ -816,8 +896,8 @@ case 0x7f:				/* BIT 7,(IY+d) */
 		F &= ~S_FLAG;
 	}
 #ifdef UNDOC_FLAGS
-	(addr & (32 << 8)) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
-	(addr & (8 << 8)) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+	(addr & 0x2000) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
+	(addr & 0x0800) ? (F |= X_FLAG) : (F &= ~X_FLAG);
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2745,12 +2825,22 @@ INSTRD(0x07, op_undoc_rlciyda)		/* RLC (IY+d),A */
 	if (i) A |= 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2774,12 +2864,22 @@ INSTRD(0x00, op_undoc_rlciydb)		/* RLC (IY+d),B */
 	if (i) B |= 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2803,12 +2903,22 @@ INSTRD(0x01, op_undoc_rlciydc)		/* RLC (IY+d),C */
 	if (i) C |= 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2832,12 +2942,22 @@ INSTRD(0x02, op_undoc_rlciydd)		/* RLC (IY+d),D */
 	if (i) D |= 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2861,12 +2981,22 @@ INSTRD(0x03, op_undoc_rlciyde)		/* RLC (IY+d),E */
 	if (i) E |= 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2890,12 +3020,22 @@ INSTRD(0x04, op_undoc_rlciydh)		/* RLC (IY+d),H */
 	if (i) H |= 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2919,12 +3059,22 @@ INSTRD(0x05, op_undoc_rlciydl)		/* RLC (IY+d),L */
 	if (i) L |= 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2948,12 +3098,22 @@ INSTRD(0x0f, op_undoc_rrciyda)		/* RRC (IY+d),A */
 	if (i) A |= 128;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -2977,12 +3137,22 @@ INSTRD(0x08, op_undoc_rrciydb)		/* RRC (IY+d),B */
 	if (i) B |= 128;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3006,12 +3176,22 @@ INSTRD(0x09, op_undoc_rrciydc)		/* RRC (IY+d),C */
 	if (i) C |= 128;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3035,12 +3215,22 @@ INSTRD(0x0a, op_undoc_rrciydd)		/* RRC (IY+d),D */
 	if (i) D |= 128;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3064,12 +3254,22 @@ INSTRD(0x0b, op_undoc_rrciyde)		/* RRC (IY+d),E */
 	if (i) E |= 128;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3093,12 +3293,22 @@ INSTRD(0x0c, op_undoc_rrciydh)		/* RRC (IY+d),H */
 	if (i) H |= 128;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3122,12 +3332,22 @@ INSTRD(0x0d, op_undoc_rrciydl)		/* RRC (IY+d),L */
 	if (i) L |= 128;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3151,12 +3371,22 @@ INSTRD(0x17, op_undoc_rliyda)		/* RL (IY+d),A */
 	if (old_c_flag) A |= 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3180,12 +3410,22 @@ INSTRD(0x10, op_undoc_rliydb)		/* RL (IY+d),B */
 	if (old_c_flag) B |= 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3209,12 +3449,22 @@ INSTRD(0x11, op_undoc_rliydc)		/* RL (IY+d),C */
 	if (old_c_flag) C |= 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3238,12 +3488,22 @@ INSTRD(0x12, op_undoc_rliydd)		/* RL (IY+d),D */
 	if (old_c_flag) D |= 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3267,12 +3527,22 @@ INSTRD(0x13, op_undoc_rliyde)		/* RL (IY+d),E */
 	if (old_c_flag) E |= 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3296,12 +3566,22 @@ INSTRD(0x14, op_undoc_rliydh)		/* RL (IY+d),H */
 	if (old_c_flag) H |= 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3325,12 +3605,22 @@ INSTRD(0x15, op_undoc_rliydl)		/* RL (IY+d),L */
 	if (old_c_flag) L |= 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3354,12 +3644,22 @@ INSTRD(0x1f, op_undoc_rriyda)		/* RR (IY+d),A */
 	if (old_c_flag) A |= 128;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3383,12 +3683,22 @@ INSTRD(0x18, op_undoc_rriydb)		/* RR (IY+d),B */
 	if (old_c_flag) B |= 128;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3412,12 +3722,22 @@ INSTRD(0x19, op_undoc_rriydc)		/* RR (IY+d),C */
 	if (old_c_flag) C |= 128;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3441,12 +3761,22 @@ INSTRD(0x1a, op_undoc_rriydd)		/* RR (IY+d),D */
 	if (old_c_flag) D |= 128;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3470,12 +3800,22 @@ INSTRD(0x1b, op_undoc_rriyde)		/* RR (IY+d),E */
 	if (old_c_flag) E |= 128;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3499,12 +3839,22 @@ INSTRD(0x1c, op_undoc_rriydh)		/* RR (IY+d),H */
 	if (old_c_flag) H |= 128;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3528,12 +3878,22 @@ INSTRD(0x1d, op_undoc_rriydl)		/* RR (IY+d),L */
 	if (old_c_flag) L |= 128;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3554,12 +3914,22 @@ INSTRD(0x27, op_undoc_slaiyda)		/* SLA (IY+d),A */
 	A <<= 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3580,12 +3950,22 @@ INSTRD(0x20, op_undoc_slaiydb)		/* SLA (IY+d),B */
 	B <<= 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3606,12 +3986,22 @@ INSTRD(0x21, op_undoc_slaiydc)		/* SLA (IY+d),C */
 	C <<= 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3632,12 +4022,22 @@ INSTRD(0x22, op_undoc_slaiydd)		/* SLA (IY+d),D */
 	D <<= 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3658,12 +4058,22 @@ INSTRD(0x23, op_undoc_slaiyde)		/* SLA (IY+d),E */
 	E <<= 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3684,12 +4094,22 @@ INSTRD(0x24, op_undoc_slaiydh)		/* SLA (IY+d),H */
 	H <<= 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3710,12 +4130,22 @@ INSTRD(0x25, op_undoc_slaiydl)		/* SLA (IY+d),L */
 	L <<= 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3738,12 +4168,22 @@ INSTRD(0x2f, op_undoc_sraiyda)		/* SRA (IY+d),A */
 	A = (A >> 1) | i;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3766,12 +4206,22 @@ INSTRD(0x28, op_undoc_sraiydb)		/* SRA (IY+d),B */
 	B = (B >> 1) | i;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3794,12 +4244,22 @@ INSTRD(0x29, op_undoc_sraiydc)		/* SRA (IY+d),C */
 	C = (C >> 1) | i;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3822,12 +4282,22 @@ INSTRD(0x2a, op_undoc_sraiydd)		/* SRA (IY+d),D */
 	D = (D >> 1) | i;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3850,12 +4320,22 @@ INSTRD(0x2b, op_undoc_sraiyde)		/* SRA (IY+d),E */
 	E = (E >> 1) | i;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3878,12 +4358,22 @@ INSTRD(0x2c, op_undoc_sraiydh)		/* SRA (IY+d),H */
 	H = (H >> 1) | i;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3906,12 +4396,22 @@ INSTRD(0x2d, op_undoc_sraiydl)		/* SRA (IY+d),L */
 	L = (L >> 1) | i;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3932,12 +4432,22 @@ INSTRD(0x37, op_undoc_slliyda)		/* SLL (IY+d),A */
 	A = (A << 1) | 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3958,12 +4468,22 @@ INSTRD(0x30, op_undoc_slliydb)		/* SLL (IY+d),B */
 	B = (B << 1) | 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -3984,12 +4504,22 @@ INSTRD(0x31, op_undoc_slliydc)		/* SLL (IY+d),C */
 	C = (C << 1) | 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4010,12 +4540,22 @@ INSTRD(0x32, op_undoc_slliydd)		/* SLL (IY+d),D */
 	D = (D << 1) | 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4036,12 +4576,22 @@ INSTRD(0x33, op_undoc_slliyde)		/* SLL (IY+d),E */
 	E = (E << 1) | 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4062,12 +4612,22 @@ INSTRD(0x34, op_undoc_slliydh)		/* SLL (IY+d),H */
 	H = (H << 1) | 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4088,12 +4648,22 @@ INSTRD(0x35, op_undoc_slliydl)		/* SLL (IY+d),L */
 	L = (L << 1) | 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4114,12 +4684,22 @@ INSTRD(0x3f, op_undoc_srliyda)		/* SRL (IY+d),A */
 	A >>= 1;
 	memwrt(addr, A);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(A & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(A & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[A];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[A];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4140,12 +4720,22 @@ INSTRD(0x38, op_undoc_srliydb)		/* SRL (IY+d),B */
 	B >>= 1;
 	memwrt(addr, B);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(B) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(B & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[B]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(B & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(B & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[B];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[B];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4166,12 +4756,22 @@ INSTRD(0x39, op_undoc_srliydc)		/* SRL (IY+d),C */
 	C >>= 1;
 	memwrt(addr, C);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(C) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(C & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[C]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(C & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(C & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[C];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[C];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4192,12 +4792,22 @@ INSTRD(0x3a, op_undoc_srliydd)		/* SRL (IY+d),D */
 	D >>= 1;
 	memwrt(addr, D);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(D) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(D & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[D]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(D & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(D & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[D];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[D];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4218,12 +4828,22 @@ INSTRD(0x3b, op_undoc_srliyde)		/* SRL (IY+d),E */
 	E >>= 1;
 	memwrt(addr, E);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(E) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(E & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[E]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(E & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(E & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[E];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[E];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4244,12 +4864,22 @@ INSTRD(0x3c, op_undoc_srliydh)		/* SRL (IY+d),H */
 	H >>= 1;
 	memwrt(addr, H);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(H) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(H & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[H]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(H & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(H & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[H];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[H];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif
@@ -4270,12 +4900,22 @@ INSTRD(0x3d, op_undoc_srliydl)		/* SRL (IY+d),L */
 	L >>= 1;
 	memwrt(addr, L);
 	F &= ~(H_FLAG | N_FLAG);
+#ifndef FLAG_TABLES
 	(L) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(L & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(parity[L]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
 #ifdef UNDOC_FLAGS
 	(L & 32) ? (F |= Y_FLAG) : (F &= ~Y_FLAG);
 	(L & 8) ? (F |= X_FLAG) : (F &= ~X_FLAG);
+#endif
+#else /* FLAG_TABLES */
+#ifndef UNDOC_FLAGS
+	F = (F & ~SZP_FLAGS) | szp_flags[L];
+#else
+	F = (F & ~SZYXP_FLAGS) | szyxp_flags[L];
+#endif
+#endif /* FLAG_TABLES */
+#ifdef UNDOC_FLAGS
 	WZ = addr;
 	modF = 1;
 #endif

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -29,7 +29,7 @@ extern void check_gui_break(void);
 static int trap_cb(void), trap_dd(void), trap_ddcb(int);
 static int trap_ed(void), trap_fd(void), trap_fdcb(int);
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 
 static int op_nop(void), op_halt(void), op_scf(void);
 static int op_ccf(void), op_cpl(void), op_daa(void);
@@ -495,13 +495,13 @@ static int op_undoc_srliydl(int);
 #define INSTRD(opcode, func)	static int func(int data)
 #define STATES(states)		return (states)
 
-#else /* FAST_INSTR */
+#else /* INSTR_SWTCH */
 
 #define INSTR(opcode, func)	case opcode:
 #define INSTRD(opcode, func)	case opcode:
 #define STATES(states)		t = states; break
 
-#endif /* FAST_INSTR */
+#endif /* INSTR_SWTCH */
 
 /*
  *	This function builds the Z80 central processing unit.
@@ -514,7 +514,7 @@ void cpu_z80(void)
 {
 	extern unsigned long long get_clock_us(void);
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 	static int (*op_sim[256])(void) = {
 		op_nop,				/* 0x00 */
 		op_ldbcnn,			/* 0x01 */
@@ -773,7 +773,7 @@ void cpu_z80(void)
 		op_cpn,				/* 0xfe */
 		op_rst38			/* 0xff */
 	};
-#endif /* !FAST_INSTR */
+#endif /* !INSTR_SWTCH */
 
 	Tstates_t T_max;
 	unsigned long long t1, t2;
@@ -984,7 +984,7 @@ leave:
 
 		int_protection = 0;
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 		t = (*op_sim[memrdr(PC++)])();	/* execute next opcode */
 #else
 		switch (memrdr(PC++)) {		/* execute next opcode */
@@ -1038,7 +1038,7 @@ leave:
 #endif
 }
 
-#ifndef FAST_INSTR
+#ifndef INSTR_SWTCH
 #include "simz80-00.c"
 #endif
 

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -18,7 +18,8 @@
 /*#define UNDOC_INST*/	/* compile undocumented instructions */
 /*#define UNDOC_IALL*/	/* compile rarely used undoc'd Z80 instructions */
 /*#define UNDOC_FLAGS*/	/* compile undocumented Z80 flags */
-/*#define FAST_INSTR*/	/* faster instr. & smaller size, but less debuggable */
+/*#define INSTR_SWTCH*/	/* big switch instead of functions, less debuggable */
+/*#define FLAG_TABLES*/	/* use table lookups for flags */
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 
 #define WANT_ICE	/* attach ICE to headless machine */

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -19,7 +19,8 @@
 #define UNDOC_INST	/* compile undocumented instructions */
 #define UNDOC_IALL	/* compile rarely used undoc'd Z80 instructions */
 #define UNDOC_FLAGS	/* compile undocumented Z80 flags */
-#define FAST_INSTR	/* faster instr. & smaller size, but less debuggable */
+#define INSTR_SWTCH	/* big switch instead of functions, less debuggable */
+#define FLAG_TABLES	/* use table lookups for flags */
 #define FAST_BLOCK	/* much faster but not accurate Z80 block instr. */
 
 #define WANT_ICE	/* attach ICE to headless machine */


### PR DESCRIPTION
Seperated big switch and flag tables into two options: INSTR_SWTCH and FLAG_TABLES

Add more option defines checking in simcore.h

Fixed a cut & paste error in simz80-fdcb.c: trap_ddcb -> trap_fdcb