### PR TITLE
use new -d syntax

### DIFF
--- a/cpmtools/Makefile
+++ b/cpmtools/Makefile
@@ -29,13 +29,13 @@ swz80.com: swz80.asm $(Z80ASM)
 	$(Z80ASM) $(Z80ASMFLAGS) -8 -fb -o$@ $<
 
 ex8080.com: ex.mac $(Z80ASM)
-	$(Z80ASM) $(Z80ASMFLAGS) -dex8080 -fb -l$(@:.com=.lis) -o$@ $<
+	$(Z80ASM) $(Z80ASMFLAGS) -dexkind=0 -fb -l$(@:.com=.lis) -o$@ $<
 
 exz80doc.com: ex.mac $(Z80ASM)
-	$(Z80ASM) $(Z80ASMFLAGS) -dexz80doc -fb -l$(@:.com=.lis) -o$@ $<
+	$(Z80ASM) $(Z80ASMFLAGS) -dexkind=1 -fb -l$(@:.com=.lis) -o$@ $<
 
 exz80all.com: ex.mac $(Z80ASM)
-	$(Z80ASM) $(Z80ASMFLAGS) -dexz80all -fb -l$(@:.com=.lis) -o$@ $<
+	$(Z80ASM) $(Z80ASMFLAGS) -dexkind=2 -fb -l$(@:.com=.lis) -o$@ $<
 
 prelim.com: prelim.mac $(Z80ASM)
 	$(Z80ASM) $(Z80ASMFLAGS) -fb -o$@ $<

--- a/cpmtools/ex.mac
+++ b/cpmtools/ex.mac
@@ -5,14 +5,8 @@
 ; exkind	equ	0	; for 8080 only, Z80 instructions are not tested, EX8080.COM
 ; exkind	equ	1	; for Z80 only, undefined status bits are NOT tested, EXZ80DOC.COM
 ; exkind	equ	2	; for Z80 only, undefined status bits ARE tested, EXZ80ALL.COM
-     ifdef ex8080
-exkind	equ	0
-     endif
-     ifdef exz80doc
+     ifndef exkind
 exkind	equ	1
-     endif
-     ifdef exz80all
-exkind	equ	2
      endif
 
 ; trace defines whether verbose state information is sent to the console

--- a/z80asm/z80aout.c
+++ b/z80asm/z80aout.c
@@ -89,7 +89,7 @@ static char hex_out[MAXHEX * 2 + 13];	/* ASCII buffer for one HEX record */
 void asmerr(int i)
 {
 	if (pass == 0) {
-		fputs("invalid expression in option -d: ", errfp);
+		fputs("error in option -d: ", errfp);
 		fputs(errmsg[i], errfp);
 		fputc('\n', errfp);
 	} else if (pass == 1) {


### PR DESCRIPTION
Change error message.
"invalid expression in option -d: invalid expression" looks silly.