### PR TITLE
ICE timing option for 'g' and new DAA implementation

### DIFF
--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -580,6 +580,7 @@ leave:
 #ifndef INSTR_SWTCH
 		t = (*op_sim[memrdr(PC++)])();	/* execute next opcode */
 #else
+		t = 4;
 		switch (memrdr(PC++)) {		/* execute next opcode */
 
 #include "sim8080-00.c"


### PR DESCRIPTION
New DAA implementation, much cleaner

Produces exactly the same output (A, H, and C) for all 2048 combinations of A, N-FLAG, H-FLAG, and C_FLAG as the one from Mark Garlanger.
