### PR TITLE
fix errors

### DIFF
--- a/z80core/alt8080.h
+++ b/z80core/alt8080.h
@@ -1523,6 +1523,7 @@ finish_call:
 
 	case 0xfb:			/* EI */
 		IFF = 3;
+		int_protection = 1;	/* protect next instruction */
 		break;
 
 	case 0xfc:			/* CM nn */

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -3044,6 +3044,7 @@ static int op_retc(void)		/* RET C */
 		i = memrdr(SP++);
 		i += memrdr(SP++) << 8;
 		PC = i;
+		return (11);
 	}
 	return (5);
 }


### PR DESCRIPTION
Forgot int_protection in alt8080 EI.
Restore T-states in RET C in simz80.c broken in unmessify commit.