### PR TITLE
try to improve the accuracy of cpu frequency reporting

### DIFF
--- a/altairsim/srcsim/iosim.c
+++ b/altairsim/srcsim/iosim.c
@@ -30,6 +30,7 @@
  * 10-AUG-2018 added MITS 88-DCDD floppy disk controller
  * 08-OCT-2019 (Mike Douglas) added OUT 161 trap to simbdos.c for host file I/O
  * 31-JUL-2021 allow building machine without frontpanel
+ * 27-MAY-2024 moved io_in & io_out to simcore
  */
 
 #include <unistd.h>
@@ -60,8 +61,6 @@
 /*
  *	Forward declarations for I/O functions
  */
-static BYTE io_trap_in(void);
-static void io_trap_out(BYTE);
 static BYTE hwctl_in(void), fp_in(void);
 static void hwctl_out(BYTE), fp_out(BYTE);
 static BYTE lpt_status_in(void), lpt_data_in(void);
@@ -84,525 +83,62 @@ BYTE hwctl_lock = 0xff;		/* lock status hardware control port */
  *	input I/O port (0 - 255), to do the required I/O.
  */
 BYTE (*port_in[256])(void) = {
-	altair_sio0_status_in,	/* port 0 */ /* SIO 0 connected to console */
-	altair_sio0_data_in,	/* port 1 */ /*  "  */
-	lpt_status_in,		/* port 2 */ /* printer status */
-	lpt_data_in,		/* port 3 */ /* printer data */
-	kbd_status_in,		/* port 4 */ /* status VDM keyboard */
-	kbd_data_in,		/* port 5 */ /* data VDM keyboard */
-	altair_sio3_status_in,	/* port 6 */ /* SIO 3 connected to socket */
-	altair_sio3_data_in,	/* port 7 */ /*  "  */
-	altair_dsk_status_in,	/* port 8 */ /* MITS 88-DCDD status */
-	altair_dsk_sec_in,	/* port 9 */ /* MITS 88-DCDD sector position */
-	altair_dsk_data_in,	/* port 10 *//* MITS 88-DCDD read data */
-	io_trap_in,		/* port 11 */
-	io_trap_in,		/* port 12 */
-	io_trap_in,		/* port 13 */
-	cromemco_dazzler_flags_in, /* port 14 */ /* Cromemco Dazzler */
-	io_trap_in,		/* port 15 */
-	altair_sio1_status_in,	/* port 16 */ /* SIO 1 connected to console */
-	altair_sio1_data_in,	/* port 17 */ /*  "  */
-	altair_sio2_status_in,	/* port 18 */ /* SIO 2 connected to socket */
-	altair_sio2_data_in,	/* port 19 */ /*  "  */
-	io_trap_in,		/* port 20 */
-	io_trap_in,		/* port 21 */
-	io_trap_in,		/* port 22 */
-	io_trap_in,		/* port 23 */
-	io_trap_in,		/* port 24 */
-	io_trap_in,		/* port 25 */
-	io_trap_in,		/* port 26 */
-	io_trap_in,		/* port 27 */
-	io_trap_in,		/* port 28 */
-	io_trap_in,		/* port 29 */
-	io_trap_in,		/* port 30 */
-	io_trap_in,		/* port 31 */
-	io_trap_in,		/* port 32 */
-	io_trap_in,		/* port 33 */
-	io_trap_in,		/* port 34 */
-	io_trap_in,		/* port 35 */
-	io_trap_in,		/* port 36 */
-	io_trap_in,		/* port 37 */
-	io_trap_in,		/* port 38 */
-	io_trap_in,		/* port 39 */
-	io_trap_in,		/* port 40 */
-	io_trap_in,		/* port 41 */
-	io_trap_in,		/* port 42 */
-	io_trap_in,		/* port 43 */
-	io_trap_in,		/* port 44 */
-	io_trap_in,		/* port 45 */
-	io_trap_in,		/* port 46 */
-	io_trap_in,		/* port 47 */
-	io_trap_in,		/* port 48 */
-	io_trap_in,		/* port 49 */
-	io_trap_in,		/* port 50 */
-	io_trap_in,		/* port 51 */
-	io_trap_in,		/* port 52 */
-	io_trap_in,		/* port 53 */
-	io_trap_in,		/* port 54 */
-	io_trap_in,		/* port 55 */
-	io_trap_in,		/* port 56 */
-	io_trap_in,		/* port 57 */
-	io_trap_in,		/* port 58 */
-	io_trap_in,		/* port 59 */
-	io_trap_in,		/* port 60 */
-	io_trap_in,		/* port 61 */
-	io_trap_in,		/* port 62 */
-	io_trap_in,		/* port 63 */
-	io_trap_in,		/* port 64 */
-	io_trap_in,		/* port 65 */
-	io_trap_in,		/* port 66 */
-	io_trap_in,		/* port 67 */
-	io_trap_in,		/* port 68 */
-	io_trap_in,		/* port 69 */
-	io_trap_in,		/* port 70 */
-	io_trap_in,		/* port 71 */
-	io_trap_in,		/* port 72 */
-	io_trap_in,		/* port 73 */
-	io_trap_in,		/* port 74 */
-	io_trap_in,		/* port 75 */
-	io_trap_in,		/* port 76 */
-	io_trap_in,		/* port 77 */
-	io_trap_in,		/* port 78 */
-	io_trap_in,		/* port 79 */
-	io_trap_in,		/* port 80 */
-	io_trap_in,		/* port 81 */
-	io_trap_in,		/* port 82 */
-	io_trap_in,		/* port 83 */
-	io_trap_in,		/* port 84 */
-	io_trap_in,		/* port 85 */
-	io_trap_in,		/* port 86 */
-	io_trap_in,		/* port 87 */
-	io_trap_in,		/* port 88 */
-	io_trap_in,		/* port 89 */
-	io_trap_in,		/* port 90 */
-	io_trap_in,		/* port 91 */
-	io_trap_in,		/* port 92 */
-	io_trap_in,		/* port 93 */
-	io_trap_in,		/* port 94 */
-	io_trap_in,		/* port 95 */
-	io_trap_in,		/* port 96 */
-	io_trap_in,		/* port 97 */
-	io_trap_in,		/* port 98 */
-	io_trap_in,		/* port 99 */
-	io_trap_in,		/* port 100 */
-	io_trap_in,		/* port 101 */
-	io_trap_in,		/* port 102 */
-	io_trap_in,		/* port 103 */
-	io_trap_in,		/* port 104 */
-	io_trap_in,		/* port 105 */
-	io_trap_in,		/* port 106 */
-	io_trap_in,		/* port 107 */
-	io_trap_in,		/* port 108 */
-	io_trap_in,		/* port 109 */
-	io_trap_in,		/* port 110 */
-	io_trap_in,		/* port 111 */
-	io_trap_in,		/* port 112 */
-	io_trap_in,		/* port 113 */
-	io_trap_in,		/* port 114 */
-	io_trap_in,		/* port 115 */
-	io_trap_in,		/* port 116 */
-	io_trap_in,		/* port 117 */
-	io_trap_in,		/* port 118 */
-	io_trap_in,		/* port 119 */
-	io_trap_in,		/* port 120 */
-	io_trap_in,		/* port 121 */
-	io_trap_in,		/* port 122 */
-	io_trap_in,		/* port 123 */
-	io_trap_in,		/* port 124 */
-	io_trap_in,		/* port 125 */
-	io_trap_in,		/* port 126 */
-	io_trap_in,		/* port 127 */
-	io_trap_in,		/* port 128 */
-	io_trap_in,		/* port 129 */
-	io_trap_in,		/* port 130 */
-	io_trap_in,		/* port 131 */
-	io_trap_in,		/* port 132 */
-	io_trap_in,		/* port 133 */
-	io_trap_in,		/* port 134 */
-	io_trap_in,		/* port 135 */
-	io_trap_in,		/* port 136 */
-	io_trap_in,		/* port 137 */
-	io_trap_in,		/* port 138 */
-	io_trap_in,		/* port 139 */
-	io_trap_in,		/* port 140 */
-	io_trap_in,		/* port 141 */
-	io_trap_in,		/* port 142 */
-	io_trap_in,		/* port 143 */
-	io_trap_in,		/* port 144 */
-	io_trap_in,		/* port 145 */
-	io_trap_in,		/* port 146 */
-	io_trap_in,		/* port 147 */
-	io_trap_in,		/* port 148 */
-	io_trap_in,		/* port 149 */
-	io_trap_in,		/* port 150 */
-	io_trap_in,		/* port 151 */
-	io_trap_in,		/* port 152 */
-	io_trap_in,		/* port 153 */
-	io_trap_in,		/* port 154 */
-	io_trap_in,		/* port 155 */
-	io_trap_in,		/* port 156 */
-	io_trap_in,		/* port 157 */
-	io_trap_in,		/* port 158 */
-	io_trap_in,		/* port 159 */
-	hwctl_in,		/* port 160 */	/* virtual hardware control */
-	io_trap_in,		/* port 161 */
-	io_trap_in,		/* port 162 */
-	io_trap_in,		/* port 163 */
-	io_trap_in,		/* port 164 */
-	io_trap_in,		/* port 165 */
-	io_trap_in,		/* port 166 */
-	io_trap_in,		/* port 167 */
-	io_trap_in,		/* port 168 */
-	io_trap_in,		/* port 169 */
-	io_trap_in,		/* port 170 */
-	io_trap_in,		/* port 171 */
-	io_trap_in,		/* port 172 */
-	io_trap_in,		/* port 173 */
-	io_trap_in,		/* port 174 */
-	io_trap_in,		/* port 175 */
-	io_trap_in,		/* port 176 */
-	io_trap_in,		/* port 177 */
-	io_trap_in,		/* port 178 */
-	io_trap_in,		/* port 179 */
-	io_trap_in,		/* port 180 */
-	io_trap_in,		/* port 181 */
-	io_trap_in,		/* port 182 */
-	io_trap_in,		/* port 183 */
-	io_trap_in,		/* port 184 */
-	io_trap_in,		/* port 185 */
-	io_trap_in,		/* port 186 */
-	io_trap_in,		/* port 187 */
-	io_trap_in,		/* port 188 */
-	io_trap_in,		/* port 189 */
-	io_trap_in,		/* port 190 */
-	io_trap_in,		/* port 191 */
-	io_trap_in,		/* port 192 */
-	io_trap_in,		/* port 193 */
-	io_trap_in,		/* port 194 */
-	io_trap_in,		/* port 195 */
-	io_trap_in,		/* port 196 */
-	io_trap_in,		/* port 197 */
-	io_trap_in,		/* port 198 */
-	io_trap_in,		/* port 199 */
-	io_trap_in,		/* port 200 */
-	io_trap_in,		/* port 201 */
-	io_trap_in,		/* port 202 */
-	io_trap_in,		/* port 203 */
-	io_trap_in,		/* port 204 */
-	io_trap_in,		/* port 205 */
-	io_trap_in,		/* port 206 */
-	io_trap_in,		/* port 207 */
-	io_trap_in,		/* port 208 */
-	io_trap_in,		/* port 209 */
-	io_trap_in,		/* port 210 */
-	io_trap_in,		/* port 211 */
-	io_trap_in,		/* port 212 */
-	io_trap_in,		/* port 213 */
-	io_trap_in,		/* port 214 */
-	io_trap_in,		/* port 215 */
-	io_trap_in,		/* port 216 */
-	io_trap_in,		/* port 217 */
-	io_trap_in,		/* port 218 */
-	io_trap_in,		/* port 219 */
-	io_trap_in,		/* port 220 */
-	io_trap_in,		/* port 221 */
-	io_trap_in,		/* port 222 */
-	io_trap_in,		/* port 223 */
-	io_trap_in,		/* port 224 */
-	io_trap_in,		/* port 225 */
-	io_trap_in,		/* port 226 */
-	io_trap_in,		/* port 227 */
-	io_trap_in,		/* port 228 */
-	io_trap_in,		/* port 229 */
-	io_trap_in,		/* port 230 */
-	io_trap_in,		/* port 231 */
-	io_trap_in,		/* port 232 */
-	io_trap_in,		/* port 233 */
-	io_trap_in,		/* port 234 */
-	io_trap_in,		/* port 235 */
-	io_trap_in,		/* port 236 */
-	io_trap_in,		/* port 237 */
-	io_trap_in,		/* port 238 */
-	io_trap_in,		/* port 239 */
-	io_trap_in,		/* port 240 */
-	io_trap_in,		/* port 241 */
-	io_trap_in,		/* port 242 */
-	io_trap_in,		/* port 243 */
-	io_trap_in,		/* port 244 */
-	io_trap_in,		/* port 245 */
-	io_trap_in,		/* port 246 */
-	io_trap_in,		/* port 247 */
-	tarbell_stat_in,	/* port 248 */ /* Tarbell 1011D status */
-	tarbell_track_in,	/* port 249 */ /* Tarbell 1011D track */
-	tarbell_sec_in,		/* port 250 */ /* Tarbell 1011D sector */
-	tarbell_data_in,	/* port 251 */ /* Tarbell 1011D data */
-	tarbell_wait_in,	/* port 252 */ /* Tarbell 1011D wait */
-	io_trap_in,		/* port 253 */
-	io_trap_in,		/* port 254 */
-	fp_in			/* port 255 */ /* frontpanel */
+	[  0] altair_sio0_status_in,	/* SIO 0 connected to console */
+	[  1] altair_sio0_data_in,	/*  "  */
+	[  2] lpt_status_in,		/* printer status */
+	[  3] lpt_data_in,		/* printer data */
+	[  4] kbd_status_in,		/* status VDM keyboard */
+	[  5] kbd_data_in,		/* data VDM keyboard */
+	[  6] altair_sio3_status_in,	/* SIO 3 connected to socket */
+	[  7] altair_sio3_data_in,	/*  "  */
+	[  8] altair_dsk_status_in,	/* MITS 88-DCDD status */
+	[  9] altair_dsk_sec_in,	/* MITS 88-DCDD sector position */
+	[ 10] altair_dsk_data_in,	/* MITS 88-DCDD read data */
+	[ 14] cromemco_dazzler_flags_in, /* Cromemco Dazzler */
+	[ 16] altair_sio1_status_in,	/* SIO 1 connected to console */
+	[ 17] altair_sio1_data_in,	/*  "  */
+	[ 18] altair_sio2_status_in,	/* SIO 2 connected to socket */
+	[ 19] altair_sio2_data_in,	/*  "  */
+	[160] hwctl_in,			/* virtual hardware control */
+	[248] tarbell_stat_in,		/* Tarbell 1011D status */
+	[249] tarbell_track_in,		/* Tarbell 1011D track */
+	[250] tarbell_sec_in,		/* Tarbell 1011D sector */
+	[251] tarbell_data_in,		/* Tarbell 1011D data */
+	[252] tarbell_wait_in,		/* Tarbell 1011D wait */
+	[255] fp_in			/* frontpanel */
 };
 
 /*
  *	This array contains function pointers for every
  *	output I/O port (0 - 255), to do the required I/O.
  */
-static void (*port_out[256])(BYTE) = {
-	altair_sio0_status_out,	/* port 0 */ /* SIO 0 connected to console */
-	altair_sio0_data_out,	/* port 1 */ /*  "  */
-	lpt_status_out,		/* port 2 */ /* printer status */
-	lpt_data_out,		/* port 3 */ /* printer data */
-	io_no_card_out,		/* port 4 */ /* status VDM keyboard */
-	io_no_card_out,		/* port 5 */ /* data VDM keyboard */
-	altair_sio3_status_out,	/* port 6 */ /* SIO 3 connected to socket */
-	altair_sio3_data_out,	/* port 7 */ /*  "  */
-	altair_dsk_select_out,	/* port 8 */ /* MITS 88-DCDD disk select */
-	altair_dsk_control_out,	/* port 9 */ /* MITS 88-DCDD control disk */
-	altair_dsk_data_out,	/* port 10 *//* MITS 88-DCDD write data */
-	io_trap_out,		/* port 11 */
-	io_trap_out,		/* port 12 */
-	io_trap_out,		/* port 13 */
-	cromemco_dazzler_ctl_out,	/* port 14 */ /* Cromemco Dazzler */
-	cromemco_dazzler_format_out,	/* port 15 */ /*  "  */
-	altair_sio1_status_out,	/* port 16 */ /* SIO 1 connected to console */
-	altair_sio1_data_out,	/* port 17 */
-	altair_sio2_status_out,	/* port 18 */ /* SIO 2 connected to socket */
-	altair_sio2_data_out,	/* port 19 */ /*  "  */
-	io_trap_out,		/* port 20 */
-	io_trap_out,		/* port 21 */
-	io_trap_out,		/* port 22 */
-	io_trap_out,		/* port 23 */
-	io_trap_out,		/* port 24 */
-	io_trap_out,		/* port 25 */
-	io_trap_out,		/* port 26 */
-	io_trap_out,		/* port 27 */
-	io_trap_out,		/* port 28 */
-	io_trap_out,		/* port 29 */
-	io_trap_out,		/* port 30 */
-	io_trap_out,		/* port 31 */
-	io_trap_out,		/* port 32 */
-	io_trap_out,		/* port 33 */
-	io_trap_out,		/* port 34 */
-	io_trap_out,		/* port 35 */
-	io_trap_out,		/* port 36 */
-	io_trap_out,		/* port 37 */
-	io_trap_out,		/* port 38 */
-	io_trap_out,		/* port 39 */
-	io_trap_out,		/* port 40 */
-	io_trap_out,		/* port 41 */
-	io_trap_out,		/* port 42 */
-	io_trap_out,		/* port 43 */
-	io_trap_out,		/* port 44 */
-	io_trap_out,		/* port 45 */
-	io_trap_out,		/* port 46 */
-	io_trap_out,		/* port 47 */
-	io_trap_out,		/* port 48 */
-	io_trap_out,		/* port 49 */
-	io_trap_out,		/* port 50 */
-	io_trap_out,		/* port 51 */
-	io_trap_out,		/* port 52 */
-	io_trap_out,		/* port 53 */
-	io_trap_out,		/* port 54 */
-	io_trap_out,		/* port 55 */
-	io_trap_out,		/* port 56 */
-	io_trap_out,		/* port 57 */
-	io_trap_out,		/* port 58 */
-	io_trap_out,		/* port 59 */
-	io_trap_out,		/* port 60 */
-	io_trap_out,		/* port 61 */
-	io_trap_out,		/* port 62 */
-	io_trap_out,		/* port 63 */
-	io_trap_out,		/* port 64 */
-	io_trap_out,		/* port 65 */
-	io_trap_out,		/* port 66 */
-	io_trap_out,		/* port 67 */
-	io_trap_out,		/* port 68 */
-	io_trap_out,		/* port 69 */
-	io_trap_out,		/* port 70 */
-	io_trap_out,		/* port 71 */
-	io_trap_out,		/* port 72 */
-	io_trap_out,		/* port 73 */
-	io_trap_out,		/* port 74 */
-	io_trap_out,		/* port 75 */
-	io_trap_out,		/* port 76 */
-	io_trap_out,		/* port 77 */
-	io_trap_out,		/* port 78 */
-	io_trap_out,		/* port 79 */
-	io_trap_out,		/* port 80 */
-	io_trap_out,		/* port 81 */
-	io_trap_out,		/* port 82 */
-	io_trap_out,		/* port 83 */
-	io_trap_out,		/* port 84 */
-	io_trap_out,		/* port 85 */
-	io_trap_out,		/* port 86 */
-	io_trap_out,		/* port 87 */
-	io_trap_out,		/* port 88 */
-	io_trap_out,		/* port 89 */
-	io_trap_out,		/* port 90 */
-	io_trap_out,		/* port 91 */
-	io_trap_out,		/* port 92 */
-	io_trap_out,		/* port 93 */
-	io_trap_out,		/* port 94 */
-	io_trap_out,		/* port 95 */
-	io_trap_out,		/* port 96 */
-	io_trap_out,		/* port 97 */
-	io_trap_out,		/* port 98 */
-	io_trap_out,		/* port 99 */
-	io_trap_out,		/* port 100 */
-	io_trap_out,		/* port 101 */
-	io_trap_out,		/* port 102 */
-	io_trap_out,		/* port 103 */
-	io_trap_out,		/* port 104 */
-	io_trap_out,		/* port 105 */
-	io_trap_out,		/* port 106 */
-	io_trap_out,		/* port 107 */
-	io_trap_out,		/* port 108 */
-	io_trap_out,		/* port 109 */
-	io_trap_out,		/* port 110 */
-	io_trap_out,		/* port 111 */
-	io_trap_out,		/* port 112 */
-	io_trap_out,		/* port 113 */
-	io_trap_out,		/* port 114 */
-	io_trap_out,		/* port 115 */
-	io_trap_out,		/* port 116 */
-	io_trap_out,		/* port 117 */
-	io_trap_out,		/* port 118 */
-	io_trap_out,		/* port 119 */
-	io_trap_out,		/* port 120 */
-	io_trap_out,		/* port 121 */
-	io_trap_out,		/* port 122 */
-	io_trap_out,		/* port 123 */
-	io_trap_out,		/* port 124 */
-	io_trap_out,		/* port 125 */
-	io_trap_out,		/* port 126 */
-	io_trap_out,		/* port 127 */
-	io_trap_out,		/* port 128 */
-	io_trap_out,		/* port 129 */
-	io_trap_out,		/* port 130 */
-	io_trap_out,		/* port 131 */
-	io_trap_out,		/* port 132 */
-	io_trap_out,		/* port 133 */
-	io_trap_out,		/* port 134 */
-	io_trap_out,		/* port 135 */
-	io_trap_out,		/* port 136 */
-	io_trap_out,		/* port 137 */
-	io_trap_out,		/* port 138 */
-	io_trap_out,		/* port 139 */
-	io_trap_out,		/* port 140 */
-	io_trap_out,		/* port 141 */
-	io_trap_out,		/* port 142 */
-	io_trap_out,		/* port 143 */
-	io_trap_out,		/* port 144 */
-	io_trap_out,		/* port 145 */
-	io_trap_out,		/* port 146 */
-	io_trap_out,		/* port 147 */
-	io_trap_out,		/* port 148 */
-	io_trap_out,		/* port 149 */
-	io_trap_out,		/* port 150 */
-	io_trap_out,		/* port 151 */
-	io_trap_out,		/* port 152 */
-	io_trap_out,		/* port 153 */
-	io_trap_out,		/* port 154 */
-	io_trap_out,		/* port 155 */
-	io_trap_out,		/* port 156 */
-	io_trap_out,		/* port 157 */
-	io_trap_out,		/* port 158 */
-	io_trap_out,		/* port 159 */
-	hwctl_out,		/* port 160 */	/* virtual hardware control */
-	host_bdos_out,		/* port 161 */  /* host file I/O hook */
-	io_trap_out,		/* port 162 */
-	io_trap_out,		/* port 163 */
-	io_trap_out,		/* port 164 */
-	io_trap_out,		/* port 165 */
-	io_trap_out,		/* port 166 */
-	io_trap_out,		/* port 167 */
-	io_trap_out,		/* port 168 */
-	io_trap_out,		/* port 169 */
-	io_trap_out,		/* port 170 */
-	io_trap_out,		/* port 171 */
-	io_trap_out,		/* port 172 */
-	io_trap_out,		/* port 173 */
-	io_trap_out,		/* port 174 */
-	io_trap_out,		/* port 175 */
-	io_trap_out,		/* port 176 */
-	io_trap_out,		/* port 177 */
-	io_trap_out,		/* port 178 */
-	io_trap_out,		/* port 179 */
-	io_trap_out,		/* port 180 */
-	io_trap_out,		/* port 181 */
-	io_trap_out,		/* port 182 */
-	io_trap_out,		/* port 183 */
-	io_trap_out,		/* port 184 */
-	io_trap_out,		/* port 185 */
-	io_trap_out,		/* port 186 */
-	io_trap_out,		/* port 187 */
-	io_trap_out,		/* port 188 */
-	io_trap_out,		/* port 189 */
-	io_trap_out,		/* port 190 */
-	io_trap_out,		/* port 191 */
-	io_trap_out,		/* port 192 */
-	io_trap_out,		/* port 193 */
-	io_trap_out,		/* port 194 */
-	io_trap_out,		/* port 195 */
-	io_trap_out,		/* port 196 */
-	io_trap_out,		/* port 197 */
-	io_trap_out,		/* port 198 */
-	io_trap_out,		/* port 199 */
-	proctec_vdm_out,	/* port 200 */ /* Processor Technology VDM */
-	io_trap_out,		/* port 201 */
-	io_trap_out,		/* port 202 */
-	io_trap_out,		/* port 203 */
-	io_trap_out,		/* port 204 */
-	io_trap_out,		/* port 205 */
-	io_trap_out,		/* port 206 */
-	io_trap_out,		/* port 207 */
-	io_trap_out,		/* port 208 */
-	io_trap_out,		/* port 209 */
-	io_trap_out,		/* port 210 */
-	io_trap_out,		/* port 211 */
-	io_trap_out,		/* port 212 */
-	io_trap_out,		/* port 213 */
-	io_trap_out,		/* port 214 */
-	io_trap_out,		/* port 215 */
-	io_trap_out,		/* port 216 */
-	io_trap_out,		/* port 217 */
-	io_trap_out,		/* port 218 */
-	io_trap_out,		/* port 219 */
-	io_trap_out,		/* port 220 */
-	io_trap_out,		/* port 221 */
-	io_trap_out,		/* port 222 */
-	io_trap_out,		/* port 223 */
-	io_trap_out,		/* port 224 */
-	io_trap_out,		/* port 225 */
-	io_trap_out,		/* port 226 */
-	io_trap_out,		/* port 227 */
-	io_trap_out,		/* port 228 */
-	io_trap_out,		/* port 229 */
-	io_trap_out,		/* port 230 */
-	io_trap_out,		/* port 231 */
-	io_trap_out,		/* port 232 */
-	io_trap_out,		/* port 233 */
-	io_trap_out,		/* port 234 */
-	io_trap_out,		/* port 235 */
-	io_trap_out,		/* port 236 */
-	io_trap_out,		/* port 237 */
-	io_trap_out,		/* port 238 */
-	io_trap_out,		/* port 239 */
-	io_trap_out,		/* port 240 */
-	io_trap_out,		/* port 241 */
-	io_trap_out,		/* port 242 */
-	io_trap_out,		/* port 243 */
-	io_trap_out,		/* port 244 */
-	io_trap_out,		/* port 245 */
-	io_trap_out,		/* port 246 */
-	io_trap_out,		/* port 247 */
-	tarbell_cmd_out,	/* port 248 */ /* Tarbell 1011D command */
-	tarbell_track_out,	/* port 249 */ /* Tarbell 1011D track */
-	tarbell_sec_out,	/* port 250 */ /* Tarbell 1011D sector */
-	tarbell_data_out,	/* port 251 */ /* Tarbell 1011D data */
-	tarbell_ext_out,	/* port 252 */ /* Tarbell 1011D extended cmd */
-	io_trap_out,		/* port 253 */
-	io_trap_out,		/* port 254 */
-	fp_out			/* port 255 */ /* front panel */
+void (*port_out[256])(BYTE) = {
+	[  0] altair_sio0_status_out,	/* SIO 0 connected to console */
+	[  1] altair_sio0_data_out,	/*  "  */
+	[  2] lpt_status_out,		/* printer status */
+	[  3] lpt_data_out,		/* printer data */
+	[  4] io_no_card_out,		/* status VDM keyboard */
+	[  5] io_no_card_out,		/* data VDM keyboard */
+	[  6] altair_sio3_status_out,	/* SIO 3 connected to socket */
+	[  7] altair_sio3_data_out,	/*  "  */
+	[  8] altair_dsk_select_out,	/* MITS 88-DCDD disk select */
+	[  9] altair_dsk_control_out,	/* MITS 88-DCDD control disk */
+	[ 10] altair_dsk_data_out,	/* MITS 88-DCDD write data */
+	[ 14] cromemco_dazzler_ctl_out,	/* Cromemco Dazzler */
+	[ 15] cromemco_dazzler_format_out, /*  "  */
+	[ 16] altair_sio1_status_out,	/* SIO 1 connected to console */
+	[ 17] altair_sio1_data_out,	/*  "  */
+	[ 18] altair_sio2_status_out,	/* SIO 2 connected to socket */
+	[ 19] altair_sio2_data_out,	/*  "  */
+	[160] hwctl_out,		/* virtual hardware control */
+	[161] host_bdos_out,		/* host file I/O hook */
+	[200] proctec_vdm_out,		/* Processor Technology VDM */
+	[248] tarbell_cmd_out,		/* Tarbell 1011D command */
+	[249] tarbell_track_out,	/* Tarbell 1011D track */
+	[250] tarbell_sec_out,		/* Tarbell 1011D sector */
+	[251] tarbell_data_out,		/* Tarbell 1011D data */
+	[252] tarbell_ext_out,		/* Tarbell 1011D extended cmd */
+	[255] fp_out			/* front panel */
 };
 
 /*
@@ -654,90 +190,9 @@ void reset_io(void)
 	hwctl_lock = 0xff;
 }
 
-/*
- *	This is the main handler for all IN op-codes,
- *	called by the simulator. It calls the input
- *	function for port addrl.
- */
-BYTE io_in(BYTE addrl, BYTE addrh)
-{
-#ifdef FRONTPANEL
-	int val;
-#else
-	UNUSED(addrh);
-#endif
-
-	io_port = addrl;
-	io_data = (*port_in[addrl])();
-
-#ifdef BUS_8080
-	cpu_bus = CPU_WO | CPU_INP;
-#endif
-
-#ifdef FRONTPANEL
-	if (F_flag) {
-		fp_clock += 3;
-		fp_led_address = (addrh << 8) + addrl;
-		fp_led_data = io_data;
-		fp_sampleData();
-		val = wait_step();
-
-		/* when single stepped INP get last set value of port */
-		if (val)
-			io_data = (*port_in[io_port])();
-	}
-#endif
-
-	return (io_data);
-}
-
-/*
- *	This is the main handler for all OUT op-codes,
- *	called by the simulator. It calls the output
- *	function for port addrl.
- */
-void io_out(BYTE addrl, BYTE addrh, BYTE data)
-{
-#ifndef FRONTPANEL
-	UNUSED(addrh);
-#endif
-	io_port = addrl;
-	io_data = data;
-	(*port_out[addrl])(data);
-
-#ifdef BUS_8080
-	cpu_bus = CPU_OUT;
-#endif
-
-#ifdef FRONTPANEL
-	if (F_flag) {
-		fp_clock += 6;
-		fp_led_address = (addrh << 8) + addrl;
-		fp_led_data = 0xff;
-		fp_sampleData();
-		wait_step();
-	}
-#endif
-}
-
-/*
- *	I/O input trap function
- *	This function should be added into all unused
- *	entries of the input port array. It can stop the
- *	emulation with an I/O error.
- */
-static BYTE io_trap_in(void)
-{
-	if (i_flag) {
-		cpu_error = IOTRAPIN;
-		cpu_state = STOPPED;
-	}
-	return ((BYTE) 0xff);
-}
-
 #if 0		/* currently not used */
 /*
- *	Same as above, but don't trap as I/O error.
+ *	No card I/O input trap function
  *	Used for input ports where I/O cards might be
  *	installed, but haven't.
  */
@@ -748,23 +203,7 @@ static BYTE io_no_card_in(void)
 #endif
 
 /*
- *      I/O output trap function
- *      This function should be added into all unused
- *      entries of the output port array. It can stop the
- *      emulation with an I/O error.
- */
-static void io_trap_out(BYTE data)
-{
-	UNUSED(data);
-
-	if (i_flag) {
-		cpu_error = IOTRAPOUT;
-		cpu_state = STOPPED;
-	}
-}
-
-/*
- *	Same as above, but don't trap as I/O error.
+ *	No card I/O output trap function
  *	Used for output ports where I/O cards might be
  *	installed, but haven't.
  */

--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -54,6 +54,8 @@
 #define NUMNSOC 0	/* number of TCP/IP sockets for SIO connections */
 #define NUMUSOC 2	/* number of UNIX sockets for SIO connections */
 
+extern void sleep_us(long);
+#define SLEEP_US(t)	sleep_us(t)
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
 

--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -55,7 +55,6 @@
 extern void reset_cpu(void), reset_io(void);
 extern void run_cpu(void), step_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
-extern unsigned long long get_clock_us(void);
 
 #ifdef FRONTPANEL
 static const char *TAG = "system";
@@ -171,11 +170,8 @@ void mon(void)
 			/* run CPU if not idling */
 			switch (cpu_switch) {
 			case 1:
-				if (!reset) {
-					cpu_start = get_clock_us();
+				if (!reset)
 					run_cpu();
-					cpu_stop = get_clock_us();
-				}
 				break;
 			case 2:
 				step_cpu();
@@ -204,9 +200,7 @@ void mon(void)
 		ice_cmd_loop(0);
 #else
 		/* run the CPU */
-		cpu_start = get_clock_us();
 		run_cpu();
-		cpu_stop = get_clock_us();
 #endif
 #ifdef FRONTPANEL
 	}

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -33,6 +33,8 @@
 /*#define CNETDEBUG*/	/* client network protocol debugger */
 /*#define SNETDEBUG*/	/* server network protocol debugger */
 
+extern void sleep_us(long);
+#define SLEEP_US(t)	sleep_us(t)
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
 

--- a/cpmsim/srcsim/simctl.c
+++ b/cpmsim/srcsim/simctl.c
@@ -17,7 +17,6 @@
 #include "log.h"
 
 extern void run_cpu(void);
-extern unsigned long long get_clock_us(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
 
 int boot(int);
@@ -53,9 +52,7 @@ void mon(void)
 	atexit(reset_unix_terminal);
 
 	/* start CPU emulation */
-	cpu_start = get_clock_us();
 	run_cpu();
-	cpu_stop = get_clock_us();
 
 	/* reset terminal */
 	reset_unix_terminal();

--- a/cromemcosim/srcsim/iosim.c
+++ b/cromemcosim/srcsim/iosim.c
@@ -31,6 +31,7 @@
  * 19-JUL-2020 avoid problems with some third party terminal emulations
  * 17-JUN-2021 allow building machine without frontpanel
  * 29-JUL-2021 add boot config for machine without frontpanel
+ * 27-MAY-2024 moved io_in & io_out to simcore
  */
 
 #include <pthread.h>
@@ -68,8 +69,6 @@
 /*
  *	Forward declarations for I/O functions
  */
-static BYTE io_trap_in(void);
-static void io_trap_out(BYTE);
 static BYTE fp_in(void), mmu_in(void);
 static void fp_out(BYTE), mmu_out(BYTE);
 static BYTE hwctl_in(void);
@@ -98,525 +97,113 @@ static int th_suspend;		/* timing thread suspend flag */
  *	input I/O port (0 - 255), to do the required I/O.
  */
 BYTE (*port_in[256])(void) = {
-	cromemco_tuart_0a_status_in,	/* port 0 */
-	cromemco_tuart_0a_data_in,	/* port 1 */
-	io_trap_in,			/* port 2 */
-	cromemco_tuart_0a_interrupt_in,	/* port 3 */
-	cromemco_fdc_aux_in,		/* port 4 */
-	io_trap_in,			/* port 5 */
-	io_trap_in,			/* port 6 */
-	io_trap_in,			/* port 7 */
-	io_trap_in,			/* port 8 */
-	io_trap_in,			/* port 9 */
-	io_trap_in,			/* port 10 */
-	io_trap_in,			/* port 11 */
-	io_trap_in,			/* port 12 */
-	io_trap_in,			/* port 13 */
-	cromemco_dazzler_flags_in,	/* port 14 */
-	io_trap_in,			/* port 15 */
-	io_trap_in,			/* port 16 */
-	io_trap_in,			/* port 17 */
-	io_trap_in,			/* port 18 */
-	io_trap_in,			/* port 19 */
-	io_trap_in,			/* port 20 */
-	io_trap_in,			/* port 21 */
-	io_trap_in,			/* port 22 */
-	io_trap_in,			/* port 23 */
-	cromemco_d7a_D_in,		/* port 24 */
-	cromemco_d7a_A1_in,		/* port 25 */
-	cromemco_d7a_A2_in,		/* port 26 */
-	cromemco_d7a_A3_in,		/* port 27 */
-	cromemco_d7a_A4_in,		/* port 28 */
-	cromemco_d7a_A5_in,		/* port 29 */
-	cromemco_d7a_A6_in,		/* port 30 */
-	cromemco_d7a_A7_in,		/* port 31 */
-	cromemco_tuart_1a_status_in,	/* port 32 */
-	cromemco_tuart_1a_data_in,	/* port 33 */
-	io_trap_in,			/* port 34 */
-	cromemco_tuart_1a_interrupt_in,	/* port 35 */
-	cromemco_tuart_1a_parallel_in,	/* port 36 */
-	io_trap_in,			/* port 37 */
-	io_trap_in,			/* port 38 */
-	io_trap_in,			/* port 39 */
-	io_trap_in,			/* port 40 */
-	io_trap_in,			/* port 41 */
-	io_trap_in,			/* port 42 */
-	io_trap_in,			/* port 43 */
-	io_trap_in,			/* port 44 */
-	io_trap_in,			/* port 45 */
-	io_trap_in,			/* port 46 */
-	io_trap_in,			/* port 47 */
-	cromemco_fdc_status_in,		/* port 48 */
-	cromemco_fdc_track_in,		/* port 49 */
-	cromemco_fdc_sector_in,		/* port 50 */
-	cromemco_fdc_data_in,		/* port 51 */
-	cromemco_fdc_diskflags_in,	/* port 52 */
-	io_trap_in,			/* port 53 */
-	io_trap_in,			/* port 54 */
-	io_trap_in,			/* port 55 */
-	io_trap_in,			/* port 56 */
-	io_trap_in,			/* port 57 */
-	io_trap_in,			/* port 58 */
-	io_trap_in,			/* port 59 */
-	io_trap_in,			/* port 60 */
-	io_trap_in,			/* port 61 */
-	io_trap_in,			/* port 62 */
-	io_trap_in,			/* port 63 */
-	mmu_in,				/* port 64 */
-	io_trap_in,			/* port 65 */
-	io_trap_in,			/* port 66 */
-	io_trap_in,			/* port 67 */
-	io_trap_in,			/* port 68 */
-	io_trap_in,			/* port 69 */
-	io_trap_in,			/* port 70 */
-	io_trap_in,			/* port 71 */
-	io_trap_in,			/* port 72 */
-	io_trap_in,			/* port 73 */
-	io_trap_in,			/* port 74 */
-	io_trap_in,			/* port 75 */
-	io_trap_in,			/* port 76 */
-	io_trap_in,			/* port 77 */
-	io_trap_in,			/* port 78 */
-	io_trap_in,			/* port 79 */
-	cromemco_tuart_1b_status_in,	/* port 80 */
-	cromemco_tuart_1b_data_in,	/* port 81 */
-	io_trap_in,			/* port 82 */
-	cromemco_tuart_1b_interrupt_in,	/* port 83 */
-	cromemco_tuart_1b_parallel_in,	/* port 84 */
-	io_trap_in,			/* port 85 */
-	io_trap_in,			/* port 86 */
-	io_trap_in,			/* port 87 */
-	io_trap_in,			/* port 88 */
-	io_trap_in,			/* port 89 */
-	io_trap_in,			/* port 90 */
-	io_trap_in,			/* port 91 */
-	io_trap_in,			/* port 92 */
-	io_trap_in,			/* port 93 */
-	io_trap_in,			/* port 94 */
-	io_trap_in,			/* port 95 */
-	io_trap_in,			/* port 96 */
-	io_trap_in,			/* port 97 */
-	io_trap_in,			/* port 98 */
-	io_trap_in,			/* port 99 */
-	io_trap_in,			/* port 100 */
-	io_trap_in,			/* port 101 */
-	io_trap_in,			/* port 102 */
-	io_trap_in,			/* port 103 */
-	io_trap_in,			/* port 104 */
-	io_trap_in,			/* port 105 */
-	io_trap_in,			/* port 106 */
-	io_trap_in,			/* port 107 */
-	io_trap_in,			/* port 108 */
-	io_trap_in,			/* port 109 */
-	io_trap_in,			/* port 110 */
-	io_trap_in,			/* port 111 */
-	io_trap_in,			/* port 112 */
-	io_trap_in,			/* port 113 */
-	io_trap_in,			/* port 114 */
-	io_trap_in,			/* port 115 */
-	io_trap_in,			/* port 116 */
-	io_trap_in,			/* port 117 */
-	io_trap_in,			/* port 118 */
-	io_trap_in,			/* port 119 */
-	io_trap_in,			/* port 120 */
-	io_trap_in,			/* port 121 */
-	io_trap_in,			/* port 122 */
-	io_trap_in,			/* port 123 */
-	io_trap_in,			/* port 124 */
-	io_trap_in,			/* port 125 */
-	io_trap_in,			/* port 126 */
-	io_trap_in,			/* port 127 */
-	io_trap_in,			/* port 128 */
-	io_trap_in,			/* port 129 */
-	io_trap_in,			/* port 130 */
-	io_trap_in,			/* port 131 */
-	io_trap_in,			/* port 132 */
-	io_trap_in,			/* port 133 */
-	io_trap_in,			/* port 134 */
-	io_trap_in,			/* port 135 */
-	io_trap_in,			/* port 136 */
-	io_trap_in,			/* port 137 */
-	io_trap_in,			/* port 138 */
-	io_trap_in,			/* port 139 */
-	io_trap_in,			/* port 140 */
-	io_trap_in,			/* port 141 */
-	io_trap_in,			/* port 142 */
-	io_trap_in,			/* port 143 */
-	io_trap_in,			/* port 144 */
-	io_trap_in,			/* port 145 */
-	io_trap_in,			/* port 146 */
-	io_trap_in,			/* port 147 */
-	io_trap_in,			/* port 148 */
-	io_trap_in,			/* port 149 */
-	io_trap_in,			/* port 150 */
-	io_trap_in,			/* port 151 */
-	io_trap_in,			/* port 152 */
-	io_trap_in,			/* port 153 */
-	io_trap_in,			/* port 154 */
-	io_trap_in,			/* port 155 */
-	io_trap_in,			/* port 156 */
-	io_trap_in,			/* port 157 */
-	io_trap_in,			/* port 158 */
-	io_trap_in,			/* port 159 */
-	hwctl_in,			/* port 160 */
-	io_trap_in,			/* port 161 */
-	io_trap_in,			/* port 162 */
-	io_trap_in,			/* port 163 */
-	io_trap_in,			/* port 164 */
-	io_trap_in,			/* port 165 */
-	io_trap_in,			/* port 166 */
-	io_trap_in,			/* port 167 */
-	io_trap_in,			/* port 168 */
-	io_trap_in,			/* port 169 */
-	io_trap_in,			/* port 170 */
-	io_trap_in,			/* port 171 */
-	io_trap_in,			/* port 172 */
-	io_trap_in,			/* port 173 */
-	io_trap_in,			/* port 174 */
-	io_trap_in,			/* port 175 */
-	io_trap_in,			/* port 176 */
-	io_trap_in,			/* port 177 */
-	io_trap_in,			/* port 178 */
-	io_trap_in,			/* port 179 */
-	io_trap_in,			/* port 180 */
-	io_trap_in,			/* port 181 */
-	io_trap_in,			/* port 182 */
-	io_trap_in,			/* port 183 */
-	io_trap_in,			/* port 184 */
-	io_trap_in,			/* port 185 */
-	io_trap_in,			/* port 186 */
-	io_trap_in,			/* port 187 */
-	io_trap_in,			/* port 188 */
-	io_trap_in,			/* port 189 */
-	io_trap_in,			/* port 190 */
-	io_trap_in,			/* port 191 */
-	io_trap_in,			/* port 192 */
-	io_trap_in,			/* port 193 */
-	io_trap_in,			/* port 194 */
-	io_trap_in,			/* port 195 */
-	io_trap_in,			/* port 196 */
-	io_trap_in,			/* port 197 */
-	io_trap_in,			/* port 198 */
-	io_trap_in,			/* port 199 */
-	io_trap_in,			/* port 200 */
-	io_trap_in,			/* port 201 */
-	io_trap_in,			/* port 202 */
-	io_trap_in,			/* port 203 */
-	io_trap_in,			/* port 204 */
-	io_trap_in,			/* port 205 */
-	io_trap_in,			/* port 206 */
-	io_trap_in,			/* port 207 */
-	io_trap_in,			/* port 208 */
-	io_trap_in,			/* port 209 */
-	io_trap_in,			/* port 210 */
-	io_trap_in,			/* port 211 */
-	io_trap_in,			/* port 212 */
-	io_trap_in,			/* port 213 */
-	io_trap_in,			/* port 214 */
-	io_trap_in,			/* port 215 */
-	io_trap_in,			/* port 216 */
-	io_trap_in,			/* port 217 */
-	io_trap_in,			/* port 218 */
-	io_trap_in,			/* port 219 */
-	io_trap_in,			/* port 220 */
-	io_trap_in,			/* port 221 */
-	io_trap_in,			/* port 222 */
-	io_trap_in,			/* port 223 */
-	cromemco_wdi_pio0a_data_in,	/* port 224 */
-	cromemco_wdi_pio0b_data_in,	/* port 225 */
-	cromemco_wdi_pio0a_cmd_in,	/* port 226 */
-	cromemco_wdi_pio0b_cmd_in,	/* port 227 */
-	cromemco_wdi_pio1a_data_in,	/* port 228 */
-	cromemco_wdi_pio1b_data_in,	/* port 229 */
-	cromemco_wdi_pio1a_cmd_in,	/* port 230 */
-	cromemco_wdi_pio1b_cmd_in,	/* port 231 */
-	cromemco_wdi_dma0_in,		/* port 232 */
-	cromemco_wdi_dma1_in,		/* port 233 */
-	cromemco_wdi_dma2_in,		/* port 234 */
-	cromemco_wdi_dma3_in,		/* port 235 */
-	cromemco_wdi_ctc0_in,		/* port 236 */
-	cromemco_wdi_ctc1_in,		/* port 237 */
-	cromemco_wdi_ctc2_in,		/* port 238 */
-	cromemco_wdi_ctc3_in,		/* port 239 */
-	io_trap_in,			/* port 240 */
-	io_trap_in,			/* port 241 */
-	io_trap_in,			/* port 242 */
-	io_trap_in,			/* port 243 */
-	io_trap_in,			/* port 244 */
-	io_trap_in,			/* port 245 */
-	io_trap_in,			/* port 246 */
-	io_trap_in,			/* port 247 */
-	io_trap_in,			/* port 248 */
-	io_trap_in,			/* port 249 */
-	io_trap_in,			/* port 250 */
-	io_trap_in,			/* port 251 */
-	io_trap_in,			/* port 252 */
-	io_trap_in,			/* port 253 */
-	io_trap_in,			/* port 254 */
-	fp_in				/* port 255 */ /* front panel */
+	[  0] cromemco_tuart_0a_status_in,
+	[  1] cromemco_tuart_0a_data_in,
+	[  3] cromemco_tuart_0a_interrupt_in,
+	[  4] cromemco_fdc_aux_in,
+	[ 14] cromemco_dazzler_flags_in,
+	[ 24] cromemco_d7a_D_in,
+	[ 25] cromemco_d7a_A1_in,
+	[ 26] cromemco_d7a_A2_in,
+	[ 27] cromemco_d7a_A3_in,
+	[ 28] cromemco_d7a_A4_in,
+	[ 29] cromemco_d7a_A5_in,
+	[ 30] cromemco_d7a_A6_in,
+	[ 31] cromemco_d7a_A7_in,
+	[ 32] cromemco_tuart_1a_status_in,
+	[ 33] cromemco_tuart_1a_data_in,
+	[ 35] cromemco_tuart_1a_interrupt_in,
+	[ 36] cromemco_tuart_1a_parallel_in,
+	[ 48] cromemco_fdc_status_in,
+	[ 49] cromemco_fdc_track_in,
+	[ 50] cromemco_fdc_sector_in,
+	[ 51] cromemco_fdc_data_in,
+	[ 52] cromemco_fdc_diskflags_in,
+	[ 64] mmu_in,
+	[ 80] cromemco_tuart_1b_status_in,
+	[ 81] cromemco_tuart_1b_data_in,
+	[ 83] cromemco_tuart_1b_interrupt_in,
+	[ 84] cromemco_tuart_1b_parallel_in,
+	[160] hwctl_in,
+	[224] cromemco_wdi_pio0a_data_in,
+	[225] cromemco_wdi_pio0b_data_in,
+	[226] cromemco_wdi_pio0a_cmd_in,
+	[227] cromemco_wdi_pio0b_cmd_in,
+	[228] cromemco_wdi_pio1a_data_in,
+	[229] cromemco_wdi_pio1b_data_in,
+	[230] cromemco_wdi_pio1a_cmd_in,
+	[231] cromemco_wdi_pio1b_cmd_in,
+	[232] cromemco_wdi_dma0_in,
+	[233] cromemco_wdi_dma1_in,
+	[234] cromemco_wdi_dma2_in,
+	[235] cromemco_wdi_dma3_in,
+	[236] cromemco_wdi_ctc0_in,
+	[237] cromemco_wdi_ctc1_in,
+	[238] cromemco_wdi_ctc2_in,
+	[239] cromemco_wdi_ctc3_in,
+	[255] fp_in				/* front panel */
 };
 
 /*
  *	This array contains function pointers for every
  *	output I/O port (0 - 255), to do the required I/O.
  */
-static void (*port_out[256])(BYTE) = {
-	cromemco_tuart_0a_baud_out,	/* port 0 */
-	cromemco_tuart_0a_data_out,	/* port 1 */
-	cromemco_tuart_0a_command_out,	/* port 2 */
-	cromemco_tuart_0a_interrupt_out,/* port 3 */
-	cromemco_fdc_aux_out,		/* port 4 */
-	cromemco_tuart_0a_timer1_out,	/* port 5 */
-	cromemco_tuart_0a_timer2_out,	/* port 6 */
-	cromemco_tuart_0a_timer3_out,	/* port 7 */
-	cromemco_tuart_0a_timer4_out,	/* port 8 */
-	cromemco_tuart_0a_timer5_out,	/* port 9 */
-	io_trap_out,			/* port 10 */
-	io_trap_out,			/* port 11 */
-	io_trap_out,			/* port 12 */
-	io_trap_out,			/* port 13 */
-	cromemco_dazzler_ctl_out,	/* port 14 */
-	cromemco_dazzler_format_out,	/* port 15 */
-	io_trap_out,			/* port 16 */
-	io_trap_out,			/* port 17 */
-	io_trap_out,			/* port 18 */
-	io_trap_out,			/* port 19 */
-	io_trap_out,			/* port 20 */
-	io_trap_out,			/* port 21 */
-	io_trap_out,			/* port 22 */
-	io_trap_out,			/* port 23 */
-	cromemco_d7a_D_out,		/* port 24 */
-	cromemco_d7a_A1_out,		/* port 25 */
-	cromemco_d7a_A2_out,		/* port 26 */
-	cromemco_d7a_A3_out,		/* port 27 */
-	cromemco_d7a_A4_out,		/* port 28 */
-	cromemco_d7a_A5_out,		/* port 29 */
-	cromemco_d7a_A6_out,		/* port 30 */
-	cromemco_d7a_A7_out,		/* port 31 */
-	cromemco_tuart_1a_baud_out,	/* port 32 */
-	cromemco_tuart_1a_data_out,	/* port 33 */
-	cromemco_tuart_1a_command_out,	/* port 34 */
-	cromemco_tuart_1a_interrupt_out,/* port 35 */
-	cromemco_tuart_1a_parallel_out,	/* port 36 */
-	io_trap_out,			/* port 37 */
-	io_trap_out,			/* port 38 */
-	io_trap_out,			/* port 39 */
-	io_trap_out,			/* port 40 */
-	io_trap_out,			/* port 41 */
-	io_trap_out,			/* port 42 */
-	io_trap_out,			/* port 43 */
-	io_trap_out,			/* port 44 */
-	io_trap_out,			/* port 45 */
-	io_trap_out,			/* port 46 */
-	io_trap_out,			/* port 47 */
-	cromemco_fdc_cmd_out,		/* port 48 */
-	cromemco_fdc_track_out,		/* port 49 */
-	cromemco_fdc_sector_out,	/* port 50 */
-	cromemco_fdc_data_out,		/* port 51 */
-	cromemco_fdc_diskctl_out,	/* port 52 */
-	io_trap_out,			/* port 53 */
-	io_trap_out,			/* port 54 */
-	io_trap_out,			/* port 55 */
-	io_trap_out,			/* port 56 */
-	io_trap_out,			/* port 57 */
-	io_trap_out,			/* port 58 */
-	io_trap_out,			/* port 59 */
-	io_trap_out,			/* port 60 */
-	io_trap_out,			/* port 61 */
-	io_trap_out,			/* port 62 */
-	io_trap_out,			/* port 63 */
-	mmu_out,			/* port 64 */
-	io_trap_out,			/* port 65 */
-	io_trap_out,			/* port 66 */
-	io_trap_out,			/* port 67 */
-	io_trap_out,			/* port 68 */
-	io_trap_out,			/* port 69 */
-	io_trap_out,			/* port 70 */
-	io_trap_out,			/* port 71 */
-	io_trap_out,			/* port 72 */
-	io_trap_out,			/* port 73 */
-	io_trap_out,			/* port 74 */
-	io_trap_out,			/* port 75 */
-	io_trap_out,			/* port 76 */
-	io_trap_out,			/* port 77 */
-	io_trap_out,			/* port 78 */
-	io_trap_out,			/* port 79 */
-	cromemco_tuart_1b_baud_out,	/* port 80 */
-	cromemco_tuart_1b_data_out,	/* port 81 */
-	cromemco_tuart_1b_command_out,	/* port 82 */
-	cromemco_tuart_1b_interrupt_out,/* port 83 */
-	cromemco_tuart_1b_parallel_out,	/* port 84 */
-	io_trap_out,			/* port 85 */
-	io_trap_out,			/* port 86 */
-	io_trap_out,			/* port 87 */
-	io_trap_out,			/* port 88 */
-	io_trap_out,			/* port 89 */
-	io_trap_out,			/* port 90 */
-	io_trap_out,			/* port 91 */
-	io_trap_out,			/* port 92 */
-	io_trap_out,			/* port 93 */
-	io_trap_out,			/* port 94 */
-	io_trap_out,			/* port 95 */
-	io_trap_out,			/* port 96 */
-	io_trap_out,			/* port 97 */
-	io_trap_out,			/* port 98 */
-	io_trap_out,			/* port 99 */
-	io_trap_out,			/* port 100 */
-	io_trap_out,			/* port 101 */
-	io_trap_out,			/* port 102 */
-	io_trap_out,			/* port 103 */
-	io_trap_out,			/* port 104 */
-	io_trap_out,			/* port 105 */
-	io_trap_out,			/* port 106 */
-	io_trap_out,			/* port 107 */
-	io_trap_out,			/* port 108 */
-	io_trap_out,			/* port 109 */
-	io_trap_out,			/* port 110 */
-	io_trap_out,			/* port 111 */
-	io_trap_out,			/* port 112 */
-	io_trap_out,			/* port 113 */
-	io_trap_out,			/* port 114 */
-	io_trap_out,			/* port 115 */
-	io_trap_out,			/* port 116 */
-	io_trap_out,			/* port 117 */
-	io_trap_out,			/* port 118 */
-	io_trap_out,			/* port 119 */
-	io_trap_out,			/* port 120 */
-	io_trap_out,			/* port 121 */
-	io_trap_out,			/* port 122 */
-	io_trap_out,			/* port 123 */
-	io_trap_out,			/* port 124 */
-	io_trap_out,			/* port 125 */
-	io_trap_out,			/* port 126 */
-	io_trap_out,			/* port 127 */
-	io_trap_out,			/* port 128 */
-	io_trap_out,			/* port 129 */
-	io_trap_out,			/* port 130 */
-	io_trap_out,			/* port 131 */
-	io_trap_out,			/* port 132 */
-	io_trap_out,			/* port 133 */
-	io_trap_out,			/* port 134 */
-	io_trap_out,			/* port 135 */
-	io_trap_out,			/* port 136 */
-	io_trap_out,			/* port 137 */
-	io_trap_out,			/* port 138 */
-	io_trap_out,			/* port 139 */
-	io_trap_out,			/* port 140 */
-	io_trap_out,			/* port 141 */
-	io_trap_out,			/* port 142 */
-	io_trap_out,			/* port 143 */
-	io_trap_out,			/* port 144 */
-	io_trap_out,			/* port 145 */
-	io_trap_out,			/* port 146 */
-	io_trap_out,			/* port 147 */
-	io_trap_out,			/* port 148 */
-	io_trap_out,			/* port 149 */
-	io_trap_out,			/* port 150 */
-	io_trap_out,			/* port 151 */
-	io_trap_out,			/* port 152 */
-	io_trap_out,			/* port 153 */
-	io_trap_out,			/* port 154 */
-	io_trap_out,			/* port 155 */
-	io_trap_out,			/* port 156 */
-	io_trap_out,			/* port 157 */
-	io_trap_out,			/* port 158 */
-	io_trap_out,			/* port 159 */
-	hwctl_out,			/* port 160 */
-	host_bdos_out,			/* port 161 */  /* host file I/O hook */
-	io_trap_out,			/* port 162 */
-	io_trap_out,			/* port 163 */
-	io_trap_out,			/* port 164 */
-	io_trap_out,			/* port 165 */
-	io_trap_out,			/* port 166 */
-	io_trap_out,			/* port 167 */
-	io_trap_out,			/* port 168 */
-	io_trap_out,			/* port 169 */
-	io_trap_out,			/* port 170 */
-	io_trap_out,			/* port 171 */
-	io_trap_out,			/* port 172 */
-	io_trap_out,			/* port 173 */
-	io_trap_out,			/* port 174 */
-	io_trap_out,			/* port 175 */
-	io_trap_out,			/* port 176 */
-	io_trap_out,			/* port 177 */
-	io_trap_out,			/* port 178 */
-	io_trap_out,			/* port 179 */
-	io_trap_out,			/* port 180 */
-	io_trap_out,			/* port 181 */
-	io_trap_out,			/* port 182 */
-	io_trap_out,			/* port 183 */
-	io_trap_out,			/* port 184 */
-	io_trap_out,			/* port 185 */
-	io_trap_out,			/* port 186 */
-	io_trap_out,			/* port 187 */
-	io_trap_out,			/* port 188 */
-	io_trap_out,			/* port 189 */
-	io_trap_out,			/* port 190 */
-	io_trap_out,			/* port 191 */
-	io_trap_out,			/* port 192 */
-	io_trap_out,			/* port 193 */
-	io_trap_out,			/* port 194 */
-	io_trap_out,			/* port 195 */
-	io_trap_out,			/* port 196 */
-	io_trap_out,			/* port 197 */
-	io_trap_out,			/* port 198 */
-	io_trap_out,			/* port 199 */
-	io_trap_out,			/* port 200 */
-	io_trap_out,			/* port 201 */
-	io_trap_out,			/* port 202 */
-	io_trap_out,			/* port 203 */
-	io_trap_out,			/* port 204 */
-	io_trap_out,			/* port 205 */
-	io_trap_out,			/* port 206 */
-	io_trap_out,			/* port 207 */
-	io_trap_out,			/* port 208 */
-	io_trap_out,			/* port 209 */
-	io_trap_out,			/* port 210 */
-	io_trap_out,			/* port 211 */
-	io_trap_out,			/* port 212 */
-	io_trap_out,			/* port 213 */
-	io_trap_out,			/* port 214 */
-	io_trap_out,			/* port 215 */
-	io_trap_out,			/* port 216 */
-	io_trap_out,			/* port 217 */
-	io_trap_out,			/* port 218 */
-	io_trap_out,			/* port 219 */
-	io_trap_out,			/* port 220 */
-	io_trap_out,			/* port 221 */
-	io_trap_out,			/* port 222 */
-	io_trap_out,			/* port 223 */
-	cromemco_wdi_pio0a_data_out,	/* port 224 */
-	cromemco_wdi_pio0b_data_out,	/* port 225 */
-	cromemco_wdi_pio0a_cmd_out,	/* port 226 */
-	cromemco_wdi_pio0b_cmd_out,	/* port 227 */
-	cromemco_wdi_pio1a_data_out,	/* port 228 */
-	cromemco_wdi_pio1b_data_out,	/* port 229 */
-	cromemco_wdi_pio1a_cmd_out,	/* port 230 */
-	cromemco_wdi_pio1b_cmd_out,	/* port 231 */
-	cromemco_wdi_dma0_out,		/* port 232 */
-	cromemco_wdi_dma1_out,		/* port 233 */
-	cromemco_wdi_dma2_out,		/* port 234 */
-	cromemco_wdi_dma3_out,		/* port 235 */
-	cromemco_wdi_ctc0_out,		/* port 236 */
-	cromemco_wdi_ctc1_out,		/* port 237 */
-	cromemco_wdi_ctc2_out,		/* port 238 */
-	cromemco_wdi_ctc3_out,		/* port 239 */
-	io_trap_out,			/* port 240 */
-	io_trap_out,			/* port 241 */
-	io_trap_out,			/* port 242 */
-	io_trap_out,			/* port 243 */
-	io_trap_out,			/* port 244 */
-	io_trap_out,			/* port 245 */
-	io_trap_out,			/* port 246 */
-	io_trap_out,			/* port 247 */
-	io_trap_out,			/* port 248 */
-	io_trap_out,			/* port 249 */
-	io_trap_out,			/* port 250 */
-	io_trap_out,			/* port 251 */
-	io_trap_out,			/* port 252 */
-	io_trap_out,			/* port 253 */
-	io_trap_out,			/* port 254 */
-	fp_out				/* port 255 */ /* front panel */
+void (*port_out[256])(BYTE) = {
+	[  0] cromemco_tuart_0a_baud_out,
+	[  1] cromemco_tuart_0a_data_out,
+	[  2] cromemco_tuart_0a_command_out,
+	[  3] cromemco_tuart_0a_interrupt_out,
+	[  4] cromemco_fdc_aux_out,
+	[  5] cromemco_tuart_0a_timer1_out,
+	[  6] cromemco_tuart_0a_timer2_out,
+	[  7] cromemco_tuart_0a_timer3_out,
+	[  8] cromemco_tuart_0a_timer4_out,
+	[  9] cromemco_tuart_0a_timer5_out,
+	[ 14] cromemco_dazzler_ctl_out,
+	[ 15] cromemco_dazzler_format_out,
+	[ 24] cromemco_d7a_D_out,
+	[ 25] cromemco_d7a_A1_out,
+	[ 26] cromemco_d7a_A2_out,
+	[ 27] cromemco_d7a_A3_out,
+	[ 28] cromemco_d7a_A4_out,
+	[ 29] cromemco_d7a_A5_out,
+	[ 30] cromemco_d7a_A6_out,
+	[ 31] cromemco_d7a_A7_out,
+	[ 32] cromemco_tuart_1a_baud_out,
+	[ 33] cromemco_tuart_1a_data_out,
+	[ 34] cromemco_tuart_1a_command_out,
+	[ 35] cromemco_tuart_1a_interrupt_out,
+	[ 36] cromemco_tuart_1a_parallel_out,
+	[ 48] cromemco_fdc_cmd_out,
+	[ 49] cromemco_fdc_track_out,
+	[ 50] cromemco_fdc_sector_out,
+	[ 51] cromemco_fdc_data_out,
+	[ 52] cromemco_fdc_diskctl_out,
+	[ 64] mmu_out,
+	[ 80] cromemco_tuart_1b_baud_out,
+	[ 81] cromemco_tuart_1b_data_out,
+	[ 82] cromemco_tuart_1b_command_out,
+	[ 83] cromemco_tuart_1b_interrupt_out,
+	[ 84] cromemco_tuart_1b_parallel_out,
+	[160] hwctl_out,
+	[161] host_bdos_out,			/* host file I/O hook */
+	[224] cromemco_wdi_pio0a_data_out,
+	[225] cromemco_wdi_pio0b_data_out,
+	[226] cromemco_wdi_pio0a_cmd_out,
+	[227] cromemco_wdi_pio0b_cmd_out,
+	[228] cromemco_wdi_pio1a_data_out,
+	[229] cromemco_wdi_pio1b_data_out,
+	[230] cromemco_wdi_pio1a_cmd_out,
+	[231] cromemco_wdi_pio1b_cmd_out,
+	[232] cromemco_wdi_dma0_out,
+	[233] cromemco_wdi_dma1_out,
+	[234] cromemco_wdi_dma2_out,
+	[235] cromemco_wdi_dma3_out,
+	[236] cromemco_wdi_ctc0_out,
+	[237] cromemco_wdi_ctc1_out,
+	[238] cromemco_wdi_ctc2_out,
+	[239] cromemco_wdi_ctc3_out,
+	[255] fp_out				/* front panel */
 };
 
 /*
@@ -723,103 +310,6 @@ void reset_io(void)
 	hwctl_lock = 0xff;
 	wdi_exit();
 	wdi_init();
-}
-
-/*
- *	This is the main handler for all IN op-codes,
- *	called by the simulator. It calls the input
- *	function for port addrl.
- */
-BYTE io_in(BYTE addrl, BYTE addrh)
-{
-#ifdef FRONTPANEL
-	int val;
-#else
-	UNUSED(addrh);
-#endif
-
-	io_port = addrl;
-	io_data = (*port_in[addrl])();
-
-#ifdef BUS_8080
-	cpu_bus = CPU_WO | CPU_INP;
-#endif
-
-#ifdef FRONTPANEL
-	if (F_flag) {
-		fp_clock += 3;
-		fp_led_address = (addrh << 8) + addrl;
-		fp_led_data = io_data;
-		fp_sampleData();
-		val = wait_step();
-
-		/* when single stepped INP get last set value of port */
-		if (val)
-			io_data = (*port_in[io_port])();
-	}
-#endif
-
-	return (io_data);
-}
-
-/*
- *	This is the main handler for all OUT op-codes,
- *	called by the simulator. It calls the output
- *	function for port addrl.
- */
-void io_out(BYTE addrl, BYTE addrh, BYTE data)
-{
-#ifndef FRONTPANEL
-	UNUSED(addrh);
-#endif
-	io_port = addrl;
-	io_data = data;
-	(*port_out[addrl])(data);
-
-#ifdef BUS_8080
-	cpu_bus = CPU_OUT;
-#endif
-
-#ifdef FRONTPANEL
-	if (F_flag) {
-		fp_clock += 6;
-		fp_led_address = (addrh << 8) + addrl;
-		fp_led_data = io_data;
-		fp_sampleData();
-		wait_step();
-	}
-#endif
-}
-
-/*
- *	I/O input trap function
- *	This function should be added into all unused
- *	entries of the input port array. It can stop the
- *	emulation with an I/O error.
- */
-static BYTE io_trap_in(void)
-{
-	if (i_flag) {
-		cpu_error = IOTRAPIN;
-		cpu_state = STOPPED;
-	}
-	return ((BYTE) 0xff);
-}
-
-/*
- *	I/O output trap function
- *	This function should be added into all unused
- *	entries of the output port array. It can stop the
- *	emulation with an I/O error.
- */
-static void io_trap_out(BYTE data)
-{
-	UNUSED(data);
-
-	if (i_flag) {
-		cpu_error = IOTRAPOUT;
-		cpu_state = STOPPED;
-	}
 }
 
 /*

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -66,6 +66,8 @@
 #define SERVERPORT 4010	/* first TCP/IP server port used */
 #define NUMUSOC 0	/* number of UNIX sockets */
 
+extern void sleep_us(long);
+#define SLEEP_US(t)	sleep_us(t)
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
 

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -50,7 +50,6 @@
 extern void reset_cpu(void), reset_io(void);
 extern void run_cpu(void), step_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
-extern unsigned long long get_clock_us(void);
 
 #ifdef FRONTPANEL
 static const char *TAG = "system";
@@ -174,11 +173,8 @@ void mon(void)
 			/* run CPU if not idling */
 			switch (cpu_switch) {
 			case 1:
-				if (!reset) {
-					cpu_start = get_clock_us();
+				if (!reset)
 					run_cpu();
-					cpu_stop = get_clock_us();
-				}
 				break;
 			case 2:
 				step_cpu();
@@ -208,9 +204,7 @@ void mon(void)
 		ice_cmd_loop(0);
 #else
 		/* run the CPU */
-		cpu_start = get_clock_us();
 		run_cpu();
-		cpu_stop = get_clock_us();
 #endif
 #ifdef FRONTPANEL
 	}

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -37,6 +37,7 @@
  * 01-AUG-2021 integrated HAL
  * 05-AUG-2021 add boot config for machine without frontpanel
  * 07-AUG-2021 add APU emulation
+ * 27-MAY-2024 moved io_in & io_out to simcore
  */
 
 #include <unistd.h>
@@ -85,8 +86,8 @@
 /*
  *	Forward declarations for I/O functions
  */
-static BYTE io_trap_in(void), io_no_card_in(void);
-static void io_trap_out(BYTE), io_no_card_out(BYTE);
+static BYTE io_no_card_in(void);
+static void io_no_card_out(BYTE);
 static BYTE fp_in(void);
 static void fp_out(BYTE);
 static BYTE hwctl_in(void);
@@ -120,554 +121,145 @@ void *am9511 = NULL;		/* am9511 instantiation */
  *	input I/O port (0 - 255), to do the required I/O.
  */
 BYTE (*port_in[256])(void) = {
-	imsai_sio_nofun_in,	/* port 0 */ /* IMSAI SIO-2 */
-	imsai_sio_nofun_in,	/* port 1 */
-	imsai_sio1a_data_in,	/* port 2 */ /* Channel A, console */
-	imsai_sio1a_status_in,	/* port 3 */
-	imsai_sio1b_data_in,	/* port 4 */ /* Channel B, keyboard for VIO */
-	imsai_sio1b_status_in,	/* port 5 */
-	imsai_sio_nofun_in,	/* port 6 */
-	imsai_sio_nofun_in,	/* port 7 */
-	imsai_sio1_ctl_in,	/* port 8 */ /* SIO Control for A and B */
-	imsai_sio_nofun_in,	/* port 9 */
-	imsai_sio_nofun_in,	/* port 10 */
-	imsai_sio_nofun_in,	/* port 11 */
-	imsai_sio_nofun_in,	/* port 12 */
-	imsai_sio_nofun_in,	/* port 13 */
+	[  0] imsai_sio_nofun_in,	/* IMSAI SIO-2 */
+	[  1] imsai_sio_nofun_in,
+	[  2] imsai_sio1a_data_in,	/* Channel A, console */
+	[  3] imsai_sio1a_status_in,
+	[  4] imsai_sio1b_data_in,	/* Channel B, keyboard for VIO */
+	[  5] imsai_sio1b_status_in,
+	[  6] imsai_sio_nofun_in,
+	[  7] imsai_sio_nofun_in,
+	[  8] imsai_sio1_ctl_in,	/* SIO Control for A and B */
+	[  9] imsai_sio_nofun_in,
+	[ 10] imsai_sio_nofun_in,
+	[ 11] imsai_sio_nofun_in,
+	[ 12] imsai_sio_nofun_in,
+	[ 13] imsai_sio_nofun_in,
 #ifdef HAS_DAZZLER
-	cromemco_dazzler_flags_in, /* port 14 */
+	[ 14] cromemco_dazzler_flags_in,
 #else
-	imsai_sio_nofun_in,	/* port 14 */
-#endif /* HAS_DAZZLER */
-	imsai_sio_nofun_in,	/* port 15 */
+	[ 14] imsai_sio_nofun_in,
+#endif /* !HAS_DAZZLER */
+	[ 15] imsai_sio_nofun_in,
 #ifdef HAS_CYCLOPS
-	cromemco_88ccc_ctrl_a_in, /* port 16 */
-#else
-	io_trap_in,		/* port 16 */
+	[ 16] cromemco_88ccc_ctrl_a_in,
 #endif
-	io_trap_in,		/* port 17 */
-	io_trap_in,		/* port 18 */
-	io_trap_in,		/* port 19 */
-	io_pport_in,		/* port 20 */ /* parallel port */
-	io_pport_in,		/* port 21 */ /*       "       */
-	io_trap_in,		/* port 22 */
-	io_trap_in,		/* port 23 */
-	cromemco_d7a_D_in,	/* port 24 */
-	cromemco_d7a_A1_in,	/* port 25 */
-	cromemco_d7a_A2_in,	/* port 26 */
-	cromemco_d7a_A3_in,	/* port 27 */
-	cromemco_d7a_A4_in,	/* port 28 */
-	cromemco_d7a_A5_in,	/* port 29 */
-	cromemco_d7a_A6_in,	/* port 30 */
-	cromemco_d7a_A7_in,	/* port 31 */
-	imsai_sio_nofun_in,	/* port 32 */ /* IMSAI SIO-2 */
-	imsai_sio_nofun_in,	/* port 33 */
-	imsai_sio2a_data_in,	/* port 34 */ /* Channel A, UNIX socket */
-	imsai_sio2a_status_in,	/* port 35 */
-	imsai_sio2b_data_in,	/* port 36 */ /* Channel B, AT-modem over TCP/IP (telnet) */
-	imsai_sio2b_status_in,	/* port 37 */
-	imsai_sio_nofun_in,	/* port 38 */
-	imsai_sio_nofun_in,	/* port 39 */
-	imsai_sio2_ctl_in,	/* port 40 */ /* SIO Control for A and B */
-	imsai_sio_nofun_in,	/* port 41 */
-	imsai_sio_nofun_in,	/* port 42 */
-	imsai_sio_nofun_in,	/* port 43 */
-	imsai_sio_nofun_in,	/* port 44 */
-	imsai_sio_nofun_in,	/* port 45 */
-	imsai_sio_nofun_in,	/* port 46 */
-	imsai_sio_nofun_in,	/* port 47 */
-	io_trap_in,		/* port 48 */
-	io_trap_in,		/* port 49 */
-	io_trap_in,		/* port 50 */
-	io_trap_in,		/* port 51 */
-	io_trap_in,		/* port 52 */
-	io_trap_in,		/* port 53 */
-	io_trap_in,		/* port 54 */
-	io_trap_in,		/* port 55 */
-	io_trap_in,		/* port 56 */
-	io_trap_in,		/* port 57 */
-	io_trap_in,		/* port 58 */
-	io_trap_in,		/* port 59 */
-	io_trap_in,		/* port 60 */
-	io_trap_in,		/* port 61 */
-	io_trap_in,		/* port 62 */
-	io_trap_in,		/* port 63 */
-	mmu_in,			/* port 64 */ /* MMU */
-	clkc_in,		/* port 65 */ /* RTC command */
-	clkd_in,		/* port 66 */ /* RTC data */
-	io_trap_in,		/* port 67 */
-	io_trap_in,		/* port 68 */
-	io_trap_in,		/* port 69 */
-	io_trap_in,		/* port 70 */
-	io_trap_in,		/* port 71 */
-	io_trap_in,		/* port 72 */
-	io_trap_in,		/* port 73 */
-	io_trap_in,		/* port 74 */
-	io_trap_in,		/* port 75 */
-	io_trap_in,		/* port 76 */
-	io_trap_in,		/* port 77 */
-	io_trap_in,		/* port 78 */
-	io_trap_in,		/* port 79 */
-	io_trap_in,		/* port 80 */
-	io_trap_in,		/* port 81 */
-	io_trap_in,		/* port 82 */
-	io_trap_in,		/* port 83 */
-	io_trap_in,		/* port 84 */
-	io_trap_in,		/* port 85 */
-	io_trap_in,		/* port 86 */
-	io_trap_in,		/* port 87 */
-	io_trap_in,		/* port 88 */
-	io_trap_in,		/* port 89 */
-	io_trap_in,		/* port 90 */
-	io_trap_in,		/* port 91 */
-	io_trap_in,		/* port 92 */
-	io_trap_in,		/* port 93 */
-	io_trap_in,		/* port 94 */
-	io_trap_in,		/* port 95 */
-	io_trap_in,		/* port 96 */
-	io_trap_in,		/* port 97 */
-	io_trap_in,		/* port 98 */
-	io_trap_in,		/* port 99 */
-	io_trap_in,		/* port 100 */
-	io_trap_in,		/* port 101 */
-	io_trap_in,		/* port 102 */
-	io_trap_in,		/* port 103 */
-	io_trap_in,		/* port 104 */
-	io_trap_in,		/* port 105 */
-	io_trap_in,		/* port 106 */
-	io_trap_in,		/* port 107 */
-	io_trap_in,		/* port 108 */
-	io_trap_in,		/* port 109 */
-	io_trap_in,		/* port 110 */
-	io_trap_in,		/* port 111 */
-	io_trap_in,		/* port 112 */
-	io_trap_in,		/* port 113 */
-	io_trap_in,		/* port 114 */
-	io_trap_in,		/* port 115 */
-	io_trap_in,		/* port 116 */
-	io_trap_in,		/* port 117 */
-	io_trap_in,		/* port 118 */
-	io_trap_in,		/* port 119 */
-	io_trap_in,		/* port 120 */
-	io_trap_in,		/* port 121 */
-	io_trap_in,		/* port 122 */
-	io_trap_in,		/* port 123 */
-	io_trap_in,		/* port 124 */
-	io_trap_in,		/* port 125 */
-	io_trap_in,		/* port 126 */
-	io_trap_in,		/* port 127 */
-	io_trap_in,		/* port 128 */
-	io_trap_in,		/* port 129 */
-	io_trap_in,		/* port 130 */
-	io_trap_in,		/* port 131 */
-	io_trap_in,		/* port 132 */
-	io_trap_in,		/* port 133 */
-	io_trap_in,		/* port 134 */
-	io_trap_in,		/* port 135 */
-	io_trap_in,		/* port 136 */
-	io_trap_in,		/* port 137 */
-	io_trap_in,		/* port 138 */
-	io_trap_in,		/* port 139 */
-	io_trap_in,		/* port 140 */
-	io_trap_in,		/* port 141 */
-	io_trap_in,		/* port 142 */
-	io_trap_in,		/* port 143 */
-	io_trap_in,		/* port 144 */
-	io_trap_in,		/* port 145 */
-	io_trap_in,		/* port 146 */
-	io_trap_in,		/* port 147 */
-	io_trap_in,		/* port 148 */
-	io_trap_in,		/* port 149 */
-	io_trap_in,		/* port 150 */
-	io_trap_in,		/* port 151 */
-	io_trap_in,		/* port 152 */
-	io_trap_in,		/* port 153 */
-	io_trap_in,		/* port 154 */
-	io_trap_in,		/* port 155 */
-	io_trap_in,		/* port 156 */
-	io_trap_in,		/* port 157 */
-	io_trap_in,		/* port 158 */
-	io_trap_in,		/* port 159 */
-	hwctl_in,		/* port 160 */	/* virtual hardware control */
-	io_trap_in,		/* port 161 */
+	[ 20] io_pport_in,		/* parallel port */
+	[ 21] io_pport_in,		/*       "       */
+	[ 24] cromemco_d7a_D_in,
+	[ 25] cromemco_d7a_A1_in,
+	[ 26] cromemco_d7a_A2_in,
+	[ 27] cromemco_d7a_A3_in,
+	[ 28] cromemco_d7a_A4_in,
+	[ 29] cromemco_d7a_A5_in,
+	[ 30] cromemco_d7a_A6_in,
+	[ 31] cromemco_d7a_A7_in,
+	[ 32] imsai_sio_nofun_in,	/* IMSAI SIO-2 */
+	[ 33] imsai_sio_nofun_in,
+	[ 34] imsai_sio2a_data_in,	/* Channel A, UNIX socket */
+	[ 35] imsai_sio2a_status_in,
+	[ 36] imsai_sio2b_data_in,	/* Channel B, AT-modem over TCP/IP (telnet) */
+	[ 37] imsai_sio2b_status_in,
+	[ 38] imsai_sio_nofun_in,
+	[ 39] imsai_sio_nofun_in,
+	[ 40] imsai_sio2_ctl_in,	/* SIO Control for A and B */
+	[ 41] imsai_sio_nofun_in,
+	[ 42] imsai_sio_nofun_in,
+	[ 43] imsai_sio_nofun_in,
+	[ 44] imsai_sio_nofun_in,
+	[ 45] imsai_sio_nofun_in,
+	[ 46] imsai_sio_nofun_in,
+	[ 47] imsai_sio_nofun_in,
+	[ 64] mmu_in,			/* MMU */
+	[ 65] clkc_in,			/* RTC command */
+	[ 66] clkd_in,			/* RTC data */
+	[160] hwctl_in,			/* virtual hardware control */
 #ifdef HAS_APU
-	apu_data_in,		/* port 162 */
-	apu_status_in,		/* port 163 */
-#else
-	io_trap_in,		/* port 162 */
-	io_trap_in,		/* port 163 */
+	[162] apu_data_in,
+	[163] apu_status_in,
 #endif
-	io_trap_in,		/* port 164 */
-	io_trap_in,		/* port 165 */
-	io_trap_in,		/* port 166 */
-	io_trap_in,		/* port 167 */
-	io_trap_in,		/* port 168 */
-	io_trap_in,		/* port 169 */
-	io_trap_in,		/* port 170 */
-	io_trap_in,		/* port 171 */
-	io_trap_in,		/* port 172 */
-	io_trap_in,		/* port 173 */
-	io_trap_in,		/* port 174 */
-	io_trap_in,		/* port 175 */
-	io_trap_in,		/* port 176 */
-	io_trap_in,		/* port 177 */
-	io_trap_in,		/* port 178 */
-	io_trap_in,		/* port 179 */
-	io_trap_in,		/* port 180 */
-	io_trap_in,		/* port 181 */
-	io_trap_in,		/* port 182 */
-	io_trap_in,		/* port 183 */
-	io_trap_in,		/* port 184 */
-	io_trap_in,		/* port 185 */
-	io_trap_in,		/* port 186 */
-	io_trap_in,		/* port 187 */
-	io_trap_in,		/* port 188 */
-	io_trap_in,		/* port 189 */
-	io_trap_in,		/* port 190 */
-	io_trap_in,		/* port 191 */
-	io_trap_in,		/* port 192 */
-	io_trap_in,		/* port 193 */
-	io_trap_in,		/* port 194 */
-	io_trap_in,		/* port 195 */
-	io_trap_in,		/* port 196 */
-	io_trap_in,		/* port 197 */
-	io_trap_in,		/* port 198 */
-	io_trap_in,		/* port 199 */
-	io_trap_in,		/* port 200 */
-	io_trap_in,		/* port 201 */
-	io_trap_in,		/* port 202 */
-	io_trap_in,		/* port 203 */
-	io_trap_in,		/* port 204 */
-	io_trap_in,		/* port 205 */
-	io_trap_in,		/* port 206 */
-	io_trap_in,		/* port 207 */
-	io_trap_in,		/* port 208 */
-	io_trap_in,		/* port 209 */
-	io_trap_in,		/* port 210 */
-	io_trap_in,		/* port 211 */
-	io_trap_in,		/* port 212 */
-	io_trap_in,		/* port 213 */
-	io_trap_in,		/* port 214 */
-	io_trap_in,		/* port 215 */
-	io_trap_in,		/* port 216 */
-	io_trap_in,		/* port 217 */
-	io_trap_in,		/* port 218 */
-	io_trap_in,		/* port 219 */
-	io_trap_in,		/* port 220 */
-	io_trap_in,		/* port 221 */
-	io_trap_in,		/* port 222 */
-	io_trap_in,		/* port 223 */
-	io_trap_in,		/* port 224 */
-	io_trap_in,		/* port 225 */
-	io_trap_in,		/* port 226 */
-	io_trap_in,		/* port 227 */
-	io_trap_in,		/* port 228 */
-	io_trap_in,		/* port 229 */
-	io_trap_in,		/* port 230 */
-	io_trap_in,		/* port 231 */
-	io_trap_in,		/* port 232 */
-	io_trap_in,		/* port 233 */
-	io_trap_in,		/* port 234 */
-	io_trap_in,		/* port 235 */
-	io_trap_in,		/* port 236 */
-	io_trap_in,		/* port 237 */
-	io_trap_in,		/* port 238 */
-	io_no_card_in,		/* port 239 */ /* unknown card */
-	io_trap_in,		/* port 240 */
-	io_trap_in,		/* port 241 */
-	io_trap_in,		/* port 242 */
-	ctrl_port_in,		/* port 243 */ /* software memory control */
-	io_trap_in,		/* port 244 */
-	io_trap_in,		/* port 245 */
-	lpt_in,			/* port 246 */ /* IMSAI PTR-300 line printer */
-	io_no_card_in,		/* port 247 */ /* prio interrupt controller */
-	io_trap_in,		/* port 248 */
-	io_trap_in,		/* port 249 */
-	io_trap_in,		/* port 250 */
-	io_trap_in,		/* port 251 */
-	io_trap_in,		/* port 252 */
-	imsai_fif_in,		/* port 253 */ /* FIF disk controller */
-	io_no_card_in,		/* port 254 */ /* memory write protect */
-	fp_in			/* port 255 */ /* front panel */
+	[239] io_no_card_in,		/* unknown card */
+	[243] ctrl_port_in,		/* software memory control */
+	[246] lpt_in,			/* IMSAI PTR-300 line printer */
+	[247] io_no_card_in,		/* prio interrupt controller */
+	[253] imsai_fif_in,		/* FIF disk controller */
+	[254] io_no_card_in,		/* memory write protect */
+	[255] fp_in			/* front panel */
 };
 
 /*
  *	This array contains function pointers for every
  *	output I/O port (0 - 255), to do the required I/O.
  */
-static void (*port_out[256])(BYTE) = {
-	imsai_sio_nofun_out,	/* port 0 */ /* IMSAI SIO-2 */
-	imsai_sio_nofun_out,	/* port 1 */
-	imsai_sio1a_data_out,	/* port 2 */ /* Channel A, console */
-	imsai_sio1a_status_out,	/* port 3 */
-	imsai_sio1b_data_out,	/* port 4 */ /* Channel B, keyboard */
-	imsai_sio1b_status_out,	/* port 5 */
-	imsai_sio_nofun_out,	/* port 6 */
-	imsai_sio_nofun_out,	/* port 7 */
-	imsai_sio1_ctl_out,	/* port 8 */ /* SIO Control for A and B */
-	imsai_sio_nofun_out,	/* port 9 */
-	imsai_sio_nofun_out,	/* port 10 */
-	imsai_sio_nofun_out,	/* port 11 */
-	imsai_sio_nofun_out,	/* port 12 */
-	imsai_sio_nofun_out,	/* port 13 */
+void (*port_out[256])(BYTE) = {
+	[  0] imsai_sio_nofun_out,	/* IMSAI SIO-2 */
+	[  1] imsai_sio_nofun_out,
+	[  2] imsai_sio1a_data_out,	/* Channel A, console */
+	[  3] imsai_sio1a_status_out,
+	[  4] imsai_sio1b_data_out,	/* Channel B, keyboard */
+	[  5] imsai_sio1b_status_out,
+	[  6] imsai_sio_nofun_out,
+	[  7] imsai_sio_nofun_out,
+	[  8] imsai_sio1_ctl_out,	/* SIO Control for A and B */
+	[  9] imsai_sio_nofun_out,
+	[ 10] imsai_sio_nofun_out,
+	[ 11] imsai_sio_nofun_out,
+	[ 12] imsai_sio_nofun_out,
+	[ 13] imsai_sio_nofun_out,
 #ifdef HAS_DAZZLER
-	cromemco_dazzler_ctl_out,	/* port 14 */
-	cromemco_dazzler_format_out,	/* port 15 */
+	[ 14] cromemco_dazzler_ctl_out,
+	[ 15] cromemco_dazzler_format_out,
 #else
-	imsai_sio_nofun_out,	/* port 14 */
-	imsai_sio_nofun_out,	/* port 15 */
-#endif /* HAS_DAZZLER */
+	[ 14] imsai_sio_nofun_out,
+	[ 15] imsai_sio_nofun_out,
+#endif /* !HAS_DAZZLER */
 #ifdef HAS_CYCLOPS
-	cromemco_88ccc_ctrl_a_out, /* port 16 */
-	cromemco_88ccc_ctrl_b_out, /* port 17 */
-	cromemco_88ccc_ctrl_c_out, /* port 18 */
-#else
-	io_trap_out,		/* port 16 */
-	io_trap_out,		/* port 17 */
-	io_trap_out,		/* port 18 */
+	[ 16] cromemco_88ccc_ctrl_a_out,
+	[ 17] cromemco_88ccc_ctrl_b_out,
+	[ 18] cromemco_88ccc_ctrl_c_out,
 #endif
-	io_trap_out,		/* port 19 */
-	io_no_card_out,		/* port 20 */ /* parallel port */
-	io_no_card_out,		/* port 21 */ /*       "       */
-	io_trap_out,		/* port 22 */
-	io_trap_out,		/* port 23 */
-	cromemco_d7a_D_out,	/* port 24 */
-	cromemco_d7a_A1_out,	/* port 25 */
-	cromemco_d7a_A2_out,	/* port 26 */
-	cromemco_d7a_A3_out,	/* port 27 */
-	cromemco_d7a_A4_out,	/* port 28 */
-	cromemco_d7a_A5_out,	/* port 29 */
-	cromemco_d7a_A6_out,	/* port 30 */
-	cromemco_d7a_A7_out,	/* port 31 */
-	imsai_sio_nofun_out,	/* port 32 */ /* IMSAI SIO-2 */
-	imsai_sio_nofun_out,	/* port 33 */
-	imsai_sio2a_data_out,	/* port 34 */ /* Channel A, UNIX socket */
-	imsai_sio2a_status_out,	/* port 35 */
-	imsai_sio2b_data_out,	/* port 36 */ /* Channel B, AT-modem over TCP/IP (telnet) */
-	imsai_sio2b_status_out,	/* port 37 */
-	imsai_sio_nofun_out,	/* port 38 */
-	imsai_sio_nofun_out,	/* port 39 */
-	imsai_sio2_ctl_out,	/* port 40 */ /* SIO Control for A and B */
-	imsai_sio_nofun_out,	/* port 41 */
-	imsai_sio_nofun_out,	/* port 42 */
-	imsai_sio_nofun_out,	/* port 43 */
-	imsai_sio_nofun_out,	/* port 44 */
-	imsai_sio_nofun_out,	/* port 45 */
-	imsai_sio_nofun_out,	/* port 46 */
-	imsai_sio_nofun_out,	/* port 47 */
-	io_trap_out,		/* port 48 */
-	io_trap_out,		/* port 49 */
-	io_trap_out,		/* port 50 */
-	io_trap_out,		/* port 51 */
-	io_trap_out,		/* port 52 */
-	io_trap_out,		/* port 53 */
-	io_trap_out,		/* port 54 */
-	io_trap_out,		/* port 55 */
-	io_trap_out,		/* port 56 */
-	io_trap_out,		/* port 57 */
-	io_trap_out,		/* port 58 */
-	io_trap_out,		/* port 59 */
-	io_trap_out,		/* port 60 */
-	io_trap_out,		/* port 61 */
-	io_trap_out,		/* port 62 */
-	io_trap_out,		/* port 63 */
-	mmu_out,		/* port 64 */ /* MMU */
-	clkc_out,		/* port 65 */ /* RTC command */
-	clkd_out,		/* port 66 */ /* RTC data */
-	io_trap_out,		/* port 67 */
-	io_trap_out,		/* port 68 */
-	io_trap_out,		/* port 69 */
-	io_trap_out,		/* port 70 */
-	io_trap_out,		/* port 71 */
-	io_trap_out,		/* port 72 */
-	io_trap_out,		/* port 73 */
-	io_trap_out,		/* port 74 */
-	io_trap_out,		/* port 75 */
-	io_trap_out,		/* port 76 */
-	io_trap_out,		/* port 77 */
-	io_trap_out,		/* port 78 */
-	io_trap_out,		/* port 79 */
-	io_trap_out,		/* port 80 */
-	io_trap_out,		/* port 81 */
-	io_trap_out,		/* port 82 */
-	io_trap_out,		/* port 83 */
-	io_trap_out,		/* port 84 */
-	io_trap_out,		/* port 85 */
-	io_trap_out,		/* port 86 */
-	io_trap_out,		/* port 87 */
-	io_trap_out,		/* port 88 */
-	io_trap_out,		/* port 89 */
-	io_trap_out,		/* port 90 */
-	io_trap_out,		/* port 91 */
-	io_trap_out,		/* port 92 */
-	io_trap_out,		/* port 93 */
-	io_trap_out,		/* port 94 */
-	io_trap_out,		/* port 95 */
-	io_trap_out,		/* port 96 */
-	io_trap_out,		/* port 97 */
-	io_trap_out,		/* port 98 */
-	io_trap_out,		/* port 99 */
-	io_trap_out,		/* port 100 */
-	io_trap_out,		/* port 101 */
-	io_trap_out,		/* port 102 */
-	io_trap_out,		/* port 103 */
-	io_trap_out,		/* port 104 */
-	io_trap_out,		/* port 105 */
-	io_trap_out,		/* port 106 */
-	io_trap_out,		/* port 107 */
-	io_trap_out,		/* port 108 */
-	io_trap_out,		/* port 109 */
-	io_trap_out,		/* port 110 */
-	io_trap_out,		/* port 111 */
-	io_trap_out,		/* port 112 */
-	io_trap_out,		/* port 113 */
-	io_trap_out,		/* port 114 */
-	io_trap_out,		/* port 115 */
-	io_trap_out,		/* port 116 */
-	io_trap_out,		/* port 117 */
-	io_trap_out,		/* port 118 */
-	io_trap_out,		/* port 119 */
-	io_trap_out,		/* port 120 */
-	io_trap_out,		/* port 121 */
-	io_trap_out,		/* port 122 */
-	io_trap_out,		/* port 123 */
-	io_trap_out,		/* port 124 */
-	io_trap_out,		/* port 125 */
-	io_trap_out,		/* port 126 */
-	io_trap_out,		/* port 127 */
-	io_trap_out,		/* port 128 */
-	io_trap_out,		/* port 129 */
-	io_trap_out,		/* port 130 */
-	io_trap_out,		/* port 131 */
-	io_trap_out,		/* port 132 */
-	io_trap_out,		/* port 133 */
-	io_trap_out,		/* port 134 */
-	io_trap_out,		/* port 135 */
-	io_trap_out,		/* port 136 */
-	io_trap_out,		/* port 137 */
-	io_trap_out,		/* port 138 */
-	io_trap_out,		/* port 139 */
-	io_trap_out,		/* port 140 */
-	io_trap_out,		/* port 141 */
-	io_trap_out,		/* port 142 */
-	io_trap_out,		/* port 143 */
-	io_trap_out,		/* port 144 */
-	io_trap_out,		/* port 145 */
-	io_trap_out,		/* port 146 */
-	io_trap_out,		/* port 147 */
-	io_trap_out,		/* port 148 */
-	io_trap_out,		/* port 149 */
-	io_trap_out,		/* port 150 */
-	io_trap_out,		/* port 151 */
-	io_trap_out,		/* port 152 */
-	io_trap_out,		/* port 153 */
-	io_trap_out,		/* port 154 */
-	io_trap_out,		/* port 155 */
-	io_trap_out,		/* port 156 */
-	io_trap_out,		/* port 157 */
-	io_trap_out,		/* port 158 */
-	io_trap_out,		/* port 159 */
-	hwctl_out,		/* port 160 */	/* virtual hardware control */
-	host_bdos_out,		/* port 161 */  /* host file I/O hook */
+	[ 20] io_no_card_out,		/* parallel port */
+	[ 21] io_no_card_out,		/*       "       */
+	[ 24] cromemco_d7a_D_out,
+	[ 25] cromemco_d7a_A1_out,
+	[ 26] cromemco_d7a_A2_out,
+	[ 27] cromemco_d7a_A3_out,
+	[ 28] cromemco_d7a_A4_out,
+	[ 29] cromemco_d7a_A5_out,
+	[ 30] cromemco_d7a_A6_out,
+	[ 31] cromemco_d7a_A7_out,
+	[ 32] imsai_sio_nofun_out,	/* IMSAI SIO-2 */
+	[ 33] imsai_sio_nofun_out,
+	[ 34] imsai_sio2a_data_out,	/* Channel A, UNIX socket */
+	[ 35] imsai_sio2a_status_out,
+	[ 36] imsai_sio2b_data_out,	/* Channel B, AT-modem over TCP/IP (telnet) */
+	[ 37] imsai_sio2b_status_out,
+	[ 38] imsai_sio_nofun_out,
+	[ 39] imsai_sio_nofun_out,
+	[ 40] imsai_sio2_ctl_out,	/* SIO Control for A and B */
+	[ 41] imsai_sio_nofun_out,
+	[ 42] imsai_sio_nofun_out,
+	[ 43] imsai_sio_nofun_out,
+	[ 44] imsai_sio_nofun_out,
+	[ 45] imsai_sio_nofun_out,
+	[ 46] imsai_sio_nofun_out,
+	[ 47] imsai_sio_nofun_out,
+	[ 64] mmu_out,			/* MMU */
+	[ 65] clkc_out,			/* RTC command */
+	[ 66] clkd_out,			/* RTC data */
+	[160] hwctl_out,		/* virtual hardware control */
+	[161] host_bdos_out,		/* host file I/O hook */
 #ifdef HAS_APU
-	apu_data_out,		/* port 162 */
-	apu_status_out,		/* port 163 */
-#else
-	io_trap_out,		/* port 162 */
-	io_trap_out,		/* port 163 */
+	[162] apu_data_out,
+	[163] apu_status_out,
 #endif
-	io_trap_out,		/* port 164 */
-	io_trap_out,		/* port 165 */
-	io_trap_out,		/* port 166 */
-	io_trap_out,		/* port 167 */
-	io_trap_out,		/* port 168 */
-	io_trap_out,		/* port 169 */
-	io_trap_out,		/* port 170 */
-	io_trap_out,		/* port 171 */
-	io_trap_out,		/* port 172 */
-	io_trap_out,		/* port 173 */
-	io_trap_out,		/* port 174 */
-	io_trap_out,		/* port 175 */
-	io_trap_out,		/* port 176 */
-	io_trap_out,		/* port 177 */
-	io_trap_out,		/* port 178 */
-	io_trap_out,		/* port 179 */
-	io_trap_out,		/* port 180 */
-	io_trap_out,		/* port 181 */
-	io_trap_out,		/* port 182 */
-	io_trap_out,		/* port 183 */
-	io_trap_out,		/* port 184 */
-	io_trap_out,		/* port 185 */
-	io_trap_out,		/* port 186 */
-	io_trap_out,		/* port 187 */
-	io_trap_out,		/* port 188 */
-	io_trap_out,		/* port 189 */
-	io_trap_out,		/* port 190 */
-	io_trap_out,		/* port 191 */
-	io_trap_out,		/* port 192 */
-	io_trap_out,		/* port 193 */
-	io_trap_out,		/* port 194 */
-	io_trap_out,		/* port 195 */
-	io_trap_out,		/* port 196 */
-	io_trap_out,		/* port 197 */
-	io_trap_out,		/* port 198 */
-	io_trap_out,		/* port 199 */
-	io_trap_out,		/* port 200 */
-	io_trap_out,		/* port 201 */
-	io_trap_out,		/* port 202 */
-	io_trap_out,		/* port 203 */
-	io_trap_out,		/* port 204 */
-	io_trap_out,		/* port 205 */
-	io_trap_out,		/* port 206 */
-	io_trap_out,		/* port 207 */
-	io_trap_out,		/* port 208 */
-	io_trap_out,		/* port 209 */
-	io_trap_out,		/* port 210 */
-	io_trap_out,		/* port 211 */
-	io_trap_out,		/* port 212 */
-	io_trap_out,		/* port 213 */
-	io_trap_out,		/* port 214 */
-	io_trap_out,		/* port 215 */
-	io_trap_out,		/* port 216 */
-	io_trap_out,		/* port 217 */
-	io_trap_out,		/* port 218 */
-	io_trap_out,		/* port 219 */
-	io_trap_out,		/* port 220 */
-	io_trap_out,		/* port 221 */
-	io_trap_out,		/* port 222 */
-	io_trap_out,		/* port 223 */
-	io_trap_out,		/* port 224 */
-	io_trap_out,		/* port 225 */
-	io_trap_out,		/* port 226 */
-	io_trap_out,		/* port 227 */
-	io_trap_out,		/* port 228 */
-	io_trap_out,		/* port 229 */
-	io_trap_out,		/* port 230 */
-	io_trap_out,		/* port 231 */
-	io_trap_out,		/* port 232 */
-	io_trap_out,		/* port 233 */
-	io_trap_out,		/* port 234 */
-	io_trap_out,		/* port 235 */
-	io_trap_out,		/* port 236 */
-	io_trap_out,		/* port 237 */
-	io_trap_out,		/* port 238 */
-	io_no_card_out,		/* port 239 */ /* unknown card */
-	io_trap_out,		/* port 240 */
-	io_trap_out,		/* port 241 */
-	io_trap_out,		/* port 242 */
-	ctrl_port_out,		/* port 243 */ /* software memory control */
-	io_trap_out,		/* port 244 */
-	io_trap_out,		/* port 245 */
-	lpt_out,		/* port 246 */ /* IMSAI PTR-300 line printer */
-	io_no_card_out,		/* port 247 */ /* prio interrupt controller */
-	io_trap_out,		/* port 248 */
-	io_trap_out,		/* port 249 */
-	io_trap_out,		/* port 250 */
-	io_trap_out,		/* port 251 */
-	io_trap_out,		/* port 252 */
-	imsai_fif_out,		/* port 253 */ /* FIF disk controller */
-	io_no_card_out,		/* port 254 */ /* memory write protect */
-	fp_out			/* port 255 */ /* front panel */
+	[239] io_no_card_out,		/* unknown card */
+	[243] ctrl_port_out,		/* software memory control */
+	[246] lpt_out,			/* IMSAI PTR-300 line printer */
+	[247] io_no_card_out,		/* prio interrupt controller */
+	[253] imsai_fif_out,		/* FIF disk controller */
+	[254] io_no_card_out,		/* memory write protect */
+	[255] fp_out			/* front panel */
 };
 
 /*
@@ -746,88 +338,7 @@ void reset_io(void)
 }
 
 /*
- *	This is the main handler for all IN op-codes,
- *	called by the simulator. It calls the input
- *	function for port addrl.
- */
-BYTE io_in(BYTE addrl, BYTE addrh)
-{
-#ifdef FRONTPANEL
-	int val = 0;
-#else
-	UNUSED(addrh);
-#endif
-
-	io_port = addrl;
-	io_data = (*port_in[addrl])();
-
-#ifdef BUS_8080
-	cpu_bus = CPU_WO | CPU_INP;
-#endif
-
-#ifdef FRONTPANEL
-	if (F_flag) {
-		fp_clock += 3;
-		fp_led_address = (addrh << 8) + addrl;
-		fp_led_data = io_data;
-		fp_sampleData();
-		val = wait_step();
-
-		/* when single stepped INP get last set value of port */
-		if (val)
-			io_data = (*port_in[io_port])();
-	}
-#endif
-
-	return (io_data);
-}
-
-/*
- *	This is the main handler for all OUT op-codes,
- *	called by the simulator. It calls the output
- *	function for port addrl.
- */
-void io_out(BYTE addrl, BYTE addrh, BYTE data)
-{
-#ifndef FRONTPANEL
-	UNUSED(addrh);
-#endif
-	io_port = addrl;
-	io_data = data;
-	(*port_out[addrl])(data);
-
-#ifdef BUS_8080
-	cpu_bus = CPU_OUT;
-#endif
-
-#ifdef FRONTPANEL
-	if (F_flag) {
-		fp_clock += 6;
-		fp_led_address = (addrh << 8) + addrl;
-		fp_led_data = io_data;
-		fp_sampleData();
-		wait_step();
-	}
-#endif
-}
-
-/*
- *	I/O input trap function
- *	This function should be added into all unused
- *	entries of the input port array. It can stop the
- *	emulation with an I/O error.
- */
-static BYTE io_trap_in(void)
-{
-	if (i_flag) {
-		cpu_error = IOTRAPIN;
-		cpu_state = STOPPED;
-	}
-	return ((BYTE) 0xff);
-}
-
-/*
- *	Same as above, but don't trap as I/O error.
+ *	No card I/O input trap function
  *	Used for input ports where I/O cards might be
  *	installed, but haven't.
  */
@@ -837,23 +348,7 @@ static BYTE io_no_card_in(void)
 }
 
 /*
- *	I/O output trap function
- *	This function should be added into all unused
- *	entries of the output port array. It can stop the
- *	emulation with an I/O error.
- */
-static void io_trap_out(BYTE data)
-{
-	UNUSED(data);
-
-	if (i_flag) {
-		cpu_error = IOTRAPOUT;
-		cpu_state = STOPPED;
-	}
-}
-
-/*
- *	Same as above, but don't trap as I/O error.
+ *	No card I/O output trap function
  *	Used for output ports where I/O cards might be
  *	installed, but haven't.
  */

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -68,6 +68,8 @@
 #define NUMNSOC 0	/* number of TCP/IP sockets for SIO connections */
 #define NUMUSOC 1	/* number of UNIX sockets for SIO connections */
 
+extern void sleep_us(long);
+#define SLEEP_US(t)	sleep_us(t)
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
 

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -54,7 +54,6 @@
 extern void reset_cpu(void), reset_io(void);
 extern void run_cpu(void), step_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
-extern unsigned long long get_clock_us(void);
 
 #ifdef FRONTPANEL
 static const char *TAG = "system";
@@ -172,11 +171,8 @@ void mon(void)
 
 			switch (cpu_switch) {
 			case 1:
-				if (!reset) {
-					cpu_start = get_clock_us();
+				if (!reset)
 					run_cpu();
-					cpu_stop = get_clock_us();
-				}
 				break;
 			case 2:
 				step_cpu();
@@ -205,9 +201,7 @@ void mon(void)
 		ice_cmd_loop(0);
 #else
 		/* run the CPU */
-		cpu_start = get_clock_us();
 		run_cpu();
-		cpu_stop = get_clock_us();
 #endif
 #ifdef FRONTPANEL
 	}

--- a/mosteksim/srcsim/iosim.c
+++ b/mosteksim/srcsim/iosim.c
@@ -10,6 +10,7 @@
  * 15-SEP-2019 (Mike Douglas) created from iosim.c for the Altair
  * 28-SEP-2019 (Udo Munk) use logging
  * 08-OCT-2019 (Mike Douglas) added OUT 161 trap to simbdos.c for host file I/O
+ * 27-MAY-2024 moved io_in & io_out to simcore
  */
 
 #include <unistd.h>
@@ -25,16 +26,16 @@
 #include "simbdos.h"
 #include "mostek-cpu.h"
 #include "mostek-fdc.h"
+#if 0
 /* #define LOG_LOCAL_LEVEL LOG_DEBUG */
 #include "log.h"
 
 static const char *TAG = "I/O";
+#endif
 
 /*
  *	Forward declarations for I/O functions
  */
-static BYTE io_trap_in(void);
-static void io_trap_out(BYTE);
 static BYTE io_no_card_in(void);
 static void io_no_card_out(BYTE);
 
@@ -42,526 +43,59 @@ static void io_no_card_out(BYTE);
  *	This array contains function pointers for every
  *	input I/O port (0 - 255), to do the required I/O.
  */
-static BYTE (*port_in[256])(void) = {
-	io_trap_in,			/* port 0 */
-	io_trap_in,			/* port 1 */
-	io_trap_in,			/* port 2 */
-	io_trap_in,			/* port 3 */
-	io_trap_in,			/* port 4 */
-	io_trap_in,			/* port 5 */
-	io_trap_in,			/* port 6 */
-	io_trap_in,			/* port 7 */
-	io_trap_in,			/* port 8 */
-	io_trap_in,			/* port 9 */
-	io_trap_in,			/* port 10 */
-	io_trap_in,			/* port 11 */
-	io_trap_in,			/* port 12 */
-	io_trap_in,			/* port 13 */
-	io_trap_in,	 		/* port 14 */
-	io_trap_in,			/* port 15 */
-	io_trap_in,			/* port 16 */
-	io_trap_in,			/* port 17 */
-	io_trap_in,			/* port 18 */
-	io_trap_in,			/* port 19 */
-	io_trap_in,			/* port 20 */
-	io_trap_in,			/* port 21 */
-	io_trap_in,			/* port 22 */
-	io_trap_in,			/* port 23 */
-	io_trap_in,			/* port 24 */
-	io_trap_in,			/* port 25 */
-	io_trap_in,			/* port 26 */
-	io_trap_in,			/* port 27 */
-	io_trap_in,			/* port 28 */
-	io_trap_in,			/* port 29 */
-	io_trap_in,			/* port 30 */
-	io_trap_in,			/* port 31 */
-	io_trap_in,			/* port 32 */
-	io_trap_in,			/* port 33 */
-	io_trap_in,			/* port 34 */
-	io_trap_in,			/* port 35 */
-	io_trap_in,			/* port 36 */
-	io_trap_in,			/* port 37 */
-	io_trap_in,			/* port 38 */
-	io_trap_in,			/* port 39 */
-	io_trap_in,			/* port 40 */
-	io_trap_in,			/* port 41 */
-	io_trap_in,			/* port 42 */
-	io_trap_in,			/* port 43 */
-	io_trap_in,			/* port 44 */
-	io_trap_in,			/* port 45 */
-	io_trap_in,			/* port 46 */
-	io_trap_in,			/* port 47 */
-	io_trap_in,			/* port 48 */
-	io_trap_in,			/* port 49 */
-	io_trap_in,			/* port 50 */
-	io_trap_in,			/* port 51 */
-	io_trap_in,			/* port 52 */
-	io_trap_in,			/* port 53 */
-	io_trap_in,			/* port 54 */
-	io_trap_in,			/* port 55 */
-	io_trap_in,			/* port 56 */
-	io_trap_in,			/* port 57 */
-	io_trap_in,			/* port 58 */
-	io_trap_in,			/* port 59 */
-	io_trap_in,			/* port 60 */
-	io_trap_in,			/* port 61 */
-	io_trap_in,			/* port 62 */
-	io_trap_in,			/* port 63 */
-	io_trap_in,			/* port 64 */
-	io_trap_in,			/* port 65 */
-	io_trap_in,			/* port 66 */
-	io_trap_in,			/* port 67 */
-	io_trap_in,			/* port 68 */
-	io_trap_in,			/* port 69 */
-	io_trap_in,			/* port 70 */
-	io_trap_in,			/* port 71 */
-	io_trap_in,			/* port 72 */
-	io_trap_in,			/* port 73 */
-	io_trap_in,			/* port 74 */
-	io_trap_in,			/* port 75 */
-	io_trap_in,			/* port 76 */
-	io_trap_in,			/* port 77 */
-	io_trap_in,			/* port 78 */
-	io_trap_in,			/* port 79 */
-	io_trap_in,			/* port 80 */
-	io_trap_in,			/* port 81 */
-	io_trap_in,			/* port 82 */
-	io_trap_in,			/* port 83 */
-	io_trap_in,			/* port 84 */
-	io_trap_in,			/* port 85 */
-	io_trap_in,			/* port 86 */
-	io_trap_in,			/* port 87 */
-	io_trap_in,			/* port 88 */
-	io_trap_in,			/* port 89 */
-	io_trap_in,			/* port 90 */
-	io_trap_in,			/* port 91 */
-	io_trap_in,			/* port 92 */
-	io_trap_in,			/* port 93 */
-	io_trap_in,			/* port 94 */
-	io_trap_in,			/* port 95 */
-	io_trap_in,			/* port 96 */
-	io_trap_in,			/* port 97 */
-	io_trap_in,			/* port 98 */
-	io_trap_in,			/* port 99 */
-	io_trap_in,			/* port 100 */
-	io_trap_in,			/* port 101 */
-	io_trap_in,			/* port 102 */
-	io_trap_in,			/* port 103 */
-	io_trap_in,			/* port 104 */
-	io_trap_in,			/* port 105 */
-	io_trap_in,			/* port 106 */
-	io_trap_in,			/* port 107 */
-	io_trap_in,			/* port 108 */
-	io_trap_in,			/* port 109 */
-	io_trap_in,			/* port 110 */
-	io_trap_in,			/* port 111 */
-	io_trap_in,			/* port 112 */
-	io_trap_in,			/* port 113 */
-	io_trap_in,			/* port 114 */
-	io_trap_in,			/* port 115 */
-	io_trap_in,			/* port 116 */
-	io_trap_in,			/* port 117 */
-	io_trap_in,			/* port 118 */
-	io_trap_in,			/* port 119 */
-	io_trap_in,			/* port 120 */
-	io_trap_in,			/* port 121 */
-	io_trap_in,			/* port 122 */
-	io_trap_in,			/* port 123 */
-	io_trap_in,			/* port 124 */
-	io_trap_in,			/* port 125 */
-	io_trap_in,			/* port 126 */
-	io_trap_in,			/* port 127 */
-	io_trap_in,			/* port 128 */
-	io_trap_in,			/* port 129 */
-	io_trap_in,			/* port 130 */
-	io_trap_in,			/* port 131 */
-	io_trap_in,			/* port 132 */
-	io_trap_in,			/* port 133 */
-	io_trap_in,			/* port 134 */
-	io_trap_in,			/* port 135 */
-	io_trap_in,			/* port 136 */
-	io_trap_in,			/* port 137 */
-	io_trap_in,			/* port 138 */
-	io_trap_in,			/* port 139 */
-	io_trap_in,			/* port 140 */
-	io_trap_in,			/* port 141 */
-	io_trap_in,			/* port 142 */
-	io_trap_in,			/* port 143 */
-	io_trap_in,			/* port 144 */
-	io_trap_in,			/* port 145 */
-	io_trap_in,			/* port 146 */
-	io_trap_in,			/* port 147 */
-	io_trap_in,			/* port 148 */
-	io_trap_in,			/* port 149 */
-	io_trap_in,			/* port 150 */
-	io_trap_in,			/* port 151 */
-	io_trap_in,			/* port 152 */
-	io_trap_in,			/* port 153 */
-	io_trap_in,			/* port 154 */
-	io_trap_in,			/* port 155 */
-	io_trap_in,			/* port 156 */
-	io_trap_in,			/* port 157 */
-	io_trap_in,			/* port 158 */
-	io_trap_in,			/* port 159 */
-	io_trap_in,			/* port 160 */
-	io_trap_in,			/* port 161 */
-	io_trap_in,			/* port 162 */
-	io_trap_in,			/* port 163 */
-	io_trap_in,			/* port 164 */
-	io_trap_in,			/* port 165 */
-	io_trap_in,			/* port 166 */
-	io_trap_in,			/* port 167 */
-	io_trap_in,			/* port 168 */
-	io_trap_in,			/* port 169 */
-	io_trap_in,			/* port 170 */
-	io_trap_in,			/* port 171 */
-	io_trap_in,			/* port 172 */
-	io_trap_in,			/* port 173 */
-	io_trap_in,			/* port 174 */
-	io_trap_in,			/* port 175 */
-	io_trap_in,			/* port 176 */
-	io_trap_in,			/* port 177 */
-	io_trap_in,			/* port 178 */
-	io_trap_in,			/* port 179 */
-	io_trap_in,			/* port 180 */
-	io_trap_in,			/* port 181 */
-	io_trap_in,			/* port 182 */
-	io_trap_in,			/* port 183 */
-	io_trap_in,			/* port 184 */
-	io_trap_in,			/* port 185 */
-	io_trap_in,			/* port 186 */
-	io_trap_in,			/* port 187 */
-	io_trap_in,			/* port 188 */
-	io_trap_in,			/* port 189 */
-	io_trap_in,			/* port 190 */
-	io_trap_in,			/* port 191 */
-	io_trap_in,			/* port 192 */
-	io_trap_in,			/* port 193 */
-	io_trap_in,			/* port 194 */
-	io_trap_in,			/* port 195 */
-	io_trap_in,			/* port 196 */
-	io_trap_in,			/* port 197 */
-	io_trap_in,			/* port 198 */
-	io_trap_in,			/* port 199 */
-	io_trap_in,			/* port 200 */
-	io_trap_in,			/* port 201 */
-	io_trap_in,			/* port 202 */
-	io_trap_in,			/* port 203 */
-	io_trap_in,			/* port 204 */
-	io_trap_in,			/* port 205 */
-	io_trap_in,			/* port 206 */
-	io_trap_in,			/* port 207 */
-	io_no_card_in,		/* port 208 (d0) PIO1 Data A */
-	io_no_card_in,		/* port 209 (d1) PIO1 Control A */
-	io_no_card_in,		/* port 210 (d2) PIO1 Data B */
-	io_no_card_in,		/* port 211 (d3) PIO1 Control B */
-	io_no_card_in,		/* port 212 (d4) PIO2 Data A */
-	io_no_card_in,		/* port 213 (d5) PIO2 Control A */
-	io_no_card_in,		/* port 214 (d6) PIO2 Data B */
-	io_no_card_in,		/* port 215 (d7) PIO2 Control B */
-	io_no_card_in,		/* port 216 (d8) CTC 0 (baud rate) */
-	io_no_card_in,		/* port 217 (d9) CTC 1 */
-	io_no_card_in,		/* port 218 (da) CTC 2 */
-	io_no_card_in,		/* port 219 (db) CTC 3 */
-	sio_data_in,		/* port 220 (dc) SIO Data */
-	sio_status_in,		/* port 221 (dd) SIO Status */
-	sio_handshake_in,	/* port 222 (de) Sys Control (handshake lines in) */
-	io_no_card_in,		/* port 223 (df) Debug Control */
-	io_trap_in,			/* port 224 */
-	io_trap_in,			/* port 225 */
-	fdcBoard_stat_in,	/* port 226 (e2) FDC board status */
-	fdcBoard_ctl_in,	/* port 227 (e3) FDC board control */
-	fdc1771_stat_in,	/* port 228 (e4) WD1771 Command/Status */
-	fdc1771_track_in,	/* port 229 (e5) WD1771 Track */
-	fdc1771_sec_in,		/* port 230 (e6) WD1771 Sector */
-	fdc1771_data_in,	/* port 231 (e7) WD1771 Data */
-	io_trap_in,			/* port 232 */
-	io_trap_in,			/* port 233 */
-	io_trap_in,			/* port 234 */
-	io_trap_in,			/* port 235 */
-	io_trap_in,			/* port 236 */
-	io_trap_in,			/* port 237 */
-	io_trap_in,			/* port 238 */
-	io_trap_in,			/* port 239 */
-	io_trap_in,			/* port 240 */
-	io_trap_in,			/* port 241 */
-	io_trap_in,			/* port 242 */
-	io_trap_in,			/* port 243 */
-	io_trap_in,			/* port 244 */
-	io_trap_in,			/* port 245 */
-	io_trap_in,			/* port 246 */
-	io_trap_in,			/* port 247 */
-	io_trap_in,			/* port 248 */
-	io_trap_in,			/* port 249 */
-	io_trap_in,			/* port 250 */
-	io_trap_in,			/* port 251 */
-	io_trap_in,			/* port 252 */
-	io_trap_in,			/* port 253 */
-	io_trap_in,			/* port 254 */
-	io_trap_in			/* port 255 */
+BYTE (*port_in[256])(void) = {
+	[208] io_no_card_in,		/* (d0) PIO1 Data A */
+	[209] io_no_card_in,		/* (d1) PIO1 Control A */
+	[210] io_no_card_in,		/* (d2) PIO1 Data B */
+	[211] io_no_card_in,		/* (d3) PIO1 Control B */
+	[212] io_no_card_in,		/* (d4) PIO2 Data A */
+	[213] io_no_card_in,		/* (d5) PIO2 Control A */
+	[214] io_no_card_in,		/* (d6) PIO2 Data B */
+	[215] io_no_card_in,		/* (d7) PIO2 Control B */
+	[216] io_no_card_in,		/* (d8) CTC 0 (baud rate) */
+	[217] io_no_card_in,		/* (d9) CTC 1 */
+	[218] io_no_card_in,		/* (da) CTC 2 */
+	[219] io_no_card_in,		/* (db) CTC 3 */
+	[220] sio_data_in,		/* (dc) SIO Data */
+	[221] sio_status_in,		/* (dd) SIO Status */
+	[222] sio_handshake_in,		/* (de) Sys Control (handshake lines in) */
+	[223] io_no_card_in,		/* (df) Debug Control */
+	[226] fdcBoard_stat_in,		/* (e2) FDC board status */
+	[227] fdcBoard_ctl_in,		/* (e3) FDC board control */
+	[228] fdc1771_stat_in,		/* (e4) WD1771 Command/Status */
+	[229] fdc1771_track_in,		/* (e5) WD1771 Track */
+	[230] fdc1771_sec_in,		/* (e6) WD1771 Sector */
+	[231] fdc1771_data_in		/* (e7) WD1771 Data */
 };
 
 /*
  *	This array contains function pointers for every
  *	output I/O port (0 - 255), to do the required I/O.
  */
-static void (*port_out[256])(BYTE) = {
-	io_trap_out,		/* port 0 */
-	io_trap_out,		/* port 1 */
-	io_trap_out,		/* port 2 */
-	io_trap_out,		/* port 3 */
-	io_trap_out,		/* port 4 */
-	io_trap_out,		/* port 5 */
-	io_trap_out,		/* port 6 */
-	io_trap_out,		/* port 7 */
-	io_trap_out,		/* port 8 */
-	io_trap_out,		/* port 9 */
-	io_trap_out,		/* port 10 */
-	io_trap_out,		/* port 11 */
-	io_trap_out,		/* port 12 */
-	io_trap_out,		/* port 13 */
-	io_trap_out,		/* port 14 */
-	io_trap_out,		/* port 15 */
-	io_trap_out,		/* port 16 */
-	io_trap_out,		/* port 17 */
-	io_trap_out,		/* port 18 */
-	io_trap_out,		/* port 19 */
-	io_trap_out,		/* port 20 */
-	io_trap_out,		/* port 21 */
-	io_trap_out,		/* port 22 */
-	io_trap_out,		/* port 23 */
-	io_trap_out,		/* port 24 */
-	io_trap_out,		/* port 25 */
-	io_trap_out,		/* port 26 */
-	io_trap_out,		/* port 27 */
-	io_trap_out,		/* port 28 */
-	io_trap_out,		/* port 29 */
-	io_trap_out,		/* port 30 */
-	io_trap_out,		/* port 31 */
-	io_trap_out,		/* port 32 */
-	io_trap_out,		/* port 33 */
-	io_trap_out,		/* port 34 */
-	io_trap_out,		/* port 35 */
-	io_trap_out,		/* port 36 */
-	io_trap_out,		/* port 37 */
-	io_trap_out,		/* port 38 */
-	io_trap_out,		/* port 39 */
-	io_trap_out,		/* port 40 */
-	io_trap_out,		/* port 41 */
-	io_trap_out,		/* port 42 */
-	io_trap_out,		/* port 43 */
-	io_trap_out,		/* port 44 */
-	io_trap_out,		/* port 45 */
-	io_trap_out,		/* port 46 */
-	io_trap_out,		/* port 47 */
-	io_trap_out,		/* port 48 */
-	io_trap_out,		/* port 49 */
-	io_trap_out,		/* port 50 */
-	io_trap_out,		/* port 51 */
-	io_trap_out,		/* port 52 */
-	io_trap_out,		/* port 53 */
-	io_trap_out,		/* port 54 */
-	io_trap_out,		/* port 55 */
-	io_trap_out,		/* port 56 */
-	io_trap_out,		/* port 57 */
-	io_trap_out,		/* port 58 */
-	io_trap_out,		/* port 59 */
-	io_trap_out,		/* port 60 */
-	io_trap_out,		/* port 61 */
-	io_trap_out,		/* port 62 */
-	io_trap_out,		/* port 63 */
-	io_trap_out,		/* port 64 */
-	io_trap_out,		/* port 65 */
-	io_trap_out,		/* port 66 */
-	io_trap_out,		/* port 67 */
-	io_trap_out,		/* port 68 */
-	io_trap_out,		/* port 69 */
-	io_trap_out,		/* port 70 */
-	io_trap_out,		/* port 71 */
-	io_trap_out,		/* port 72 */
-	io_trap_out,		/* port 73 */
-	io_trap_out,		/* port 74 */
-	io_trap_out,		/* port 75 */
-	io_trap_out,		/* port 76 */
-	io_trap_out,		/* port 77 */
-	io_trap_out,		/* port 78 */
-	io_trap_out,		/* port 79 */
-	io_trap_out,		/* port 80 */
-	io_trap_out,		/* port 81 */
-	io_trap_out,		/* port 82 */
-	io_trap_out,		/* port 83 */
-	io_trap_out,		/* port 84 */
-	io_trap_out,		/* port 85 */
-	io_trap_out,		/* port 86 */
-	io_trap_out,		/* port 87 */
-	io_trap_out,		/* port 88 */
-	io_trap_out,		/* port 89 */
-	io_trap_out,		/* port 90 */
-	io_trap_out,		/* port 91 */
-	io_trap_out,		/* port 92 */
-	io_trap_out,		/* port 93 */
-	io_trap_out,		/* port 94 */
-	io_trap_out,		/* port 95 */
-	io_trap_out,		/* port 96 */
-	io_trap_out,		/* port 97 */
-	io_trap_out,		/* port 98 */
-	io_trap_out,		/* port 99 */
-	io_trap_out,		/* port 100 */
-	io_trap_out,		/* port 101 */
-	io_trap_out,		/* port 102 */
-	io_trap_out,		/* port 103 */
-	io_trap_out,		/* port 104 */
-	io_trap_out,		/* port 105 */
-	io_trap_out,		/* port 106 */
-	io_trap_out,		/* port 107 */
-	io_trap_out,		/* port 108 */
-	io_trap_out,		/* port 109 */
-	io_trap_out,		/* port 110 */
-	io_trap_out,		/* port 111 */
-	io_trap_out,		/* port 112 */
-	io_trap_out,		/* port 113 */
-	io_trap_out,		/* port 114 */
-	io_trap_out,		/* port 115 */
-	io_trap_out,		/* port 116 */
-	io_trap_out,		/* port 117 */
-	io_trap_out,		/* port 118 */
-	io_trap_out,		/* port 119 */
-	io_trap_out,		/* port 120 */
-	io_trap_out,		/* port 121 */
-	io_trap_out,		/* port 122 */
-	io_trap_out,		/* port 123 */
-	io_trap_out,		/* port 124 */
-	io_trap_out,		/* port 125 */
-	io_trap_out,		/* port 126 */
-	io_trap_out,		/* port 127 */
-	io_trap_out,		/* port 128 */
-	io_trap_out,		/* port 129 */
-	io_trap_out,		/* port 130 */
-	io_trap_out,		/* port 131 */
-	io_trap_out,		/* port 132 */
-	io_trap_out,		/* port 133 */
-	io_trap_out,		/* port 134 */
-	io_trap_out,		/* port 135 */
-	io_trap_out,		/* port 136 */
-	io_trap_out,		/* port 137 */
-	io_trap_out,		/* port 138 */
-	io_trap_out,		/* port 139 */
-	io_trap_out,		/* port 140 */
-	io_trap_out,		/* port 141 */
-	io_trap_out,		/* port 142 */
-	io_trap_out,		/* port 143 */
-	io_trap_out,		/* port 144 */
-	io_trap_out,		/* port 145 */
-	io_trap_out,		/* port 146 */
-	io_trap_out,		/* port 147 */
-	io_trap_out,		/* port 148 */
-	io_trap_out,		/* port 149 */
-	io_trap_out,		/* port 150 */
-	io_trap_out,		/* port 151 */
-	io_trap_out,		/* port 152 */
-	io_trap_out,		/* port 153 */
-	io_trap_out,		/* port 154 */
-	io_trap_out,		/* port 155 */
-	io_trap_out,		/* port 156 */
-	io_trap_out,		/* port 157 */
-	io_trap_out,		/* port 158 */
-	io_trap_out,		/* port 159 */
-	io_trap_out,		/* port 160 */
-	host_bdos_out,		/* port 161 */  /* host file I/O hook */
-	io_trap_out,		/* port 162 */
-	io_trap_out,		/* port 163 */
-	io_trap_out,		/* port 164 */
-	io_trap_out,		/* port 165 */
-	io_trap_out,		/* port 166 */
-	io_trap_out,		/* port 167 */
-	io_trap_out,		/* port 168 */
-	io_trap_out,		/* port 169 */
-	io_trap_out,		/* port 170 */
-	io_trap_out,		/* port 171 */
-	io_trap_out,		/* port 172 */
-	io_trap_out,		/* port 173 */
-	io_trap_out,		/* port 174 */
-	io_trap_out,		/* port 175 */
-	io_trap_out,		/* port 176 */
-	io_trap_out,		/* port 177 */
-	io_trap_out,		/* port 178 */
-	io_trap_out,		/* port 179 */
-	io_trap_out,		/* port 180 */
-	io_trap_out,		/* port 181 */
-	io_trap_out,		/* port 182 */
-	io_trap_out,		/* port 183 */
-	io_trap_out,		/* port 184 */
-	io_trap_out,		/* port 185 */
-	io_trap_out,		/* port 186 */
-	io_trap_out,		/* port 187 */
-	io_trap_out,		/* port 188 */
-	io_trap_out,		/* port 189 */
-	io_trap_out,		/* port 190 */
-	io_trap_out,		/* port 191 */
-	io_trap_out,		/* port 192 */
-	io_trap_out,		/* port 193 */
-	io_trap_out,		/* port 194 */
-	io_trap_out,		/* port 195 */
-	io_trap_out,		/* port 196 */
-	io_trap_out,		/* port 197 */
-	io_trap_out,		/* port 198 */
-	io_trap_out,		/* port 199 */
-	io_trap_out,		/* port 200 */
-	io_trap_out,		/* port 201 */
-	io_trap_out,		/* port 202 */
-	io_trap_out,		/* port 203 */
-	io_trap_out,		/* port 204 */
-	io_trap_out,		/* port 205 */
-	io_trap_out,		/* port 206 */
-	io_trap_out,		/* port 207 */
-	io_no_card_out,		/* port 208 (d0) PIO1 Data A */
-	io_no_card_out,		/* port 209 (d1) PIO1 Control A */
-	io_no_card_out,		/* port 210 (d2) PIO1 Data B */
-	io_no_card_out,		/* port 211 (d3) PIO1 Control B */
-	io_no_card_out,		/* port 212 (d4) PIO2 Data A */
-	io_no_card_out,		/* port 213 (d5) PIO2 Control A */
-	io_no_card_out,		/* port 214 (d6) PIO2 Data B */
-	io_no_card_out,		/* port 215 (d7) PIO2 Control B */
-	io_no_card_out,		/* port 216 (d8) CTC 0 (baud rate) */
-	io_no_card_out,		/* port 217 (d9) CTC 1 */
-	io_no_card_out,		/* port 218 (da) CTC 2 */
-	io_no_card_out,		/* port 219 (db) CTC 3 */
-	sio_data_out,		/* port 220 (dc) SIO Data */
-	sio_control_out,	/* port 221 (dd) SIO Control */
-	sio_handshake_out,	/* port 222 (de) Sys Control (handshake lines out) */
-	io_no_card_out,		/* port 223 (df) Debug Control */
-	io_trap_out,		/* port 224 */
-	io_trap_out,		/* port 225 */
-	io_no_card_out,		/* port 226 (e2) FDC board status */
-	fdcBoard_ctl_out,	/* port 227 (e3) FDC board control */
-	fdc1771_cmd_out,	/* port 228 (e4) WD1771 Command/Status */
-	fdc1771_track_out,	/* port 229 (e5) WD1771 Track */
-	fdc1771_sec_out,	/* port 230 (e6) WD1771 Sector */
-	fdc1771_data_out,	/* port 231 (e7) WD1771 Data */
-	io_trap_out,		/* port 232 */
-	io_trap_out,		/* port 233 */
-	io_trap_out,		/* port 234 */
-	io_trap_out,		/* port 235 */
-	io_trap_out,		/* port 236 */
-	io_trap_out,		/* port 237 */
-	io_trap_out,		/* port 238 */
-	io_trap_out,		/* port 239 */
-	io_trap_out,		/* port 240 */
-	io_trap_out,		/* port 241 */
-	io_trap_out,		/* port 242 */
-	io_trap_out,		/* port 243 */
-	io_trap_out,		/* port 244 */
-	io_trap_out,		/* port 245 */
-	io_trap_out,		/* port 246 */
-	io_trap_out,		/* port 247 */
-	io_trap_out,		/* port 248 */
-	io_trap_out,		/* port 249 */
-	io_trap_out,		/* port 250 */
-	io_trap_out,		/* port 251 */
-	io_trap_out,		/* port 252 */
-	io_trap_out,		/* port 253 */
-	io_trap_out,		/* port 254 */
-	io_trap_out		/* port 255 */
+void (*port_out[256])(BYTE) = {
+	[161] host_bdos_out,		/* host file I/O hook */
+	[208] io_no_card_out,		/* (d0) PIO1 Data A */
+	[209] io_no_card_out,		/* (d1) PIO1 Control A */
+	[210] io_no_card_out,		/* (d2) PIO1 Data B */
+	[211] io_no_card_out,		/* (d3) PIO1 Control B */
+	[212] io_no_card_out,		/* (d4) PIO2 Data A */
+	[213] io_no_card_out,		/* (d5) PIO2 Control A */
+	[214] io_no_card_out,		/* (d6) PIO2 Data B */
+	[215] io_no_card_out,		/* (d7) PIO2 Control B */
+	[216] io_no_card_out,		/* (d8) CTC 0 (baud rate) */
+	[217] io_no_card_out,		/* (d9) CTC 1 */
+	[218] io_no_card_out,		/* (da) CTC 2 */
+	[219] io_no_card_out,		/* (db) CTC 3 */
+	[220] sio_data_out,		/* (dc) SIO Data */
+	[221] sio_control_out,		/* (dd) SIO Control */
+	[222] sio_handshake_out,	/* (de) Sys Control (handshake lines out) */
+	[223] io_no_card_out,		/* (df) Debug Control */
+	[226] io_no_card_out,		/* (e2) FDC board status */
+	[227] fdcBoard_ctl_out,		/* (e3) FDC board control */
+	[228] fdc1771_cmd_out,		/* (e4) WD1771 Command/Status */
+	[229] fdc1771_track_out,	/* (e5) WD1771 Track */
+	[230] fdc1771_sec_out,		/* (e6) WD1771 Sector */
+	[231] fdc1771_data_out		/* (e7) WD1771 Data */
 };
 
 /*
@@ -582,51 +116,7 @@ void exit_io(void)
 }
 
 /*
- *	This is the main handler for all IN op-codes,
- *	called by the simulator. It calls the input
- *	function for port addrl.
- */
-BYTE io_in(BYTE addrl, BYTE addrh)
-{
-	UNUSED(addrh);
-
-	io_port = addrl;
-	io_data = (*port_in[addrl])();
-	LOGD(TAG, "input %02x from port %02x", io_data, io_port);
-	return (io_data);
-}
-
-/*
- *	This is the main handler for all OUT op-codes,
- *	called by the simulator. It calls the output
- *	function for port addrl.
- */
-void io_out(BYTE addrl, BYTE addrh, BYTE data)
-{
-	UNUSED(addrh);
-
-	io_port = addrl;
-	io_data = data;
-	(*port_out[addrl])(data);
-}
-
-/*
- *	I/O input trap function
- *	This function should be added into all unused
- *	entries of the input port array. It can stop the
- *	emulation with an I/O error.
- */
-static BYTE io_trap_in(void)
-{
-	if (i_flag) {
-		cpu_error = IOTRAPIN;
-		cpu_state = STOPPED;
-	}
-	return ((BYTE) 0xff);
-}
-
-/*
- *	Same as above, but don't trap as I/O error.
+ *	No card I/O input trap function
  *	Used for input ports where I/O cards might be
  *	installed, but haven't.
  */
@@ -636,23 +126,7 @@ static BYTE io_no_card_in(void)
 }
 
 /*
- *      I/O output trap function
- *      This function should be added into all unused
- *      entries of the output port array. It can stop the
- *      emulation with an I/O error.
- */
-static void io_trap_out(BYTE data)
-{
-	UNUSED(data);
-
-	if (i_flag) {
-		cpu_error = IOTRAPOUT;
-		cpu_state = STOPPED;
-	}
-}
-
-/*
- *	Same as above, but don't trap as I/O error.
+ *	No card I/O output trap function
  *	Used for output ports where I/O cards might be
  *	installed, but haven't.
  */

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -36,6 +36,8 @@
 #define HAS_DISKS	/* uses disk images */
 #define HAS_CONFIG	/* has configuration files somewhere */
 
+extern void sleep_us(long);
+#define SLEEP_US(t)	sleep_us(t)
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
 

--- a/picosim/picosim.c
+++ b/picosim/picosim.c
@@ -82,7 +82,6 @@ int main(void)
 
 	f_flag = CPU_SPEED;
 	tmax = CPU_SPEED * 10000; /* theoretically */
-	tmax += tmax / 20;	  /* clock crystal tuning, screw here */
 
 	printf("CPU is %s\n", cpu == Z80 ? "Z80" : "8080");
 	if (f_flag > 0)
@@ -106,9 +105,7 @@ int main(void)
 
 	ice_cmd_loop(0);
 #else
-	cpu_start = get_clock_us();
 	run_cpu();		/* run the CPU with whatever is in memory */
-	cpu_stop = get_clock_us();
 #endif
 
 	/* unmount SD card */

--- a/picosim/sim.h
+++ b/picosim/sim.h
@@ -25,7 +25,9 @@
 #define HISIZE	100	/* number of entries in history */
 #define SBSIZE	4	/* number of software breakpoints */
 
-extern void sleep_ms();
+extern void sleep_us(unsigned long long);
+#define SLEEP_US(t)	sleep_us(t)
+extern void sleep_ms(unsigned long);
 #define SLEEP_MS(t)	sleep_ms(t)
 
 #define USR_COM "Raspberry Pi Pico Z80/8080 emulator"

--- a/z80core/alt8080.h
+++ b/z80core/alt8080.h
@@ -30,6 +30,7 @@
 
 	extern BYTE io_in(BYTE, BYTE);
 	extern void io_out(BYTE, BYTE, BYTE);
+	extern unsigned long long get_clock_us(void);
 
 #define H_SHIFT		4	/* H_FLAG shift */
 #define C_SHIFT		0	/* C_FLAG shift */
@@ -80,6 +81,7 @@
 
 	BYTE t, res, cout, P;
 	struct cpu_reg w;	/* working register */
+	unsigned long long clk;
 
 #define W	w.w
 #define WH	w.h
@@ -723,6 +725,7 @@
 		cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
 #endif
 
+		clk = get_clock_us();
 #ifdef FRONTPANEL
 		if (!F_flag) {
 #endif
@@ -781,6 +784,7 @@
 			}
 		}
 #endif
+		cpu_time -= get_clock_us() - clk;
 		t += 3;
 		break;
 

--- a/z80core/altz80.h
+++ b/z80core/altz80.h
@@ -29,6 +29,7 @@
 {
 	extern BYTE io_in(BYTE, BYTE);
 	extern void io_out(BYTE, BYTE, BYTE);
+	extern unsigned long long get_clock_us(void);
 
 #define S_SHIFT		7	/* S_FLAG shift */
 #define Z_SHIFT		6	/* Z_FLAG shift */
@@ -88,6 +89,7 @@
 #endif
 	struct cpu_reg w;	/* working register */
 	struct cpu_reg ir;	/* current index register (HL, IX, IY) */
+	unsigned long long clk;
 
 #define W	w.w
 #define WH	w.h
@@ -808,6 +810,7 @@ next_opcode:
 		cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
 #endif
 
+		clk = get_clock_us();
 #ifdef FRONTPANEL
 		if (!F_flag) {
 #endif
@@ -870,6 +873,7 @@ next_opcode:
 			}
 		}
 #endif
+		cpu_time -= get_clock_us() - clk;
 		break;
 
 	case 0x77:			/* LD (ir),A */
@@ -1384,9 +1388,11 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 			if (F_flag) {
+				clk = get_clock_us();
 				/* update frontpanel */
 				fp_clock++;
 				fp_sampleLightGroup(0, 0);
+				cpu_time -= get_clock_us() - clk;
 			}
 #endif
 
@@ -1626,9 +1632,11 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 		if (F_flag) {
+			clk = get_clock_us();
 			/* update frontpanel */
 			fp_clock++;
 			fp_sampleLightGroup(0, 0);
+			cpu_time -= get_clock_us() - clk;
 		}
 #endif
 
@@ -1722,9 +1730,11 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 		if (F_flag) {
+			clk = get_clock_us();
 			/* update frontpanel */
 			fp_clock++;
 			fp_sampleLightGroup(0, 0);
+			cpu_time -= get_clock_us() - clk;
 		}
 #endif
 
@@ -2400,9 +2410,11 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 		if (F_flag) {
+			clk = get_clock_us();
 			/* update frontpanel */
 			fp_clock++;
 			fp_sampleLightGroup(0, 0);
+			cpu_time -= get_clock_us() - clk;
 		}
 #endif
 

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -87,6 +87,18 @@ typedef unsigned short WORD;	/* 16 bit unsigned */
 typedef signed short   SWORD;	/* 16 bit signed */
 typedef unsigned char  BYTE;	/* 8 bit unsigned */
 
+/*
+ *	This array contains function pointers for every
+ *	input I/O port (0 - 255), to do the required I/O.
+ */
+extern BYTE (*port_in[256])(void);
+
+/*
+ *	This array contains function pointers for every
+ *	output I/O port (0 - 255), to do the required I/O.
+ */
+extern void (*port_out[256])(BYTE);
+
 #ifdef HISIZE
 struct history {		/* structure of a history entry */
 	int	h_cpu;		/* CPU type */

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -35,6 +35,34 @@ static int load_mos(char *, WORD, int);
 static int load_hex(char *, WORD, int);
 
 /*
+ *	Sleep for time microseconds, 999999 max
+ */
+void sleep_us(long time)
+{
+	struct timespec timer, rem;
+	int err;
+
+	timer.tv_sec = 0;
+	timer.tv_nsec = 1000L * time;
+
+again:
+	if (nanosleep(&timer, &rem) == -1) {
+		if ((err = errno) == EINTR) {
+			/* interrupted, resume with the remaining time */
+			if (rem.tv_nsec > 0L) {
+				timer = rem;
+				goto again;
+			}
+		} else {
+			/* some error */
+			LOGD(TAG, "sleep_us(%ld) %s", time, strerror(err));
+			// cpu_error = IOERROR;
+			// cpu_state = STOPPED;
+		}
+	}
+}
+
+/*
  *	Sleep for time milliseconds, 999 max
  */
 void sleep_ms(int time)
@@ -50,7 +78,7 @@ again:
 		if ((err = errno) == EINTR) {
 			/* interrupted, resume with the remaining time */
 			if (rem.tv_nsec > 0L) {
-				memcpy(&timer, &rem, sizeof(struct timespec));
+				timer = rem;
 				goto again;
 			}
 		} else {

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -40,7 +40,7 @@ BYTE IFF;			/* interrupt flags */
 struct cpu_regs cpu_regs;	/* CPU registers */
 #endif
 Tstates_t T;			/* CPU clock */
-unsigned long long cpu_start, cpu_stop; /* timestamps in us */
+unsigned long long cpu_time;	/* time spent running CPU in us */
 
 #ifdef BUS_8080
 BYTE cpu_bus;			/* CPU bus status, for frontpanels */

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -41,7 +41,7 @@ extern BYTE	IFF;
 #include "altregs.h"
 #endif
 extern Tstates_t T;
-extern unsigned long long cpu_start, cpu_stop;
+extern unsigned long long cpu_time;
 
 #ifdef BUS_8080
 extern BYTE	cpu_bus;

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -252,7 +252,6 @@ static void do_trace(char *s)
  */
 static void do_go(char *s)
 {
-	extern unsigned long long get_clock_us(void);
 	int timeit = 0;
 	unsigned long long start_time, stop_time;
 	Tstates_t T0 = T;
@@ -268,7 +267,7 @@ static void do_go(char *s)
 	if (ice_before_go)
 		(*ice_before_go)();
 	if (timeit)
-		start_time = get_clock_us();
+		start_time = cpu_time;
 	for (;;) {
 		run_cpu();
 		if (cpu_error) {
@@ -281,7 +280,7 @@ static void do_go(char *s)
 		}
 	}
 	if (timeit)
-		stop_time = get_clock_us();
+		stop_time = cpu_time;
 	if (ice_after_go)
 		(*ice_after_go)();
 	report_cpu_error();

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -62,7 +62,6 @@ int main(int argc, char *argv[])
 #ifdef CPU_SPEED
 	f_flag = CPU_SPEED;
 	tmax = CPU_SPEED * 10000; /* theoretically */
-	tmax += tmax / 10;	  /* clock crystal tuning, screw here */
 #endif
 
 	while (--argc > 0 && (*++argv)[0] == '-')
@@ -110,8 +109,6 @@ int main(int argc, char *argv[])
 					f_flag = atoi(argv[0]);
 				}
 				tmax = f_flag * 10000; /* theoretically */
-				tmax += tmax / 10; /* clock crystal tuning, */
-			       			   /* screw here */
 				break;
 
 			case 'x':	/* get filename with executable */

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -369,6 +369,10 @@ int op_cb_handle(void)
 #undef UNDOC
 
 	register int t;
+#ifdef FRONTPANEL
+	extern unsigned long long get_clock_us(void);
+	unsigned long long clk;
+#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -377,9 +381,11 @@ int op_cb_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
+		clk = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
+		cpu_time -= get_clock_us() - clk;
 	}
 #endif
 

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -336,6 +336,10 @@ int op_dd_handle(void)
 #undef UNDOC
 
 	register int t;
+#ifdef FRONTPANEL
+	extern unsigned long long get_clock_us(void);
+	unsigned long long clk;
+#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -344,9 +348,11 @@ int op_dd_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
+		clk = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
+		cpu_time -= get_clock_us() - clk;
 	}
 #endif
 

--- a/z80core/simz80-ddcb.c
+++ b/z80core/simz80-ddcb.c
@@ -13,9 +13,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
-#ifdef FRONTPANEL
-#include "frontpanel.h"
-#endif
 #include "memsim.h"
 
 #if !defined(EXCLUDE_Z80) && !defined(ALT_Z80)

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -318,6 +318,10 @@ int op_ed_handle(void)
 #undef UNDOC
 
 	register int t;
+#ifdef FRONTPANEL
+	extern unsigned long long get_clock_us(void);
+	unsigned long long clk;
+#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -326,9 +330,11 @@ int op_ed_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
+		clk = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
+		cpu_time -= get_clock_us() - clk;
 	}
 #endif
 

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -336,6 +336,10 @@ int op_fd_handle(void)
 #undef UNDOC
 
 	register int t;
+#ifdef FRONTPANEL
+	extern unsigned long long get_clock_us(void);
+	unsigned long long clk;
+#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -344,9 +348,11 @@ int op_fd_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
+		clk = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
+		cpu_time -= get_clock_us() - clk;
 	}
 #endif
 

--- a/z80core/simz80-fdcb.c
+++ b/z80core/simz80-fdcb.c
@@ -13,9 +13,6 @@
 #include "sim.h"
 #include "simglb.h"
 #include "config.h"
-#ifdef FRONTPANEL
-#include "frontpanel.h"
-#endif
 #include "memsim.h"
 
 #if !defined(EXCLUDE_Z80) && !defined(ALT_Z80)

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -377,10 +377,13 @@ void cpu_z80(void)
 	};
 #endif /* !ALT_Z80 */
 
-	Tstates_t T_max;
+	Tstates_t T_max, T_dma;
 	unsigned long long t1, t2;
 	int tdiff;
 	WORD p;
+#ifdef FRONTPANEL
+	unsigned long long clk;
+#endif
 
 	T_max = T + tmax;
 	t1 = get_clock_us();
@@ -420,32 +423,40 @@ void cpu_z80(void)
 				if (dma_bus_master) {
 					/* hand control to the DMA bus master
 					   without BUS_ACK */
-					T += (*dma_bus_master)(0);
+					T += (T_dma = (*dma_bus_master)(0));
+					if (f_flag)
+						cpu_time += T_dma / f_flag;
 				}
 			}
 
 			if (bus_request) {		/* DMA bus request */
 #ifdef FRONTPANEL
 				if (F_flag) {
+					clk = get_clock_us();
 					fp_clock += 1000;
 					fp_sampleData();
+					cpu_time -= get_clock_us() - clk;
 				}
 #endif
 				if (dma_bus_master) {
 					/* hand control to the DMA bus master
 					   with BUS_ACK */
-					T += (*dma_bus_master)(1);
+					T += (T_dma = (*dma_bus_master)(1));
+					if (f_flag)
+						cpu_time += T_dma / f_flag;
 				}
 				/* FOR NOW -
 				   MAY BE NEED A PRIORITY SYSTEM LATER */
 				bus_request = 0;
-				if (bus_mode == BUS_DMA_CONTINUOUS)	{
+				if (bus_mode == BUS_DMA_CONTINUOUS) {
 					end_bus_request();
 				}
 #ifdef FRONTPANEL
 				if (F_flag) {
+					clk = get_clock_us();
 					fp_clock += 1000;
 					fp_sampleData();
+					cpu_time -= get_clock_us() - clk;
 				}
 #endif
 			}
@@ -476,11 +487,13 @@ void cpu_z80(void)
 #endif
 #ifdef FRONTPANEL
 				if (F_flag) {
+					clk = get_clock_us();
 					fp_clock += 1000;
 					fp_led_data = (int_data != -1) ?
 						      (BYTE) int_data : 0xff;
 					fp_sampleData();
 					wait_int_step();
+					cpu_time -= get_clock_us() - clk;
 					if (cpu_state & RESET)
 						goto leave;
 				}
@@ -612,10 +625,12 @@ leave:
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
+		clk = get_clock_us();
 		fp_led_address = PC;
 		fp_led_data = getmem(PC);
 		fp_clock++;
 		fp_sampleData();
+		cpu_time -= get_clock_us() - clk;
 	}
 #endif
 }
@@ -629,10 +644,14 @@ static int op_nop(void)			/* NOP */
 
 static int op_halt(void)		/* HALT */
 {
+	extern unsigned long long get_clock_us(void);
+	unsigned long long clk;
+
 #ifdef BUS_8080
 	cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
 #endif
 
+	clk = get_clock_us();
 #ifdef FRONTPANEL
 	if (!F_flag) {
 #endif
@@ -692,6 +711,7 @@ static int op_halt(void)		/* HALT */
 		}
 	}
 #endif
+	cpu_time -= get_clock_us() - clk;
 
 	return (4);
 }

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -28,6 +28,8 @@
 /*#define HAS_DISKS*/	/* has no disk drives */
 /*#define HAS_CONFIG*/	/* has no configuration files */
 
+extern void sleep_us(long);
+#define SLEEP_US(t)	sleep_us(t)
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
 

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -29,6 +29,8 @@
 /*#define HAS_DISKS*/	/* has no disk drives */
 /*#define HAS_CONFIG*/	/* has no configuration files */
 
+extern void sleep_us(long);
+#define SLEEP_US(t)	sleep_us(t)
 extern void sleep_ms(int);
 #define SLEEP_MS(t)	sleep_ms(t)
 


### PR DESCRIPTION
Introduce SLEEP_US and use it in cpu_8080/cpu_z80.
Move all CPU time measurement into z80core.
Add T-states used by DMA transfers as fully spent CPU time.
Move io_in/in_out to simcore.c and remove time spent in I/O from cpu_time.
Remove time spent in frontpanel code from cpu_time (does this make sense?).
Use designated initializers for port_in/port_out.