### PR TITLE
reintroduce I/O trap handlers, small frontpanel clean-ups

### DIFF
--- a/altairsim/srcsim/iosim.c
+++ b/altairsim/srcsim/iosim.c
@@ -149,6 +149,19 @@ void (*port_out[256])(BYTE) = {
  */
 void init_io(void)
 {
+	extern BYTE io_trap_in(void);
+	extern void io_trap_out(BYTE);
+
+	register int i;
+
+	/* initialize unused ports to trap handlers */
+	for (i = 0; i <= 255; i++) {
+		if (port_in[i] == NULL)
+			port_in[i] = io_trap_in;
+		if (port_out[i] == NULL)
+			port_out[i] = io_trap_out;
+	}
+
 	/* create local sockets */
 	init_unix_server_socket(&ucons[0], "altairsim.tape");
 	init_unix_server_socket(&ucons[1], "altairsim.sio2");

--- a/cromemcosim/srcsim/iosim.c
+++ b/cromemcosim/srcsim/iosim.c
@@ -214,10 +214,21 @@ void (*port_out[256])(BYTE) = {
  */
 void init_io(void)
 {
+	extern BYTE io_trap_in(void);
+	extern void io_trap_out(BYTE);
+
 	register int i;
 	pthread_t thread;
 	static struct itimerval tim;
 	static struct sigaction newact;
+
+	/* initialize unused ports to trap handlers */
+	for (i = 0; i <= 255; i++) {
+		if (port_in[i] == NULL)
+			port_in[i] = io_trap_in;
+		if (port_out[i] == NULL)
+			port_out[i] = io_trap_out;
+	}
 
 	/* initialize TCP/IP networking */
 #ifdef TCPASYNC

--- a/frontpanel/lp_main.cpp
+++ b/frontpanel/lp_main.cpp
@@ -19,6 +19,7 @@
 /* Fixed portability problems, March 2014, Udo Munk */
 
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/frontpanel/lp_switch.cpp
+++ b/frontpanel/lp_switch.cpp
@@ -17,6 +17,7 @@
 
 */
 
+#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include "lpanel.h"

--- a/frontpanel/lp_utils.cpp
+++ b/frontpanel/lp_utils.cpp
@@ -692,7 +692,7 @@ void framerate_wait(void)
     for (;;)
         if (nanosleep(&ts, &rem) == -1 && errno == EINTR && rem.tv_nsec > 0L)
 	 {
-	    memcpy(&ts, &rem, sizeof(struct timespec));
+	    ts = rem;
 	    continue;
 	 }
 	else

--- a/frontpanel/lpanel.cpp
+++ b/frontpanel/lpanel.cpp
@@ -18,6 +18,8 @@
 
 */
 
+#include <stdint.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/frontpanel/lpanel.h
+++ b/frontpanel/lpanel.h
@@ -21,6 +21,7 @@
 #define __LPANEL_DEFS
 
 
+#include <stdint.h>
 #include <stdio.h>
 #if defined (__MINGW32__) || defined (_WIN32) || defined (_WIN32_) || defined (__WIN32__)
 #include <GL/gl.h>

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -270,6 +270,19 @@ void (*port_out[256])(BYTE) = {
  */
 void init_io(void)
 {
+	extern BYTE io_trap_in(void);
+	extern void io_trap_out(BYTE);
+
+	register int i;
+
+	/* initialize unused ports to trap handlers */
+	for (i = 0; i <= 255; i++) {
+		if (port_in[i] == NULL)
+			port_in[i] = io_trap_in;
+		if (port_out[i] == NULL)
+			port_out[i] = io_trap_out;
+	}
+
 	/* initialize IMSAI VIO if firmware is loaded */
 	if ((getmem(0xfffd) == 'V') && (getmem(0xfffe) == 'I') &&
 	    (getmem(0xffff) == '0')) {

--- a/mosteksim/srcsim/iosim.c
+++ b/mosteksim/srcsim/iosim.c
@@ -106,6 +106,18 @@ void (*port_out[256])(BYTE) = {
  */
 void init_io(void)
 {
+	extern BYTE io_trap_in(void);
+	extern void io_trap_out(BYTE);
+
+	register int i;
+
+	/* initialize unused ports to trap handlers */
+	for (i = 0; i <= 255; i++) {
+		if (port_in[i] == NULL)
+			port_in[i] = io_trap_in;
+		if (port_out[i] == NULL)
+			port_out[i] = io_trap_out;
+	}
 }
 
 /*

--- a/picosim/iosim.c
+++ b/picosim/iosim.c
@@ -61,6 +61,27 @@ void (*port_out[256])(BYTE) = {
 };
 
 /*
+ *	This function is to initiate the I/O devices.
+ *	It will be called from the CPU simulation before
+ *	any operation with the CPU is possible.
+ */
+void init_io(void)
+{
+	extern BYTE io_trap_in(void);
+	extern void io_trap_out(BYTE);
+
+	register int i;
+
+	/* initialize unused ports to trap handlers */
+	for (i = 0; i <= 255; i++) {
+		if (port_in[i] == NULL)
+			port_in[i] = io_trap_in;
+		if (port_out[i] == NULL)
+			port_out[i] = io_trap_out;
+	}
+}
+
+/*
  *	I/O function port 0 read:
  *	read status of the Pico UART and return:
  *	bit 0 = 0, character available for input from tty

--- a/picosim/picosim.c
+++ b/picosim/picosim.c
@@ -46,7 +46,7 @@ FRESULT sd_res;	/* result code from FatFS */
 char disks[2][22]; /* path name for 2 disk images /DISKS80/filename.BIN */
 
 
-extern void init_cpu(void), run_cpu(void);
+extern void init_cpu(void), init_io(void), run_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
 extern BYTE read_sec(int, int, int, WORD);
 
@@ -106,6 +106,7 @@ int main(void)
 
 	init_cpu();		/* initialize CPU */
 	init_memory();		/* initialize memory configuration */
+	init_io();		/* initialize I/O devices */
 NOPE:	config();		/* configure the machine */
 
 	/* if there is a disk in drive 0 try to boot from it */

--- a/z80sim/srcsim/iosim.c
+++ b/z80sim/srcsim/iosim.c
@@ -68,11 +68,26 @@ void (*port_out[256])(BYTE) = {
  *	It will be called from the CPU simulation before
  *	any operation with the CPU is possible.
  *
+ *	In this sample I/O simulation we initialize all
+ *	unused port with an error trap handler, so that
+ *	simulation stops at I/O on the unused ports.
+ *
  *	See the I/O simulation of of the other systems
  *	for more complex examples.
  */
 void init_io(void)
 {
+	extern BYTE io_trap_in(void);
+	extern void io_trap_out(BYTE);
+
+	register int i;
+
+	for (i = 0; i <= 255; i++) {
+		if (port_in[i] == NULL)
+			port_in[i] = io_trap_in;
+		if (port_out[i] == NULL)
+			port_out[i] = io_trap_out;
+	}
 }
 
 /*


### PR DESCRIPTION
Makes it possible to just call port_in/port_out functions without checking for NULL, like in wait_step().

Explicitly include stdint.h in frontpanel, was implicitly included by X11/Xlib.h.