### PR TITLE
define SBYTE and use it, like SWORD used for ADC/SBC HL

### DIFF
--- a/z80core/altz80.h
+++ b/z80core/altz80.h
@@ -230,7 +230,7 @@ next_opcode:
 		P = memrdr(PC++);
 		t++;
 		if (--B) {
-			PC += (signed char) P;
+			PC += (SBYTE) P;
 			t += 8;
 		}
 		break;
@@ -276,7 +276,7 @@ next_opcode:
 
 	case 0x18:			/* JR n */
 		P = memrdr(PC++);
-		PC += (signed char) P;
+		PC += (SBYTE) P;
 		t += 8;
 		break;
 
@@ -323,7 +323,7 @@ next_opcode:
 		P = memrdr(PC++);
 		t += 3;
 		if (res) {
-			PC += (signed char) P;
+			PC += (SBYTE) P;
 			t += 5;
 		}
 		break;
@@ -452,7 +452,7 @@ next_opcode:
 	case 0x34:			/* INC (ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -464,7 +464,7 @@ next_opcode:
 	case 0x35:			/* DEC (ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -476,7 +476,7 @@ next_opcode:
 	case 0x36:			/* LD (ir),n */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 5;
 		}
 		memwrt(W, memrdr(PC++));
@@ -560,7 +560,7 @@ next_opcode:
 	case 0x46:			/* LD B,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		B = memrdr(W);
@@ -594,7 +594,7 @@ next_opcode:
 	case 0x4e:			/* LD C,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		C = memrdr(W);
@@ -628,7 +628,7 @@ next_opcode:
 	case 0x56:			/* LD D,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		D = memrdr(W);
@@ -662,7 +662,7 @@ next_opcode:
 	case 0x5e:			/* LD E,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		E = memrdr(W);
@@ -696,7 +696,7 @@ next_opcode:
 	case 0x66:			/* LD H,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 			H = memrdr(W);
 		} else
@@ -731,7 +731,7 @@ next_opcode:
 	case 0x6e:			/* LD L,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 			L = memrdr(W);
 		} else
@@ -746,7 +746,7 @@ next_opcode:
 	case 0x70:			/* LD (ir),B */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		memwrt(W, B);
@@ -756,7 +756,7 @@ next_opcode:
 	case 0x71:			/* LD (ir),C */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		memwrt(W, C);
@@ -766,7 +766,7 @@ next_opcode:
 	case 0x72:			/* LD (ir),D */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		memwrt(W, D);
@@ -776,7 +776,7 @@ next_opcode:
 	case 0x73:			/* LD (ir),E */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		memwrt(W, E);
@@ -786,7 +786,7 @@ next_opcode:
 	case 0x74:			/* LD (ir),H */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 			memwrt(W, H);
 		} else
@@ -797,7 +797,7 @@ next_opcode:
 	case 0x75:			/* LD (ir),L */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 			memwrt(W, L);
 		} else
@@ -879,7 +879,7 @@ next_opcode:
 	case 0x77:			/* LD (ir),A */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		memwrt(W, A);
@@ -913,7 +913,7 @@ next_opcode:
 	case 0x7e:			/* LD A,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		A = memrdr(W);
@@ -962,7 +962,7 @@ next_opcode:
 	case 0x86:			/* ADD A,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -1008,7 +1008,7 @@ next_opcode:
 	case 0x8e:			/* ADC A,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -1063,7 +1063,7 @@ next_opcode:
 	case 0x96:			/* SUB A,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -1110,7 +1110,7 @@ next_opcode:
 	case 0x9e:			/* SBC A,(ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -1155,7 +1155,7 @@ next_opcode:
 	case 0xa6:			/* AND (ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -1198,7 +1198,7 @@ next_opcode:
 	case 0xae:			/* XOR (ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -1243,7 +1243,7 @@ next_opcode:
 	case 0xb6:			/* OR (ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -1290,7 +1290,7 @@ next_opcode:
 	case 0xbe:			/* CP (ir) */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		}
 		P = memrdr(W);
@@ -1378,7 +1378,7 @@ next_opcode:
 	case 0xcb:			/* 0xcb prefix */
 		W = IR;
 		if (curr_ir != IR_HL) {
-			W += (signed char) memrdr(PC++);
+			W += (SBYTE) memrdr(PC++);
 			t += 8;
 		} else {
 #ifdef BUS_8080

--- a/z80core/simcore.h
+++ b/z80core/simcore.h
@@ -86,6 +86,7 @@
 typedef uint16_t WORD;		/* 16 bit unsigned */
 typedef int16_t  SWORD;		/* 16 bit signed */
 typedef uint8_t  BYTE;		/* 8 bit unsigned */
+typedef int8_t   SBYTE;		/* 8 bit signed */
 
 #ifdef HISIZE
 struct history {		/* structure of a history entry */

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -454,10 +454,10 @@ static int op_adaxd(void)		/* ADD A,(IX+d) */
 	register int i;
 	register BYTE P;
 
-	P = memrdr(IX + (signed char) memrdr(PC++));
+	P = memrdr(IX + (SBYTE) memrdr(PC++));
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
+	A = i = (SBYTE) A + (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -471,10 +471,10 @@ static int op_acaxd(void)		/* ADC A,(IX+d) */
 	register BYTE P;
 
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = memrdr(IX + (signed char) memrdr(PC++));
+	P = memrdr(IX + (SBYTE) memrdr(PC++));
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
+	A = i = (SBYTE) A + (SBYTE) P + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -487,10 +487,10 @@ static int op_suaxd(void)		/* SUB A,(IX+d) */
 	register int i;
 	register BYTE P;
 
-	P = memrdr(IX + (signed char) memrdr(PC++));
+	P = memrdr(IX + (SBYTE) memrdr(PC++));
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
+	A = i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -504,10 +504,10 @@ static int op_scaxd(void)		/* SBC A,(IX+d) */
 	register BYTE P;
 
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = memrdr(IX + (signed char) memrdr(PC++));
+	P = memrdr(IX + (SBYTE) memrdr(PC++));
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
+	A = i = (SBYTE) A - (SBYTE) P - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -517,7 +517,7 @@ static int op_scaxd(void)		/* SBC A,(IX+d) */
 
 static int op_andxd(void)		/* AND (IX+d) */
 {
-	A &= memrdr(IX + (signed char) memrdr(PC++));
+	A &= memrdr(IX + (SBYTE) memrdr(PC++));
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= H_FLAG;
@@ -528,7 +528,7 @@ static int op_andxd(void)		/* AND (IX+d) */
 
 static int op_xorxd(void)		/* XOR (IX+d) */
 {
-	A ^= memrdr(IX + (signed char) memrdr(PC++));
+	A ^= memrdr(IX + (SBYTE) memrdr(PC++));
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -538,7 +538,7 @@ static int op_xorxd(void)		/* XOR (IX+d) */
 
 static int op_orxd(void)		/* OR (IX+d) */
 {
-	A |= memrdr(IX + (signed char) memrdr(PC++));
+	A |= memrdr(IX + (SBYTE) memrdr(PC++));
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -551,10 +551,10 @@ static int op_cpxd(void)		/* CP (IX+d) */
 	register int i;
 	register BYTE P;
 
-	P = memrdr(IX + (signed char) memrdr(PC++));
+	P = memrdr(IX + (SBYTE) memrdr(PC++));
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
+	i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -567,7 +567,7 @@ static int op_incxd(void)		/* INC (IX+d) */
 	register BYTE P;
 	WORD addr;
 
-	addr = IX + (signed char) memrdr(PC++);
+	addr = IX + (SBYTE) memrdr(PC++);
 	P = memrdr(addr);
 	P++;
 	memwrt(addr, P);
@@ -584,7 +584,7 @@ static int op_decxd(void)		/* DEC (IX+d) */
 	register BYTE P;
 	WORD addr;
 
-	addr = IX + (signed char) memrdr(PC++);
+	addr = IX + (SBYTE) memrdr(PC++);
 	P = memrdr(addr);
 	P--;
 	memwrt(addr, P);
@@ -680,91 +680,91 @@ static int op_decix(void)		/* DEC IX */
 
 static int op_ldaxd(void)		/* LD A,(IX+d) */
 {
-	A = memrdr(IX + (signed char) memrdr(PC++));
+	A = memrdr(IX + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldbxd(void)		/* LD B,(IX+d) */
 {
-	B = memrdr(IX + (signed char) memrdr(PC++));
+	B = memrdr(IX + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldcxd(void)		/* LD C,(IX+d) */
 {
-	C = memrdr(IX + (signed char) memrdr(PC++));
+	C = memrdr(IX + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_lddxd(void)		/* LD D,(IX+d) */
 {
-	D = memrdr(IX + (signed char) memrdr(PC++));
+	D = memrdr(IX + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldexd(void)		/* LD E,(IX+d) */
 {
-	E = memrdr(IX + (signed char) memrdr(PC++));
+	E = memrdr(IX + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldhxd(void)		/* LD H,(IX+d) */
 {
-	H = memrdr(IX + (signed char) memrdr(PC++));
+	H = memrdr(IX + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldlxd(void)		/* LD L,(IX+d) */
 {
-	L = memrdr(IX + (signed char) memrdr(PC++));
+	L = memrdr(IX + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldxda(void)		/* LD (IX+d),A */
 {
-	memwrt(IX + (signed char) memrdr(PC++), A);
+	memwrt(IX + (SBYTE) memrdr(PC++), A);
 	return (19);
 }
 
 static int op_ldxdb(void)		/* LD (IX+d),B */
 {
-	memwrt(IX + (signed char) memrdr(PC++), B);
+	memwrt(IX + (SBYTE) memrdr(PC++), B);
 	return (19);
 }
 
 static int op_ldxdc(void)		/* LD (IX+d),C */
 {
-	memwrt(IX + (signed char) memrdr(PC++), C);
+	memwrt(IX + (SBYTE) memrdr(PC++), C);
 	return (19);
 }
 
 static int op_ldxdd(void)		/* LD (IX+d),D */
 {
-	memwrt(IX + (signed char) memrdr(PC++), D);
+	memwrt(IX + (SBYTE) memrdr(PC++), D);
 	return (19);
 }
 
 static int op_ldxde(void)		/* LD (IX+d),E */
 {
-	memwrt(IX + (signed char) memrdr(PC++), E);
+	memwrt(IX + (SBYTE) memrdr(PC++), E);
 	return (19);
 }
 
 static int op_ldxdh(void)		/* LD (IX+d),H */
 {
-	memwrt(IX + (signed char) memrdr(PC++), H);
+	memwrt(IX + (SBYTE) memrdr(PC++), H);
 	return (19);
 }
 
 static int op_ldxdl(void)		/* LD (IX+d),L */
 {
-	memwrt(IX + (signed char) memrdr(PC++), L);
+	memwrt(IX + (SBYTE) memrdr(PC++), L);
 	return (19);
 }
 
 static int op_ldxdn(void)		/* LD (IX+d),n */
 {
-	register signed char d;
+	register SBYTE d;
 
 	d = memrdr(PC++);
 	memwrt(IX + d, memrdr(PC++));
@@ -1022,7 +1022,7 @@ static int op_undoc_cpixl(void)		/* CP IXL */
 	P = IX & 0xff;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
+	i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1041,7 +1041,7 @@ static int op_undoc_cpixh(void)		/* CP IXH */
 	P = IX >> 8;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
+	i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1060,7 +1060,7 @@ static int op_undoc_adaixl(void)	/* ADD A,IXL */
 	P = IX & 0xff;
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
+	A = i = (SBYTE) A + (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1079,7 +1079,7 @@ static int op_undoc_adaixh(void)	/* ADD A,IXH */
 	P = IX >> 8;
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
+	A = i = (SBYTE) A + (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1099,7 +1099,7 @@ static int op_undoc_acaixl(void)	/* ADC A,IXL */
 	P = IX & 0xff;
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
+	A = i = (SBYTE) A + (SBYTE) P + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1119,7 +1119,7 @@ static int op_undoc_acaixh(void)	/* ADC A,IXH */
 	P = IX >> 8;
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
+	A = i = (SBYTE) A + (SBYTE) P + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1138,7 +1138,7 @@ static int op_undoc_suaixl(void)	/* SUB A,IXL */
 	P = IX & 0xff;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
+	A = i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1157,7 +1157,7 @@ static int op_undoc_suaixh(void)	/* SUB A,IXH */
 	P = IX >> 8;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
+	A = i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1177,7 +1177,7 @@ static int op_undoc_scaixl(void)	/* SBC A,IXL */
 	P = IX & 0xff;
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
+	A = i = (SBYTE) A - (SBYTE) P - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1197,7 +1197,7 @@ static int op_undoc_scaixh(void)	/* SBC A,IXH */
 	P = IX >> 8;
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
+	A = i = (SBYTE) A - (SBYTE) P - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);

--- a/z80core/simz80-ddcb.c
+++ b/z80core/simz80-ddcb.c
@@ -305,7 +305,7 @@ int op_ddcb_handle(void)
 	register int d;
 	register int t;
 
-	d = (signed char) memrdr(PC++);
+	d = (SBYTE) memrdr(PC++);
 	t = (*op_ddcb[memrdr(PC++)])(d); /* execute next opcode */
 
 	return (t);

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -400,7 +400,7 @@ static int op_neg(void)			/* NEG */
 {
 	(A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
 	(A == 0x80) ? (F |= P_FLAG) : (F &= ~P_FLAG);
-	(0 - ((signed char) A & 0xf) < 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
+	(0 - ((SBYTE) A & 0xf) < 0) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	A = 0 - A;
 	F |= N_FLAG;
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -454,10 +454,10 @@ static int op_adayd(void)		/* ADD A,(IY+d) */
 	register int i;
 	register BYTE P;
 
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	P = memrdr(IY + (SBYTE) memrdr(PC++));
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
+	A = i = (SBYTE) A + (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -471,10 +471,10 @@ static int op_acayd(void)		/* ADC A,(IY+d) */
 	register BYTE P;
 
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	P = memrdr(IY + (SBYTE) memrdr(PC++));
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
+	A = i = (SBYTE) A + (SBYTE) P + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -487,10 +487,10 @@ static int op_suayd(void)		/* SUB A,(IY+d) */
 	register int i;
 	register BYTE P;
 
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	P = memrdr(IY + (SBYTE) memrdr(PC++));
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
+	A = i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -504,10 +504,10 @@ static int op_scayd(void)		/* SBC A,(IY+d) */
 	register BYTE P;
 
 	carry = (F & C_FLAG) ? 1 : 0;
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	P = memrdr(IY + (SBYTE) memrdr(PC++));
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
+	A = i = (SBYTE) A - (SBYTE) P - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -517,7 +517,7 @@ static int op_scayd(void)		/* SBC A,(IY+d) */
 
 static int op_andyd(void)		/* AND (IY+d) */
 {
-	A &= memrdr(IY + (signed char) memrdr(PC++));
+	A &= memrdr(IY + (SBYTE) memrdr(PC++));
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	F |= H_FLAG;
@@ -528,7 +528,7 @@ static int op_andyd(void)		/* AND (IY+d) */
 
 static int op_xoryd(void)		/* XOR (IY+d) */
 {
-	A ^= memrdr(IY + (signed char) memrdr(PC++));
+	A ^= memrdr(IY + (SBYTE) memrdr(PC++));
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -538,7 +538,7 @@ static int op_xoryd(void)		/* XOR (IY+d) */
 
 static int op_oryd(void)		/* OR (IY+d) */
 {
-	A |= memrdr(IY + (signed char) memrdr(PC++));
+	A |= memrdr(IY + (SBYTE) memrdr(PC++));
 	(A & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
 	(parity[A]) ? (F &= ~P_FLAG) : (F |= P_FLAG);
@@ -551,10 +551,10 @@ static int op_cpyd(void)		/* CP (IY+d) */
 	register int i;
 	register BYTE P;
 
-	P = memrdr(IY + (signed char) memrdr(PC++));
+	P = memrdr(IY + (SBYTE) memrdr(PC++));
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
+	i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -567,7 +567,7 @@ static int op_incyd(void)		/* INC (IY+d) */
 	register BYTE P;
 	WORD addr;
 
-	addr = IY + (signed char) memrdr(PC++);
+	addr = IY + (SBYTE) memrdr(PC++);
 	P = memrdr(addr);
 	P++;
 	memwrt(addr, P);
@@ -584,7 +584,7 @@ static int op_decyd(void)		/* DEC (IY+d) */
 	register BYTE P;
 	WORD addr;
 
-	addr = IY + (signed char) memrdr(PC++);
+	addr = IY + (SBYTE) memrdr(PC++);
 	P = memrdr(addr);
 	P--;
 	memwrt(addr, P);
@@ -680,91 +680,91 @@ static int op_deciy(void)		/* DEC IY */
 
 static int op_ldayd(void)		/* LD A,(IY+d) */
 {
-	A = memrdr(IY + (signed char) memrdr(PC++));
+	A = memrdr(IY + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldbyd(void)		/* LD B,(IY+d) */
 {
-	B = memrdr(IY + (signed char) memrdr(PC++));
+	B = memrdr(IY + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldcyd(void)		/* LD C,(IY+d) */
 {
-	C = memrdr(IY + (signed char) memrdr(PC++));
+	C = memrdr(IY + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_lddyd(void)		/* LD D,(IY+d) */
 {
-	D = memrdr(IY + (signed char) memrdr(PC++));
+	D = memrdr(IY + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldeyd(void)		/* LD E,(IY+d) */
 {
-	E = memrdr(IY + (signed char) memrdr(PC++));
+	E = memrdr(IY + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldhyd(void)		/* LD H,(IY+d) */
 {
-	H = memrdr(IY + (signed char) memrdr(PC++));
+	H = memrdr(IY + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldlyd(void)		/* LD L,(IY+d) */
 {
-	L = memrdr(IY + (signed char) memrdr(PC++));
+	L = memrdr(IY + (SBYTE) memrdr(PC++));
 	return (19);
 }
 
 static int op_ldyda(void)		/* LD (IY+d),A */
 {
-	memwrt(IY + (signed char) memrdr(PC++), A);
+	memwrt(IY + (SBYTE) memrdr(PC++), A);
 	return (19);
 }
 
 static int op_ldydb(void)		/* LD (IY+d),B */
 {
-	memwrt(IY + (signed char) memrdr(PC++), B);
+	memwrt(IY + (SBYTE) memrdr(PC++), B);
 	return (19);
 }
 
 static int op_ldydc(void)		/* LD (IY+d),C */
 {
-	memwrt(IY + (signed char) memrdr(PC++), C);
+	memwrt(IY + (SBYTE) memrdr(PC++), C);
 	return (19);
 }
 
 static int op_ldydd(void)		/* LD (IY+d),D */
 {
-	memwrt(IY + (signed char) memrdr(PC++), D);
+	memwrt(IY + (SBYTE) memrdr(PC++), D);
 	return (19);
 }
 
 static int op_ldyde(void)		/* LD (IY+d),E */
 {
-	memwrt(IY + (signed char) memrdr(PC++), E);
+	memwrt(IY + (SBYTE) memrdr(PC++), E);
 	return (19);
 }
 
 static int op_ldydh(void)		/* LD (IY+d),H */
 {
-	memwrt(IY + (signed char) memrdr(PC++), H);
+	memwrt(IY + (SBYTE) memrdr(PC++), H);
 	return (19);
 }
 
 static int op_ldydl(void)		/* LD (IY+d),L */
 {
-	memwrt(IY + (signed char) memrdr(PC++), L);
+	memwrt(IY + (SBYTE) memrdr(PC++), L);
 	return (19);
 }
 
 static int op_ldydn(void)		/* LD (IY+d),n */
 {
-	register signed char d;
+	register SBYTE d;
 
 	d = memrdr(PC++);
 	memwrt(IY + d, memrdr(PC++));
@@ -1022,7 +1022,7 @@ static int op_undoc_cpiyl(void)		/* CP IYL */
 	P = IY & 0xff;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
+	i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1041,7 +1041,7 @@ static int op_undoc_cpiyh(void)		/* CP IYH */
 	P = IY >> 8;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
+	i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1060,7 +1060,7 @@ static int op_undoc_adaiyl(void)	/* ADD A,IYL */
 	P = IY & 0xff;
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
+	A = i = (SBYTE) A + (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1079,7 +1079,7 @@ static int op_undoc_adaiyh(void)	/* ADD A,IYH */
 	P = IY >> 8;
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
+	A = i = (SBYTE) A + (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1099,7 +1099,7 @@ static int op_undoc_acaiyl(void)	/* ADC A,IYL */
 	P = IY & 0xff;
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
+	A = i = (SBYTE) A + (SBYTE) P + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1119,7 +1119,7 @@ static int op_undoc_acaiyh(void)	/* ADC A,IYH */
 	P = IY >> 8;
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
+	A = i = (SBYTE) A + (SBYTE) P + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1138,7 +1138,7 @@ static int op_undoc_suaiyl(void)	/* SUB A,IYL */
 	P = IY & 0xff;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
+	A = i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1157,7 +1157,7 @@ static int op_undoc_suaiyh(void)	/* SUB A,IYH */
 	P = IY >> 8;
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
+	A = i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1177,7 +1177,7 @@ static int op_undoc_scaiyl(void)	/* SBC A,IYL */
 	P = IY & 0xff;
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
+	A = i = (SBYTE) A - (SBYTE) P - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1197,7 +1197,7 @@ static int op_undoc_scaiyh(void)	/* SBC A,IYH */
 	P = IY >> 8;
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
+	A = i = (SBYTE) A - (SBYTE) P - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);

--- a/z80core/simz80-fdcb.c
+++ b/z80core/simz80-fdcb.c
@@ -305,7 +305,7 @@ int op_fdcb_handle(void)
 	register int d;
 	register int t;
 
-	d = (signed char) memrdr(PC++);
+	d = (SBYTE) memrdr(PC++);
 	t = (*op_fdcb[memrdr(PC++)])(d); /* execute next opcode */
 
 	return (t);

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -1774,7 +1774,7 @@ static int op_adda(void)		/* ADD A,A */
 
 	((A & 0xf) + (A & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	((A << 1) > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) A;
+	A = i = (SBYTE) A + (SBYTE) A;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1788,7 +1788,7 @@ static int op_addb(void)		/* ADD A,B */
 
 	((A & 0xf) + (B & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + B > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) B;
+	A = i = (SBYTE) A + (SBYTE) B;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1802,7 +1802,7 @@ static int op_addc(void)		/* ADD A,C */
 
 	((A & 0xf) + (C & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + C > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) C;
+	A = i = (SBYTE) A + (SBYTE) C;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1816,7 +1816,7 @@ static int op_addd(void)		/* ADD A,D */
 
 	((A & 0xf) + (D & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + D > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) D;
+	A = i = (SBYTE) A + (SBYTE) D;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1830,7 +1830,7 @@ static int op_adde(void)		/* ADD A,E */
 
 	((A & 0xf) + (E & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + E > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) E;
+	A = i = (SBYTE) A + (SBYTE) E;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1844,7 +1844,7 @@ static int op_addh(void)		/* ADD A,H */
 
 	((A & 0xf) + (H & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + H > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) H;
+	A = i = (SBYTE) A + (SBYTE) H;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1858,7 +1858,7 @@ static int op_addl(void)		/* ADD A,L */
 
 	((A & 0xf) + (L & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + L > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) L;
+	A = i = (SBYTE) A + (SBYTE) L;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1874,7 +1874,7 @@ static int op_addhl(void)		/* ADD A,(HL) */
 	P = memrdr((H << 8) + L);
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
+	A = i = (SBYTE) A + (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1890,7 +1890,7 @@ static int op_addn(void)		/* ADD A,n */
 	P = memrdr(PC++);
 	((A & 0xf) + (P & 0xf) > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P;
+	A = i = (SBYTE) A + (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1905,7 +1905,7 @@ static int op_adca(void)		/* ADC A,A */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (A & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	((A << 1) + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) A + carry;
+	A = i = (SBYTE) A + (SBYTE) A + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1920,7 +1920,7 @@ static int op_adcb(void)		/* ADC A,B */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (B & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + B + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) B + carry;
+	A = i = (SBYTE) A + (SBYTE) B + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1935,7 +1935,7 @@ static int op_adcc(void)		/* ADC A,C */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (C & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + C + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) C + carry;
+	A = i = (SBYTE) A + (SBYTE) C + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1950,7 +1950,7 @@ static int op_adcd(void)		/* ADC A,D */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (D & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + D + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) D + carry;
+	A = i = (SBYTE) A + (SBYTE) D + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1965,7 +1965,7 @@ static int op_adce(void)		/* ADC A,E */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (E & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + E + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) E + carry;
+	A = i = (SBYTE) A + (SBYTE) E + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1980,7 +1980,7 @@ static int op_adch(void)		/* ADC A,H */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (H & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + H + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) H + carry;
+	A = i = (SBYTE) A + (SBYTE) H + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -1995,7 +1995,7 @@ static int op_adcl(void)		/* ADC A,L */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (L & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + L + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) L + carry;
+	A = i = (SBYTE) A + (SBYTE) L + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2012,7 +2012,7 @@ static int op_adchl(void)		/* ADC A,(HL) */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
+	A = i = (SBYTE) A + (SBYTE) P + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2029,7 +2029,7 @@ static int op_adcn(void)		/* ADC A,n */
 	P = memrdr(PC++);
 	((A & 0xf) + (P & 0xf) + carry > 0xf) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(A + P + carry > 255) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A + (signed char) P + carry;
+	A = i = (SBYTE) A + (SBYTE) P + carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2051,7 +2051,7 @@ static int op_subb(void)		/* SUB A,B */
 
 	((B & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(B > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) B;
+	A = i = (SBYTE) A - (SBYTE) B;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2065,7 +2065,7 @@ static int op_subc(void)		/* SUB A,C */
 
 	((C & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(C > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) C;
+	A = i = (SBYTE) A - (SBYTE) C;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2079,7 +2079,7 @@ static int op_subd(void)		/* SUB A,D */
 
 	((D & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(D > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) D;
+	A = i = (SBYTE) A - (SBYTE) D;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2093,7 +2093,7 @@ static int op_sube(void)		/* SUB A,E */
 
 	((E & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(E > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) E;
+	A = i = (SBYTE) A - (SBYTE) E;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2107,7 +2107,7 @@ static int op_subh(void)		/* SUB A,H */
 
 	((H & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(H > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) H;
+	A = i = (SBYTE) A - (SBYTE) H;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2121,7 +2121,7 @@ static int op_subl(void)		/* SUB A,L */
 
 	((L & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(L > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) L;
+	A = i = (SBYTE) A - (SBYTE) L;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2137,7 +2137,7 @@ static int op_subhl(void)		/* SUB A,(HL) */
 	P = memrdr((H << 8) + L);
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
+	A = i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2153,7 +2153,7 @@ static int op_subn(void)		/* SUB A,n */
 	P = memrdr(PC++);
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P;
+	A = i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2182,7 +2182,7 @@ static int op_sbcb(void)		/* SBC A,B */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((B & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(B + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) B - carry;
+	A = i = (SBYTE) A - (SBYTE) B - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2197,7 +2197,7 @@ static int op_sbcc(void)		/* SBC A,C */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((C & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(C + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) C - carry;
+	A = i = (SBYTE) A - (SBYTE) C - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2212,7 +2212,7 @@ static int op_sbcd(void)		/* SBC A,D */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((D & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(D + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) D - carry;
+	A = i = (SBYTE) A - (SBYTE) D - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2227,7 +2227,7 @@ static int op_sbce(void)		/* SBC A,E */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((E & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(E + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) E - carry;
+	A = i = (SBYTE) A - (SBYTE) E - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2242,7 +2242,7 @@ static int op_sbch(void)		/* SBC A,H */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((H & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(H + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) H - carry;
+	A = i = (SBYTE) A - (SBYTE) H - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2257,7 +2257,7 @@ static int op_sbcl(void)		/* SBC A,L */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((L & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(L + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) L - carry;
+	A = i = (SBYTE) A - (SBYTE) L - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2274,7 +2274,7 @@ static int op_sbchl(void)		/* SBC A,(HL) */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
+	A = i = (SBYTE) A - (SBYTE) P - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2291,7 +2291,7 @@ static int op_sbcn(void)		/* SBC A,n */
 	carry = (F & C_FLAG) ? 1 : 0;
 	((P & 0xf) + carry > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P + carry > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	A = i = (signed char) A - (signed char) P - carry;
+	A = i = (SBYTE) A - (SBYTE) P - carry;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(A) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2312,7 +2312,7 @@ static int op_cpb(void)			/* CP B */
 
 	((B & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(B > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) B;
+	i = (SBYTE) A - (SBYTE) B;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2326,7 +2326,7 @@ static int op_cpc(void)			/* CP C */
 
 	((C & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(C > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) C;
+	i = (SBYTE) A - (SBYTE) C;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2340,7 +2340,7 @@ static int op_cpd(void)			/* CP D */
 
 	((D & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(D > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) D;
+	i = (SBYTE) A - (SBYTE) D;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2354,7 +2354,7 @@ static int op_cpe(void)			/* CP E */
 
 	((E & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(E > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) E;
+	i = (SBYTE) A - (SBYTE) E;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2368,7 +2368,7 @@ static int op_cph(void)			/* CP H */
 
 	((H & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(H > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) H;
+	i = (SBYTE) A - (SBYTE) H;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2382,7 +2382,7 @@ static int op_cplr(void)		/* CP L */
 
 	((L & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(L > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) L;
+	i = (SBYTE) A - (SBYTE) L;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2398,7 +2398,7 @@ static int op_cphl(void)		/* CP (HL) */
 	P = memrdr((H << 8) + L);
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
+	i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2414,7 +2414,7 @@ static int op_cpn(void)			/* CP n */
 	P = memrdr(PC++);
 	((P & 0xf) > (A & 0xf)) ? (F |= H_FLAG) : (F &= ~H_FLAG);
 	(P > A) ? (F |= C_FLAG) : (F &= ~C_FLAG);
-	i = (signed char) A - (signed char) P;
+	i = (SBYTE) A - (SBYTE) P;
 	(i < -128 || i > 127) ? (F |= P_FLAG) : (F &= ~P_FLAG);
 	(i & 128) ? (F |= S_FLAG) : (F &= ~S_FLAG);
 	(i) ? (F &= ~Z_FLAG) : (F |= Z_FLAG);
@@ -2799,7 +2799,7 @@ static int op_jr(void)			/* JR n */
 {
 	register int d;
 
-	d = (signed char) memrdr(PC++);
+	d = (SBYTE) memrdr(PC++);
 	PC += d;
 	return (12);
 }
@@ -2808,7 +2808,7 @@ static int op_djnz(void)		/* DJNZ n */
 {
 	register int d;
 
-	d = (signed char) memrdr(PC++);
+	d = (SBYTE) memrdr(PC++);
 	if (--B) {
 		PC += d;
 		return (13);
@@ -3154,7 +3154,7 @@ static int op_jrz(void)			/* JR Z,n */
 {
 	register int d;
 
-	d = (signed char) memrdr(PC++);
+	d = (SBYTE) memrdr(PC++);
 	if (F & Z_FLAG) {
 		PC += d;
 		return (12);
@@ -3166,7 +3166,7 @@ static int op_jrnz(void)		/* JR NZ,n */
 {
 	register int d;
 
-	d = (signed char) memrdr(PC++);
+	d = (SBYTE) memrdr(PC++);
 	if (!(F & Z_FLAG)) {
 		PC += d;
 		return (12);
@@ -3178,7 +3178,7 @@ static int op_jrc(void)			/* JR C,n */
 {
 	register int d;
 
-	d = (signed char) memrdr(PC++);
+	d = (SBYTE) memrdr(PC++);
 	if (F & C_FLAG) {
 		PC += d;
 		return (12);
@@ -3190,7 +3190,7 @@ static int op_jrnc(void)		/* JR NC,n */
 {
 	register int d;
 
-	d = (signed char) memrdr(PC++);
+	d = (SBYTE) memrdr(PC++);
 	if (!(F & C_FLAG)) {
 		PC += d;
 		return (12);


### PR DESCRIPTION
Overlooked (signed char) type casts during integer type conversion.