### PR TITLE
intelmds: monitor sources origin, RTC mutex, disk ready check

### DIFF
--- a/intelmdssim/README
+++ b/intelmdssim/README
@@ -3,5 +3,14 @@ This is a simulator for the Intel Intellec MDS-800 system.
 The front panel picture (conf/intelmds.jpg) comes from the front page
 of https://www.facebook.com/groups/IntellecMDS .
 
+The monitor ROM source code comes from the files
+monitors/MDS-I/{b1v12.asm,m1v20.asm} out of
+Bill Beech's https://www.nj7p.info/Computers/work/Intel-run.7z .
+It was compared to
+https://mark-ogden.uk/files/intel/publications/9800155D%20Intellec%20MDS%20Monitor%20V2.0-SEP75.pdf
+and corrected (lots of OCR errors in the comments) and produces the same code
+(except for filler bytes) as the files in
+http://bitsavers.informatik.uni-stuttgart.de/pdf/intel/MDS800/firmware/ .
+
 The disk images were downloaded from
 https://www.nj7p.info/Computers/Old%20Software/software.html .

--- a/intelmdssim/srcsim/simctl.c
+++ b/intelmdssim/srcsim/simctl.c
@@ -155,6 +155,7 @@ void mon(void)
 		/* all LED's off and update front panel */
 		cpu_bus = 0;
 		bus_request = 0;
+		int_requests = 0;
 		IFF = 0;
 		power = 0;
 		fp_sampleData();

--- a/iodevices/mds-monitor.c
+++ b/iodevices/mds-monitor.c
@@ -246,7 +246,6 @@ BYTE mon_tty_status_in(void)
 			tty_stat |= RBR;
 			if (mon_int & (MENB | ITTYI))
 				int_request(MON_IRQ);
-			LOG(TAG, "tty input ready\r\n");
 		} else {
 			tty_stat |= TRDY | TBE;
 			if (mon_int & (MENB | ITTYO))


### PR DESCRIPTION
Document from where the monitor sources originated.

Add an RTC mutex.

Add a disk ready check to isbc202_reset() so you can start the machine with no disk images and get to the monitor.