### PR TITLE
intelmds: implement disk change detection logic

### DIFF
--- a/intelmdssim/srcsim/iosim.c
+++ b/intelmdssim/srcsim/iosim.c
@@ -433,7 +433,11 @@ next:
  */
 static void interrupt(int sig)
 {
+	static unsigned long counter = 0L;
+
 	UNUSED(sig);
+
+	counter++;
 
 #ifndef TCPASYNC
 	/* poll TCP sockets if SIGIO not working */
@@ -445,6 +449,10 @@ static void interrupt(int sig)
 	(void) mon_crt_status_in();
 	(void) mon_pt_status_in();
 	(void) mon_lpt_status_in();
+
+	/* check disk image files each second */
+	if ((counter % 100) == 0)
+		isbc202_disk_check();
 
 #ifdef FRONTPANEL
 	if (!F_flag) {

--- a/iodevices/mds-isbc202.h
+++ b/iodevices/mds-isbc202.h
@@ -20,6 +20,7 @@ extern BYTE isbc202_res_byte_in(void);
 extern void isbc202_iopbl_out(BYTE), isbc202_iopbh_out(BYTE);
 extern void isbc202_reset_out(BYTE);
 
+extern void isbc202_disk_check(void);
 extern void isbc202_reset(void);
 
 #endif /* !MDS_ISBC202_INC */


### PR DESCRIPTION
Checks every second if disk image files have vanished or appeared.

Since ISIS doesn't use an interrupt handler for disk I/O, one can use the INT 2 LED to ones advantage:

To change a disk, remove the disk image file, wait for the INT 2 LED to go on, than put the new disk file in place.

To format a new disk image file in an empty drive use "touch drive[abcd].dsk", wait for the INT 2 LED, then use the ISIS "format" command.