### PR TITLE
intelmds: make ISIS hdcopy work

### DIFF
--- a/intelmdssim/README
+++ b/intelmdssim/README
@@ -1,5 +1,9 @@
 This is a simulator for the Intel Intellec MDS-800 system with
-64K RAM and an iSBC-202 double density diskette controller.
+64K RAM, an iSBC-202 double density diskette controller with 4 drives
+attached, an iSBC-201 single density diskette controller with 2 drives
+attached, and an iSBC-206 hard disk controller with 2 MDS-740 hard disk
+units attached. Each MDS-740 unit contains a fixed platter and a removable
+IBM-5440 type platter.
 
 The front panel picture (conf/intelmds.jpg) comes from the front page
 of https://www.facebook.com/groups/IntellecMDS .

--- a/iodevices/mds-isbc201.c
+++ b/iodevices/mds-isbc201.c
@@ -256,6 +256,12 @@ void isbc201_iopbh_out(BYTE data)
 			break;
 		}
 
+		/* expand new disk image to full size */
+		if (taddr == 0 && ftruncate(fd, (off_t) DISK_SIZE) == -1) {
+			ioerr = IO_NRDY;
+			break;
+		}
+
 		if (iocw & CW_RFS) {	/* random format sequence */
 			/*
 			 * Reads a table of (sector, data) pairs from the IOPB

--- a/iodevices/mds-isbc202.c
+++ b/iodevices/mds-isbc202.c
@@ -251,6 +251,12 @@ void isbc202_iopbh_out(BYTE data)
 			break;
 		}
 
+		/* expand new disk image to full size */
+		if (taddr == 0 && ftruncate(fd, (off_t) DISK_SIZE) == -1) {
+			ioerr = IO_NRDY;
+			break;
+		}
+
 		if (iocw & CW_RFS) {	/* random format sequence */
 			/*
 			 * Reads a table of (sector, data) pairs from the IOPB

--- a/iodevices/mds-isbc206.c
+++ b/iodevices/mds-isbc206.c
@@ -270,7 +270,7 @@ void isbc206_iopbh_out(BYTE data)
 			ioerr = IO_NRDY;
 			break;
 		}
-		if (taddr == 0 && ftruncate(fd, DISK_SIZE) == -1) {
+		if (taddr == 0 && ftruncate(fd, (off_t) DISK_SIZE) == -1) {
 			ioerr = IO_NRDY;
 			break;
 		}

--- a/iodevices/mds-isbc206.c
+++ b/iodevices/mds-isbc206.c
@@ -31,6 +31,7 @@
 #include "simglb.h"
 #include "memsim.h"
 #include "mds-isbc206.h"
+#define LOG_LOCAL_LEVEL	LOG_DEBUG
 #include "log.h"
 
 #ifdef HAS_ISBC206
@@ -222,6 +223,8 @@ void isbc206_iopbh_out(BYTE data)
 	saddr = dma_read(iopb_addr + 4);
 	addr = dma_read(iopb_addr + 5);
 	addr |= dma_read(iopb_addr + 6) << 8;
+	LOGD(TAG, "iopb(cw=%02X op=%02X n=%02X trk=%02X sec=%02X addr=%04X)",
+	     iocw, ioins, nsec, taddr, saddr, addr);
 
 	/* undo ISIS logical to physical mapping */
 	track = taddr;
@@ -264,6 +267,10 @@ void isbc206_iopbh_out(BYTE data)
 
 		/* try to create new disk image */
 		if ((fd = open(fn, O_RDWR | O_CREAT, 0644)) == -1) {
+			ioerr = IO_NRDY;
+			break;
+		}
+		if (taddr == 0 && ftruncate(fd, DISK_SIZE) == -1) {
 			ioerr = IO_NRDY;
 			break;
 		}

--- a/iodevices/mds-isbc206.c
+++ b/iodevices/mds-isbc206.c
@@ -270,6 +270,8 @@ void isbc206_iopbh_out(BYTE data)
 			ioerr = IO_NRDY;
 			break;
 		}
+
+		/* expand new disk image to full size */
 		if (taddr == 0 && ftruncate(fd, (off_t) DISK_SIZE) == -1) {
 			ioerr = IO_NRDY;
 			break;

--- a/iodevices/mds-isbc206.c
+++ b/iodevices/mds-isbc206.c
@@ -31,7 +31,7 @@
 #include "simglb.h"
 #include "memsim.h"
 #include "mds-isbc206.h"
-#define LOG_LOCAL_LEVEL	LOG_DEBUG
+/* #define LOG_LOCAL_LEVEL	LOG_DEBUG */
 #include "log.h"
 
 #ifdef HAS_ISBC206


### PR DESCRIPTION
hdcopy works by formatting 4 tracks, copy them, and repeat.

This didn't work because the format track emulation would create a new disk image file when formatting track 0 and the write emulation checks that the disk image file has the full size.

Add an ftruncate to make the file full size when formatting track 0.
    
Also expand description of what is emulated in the README.
