### PR TITLE
fix some compiler warnings when compiling on aarch64 (i.e. Raspberry Pi OS)

### DIFF
--- a/cpmsim/srctools/bin2hex.c
+++ b/cpmsim/srctools/bin2hex.c
@@ -22,7 +22,7 @@ int main(int argc,char *argv[])/*Main routine*/
 {
   char *ifile = NULL;
   char *ofile = NULL;
-  char c;
+  int c;
   FILE *inp, *outp;
   int ch,csum;
   int ofsa = 0;

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -267,8 +267,7 @@ static void do_go(char *s)
 		PC = exatoi(s);
 	if (ice_before_go)
 		(*ice_before_go)();
-	if (timeit)
-		start_time = cpu_time;
+	start_time = cpu_time;
 	for (;;) {
 		run_cpu();
 		if (cpu_error) {
@@ -280,8 +279,7 @@ static void do_go(char *s)
 				break;
 		}
 	}
-	if (timeit)
-		stop_time = cpu_time;
+	stop_time = cpu_time;
 	if (ice_after_go)
 		(*ice_after_go)();
 	report_cpu_error();


### PR DESCRIPTION
"char" is unsigned on aarch64, so use an "int" for "getopt" result in bin2hex.c.

gcc 12 doesn't seem very smart, just set the variables.