### PR TITLE
z80asm: reworked binary and C output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCDIR = $(DATAROOTDIR)/doc/$(PACKAGE)
 TOOLS = z80asm cpmsim/srctools
 LIBS = frontpanel webfrontend/civetweb
 BIOSES = cpmsim/srccpm2 cpmsim/srccpm3 cpmsim/srcmpm cpmsim/srcucsd-iv \
-	imsaisim/srcucsd-iv
+	intelmdssim/srccpm2 imsaisim/srcucsd-iv
 MISC = z80sim cpmtools
 MACHINES = altairsim cpmsim cromemcosim intelmdssim imsaisim mosteksim z80sim
 

--- a/altairsim/basic8k78.lis
+++ b/altairsim/basic8k78.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/dzmation.lis
+++ b/altairsim/dzmation.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; HAND DISASSEMBLY OF THE DAZZLEMATION MEMORY IMAGE PROVIDED IN THE

--- a/altairsim/fdct1.lis
+++ b/altairsim/fdct1.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/killbits.lis
+++ b/altairsim/killbits.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/killbits2.lis
+++ b/altairsim/killbits2.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/kscope.lis
+++ b/altairsim/kscope.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/life.lis
+++ b/altairsim/life.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; LIFE .... VERSION 2.0

--- a/altairsim/microchess.lis
+++ b/altairsim/microchess.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '8080 MICROCHESS'

--- a/altairsim/roms/als8-rom.lis
+++ b/altairsim/roms/als8-rom.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/roms/apple.lis
+++ b/altairsim/roms/apple.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '<APPLE MONITOR, *ECT ROM* V1.0  JAN 07, 1979>'

--- a/altairsim/roms/bootromt-old.lis
+++ b/altairsim/roms/bootromt-old.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;******************************************************************

--- a/altairsim/roms/bootromt.lis
+++ b/altairsim/roms/bootromt.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;******************************************************************

--- a/altairsim/roms/cuter-mits.lis
+++ b/altairsim/roms/cuter-mits.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>

--- a/altairsim/roms/dbl.lis
+++ b/altairsim/roms/dbl.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;***************************************************************

--- a/altairsim/roms/mbl.lis
+++ b/altairsim/roms/mbl.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; MBL - MULTI BOOT LOADER FOR THE ALTAIR 8800

--- a/altairsim/roms/miniboot.lis
+++ b/altairsim/roms/miniboot.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/altairsim/roms/tinybasic-1.0.lis
+++ b/altairsim/roms/tinybasic-1.0.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/altairsim/roms/tinybasic-2.0.lis
+++ b/altairsim/roms/tinybasic-2.0.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/altairsim/roms/turnmon.lis
+++ b/altairsim/roms/turnmon.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; **************************************************************

--- a/altairsim/roms/umzapex.lis
+++ b/altairsim/roms/umzapex.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 	TITLE	<Zapple Monitor Extension for MITS ALTAIR>

--- a/altairsim/roms/zapple.lis
+++ b/altairsim/roms/zapple.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;	<< ZAPPLE 2-K MONITOR SYSTEM >>

--- a/cromemcosim/dzmation.lis
+++ b/cromemcosim/dzmation.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; HAND DISASSEMBLY OF THE DAZZLEMATION MEMORY IMAGE PROVIDED IN THE

--- a/cromemcosim/kscope.lis
+++ b/cromemcosim/kscope.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/cromemcosim/life.lis
+++ b/cromemcosim/life.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; LIFE .... VERSION 2.0

--- a/cromemcosim/microchess.lis
+++ b/cromemcosim/microchess.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '8080 MICROCHESS'

--- a/cromemcosim/roms/rdos1.lis
+++ b/cromemcosim/roms/rdos1.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; COPYRIGHT (C) 1977, CROMEMCO, INC.

--- a/cromemcosim/roms/rdos252.lis
+++ b/cromemcosim/roms/rdos252.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/cromemcosim/roms/z1mon-1.0.lis
+++ b/cromemcosim/roms/z1mon-1.0.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/cromemcosim/roms/z1mon-1.4.lis
+++ b/cromemcosim/roms/z1mon-1.4.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/doc/README-asm.txt
+++ b/doc/README-asm.txt
@@ -3,6 +3,9 @@ Usage:
 z80asm -8 -u -v -U -e<num> -f{b|m|h|c} -x -h<num> -c<num> -m -T -p<num>
        -s[n|a] -o<file> -l[<file>] -d<symbol>[=<expr>] ... <file> ...
 
+Note: z80asm can only process ASCII text files and only works reliable
+on systems where stdio prints '\n' as a single character.
+
 If the file name of a source doesn't have an extension the default
 extension ".asm" will be appended.
 

--- a/imsaisim/dzmation.lis
+++ b/imsaisim/dzmation.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; HAND DISASSEMBLY OF THE DAZZLEMATION MEMORY IMAGE PROVIDED IN THE

--- a/imsaisim/kscope.lis
+++ b/imsaisim/kscope.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;

--- a/imsaisim/life.lis
+++ b/imsaisim/life.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ; LIFE .... VERSION 2.0

--- a/imsaisim/microchess.lis
+++ b/imsaisim/microchess.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE '8080 MICROCHESS'

--- a/imsaisim/roms/basic4k.lis
+++ b/imsaisim/roms/basic4k.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 *HEADING IMSAI 8080 4K BASIC

--- a/imsaisim/roms/basic8k.lis
+++ b/imsaisim/roms/basic8k.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;EDITS:

--- a/imsaisim/roms/memon80.lis
+++ b/imsaisim/roms/memon80.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;==============================================================

--- a/imsaisim/roms/viofm1.lis
+++ b/imsaisim/roms/viofm1.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1 ;*************************************************************

--- a/imsaisim/scs1.lis
+++ b/imsaisim/scs1.lis
@@ -1,4 +1,4 @@
-Z80/8080-Macro-Assembler  Release 2.0
+Z80/8080-Macro-Assembler  Release 2.1
 
 LOC   OBJECT CODE   LINE   STMT SOURCE CODE
                        1      1         TITLE           'IMSAI SCS-1 REV. 2 06 OCT. 1976'

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -20,7 +20,7 @@
  */
 #define COPYR		"Copyright (C) 1987-2024 by Udo Munk" \
 			" & 2022-2024 by Thomas Eberhardt"
-#define RELEASE		"2.0"
+#define RELEASE		"2.1"
 
 #define SRCEXT		".asm"	/* filename extension source */
 #define OBJEXTBIN	".bin"	/* filename extension object */
@@ -42,6 +42,8 @@
 #define MAXHEX		32	/* max. no bytes per HEX record */
 #define MACNEST		50	/* max. expansion nesting */
 #define CARYLEN		12	/* default number of bytes per C array line */
+#define CARYSPC		12	/* max number of bytes per C array line that
+				   are followed by a space character */
 
 #ifndef FALSE
 #define FALSE		0
@@ -222,26 +224,24 @@ struct sym {
 #define E_VALOUT	6	/* value out of range */
 #define E_MISPAR	7	/* missing right parenthesis */
 #define E_MISDEL	8	/* missing string delimiter */
-#define E_NSQWRT	9	/* non-sequential object code (binary) */
-#define E_MISIFF	10	/* missing IF at ELSE or ENDIF */
-#define E_IFNEST	11	/* IF nested too deep */
-#define E_MISEIF	12	/* missing ENDIF */
-#define E_INCNST	13	/* INCLUDE nested too deep */
-#define E_PHSNST	14	/* invalid .PHASE nesting */
-#define E_ORGPHS	15	/* invalid ORG in .PHASE block */
-#define E_MISPHS	16	/* missing .PHASE at .DEPHASE */
-#define E_DIVBY0	17	/* division by zero */
-#define E_INVEXP	18	/* invalid expression */
-#define E_BFRORG	19	/* object code before ORG (binary) */
-#define E_INVLBL	20	/* invalid label */
-#define E_MISDPH	21	/* missing .DEPHASE */
-#define E_NIMDEF	22	/* not in macro definition */
-#define E_MISEMA	23	/* missing ENDM */
-#define E_NIMEXP	24	/* not in macro expansion */
-#define E_MACNST	25	/* macro expansion nested too deep */
-#define E_OUTLCL	26	/* too many local labels */
-#define E_LBLDIF	27	/* label address differs between passes */
-#define E_MACOVF	28	/* macro buffer overflow */
+#define E_MISIFF	9	/* missing IF at ELSE or ENDIF */
+#define E_IFNEST	10	/* IF nested too deep */
+#define E_MISEIF	11	/* missing ENDIF */
+#define E_INCNST	12	/* INCLUDE nested too deep */
+#define E_PHSNST	13	/* invalid .PHASE nesting */
+#define E_ORGPHS	14	/* invalid ORG in .PHASE block */
+#define E_MISPHS	15	/* missing .PHASE at .DEPHASE */
+#define E_DIVBY0	16	/* division by zero */
+#define E_INVEXP	17	/* invalid expression */
+#define E_INVLBL	18	/* invalid label */
+#define E_MISDPH	19	/* missing .DEPHASE */
+#define E_NIMDEF	20	/* not in macro definition */
+#define E_MISEMA	21	/* missing ENDM */
+#define E_NIMEXP	22	/* not in macro expansion */
+#define E_MACNST	23	/* macro expansion nested too deep */
+#define E_OUTLCL	24	/* too many local labels */
+#define E_LBLDIF	25	/* label address differs between passes */
+#define E_MACOVF	26	/* macro buffer overflow */
 
 /*
  *	definition of fatal errors
@@ -250,11 +250,12 @@ struct sym {
 #define F_USAGE		1	/* usage: .... */
 #define F_HALT		2	/* assembly halted */
 #define F_FOPEN		3	/* can't open file */
-#define F_INTERN	4	/* internal error */
-#define F_PAGLEN	5	/* page length out of range */
-#define F_SYMLEN	6	/* symbol length out of range */
-#define F_CARYLEN	7	/* C array bytes per line out of range */
-#define F_HEXLEN	8	/* HEX record length out of range */
+#define F_OBJFILE	4	/* writing object file */
+#define F_INTERN	5	/* internal error */
+#define F_PAGLEN	6	/* page length out of range */
+#define F_SYMLEN	7	/* symbol length out of range */
+#define F_CARYLEN	8	/* C array bytes per line out of range */
+#define F_HEXLEN	9	/* HEX record length out of range */
 
 /*
  *	macro for declaring unused function parameters

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -29,7 +29,7 @@ WORD rpc,			/* real program counter */
 				/* to rpc, except when inside a .PHASE block */
      a_addr,			/* output value for A_ADDR/A_VALUE mode */
      load_addr,			/* load address of program */
-     start_addr,		/* start address of program */
+     start_addr,		/* execution start address of program */
      hexlen = MAXHEX,		/* HEX record length */
      carylen = CARYLEN;		/* C array bytes per line */
 
@@ -57,7 +57,7 @@ int  list_flag,			/* flag for option -l */
      errors,			/* error counter */
      errnum,			/* error number in pass 2 */
      a_mode,			/* address output mode for pseudo ops */
-     load_flag,			/* flag for load_addr valid */
+     load_flag,			/* flag for load_addr already set */
      obj_fmt = OBJ_HEX,		/* format of object file (default Intel HEX) */
      symlen = SYMLEN,		/* significant characters in symbols */
      symmax,			/* max. symbol name length encountered */

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -66,11 +66,12 @@ static const char *errmsg[] = {		/* error messages for fatal() */
 	 "-d<symbol>[=<expr>] ... <file> ..."), /* 1 */
 	"Assembly halted",		/* 2 */
 	"can't open file %s",		/* 3 */
-	"internal error: %s",		/* 4 */
-	"invalid page length: %s",	/* 5 */
-	"invalid symbol length: %s",	/* 6 */
-	"invalid C bytes per line: %s",	/* 7 */
-	"invalid HEX record length: %s"	/* 8 */
+	"error writing object file %s",	/* 4 */
+	"internal error: %s",		/* 5 */
+	"invalid page length: %s",	/* 6 */
+	"invalid symbol length: %s",	/* 7 */
+	"invalid C bytes per line: %s",	/* 8 */
+	"invalid HEX record length: %s"	/* 9 */
 };
 
 static const struct {
@@ -397,10 +398,12 @@ int process_line(char *l)
 		p = get_symbol(opcode, p, FALSE);
 		lbl_flag = (gencode && label[0] != '\0');
 		if (mac_def_nest > 0) {
+			/* inside macro definition, add line to macro */
 			if (opcode[0] != '\0')
 				op = search_op(opcode);
 			mac_add_line(op, l);
 		} else if (opcode[0] == '\0') {
+			/* no op-code line */
 			a_mode = A_NONE;
 			if (gencode) {
 				if (lbl_flag) {
@@ -409,6 +412,7 @@ int process_line(char *l)
 				}
 			}
 		} else if (mac_lookup(opcode)) {
+			/* macro call, start macro expansion */
 			if (gencode) {
 				if (lbl_flag)
 					put_label();
@@ -419,6 +423,7 @@ int process_line(char *l)
 			} else
 				a_mode = A_NONE;
 		} else if ((op = search_op(opcode)) != NULL) {
+			/* normal line with op-code */
 			if (lbl_flag) {
 				if (op->op_flags & OP_NOLBL)
 					asmerr(E_INVLBL);

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -81,6 +81,8 @@ WORD op_org(BYTE op_code, BYTE dummy)
 		n = eval(operand);
 		if (pass == 1) {	/* PASS 1 */
 			if (!load_flag) {
+				/* first ORG sets load address,
+				   without any ORG it defaults to 0 */
 				load_addr = n;
 				load_flag = TRUE;
 			}


### PR DESCRIPTION
Add error checks to object file output.

Major rework of the binary and C output routines. No more "non-sequential object code (binary)" messages. The "object code before ORG (binary)" is also gone. Without any "ORG" the load address defaults to 0. Increased minor version number.

microchess.asm can now be assembled with '-fb' or even '-fc'.

Needs some testing. The BIOSes assembled correctly, i.e. output files matched previous z80asm.

Regenerate assembler listings because of z80asm version number change.

Add intelmds CP/M BIOS to top level Makefile.