### PR TITLE
make port_in/port_out const arrays of pointers

### DIFF
--- a/altairsim/srcsim/iosim.c
+++ b/altairsim/srcsim/iosim.c
@@ -83,7 +83,7 @@ BYTE hwctl_lock = 0xff;		/* lock status hardware control port */
  *	This array contains function pointers for every
  *	input I/O port (0 - 255), to do the required I/O.
  */
-BYTE (*port_in[256])(void) = {
+BYTE (*const port_in[256])(void) = {
 	[  0] = altair_sio0_status_in,	/* SIO 0 connected to console */
 	[  1] = altair_sio0_data_in,	/*  "  */
 	[  2] = lpt_status_in,		/* printer status */
@@ -113,7 +113,7 @@ BYTE (*port_in[256])(void) = {
  *	This array contains function pointers for every
  *	output I/O port (0 - 255), to do the required I/O.
  */
-void (*port_out[256])(BYTE) = {
+void (*const port_out[256])(BYTE) = {
 	[  0] = altair_sio0_status_out,	/* SIO 0 connected to console */
 	[  1] = altair_sio0_data_out,	/*  "  */
 	[  2] = lpt_status_out,		/* printer status */
@@ -149,19 +149,6 @@ void (*port_out[256])(BYTE) = {
  */
 void init_io(void)
 {
-	extern BYTE io_trap_in(void);
-	extern void io_trap_out(BYTE);
-
-	register int i;
-
-	/* initialize unused ports to trap handlers */
-	for (i = 0; i <= 255; i++) {
-		if (port_in[i] == NULL)
-			port_in[i] = io_trap_in;
-		if (port_out[i] == NULL)
-			port_out[i] = io_trap_out;
-	}
-
 	/* create local sockets */
 	init_unix_server_socket(&ucons[0], "altairsim.tape");
 	init_unix_server_socket(&ucons[1], "altairsim.sio2");
@@ -212,7 +199,7 @@ void reset_io(void)
  */
 static BYTE io_no_card_in(void)
 {
-	return ((BYTE) 0xff);
+	return ((BYTE) IO_DATA_UNUSED);
 }
 #endif
 

--- a/altairsim/srcsim/memsim.h
+++ b/altairsim/srcsim/memsim.h
@@ -34,6 +34,8 @@ extern int p_tab[];
 extern BYTE tarbell_rom[];
 extern int tarbell_rom_enabled, tarbell_rom_active;
 
+#define IO_DATA_UNUSED	0xff	/* data returned on unused ports */
+
 #define MEM_RW		0	/* memory is readable and writeable */
 #define MEM_RO		1	/* memory is read-only */
 #define MEM_WPROT	2	/* memory is write protected */

--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -297,7 +297,7 @@ void step_clicked(int state, int val)
  */
 int wait_step(void)
 {
-	extern BYTE (*port_in[256])(void);
+	extern BYTE (*const port_in[256])(void);
 	int ret = 0;
 
 	if (cpu_state != SINGLE_STEP) {
@@ -315,8 +315,11 @@ int wait_step(void)
 
 	while ((cpu_switch == 3) && !reset) {
 		/* when INP update data bus LEDs */
-		if (cpu_bus == (CPU_WO | CPU_INP))
-			fp_led_data = (*port_in[fp_led_address & 0xff])();
+		if (cpu_bus == (CPU_WO | CPU_INP)) {
+			if (port_in[fp_led_address & 0xff])
+				fp_led_data =
+					(*port_in[fp_led_address & 0xff])();
+		}
 		fp_clock++;
 		fp_sampleData();
 		SLEEP_MS(1);

--- a/cpmsim/srcsim/iosim.c
+++ b/cpmsim/srcsim/iosim.c
@@ -291,7 +291,7 @@ static void int_io(int);
  *	This array contains function pointers for every
  *	input port.
  */
-BYTE (*port_in[256])(void) = {
+BYTE (*const port_in[256])(void) = {
 	[  0] = cons_in,
 	[  1] = cond_in,
 	[  2] = prts_in,
@@ -333,7 +333,7 @@ BYTE (*port_in[256])(void) = {
  *	This array contains function pointers for every
  *	output port.
  */
-void (*port_out[256])(BYTE) = {
+void (*const port_out[256])(BYTE) = {
 	[  0] = cons_out,
 	[  1] = cond_out,
 	[  2] = prts_out,
@@ -379,18 +379,14 @@ void (*port_out[256])(BYTE) = {
  *	2. Fork the process for receiving from the auxiliary serial port.
  *	3. Open the named pipes "auxin" and "auxout" for simulation
  *	   of the auxiliary serial port.
- *	4. Initialize unused ports to trap handlers.
- *	5. Open the files which emulate the disk drives.
+ *	4. Open the files which emulate the disk drives.
  *	   Errors for opening one of the drives results
  *	   in a NULL pointer for fd in the dskdef structure,
  *	   so that this drive can't be used.
- *	6. Prepare TCP/IP sockets for serial port simulation
+ *	5. Prepare TCP/IP sockets for serial port simulation
  */
 void init_io(void)
 {
-	extern BYTE io_trap_in(void);
-	extern void io_trap_out(BYTE);
-
 	register int i;
 	struct stat sbuf;
 #if defined(NETWORKING) && defined(TCPASYNC)
@@ -436,13 +432,6 @@ void init_io(void)
 		exit(EXIT_FAILURE);
 	}
 #endif
-
-	for (i = 0; i <= 255; i++) {
-		if (port_in[i] == NULL)
-			port_in[i] = io_trap_in;
-		if (port_out[i] == NULL)
-			port_out[i] = io_trap_out;
-	}
 
 	for (i = 0; i <= 15; i++) {
 

--- a/cpmsim/srcsim/memsim.h
+++ b/cpmsim/srcsim/memsim.h
@@ -33,6 +33,8 @@
 #ifndef MEMSIM_INC
 #define MEMSIM_INC
 
+#define IO_DATA_UNUSED	0xff	/* data returned on unused ports */
+
 #define MAXSEG 16		/* max. number of memory banks */
 #define SEGSIZ 49152		/* default size of one bank = 48 KBytes */
 

--- a/cromemcosim/srcsim/iosim.c
+++ b/cromemcosim/srcsim/iosim.c
@@ -97,7 +97,7 @@ static int th_suspend;		/* timing thread suspend flag */
  *	This array contains function pointers for every
  *	input I/O port (0 - 255), to do the required I/O.
  */
-BYTE (*port_in[256])(void) = {
+BYTE (*const port_in[256])(void) = {
 	[  0] = cromemco_tuart_0a_status_in,
 	[  1] = cromemco_tuart_0a_data_in,
 	[  3] = cromemco_tuart_0a_interrupt_in,
@@ -149,7 +149,7 @@ BYTE (*port_in[256])(void) = {
  *	This array contains function pointers for every
  *	output I/O port (0 - 255), to do the required I/O.
  */
-void (*port_out[256])(BYTE) = {
+void (*const port_out[256])(BYTE) = {
 	[  0] = cromemco_tuart_0a_baud_out,
 	[  1] = cromemco_tuart_0a_data_out,
 	[  2] = cromemco_tuart_0a_command_out,
@@ -214,21 +214,10 @@ void (*port_out[256])(BYTE) = {
  */
 void init_io(void)
 {
-	extern BYTE io_trap_in(void);
-	extern void io_trap_out(BYTE);
-
 	register int i;
 	pthread_t thread;
 	static struct itimerval tim;
 	static struct sigaction newact;
-
-	/* initialize unused ports to trap handlers */
-	for (i = 0; i <= 255; i++) {
-		if (port_in[i] == NULL)
-			port_in[i] = io_trap_in;
-		if (port_out[i] == NULL)
-			port_out[i] = io_trap_out;
-	}
 
 	/* initialize TCP/IP networking */
 #ifdef TCPASYNC

--- a/cromemcosim/srcsim/memsim.h
+++ b/cromemcosim/srcsim/memsim.h
@@ -25,6 +25,8 @@
 #include "frontpanel.h"
 #endif
 
+#define IO_DATA_UNUSED	0xff	/* data returned on unused ports */
+
 #define MAXSEG 7		/* max. number of 64KB memory banks */
 #define SEGSIZ 65536	/* size of the memory segments, 64 KBytes */
 

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -302,7 +302,7 @@ void step_clicked(int state, int val)
  */
 int wait_step(void)
 {
-	extern BYTE (*port_in[256])(void);
+	extern BYTE (*const port_in[256])(void);
 	int ret = 0;
 
 	if (cpu_state != SINGLE_STEP) {
@@ -320,8 +320,11 @@ int wait_step(void)
 
 	while ((cpu_switch == 3) && !reset) {
 		/* when INP update data bus LEDs */
-		if (cpu_bus == (CPU_WO | CPU_INP))
-			fp_led_data = (*port_in[fp_led_address & 0xff])();
+		if (cpu_bus == (CPU_WO | CPU_INP)) {
+			if (port_in[fp_led_address & 0xff])
+				fp_led_data =
+					(*port_in[fp_led_address & 0xff])();
+		}
 		fp_clock++;
 		fp_sampleData();
 		SLEEP_MS(10);

--- a/imsaisim/srcsim/iosim.c
+++ b/imsaisim/srcsim/iosim.c
@@ -121,7 +121,7 @@ void *am9511 = NULL;		/* am9511 instantiation */
  *	This array contains function pointers for every
  *	input I/O port (0 - 255), to do the required I/O.
  */
-BYTE (*port_in[256])(void) = {
+BYTE (*const port_in[256])(void) = {
 	[  0] = imsai_sio_nofun_in,	/* IMSAI SIO-2 */
 	[  1] = imsai_sio_nofun_in,
 	[  2] = imsai_sio1a_data_in,	/* Channel A, console */
@@ -192,7 +192,7 @@ BYTE (*port_in[256])(void) = {
  *	This array contains function pointers for every
  *	output I/O port (0 - 255), to do the required I/O.
  */
-void (*port_out[256])(BYTE) = {
+void (*const port_out[256])(BYTE) = {
 	[  0] = imsai_sio_nofun_out,	/* IMSAI SIO-2 */
 	[  1] = imsai_sio_nofun_out,
 	[  2] = imsai_sio1a_data_out,	/* Channel A, console */
@@ -270,19 +270,6 @@ void (*port_out[256])(BYTE) = {
  */
 void init_io(void)
 {
-	extern BYTE io_trap_in(void);
-	extern void io_trap_out(BYTE);
-
-	register int i;
-
-	/* initialize unused ports to trap handlers */
-	for (i = 0; i <= 255; i++) {
-		if (port_in[i] == NULL)
-			port_in[i] = io_trap_in;
-		if (port_out[i] == NULL)
-			port_out[i] = io_trap_out;
-	}
-
 	/* initialize IMSAI VIO if firmware is loaded */
 	if ((getmem(0xfffd) == 'V') && (getmem(0xfffe) == 'I') &&
 	    (getmem(0xffff) == '0')) {
@@ -358,7 +345,7 @@ void reset_io(void)
  */
 static BYTE io_no_card_in(void)
 {
-	return ((BYTE) 0xff);
+	return ((BYTE) IO_DATA_UNUSED);
 }
 
 /*

--- a/imsaisim/srcsim/memsim.h
+++ b/imsaisim/srcsim/memsim.h
@@ -38,6 +38,8 @@ extern int p_tab[];
 extern int _p_tab[];
 extern int selbnk;
 
+#define IO_DATA_UNUSED	0xff	/* data returned on unused ports */
+
 #define MEM_RW		0	/* memory is readable and writeable */
 #define MEM_RO		1	/* memory is read-only */
 #define MEM_WPROT	2	/* memory is write protected */

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -300,7 +300,7 @@ void step_clicked(int state, int val)
  */
 int wait_step(void)
 {
-	extern BYTE (*port_in[256])(void);
+	extern BYTE (*const port_in[256])(void);
 	int ret = 0;
 
 	if (cpu_state != SINGLE_STEP) {
@@ -318,8 +318,11 @@ int wait_step(void)
 
 	while ((cpu_switch == 3) && !reset) {
 		/* when INP update data bus LEDs */
-		if (cpu_bus == (CPU_WO | CPU_INP))
-			fp_led_data = (*port_in[fp_led_address & 0xff])();
+		if (cpu_bus == (CPU_WO | CPU_INP)) {
+			if (port_in[fp_led_address & 0xff])
+				fp_led_data =
+					(*port_in[fp_led_address & 0xff])();
+		}
 		fp_clock++;
 		fp_sampleData();
 		SLEEP_MS(10);

--- a/intelmdssim/srcsim/memsim.h
+++ b/intelmdssim/srcsim/memsim.h
@@ -14,6 +14,8 @@
 #ifndef MEMSIM_INC
 #define MEMSIM_INC
 
+#define IO_DATA_UNUSED	0x00	/* data returned on unused ports */
+
 #define BOOT_SIZE	256	/* bootstrap ROM size */
 #define MON_SIZE	2048	/* monitor ROM size */
 

--- a/mosteksim/srcsim/iosim.c
+++ b/mosteksim/srcsim/iosim.c
@@ -24,6 +24,7 @@
 #include <sys/time.h>
 #include "sim.h"
 #include "simglb.h"
+#include "memsim.h"
 #include "simbdos.h"
 #include "mostek-cpu.h"
 #include "mostek-fdc.h"
@@ -44,7 +45,7 @@ static void io_no_card_out(BYTE);
  *	This array contains function pointers for every
  *	input I/O port (0 - 255), to do the required I/O.
  */
-BYTE (*port_in[256])(void) = {
+BYTE (*const port_in[256])(void) = {
 	[208] = io_no_card_in,		/* (d0) PIO1 Data A */
 	[209] = io_no_card_in,		/* (d1) PIO1 Control A */
 	[210] = io_no_card_in,		/* (d2) PIO1 Data B */
@@ -73,7 +74,7 @@ BYTE (*port_in[256])(void) = {
  *	This array contains function pointers for every
  *	output I/O port (0 - 255), to do the required I/O.
  */
-void (*port_out[256])(BYTE) = {
+void (*const port_out[256])(BYTE) = {
 	[161] = host_bdos_out,		/* host file I/O hook */
 	[208] = io_no_card_out,		/* (d0) PIO1 Data A */
 	[209] = io_no_card_out,		/* (d1) PIO1 Control A */
@@ -106,18 +107,6 @@ void (*port_out[256])(BYTE) = {
  */
 void init_io(void)
 {
-	extern BYTE io_trap_in(void);
-	extern void io_trap_out(BYTE);
-
-	register int i;
-
-	/* initialize unused ports to trap handlers */
-	for (i = 0; i <= 255; i++) {
-		if (port_in[i] == NULL)
-			port_in[i] = io_trap_in;
-		if (port_out[i] == NULL)
-			port_out[i] = io_trap_out;
-	}
 }
 
 /*
@@ -135,7 +124,7 @@ void exit_io(void)
  */
 static BYTE io_no_card_in(void)
 {
-	return ((BYTE) 0xff);
+	return ((BYTE) IO_DATA_UNUSED);
 }
 
 /*

--- a/mosteksim/srcsim/memsim.h
+++ b/mosteksim/srcsim/memsim.h
@@ -18,6 +18,8 @@
 extern void init_memory(void);
 extern BYTE memory[];
 
+#define IO_DATA_UNUSED	0xff	/* data returned on unused ports */
+
 #define MAXMEMSECT	0
 
 /*

--- a/picosim/iosim.c
+++ b/picosim/iosim.c
@@ -49,7 +49,7 @@ static BYTE hwctl_lock = 0xff; /* lock status hardware control port */
  *	This array contains function pointers for every input
  *	I/O port (0 - 255), to do the required I/O.
  */
-BYTE (*port_in[256])(void) = {
+BYTE (*const port_in[256])(void) = {
 	[  0] = p000_in,	/* SIO status */
 	[  1] = p001_in,	/* SIO data */
 	[  4] = fdc_in,		/* FDC status */
@@ -61,7 +61,7 @@ BYTE (*port_in[256])(void) = {
  *	This array contains function pointers for every output
  *	I/O port (0 - 255), to do the required I/O.
  */
-void (*port_out[256])(BYTE) = {
+void (*const port_out[256])(BYTE) = {
 	[  0] = p000_out,	/* internal LED */
 	[  1] = p001_out,	/* SIO data */
 	[  4] = fdc_out,	/* FDC command */
@@ -76,18 +76,6 @@ void (*port_out[256])(BYTE) = {
  */
 void init_io(void)
 {
-	extern BYTE io_trap_in(void);
-	extern void io_trap_out(BYTE);
-
-	register int i;
-
-	/* initialize unused ports to trap handlers */
-	for (i = 0; i <= 255; i++) {
-		if (port_in[i] == NULL)
-			port_in[i] = io_trap_in;
-		if (port_out[i] == NULL)
-			port_out[i] = io_trap_out;
-	}
 }
 
 /*

--- a/picosim/memsim.h
+++ b/picosim/memsim.h
@@ -12,6 +12,8 @@
 #ifndef MEMSIM_INC
 #define MEMSIM_INC
 
+#define IO_DATA_UNUSED	0xff	/* data returned on unused ports */
+
 extern void init_memory(void);
 extern BYTE memory[];
 

--- a/z80sim/srcsim/iosim.c
+++ b/z80sim/srcsim/iosim.c
@@ -46,7 +46,7 @@ static BYTE fp_value;		/* port 255 value, can be set with p command */
  *	This array contains function pointers for every input
  *	I/O port (0 - 255), to do the required I/O.
  */
-BYTE (*port_in[256])(void) = {
+BYTE (*const port_in[256])(void) = {
 	[  0] = p000_in,
 	[  1] = p001_in,
 	[160] = hwctl_in,	/* virtual hardware control */
@@ -57,7 +57,7 @@ BYTE (*port_in[256])(void) = {
  *	This array contains function pointers for every output
  *	I/O port (0 - 255), to do the required I/O.
  */
-void (*port_out[256])(BYTE) = {
+void (*const port_out[256])(BYTE) = {
 	[  1] = p001_out,
 	[160] = hwctl_out,	/* virtual hardware control */
 	[255] = p255_out	/* for frontpanel */
@@ -68,26 +68,11 @@ void (*port_out[256])(BYTE) = {
  *	It will be called from the CPU simulation before
  *	any operation with the CPU is possible.
  *
- *	In this sample I/O simulation we initialize all
- *	unused port with an error trap handler, so that
- *	simulation stops at I/O on the unused ports.
- *
  *	See the I/O simulation of of the other systems
  *	for more complex examples.
  */
 void init_io(void)
 {
-	extern BYTE io_trap_in(void);
-	extern void io_trap_out(BYTE);
-
-	register int i;
-
-	for (i = 0; i <= 255; i++) {
-		if (port_in[i] == NULL)
-			port_in[i] = io_trap_in;
-		if (port_out[i] == NULL)
-			port_out[i] = io_trap_out;
-	}
 }
 
 /*

--- a/z80sim/srcsim/memsim.h
+++ b/z80sim/srcsim/memsim.h
@@ -15,6 +15,8 @@
 #ifndef MEMSIM_INC
 #define MEMSIM_INC
 
+#define IO_DATA_UNUSED	0xff	/* data returned on unused ports */
+
 extern void init_memory(void);
 extern BYTE memory[];
 


### PR DESCRIPTION
Mostly reverts d7f4eea85b.

Add IO_DATA_UNUSED to define the value returned by unused I/O ports (only really used by intelmdssim, which returns 0x00).

I would really like to clean things up, and move all the `extern` 's and definitions into header files, which then defines the interface of the corresponding `.c` file. This convention is already followed by `iodevices`. Opinions?