### PR TITLE
introduce new simport.h header containing system specific stuff and get rid of extern's in diskmanager.c/netsrv.c

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -56,11 +56,6 @@
 #define NUMNSOC 0	/* number of TCP/IP sockets for SIO connections */
 #define NUMUSOC 2	/* number of UNIX sockets for SIO connections */
 
-extern void sleep_us(long);
-#define SLEEP_US(t)	sleep_us(t)
-extern void sleep_ms(int);
-#define SLEEP_MS(t)	sleep_ms(t)
-
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -44,6 +44,7 @@
 #include "simcfg.h"
 #include "simmem.h"
 #include "simio.h"
+#include "simport.h"
 #ifdef WANT_ICE
 #include "simice.h"
 #endif
@@ -128,7 +129,7 @@ void mon(void)
 #endif /* FRONTPANEL */
 
 	/* give threads a bit time and then empty buffer */
-	SLEEP_MS(999);
+	sleep_for_ms(999);
 	fflush(stdout);
 
 #ifndef WANT_ICE
@@ -185,7 +186,7 @@ void mon(void)
 			fp_sampleData();
 
 			/* wait a bit, system is idling */
-			SLEEP_MS(10);
+			sleep_for_ms(10);
 		}
 	} else {
 #endif /* FRONTPANEL */
@@ -221,7 +222,7 @@ void mon(void)
 		fp_sampleData();
 
 		/* wait a bit before termination */
-		SLEEP_MS(999);
+		sleep_for_ms(999);
 
 		/* shutdown frontpanel */
 		fp_quit();
@@ -317,7 +318,7 @@ int wait_step(void)
 		}
 		fp_clock++;
 		fp_sampleData();
-		SLEEP_MS(1);
+		sleep_for_ms(1);
 		ret = 1;
 	}
 
@@ -339,7 +340,7 @@ void wait_int_step(void)
 	while ((cpu_switch == 3) && !reset) {
 		fp_clock++;
 		fp_sampleData();
-		SLEEP_MS(10);
+		sleep_for_ms(10);
 	}
 }
 

--- a/altairsim/srcsim/simport.h
+++ b/altairsim/srcsim/simport.h
@@ -1,8 +1,7 @@
 /*
  * Z80SIM  -  a Z80-CPU simulator
  *
- * Copyright (C) 1987-2024 Udo Munk
- * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2024 Thomas Eberhardt
  */
 
 #ifndef SIMPORT_INC

--- a/altairsim/srcsim/simport.h
+++ b/altairsim/srcsim/simport.h
@@ -1,0 +1,22 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 1987-2024 Udo Munk
+ * Copyright (C) 2021 David McNaughton
+ */
+
+#ifndef SIMPORT_INC
+#define SIMPORT_INC
+
+#include <stdint.h>
+
+#include "sim.h"
+
+extern void sleep_for_us(long time);
+extern void sleep_for_ms(int time);
+extern uint64_t get_clock_us(void);
+#ifdef WANT_ICE
+extern int get_cmdline(char *buf, int len);
+#endif
+
+#endif /* !SIMPORT_INC */

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -35,11 +35,6 @@
 /*#define CNETDEBUG*/	/* client network protocol debugger */
 /*#define SNETDEBUG*/	/* server network protocol debugger */
 
-extern void sleep_us(long);
-#define SLEEP_US(t)	sleep_us(t)
-extern void sleep_ms(int);
-#define SLEEP_MS(t)	sleep_ms(t)
-
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/cpmsim/srcsim/simio.c
+++ b/cpmsim/srcsim/simio.c
@@ -130,6 +130,7 @@
 #include "simcore.h"
 #include "simmem.h"
 #include "simctl.h"
+#include "simport.h"
 #include "simio.h"
 
 #include "rtc80.h"
@@ -679,7 +680,7 @@ static BYTE cons_in(void)
 	struct pollfd p[1];
 
 	if (++busy_loop_cnt >= MAX_BUSY_COUNT) {
-		SLEEP_MS(1);
+		sleep_for_ms(1);
 		busy_loop_cnt = 0;
 	}
 
@@ -1982,7 +1983,7 @@ static BYTE time_in(void)
  */
 static void delay_out(BYTE data)
 {
-	SLEEP_MS(data * 10);
+	sleep_for_ms(data * 10);
 
 #ifdef CNETDEBUG
 	printf(". ");

--- a/cpmsim/srcsim/simport.h
+++ b/cpmsim/srcsim/simport.h
@@ -1,8 +1,7 @@
 /*
  * Z80SIM  -  a Z80-CPU simulator
  *
- * Copyright (C) 1987-2024 Udo Munk
- * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2024 Thomas Eberhardt
  */
 
 #ifndef SIMPORT_INC

--- a/cpmsim/srcsim/simport.h
+++ b/cpmsim/srcsim/simport.h
@@ -1,0 +1,22 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 1987-2024 Udo Munk
+ * Copyright (C) 2021 David McNaughton
+ */
+
+#ifndef SIMPORT_INC
+#define SIMPORT_INC
+
+#include <stdint.h>
+
+#include "sim.h"
+
+extern void sleep_for_us(long time);
+extern void sleep_for_ms(int time);
+extern uint64_t get_clock_us(void);
+#ifdef WANT_ICE
+extern int get_cmdline(char *buf, int len);
+#endif
+
+#endif /* !SIMPORT_INC */

--- a/cromemcosim/srcsim/disks.h
+++ b/cromemcosim/srcsim/disks.h
@@ -2,6 +2,7 @@
 #define DISKS_INC
 
 #include "cromemco-fdc.h"
+#include "cromemco-wdi.h"
 
 #ifndef DISKMAP
 #define DISKMAP     "disk.map"

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -68,11 +68,6 @@
 #define SERVERPORT 4010	/* first TCP/IP server port used */
 #define NUMUSOC 0	/* number of UNIX sockets */
 
-extern void sleep_us(long);
-#define SLEEP_US(t)	sleep_us(t)
-extern void sleep_ms(int);
-#define SLEEP_MS(t)	sleep_ms(t)
-
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -39,6 +39,7 @@
 #include "simcfg.h"
 #include "simmem.h"
 #include "simio.h"
+#include "simport.h"
 #ifdef WANT_ICE
 #include "simice.h"
 #endif
@@ -132,7 +133,7 @@ void mon(void)
 #endif /* FRONTPANEL */
 
 	/* give threads a bit time and then empty buffer */
-	SLEEP_MS(999);
+	sleep_for_ms(999);
 	fflush(stdout);
 
 #ifndef WANT_ICE
@@ -188,7 +189,7 @@ void mon(void)
 			fp_sampleData();
 
 			/* wait a bit, system is idling */
-			SLEEP_MS(10);
+			sleep_for_ms(10);
 		}
 	} else {
 #endif /* FRONTPANEL */
@@ -227,7 +228,7 @@ void mon(void)
 		fp_sampleData();
 
 		/* wait a bit before termination */
-		SLEEP_MS(999);
+		sleep_for_ms(999);
 
 		/* shutdown frontpanel */
 		fp_quit();
@@ -322,7 +323,7 @@ int wait_step(void)
 		}
 		fp_clock++;
 		fp_sampleData();
-		SLEEP_MS(10);
+		sleep_for_ms(10);
 		ret = 1;
 	}
 
@@ -344,7 +345,7 @@ void wait_int_step(void)
 	while ((cpu_switch == 3) && !reset) {
 		fp_clock++;
 		fp_sampleData();
-		SLEEP_MS(10);
+		sleep_for_ms(10);
 	}
 }
 

--- a/cromemcosim/srcsim/simio.c
+++ b/cromemcosim/srcsim/simio.c
@@ -52,6 +52,7 @@
 #include "simcfg.h"
 #include "simmem.h"
 #include "simio.h"
+#include "simport.h"
 #if !defined (EXCLUDE_I8080) && !defined(EXCLUDE_Z80)
 #include "simcore.h"
 #endif
@@ -310,7 +311,7 @@ void exit_io(void)
 void reset_io(void)
 {
 	th_suspend = 1;		/* suspend timing thread */
-	SLEEP_MS(20);		/* give it enough time to suspend */
+	sleep_for_ms(20);		/* give it enough time to suspend */
 	cromemco_tuart_reset();
 	cromemco_fdc_reset();
 	th_suspend = 0;		/* resume timing thread */
@@ -709,7 +710,7 @@ static void *timing(void *arg)
 
 next:
 		/* sleep for 1 millisecond */
-		SLEEP_MS(1);
+		sleep_for_ms(1);
 
 		/* reset disk index pulse */
 		if (index_pulse > 2)

--- a/cromemcosim/srcsim/simmem.h
+++ b/cromemcosim/srcsim/simmem.h
@@ -60,7 +60,7 @@ extern struct memmap memconf[MAXMEMSECT][MAXMEMMAP];
 extern WORD boot_switch[MAXMEMSECT];	/* boot address */
 
 extern BYTE *memory[MAXSEG];
-extern int selbnk, common, bankio;
+extern int selbnk, common, bankio, num_banks;
 
 extern int p_tab[MAXPAGES];		/* 256 pages of 256 bytes */
 

--- a/cromemcosim/srcsim/simport.h
+++ b/cromemcosim/srcsim/simport.h
@@ -1,8 +1,7 @@
 /*
  * Z80SIM  -  a Z80-CPU simulator
  *
- * Copyright (C) 1987-2024 Udo Munk
- * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2024 Thomas Eberhardt
  */
 
 #ifndef SIMPORT_INC

--- a/cromemcosim/srcsim/simport.h
+++ b/cromemcosim/srcsim/simport.h
@@ -1,0 +1,22 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 1987-2024 Udo Munk
+ * Copyright (C) 2021 David McNaughton
+ */
+
+#ifndef SIMPORT_INC
+#define SIMPORT_INC
+
+#include <stdint.h>
+
+#include "sim.h"
+
+extern void sleep_for_us(long time);
+extern void sleep_for_ms(int time);
+extern uint64_t get_clock_us(void);
+#ifdef WANT_ICE
+extern int get_cmdline(char *buf, int len);
+#endif
+
+#endif /* !SIMPORT_INC */

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -70,11 +70,6 @@
 #define NUMNSOC 0	/* number of TCP/IP sockets for SIO connections */
 #define NUMUSOC 1	/* number of UNIX sockets for SIO connections */
 
-extern void sleep_us(long);
-#define SLEEP_US(t)	sleep_us(t)
-extern void sleep_ms(int);
-#define SLEEP_MS(t)	sleep_ms(t)
-
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -43,6 +43,7 @@
 #include "simcfg.h"
 #include "simmem.h"
 #include "simio.h"
+#include "simport.h"
 #ifdef WANT_ICE
 #include "simice.h"
 #endif
@@ -132,7 +133,7 @@ void mon(void)
 
 #ifdef UNIX_TERMINAL
 	/* give threads a bit time and then empty buffer */
-	SLEEP_MS(999);
+	sleep_for_ms(999);
 	fflush(stdout);
 
 	/* initialize terminal */
@@ -189,7 +190,7 @@ void mon(void)
 			fp_sampleData();
 
 			/* wait a bit, system is idling */
-			SLEEP_MS(10);
+			sleep_for_ms(10);
 		}
 	} else {
 #endif /* FRONTPANEL */
@@ -228,7 +229,7 @@ void mon(void)
 		fp_sampleData();
 
 		/* wait a bit before termination */
-		SLEEP_MS(999);
+		sleep_for_ms(999);
 
 		/* stop frontpanel */
 		fp_quit();
@@ -323,7 +324,7 @@ int wait_step(void)
 		}
 		fp_clock++;
 		fp_sampleData();
-		SLEEP_MS(10);
+		sleep_for_ms(10);
 		ret = 1;
 	}
 
@@ -346,7 +347,7 @@ void wait_int_step(void)
 		fp_clock++;
 		fp_sampleData();
 
-		SLEEP_MS(10);
+		sleep_for_ms(10);
 	}
 }
 

--- a/imsaisim/srcsim/simio.c
+++ b/imsaisim/srcsim/simio.c
@@ -104,7 +104,6 @@ static BYTE fp_in(void);
 static void fp_out(BYTE data);
 static BYTE hwctl_in(void);
 static void hwctl_out(BYTE data);
-void lpt_reset(void);
 static BYTE lpt_in(void);
 static void lpt_out(BYTE data);
 static BYTE io_pport_in(void);

--- a/imsaisim/srcsim/simmem.h
+++ b/imsaisim/srcsim/simmem.h
@@ -64,7 +64,7 @@ extern WORD boot_switch[MAXMEMSECT];	/* boot address */
 extern BYTE memory[64 << 10], *banks[MAXSEG];
 extern int p_tab[MAXPAGES];
 extern int _p_tab[MAXPAGES];
-extern int selbnk;
+extern int selbnk, num_banks;
 
 extern void ctrl_port_out(BYTE data);
 extern BYTE ctrl_port_in(void);

--- a/imsaisim/srcsim/simport.h
+++ b/imsaisim/srcsim/simport.h
@@ -1,8 +1,7 @@
 /*
  * Z80SIM  -  a Z80-CPU simulator
  *
- * Copyright (C) 1987-2024 Udo Munk
- * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2024 Thomas Eberhardt
  */
 
 #ifndef SIMPORT_INC

--- a/imsaisim/srcsim/simport.h
+++ b/imsaisim/srcsim/simport.h
@@ -1,0 +1,22 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 1987-2024 Udo Munk
+ * Copyright (C) 2021 David McNaughton
+ */
+
+#ifndef SIMPORT_INC
+#define SIMPORT_INC
+
+#include <stdint.h>
+
+#include "sim.h"
+
+extern void sleep_for_us(long time);
+extern void sleep_for_ms(int time);
+extern uint64_t get_clock_us(void);
+#ifdef WANT_ICE
+extern int get_cmdline(char *buf, int len);
+#endif
+
+#endif /* !SIMPORT_INC */

--- a/intelmdssim/srcsim/sim.h
+++ b/intelmdssim/srcsim/sim.h
@@ -45,11 +45,6 @@
 #define SERVERPORT 4010	/* first TCP/IP server port used */
 #define NUMUSOC 1	/* one UNIX socket for PTR/PTP */
 
-extern void sleep_us(long);
-#define SLEEP_US(t)	sleep_us(t)
-extern void sleep_ms(int);
-#define SLEEP_MS(t)	sleep_ms(t)
-
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/intelmdssim/srcsim/simctl.c
+++ b/intelmdssim/srcsim/simctl.c
@@ -22,6 +22,7 @@
 #include "simcfg.h"
 #include "simmem.h"
 #include "simio.h"
+#include "simport.h"
 #ifdef WANT_ICE
 #include "simice.h"
 #endif
@@ -101,7 +102,7 @@ void mon(void)
 #endif
 
 	/* give threads a bit time and then empty buffer */
-	SLEEP_MS(999);
+	sleep_for_ms(999);
 	fflush(stdout);
 
 #ifndef WANT_ICE
@@ -126,7 +127,7 @@ void mon(void)
 			fp_sampleData();
 
 			/* wait a bit, system is idling */
-			SLEEP_MS(10);
+			sleep_for_ms(10);
 		}
 	} else {
 #endif
@@ -159,7 +160,7 @@ void mon(void)
 		fp_sampleData();
 
 		/* wait a bit before termination */
-		SLEEP_MS(999);
+		sleep_for_ms(999);
 
 		/* shutdown frontpanel */
 		fp_quit();

--- a/intelmdssim/srcsim/simio.c
+++ b/intelmdssim/srcsim/simio.c
@@ -29,6 +29,7 @@
 #include "simfun.h"
 #include "simmem.h"
 #include "simctl.h"
+#include "simport.h"
 #include "simio.h"
 
 #include "mds-monitor.h"
@@ -255,7 +256,7 @@ void exit_io(void)
 void reset_io(void)
 {
 	th_suspend = 1;		/* suspend timing thread */
-	SLEEP_MS(20);		/* give it enough time to suspend */
+	sleep_for_ms(20);	/* give it enough time to suspend */
 
 	pthread_mutex_lock(&rtc_mutex);
 	rtc_int_enabled = 0;	/* reset real time clock */
@@ -498,7 +499,7 @@ static void *timing(void *arg)
 next:
 		tdiff = 260L - (get_clock_us() - t);
 		if (tdiff > 0)
-			SLEEP_US(tdiff);
+			sleep_for_us(tdiff);
 
 		tick++;
 	}

--- a/intelmdssim/srcsim/simport.h
+++ b/intelmdssim/srcsim/simport.h
@@ -1,8 +1,7 @@
 /*
  * Z80SIM  -  a Z80-CPU simulator
  *
- * Copyright (C) 1987-2024 Udo Munk
- * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2024 Thomas Eberhardt
  */
 
 #ifndef SIMPORT_INC

--- a/intelmdssim/srcsim/simport.h
+++ b/intelmdssim/srcsim/simport.h
@@ -1,0 +1,22 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 1987-2024 Udo Munk
+ * Copyright (C) 2021 David McNaughton
+ */
+
+#ifndef SIMPORT_INC
+#define SIMPORT_INC
+
+#include <stdint.h>
+
+#include "sim.h"
+
+extern void sleep_for_us(long time);
+extern void sleep_for_ms(int time);
+extern uint64_t get_clock_us(void);
+#ifdef WANT_ICE
+extern int get_cmdline(char *buf, int len);
+#endif
+
+#endif /* !SIMPORT_INC */

--- a/iodevices/altair-88-2sio.c
+++ b/iodevices/altair-88-2sio.c
@@ -39,7 +39,7 @@
 #include "sim.h"
 #include "simdefs.h"
 #include "simglb.h"
-#include "simfun.h"
+#include "simport.h"
 #include "simio.h"
 
 #include "unix_terminal.h"

--- a/iodevices/altair-88-dcdd.c
+++ b/iodevices/altair-88-dcdd.c
@@ -24,6 +24,7 @@
 #include "sim.h"
 #include "simdefs.h"
 #include "simglb.h"
+#include "simport.h"
 
 #include "altair-88-dcdd.h"
 
@@ -198,7 +199,7 @@ static void *timing(void *arg)
 		}
 
 		/* sleep for 1 millisecond */
-		SLEEP_MS(1);
+		sleep_for_ms(1);
 	}
 
 	pthread_exit(NULL);

--- a/iodevices/altair-88-sio.c
+++ b/iodevices/altair-88-sio.c
@@ -36,7 +36,7 @@
 #include "sim.h"
 #include "simdefs.h"
 #include "simglb.h"
-#include "simfun.h"
+#include "simport.h"
 #include "simio.h"
 
 #include "unix_terminal.h"

--- a/iodevices/cromemco-88ccc.c
+++ b/iodevices/cromemco-88ccc.c
@@ -26,7 +26,7 @@
 #include "simglb.h"
 #include "simcfg.h"
 #include "simmem.h"
-#include "simfun.h"
+#include "simport.h"
 
 #include "netsrv.h"
 #include "cromemco-88ccc.h"
@@ -98,13 +98,13 @@ static void *store_image(void *arg)
 		/* frame done, calculate total frame time */
 		j = msg.fields * (msg.interval +1) * 2;
 
-		/* SLEEP_MS(j); */
+		/* sleep_for_ms(j); */
 
 		/* sleep rest of total frame time */
 		t2 = get_clock_us();
 		tdiff = t2 - t1;
 		if (tdiff < (j*1000))
-			SLEEP_MS(j - tdiff/1000);
+			sleep_for_ms(j - tdiff/1000);
 
 		LOGD(TAG, "Time: %d", tdiff);
 
@@ -142,7 +142,9 @@ void cromemco_88ccc_ctrl_a_out(BYTE data)
 	} else {
 		if (state == 1) {
 			state = 0;
-			SLEEP_MS(50); /* Arbitrary 50ms timeout to let thread exit after state change, TODO: maybe should end thread? */
+			sleep_for_ms(50); /* Arbitrary 50ms timeout to let
+					     thread exit after state change,
+					     TODO: maybe should end thread? */
 		}
 	}
 }

--- a/iodevices/cromemco-dazzler.c
+++ b/iodevices/cromemco-dazzler.c
@@ -42,7 +42,7 @@
 #include "simglb.h"
 #include "simcfg.h"
 #include "simmem.h"
-#include "simfun.h"
+#include "simport.h"
 
 #ifdef HAS_NETSERVER
 #include "netsrv.h"
@@ -218,7 +218,7 @@ static void open_display(void)
 void cromemco_dazzler_off(void)
 {
 	state = 0;
-	SLEEP_MS(50);
+	sleep_for_ms(50);
 
 	if (thread != 0) {
 		pthread_cancel(thread);
@@ -767,14 +767,14 @@ static void *update_display(void *arg)
 
 		/* frame done, set frame flag for 4ms */
 		flags = 0;
-		SLEEP_MS(4);
+		sleep_for_ms(4);
 		flags = 64;
 
 		/* sleep rest to 33ms so that we get 30 fps */
 		t2 = get_clock_us();
 		tdiff = t2 - t1;
 		if ((tdiff > 0) && (tdiff < 33000))
-			SLEEP_MS(33 - (tdiff / 1000));
+			sleep_for_ms(33 - (tdiff / 1000));
 
 		t1 = get_clock_us();
 	}
@@ -814,7 +814,7 @@ void cromemco_dazzler_ctl_out(BYTE data)
 	} else {
 		if (state == 1) {
 			state = 0;
-			SLEEP_MS(50);
+			sleep_for_ms(50);
 #ifdef HAS_NETSERVER
 			if (!n_flag) {
 #endif

--- a/iodevices/cromemco-tu-art.h
+++ b/iodevices/cromemco-tu-art.h
@@ -28,6 +28,8 @@
 #include "sim.h"
 #include "simdefs.h"
 
+extern void lpt_reset(void);
+
 extern BYTE cromemco_tuart_0a_status_in(void);
 extern void cromemco_tuart_0a_baud_out(BYTE data);
 

--- a/iodevices/diskmanager.c
+++ b/iodevices/diskmanager.c
@@ -341,7 +341,6 @@ static void sendDisks(HttpdConnection_t *conn) {
         if (i < (_MAX_DISK - 1)) httpdPrintf(conn, ",");
     }
 
-    extern void sendHardDisks(HttpdConnection_t *conn);
     sendHardDisks(conn);
 
     httpdPrintf(conn, "}");

--- a/iodevices/diskmanager.h
+++ b/iodevices/diskmanager.h
@@ -19,8 +19,8 @@
 extern void readDiskmap(char *path_name);
 
 #ifdef HAS_NETSERVER
-int LibraryHandler(HttpdConnection_t *conn, void *unused);
-int DiskHandler(HttpdConnection_t *conn, void *unused);
+extern int LibraryHandler(HttpdConnection_t *conn, void *unused);
+extern int DiskHandler(HttpdConnection_t *conn, void *unused);
 #endif
 
 #endif /* !DISKMANAGER_INC */

--- a/iodevices/generic-at-modem.c
+++ b/iodevices/generic-at-modem.c
@@ -33,7 +33,7 @@
 
 #include "sim.h"
 #include "simdefs.h"
-#include "simfun.h"
+#include "simport.h"
 
 #include "libtelnet.h"
 

--- a/iodevices/imsai-sio2.c
+++ b/iodevices/imsai-sio2.c
@@ -42,7 +42,7 @@
 #include "sim.h"
 #include "simdefs.h"
 #include "simglb.h"
-#include "simfun.h"
+#include "simport.h"
 
 #include "imsai-hal.h"
 #include "imsai-sio2.h"

--- a/iodevices/imsai-vio.c
+++ b/iodevices/imsai-vio.c
@@ -33,7 +33,7 @@
 #include "simdefs.h"
 #include "simglb.h"
 #include "simmem.h"
-#include "simfun.h"
+#include "simport.h"
 
 #ifdef HAS_NETSERVER
 #include "netsrv.h"
@@ -127,7 +127,7 @@ static void open_display(void)
 void imsai_vio_off(void)
 {
 	state = 0;		/* tell refresh thread to stop */
-	SLEEP_MS(50);		/* and wait a bit */
+	sleep_for_ms(50);	/* and wait a bit */
 
 	/* works if X11 with posix threads implemented correct, but ... */
 	if (thread != 0) {
@@ -495,7 +495,7 @@ static void *update_display(void *arg)
 		t2 = get_clock_us();
 		tdiff = t2 - t1;
 		if ((tdiff > 0) && (tdiff < 33000))
-			SLEEP_MS(33 - (tdiff / 1000));
+			sleep_for_ms(33 - (tdiff / 1000));
 
 		t1 = get_clock_us();
 	}

--- a/iodevices/proctec-vdm.c
+++ b/iodevices/proctec-vdm.c
@@ -28,7 +28,7 @@
 #include "simdefs.h"
 #include "simglb.h"
 #include "simmem.h"
-#include "simfun.h"
+#include "simport.h"
 
 #include "proctec-vdm-charset.h"
 #include "proctec-vdm.h"
@@ -121,7 +121,7 @@ static void open_display(void)
 void proctec_vdm_off(void)
 {
 	state = 0;		/* tell refresh thread to stop */
-	SLEEP_MS(50);		/* and wait a bit */
+	sleep_for_ms(50);	/* and wait a bit */
 
 	/* works if X11 with posix threads implemented correct, but ... */
 	if (thread != 0) {
@@ -243,7 +243,7 @@ static void *update_display(void *arg)
 		t2 = get_clock_us();
 		tdiff = t2 - t1;
 		if ((tdiff > 0) && (tdiff < 33000))
-			SLEEP_MS(33 - (tdiff / 1000));
+			sleep_for_ms(33 - (tdiff / 1000));
 
 		t1 = get_clock_us();
 	}

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -38,11 +38,6 @@
 #define HAS_DISKS	/* uses disk images */
 #define HAS_CONFIG	/* has configuration files somewhere */
 
-extern void sleep_us(long);
-#define SLEEP_US(t)	sleep_us(t)
-extern void sleep_ms(int);
-#define SLEEP_MS(t)	sleep_ms(t)
-
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/mosteksim/srcsim/simport.h
+++ b/mosteksim/srcsim/simport.h
@@ -1,8 +1,7 @@
 /*
  * Z80SIM  -  a Z80-CPU simulator
  *
- * Copyright (C) 1987-2024 Udo Munk
- * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2024 Thomas Eberhardt
  */
 
 #ifndef SIMPORT_INC

--- a/mosteksim/srcsim/simport.h
+++ b/mosteksim/srcsim/simport.h
@@ -1,0 +1,22 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 1987-2024 Udo Munk
+ * Copyright (C) 2021 David McNaughton
+ */
+
+#ifndef SIMPORT_INC
+#define SIMPORT_INC
+
+#include <stdint.h>
+
+#include "sim.h"
+
+extern void sleep_for_us(long time);
+extern void sleep_for_ms(int time);
+extern uint64_t get_clock_us(void);
+#ifdef WANT_ICE
+extern int get_cmdline(char *buf, int len);
+#endif
+
+#endif /* !SIMPORT_INC */

--- a/picosim/picosim.c
+++ b/picosim/picosim.c
@@ -182,11 +182,6 @@ NOPE:	config();		/* configure the machine */
 	return 0;
 }
 
-uint64_t get_clock_us(void)
-{
-	return to_us_since_boot(get_absolute_time());
-}
-
 /*
  * interrupt handler for break switch
  * stops CPU

--- a/picosim/sim.h
+++ b/picosim/sim.h
@@ -29,13 +29,6 @@
 #define SBSIZE	4	/* number of software breakpoints */
 #endif
 
-#include <stdint.h>
-
-extern void sleep_us(uint64_t);
-#define SLEEP_US(t)	sleep_us(t)
-extern void sleep_ms(uint32_t);
-#define SLEEP_MS(t)	sleep_ms(t)
-
 #define USR_COM "Raspberry Pi Pico Z80/8080 emulator"
 #define USR_REL "1.2"
 #define USR_CPR "Copyright (C) 2024 by Udo Munk & Thomas Eberhardt"

--- a/picosim/simport.h
+++ b/picosim/simport.h
@@ -1,0 +1,24 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 1987-2024 Udo Munk
+ * Copyright (C) 2021 David McNaughton
+ */
+
+#ifndef SIMPORT_INC
+#define SIMPORT_INC
+
+#include <stdint.h>
+#include "pico/time.h"
+
+static inline void sleep_for_us(long time) { sleep_us(time); }
+static inline void sleep_for_ms(int time) { sleep_ms(time); }
+
+static inline uint64_t get_clock_us(void)
+{
+	return to_us_since_boot(get_absolute_time());
+}
+
+extern int get_cmdline(char *buf, int len);
+
+#endif /* !SIMPORT_INC */

--- a/picosim/simport.h
+++ b/picosim/simport.h
@@ -1,8 +1,7 @@
 /*
  * Z80SIM  -  a Z80-CPU simulator
  *
- * Copyright (C) 1987-2024 Udo Munk
- * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2024 Thomas Eberhardt
  */
 
 #ifndef SIMPORT_INC

--- a/webfrontend/netsrv.c
+++ b/webfrontend/netsrv.c
@@ -34,14 +34,19 @@
 #include "civetweb.h"
 #include "netsrv.h"
 
-#ifdef HAS_HAL
 #ifdef IMSAISIM
+#ifdef HAS_HAL
 #include "imsai-hal.h"
 #endif
+#include "simio.h"
+#endif
 #ifdef CROMEMCOSIM
+#ifdef HAS_HAL
 #include "cromemco-hal.h"
 #endif
+#include "cromemco-tu-art.h"
 #endif
+#include "diskmanager.h"
 
 #include "log.h"
 static const char *TAG = "netsrv";
@@ -81,11 +86,6 @@ extern int reset;
 extern int power;
 extern void quit_callback(void);
 */
-
-extern void lpt_reset(void);
-
-extern int LibraryHandler(HttpdConnection_t *conn, void *unused);
-extern int DiskHandler(HttpdConnection_t *conn, void *unused);
 
 /**
  * Check if a queue is provisioned
@@ -388,7 +388,6 @@ static int SystemHandler(HttpdConnection_t *conn, void *unused) {
             	httpdPrintf(conn, "\"%s\", ", BANKED_ROM_MSG);
 			}
 
-			extern int num_banks;
 			if (num_banks) {
             	httpdPrintf(conn, "\"MMU has %d additional RAM banks of %d KB\",", num_banks, SEGSIZ >> 10);
 			}

--- a/webfrontend/netsrv.c
+++ b/webfrontend/netsrv.c
@@ -29,6 +29,7 @@
 #include "simdefs.h"
 #include "simglb.h"
 #include "simmem.h"
+#include "simport.h"
 
 #include "civetweb.h"
 #include "netsrv.h"
@@ -593,7 +594,7 @@ static void WebSocketReadyHandler(HttpdConnection_t *conn, void *device) {
 	if (d == DEV_VIO) {
 		BYTE mode = dma_read(0xf7ff);
 		dma_write(0xf7ff, 0x00);
-		SLEEP_MS(100);
+		sleep_for_ms(100);
 		dma_write(0xf7ff, mode);
 	}
 

--- a/z80core/alt8080.h
+++ b/z80core/alt8080.h
@@ -733,7 +733,7 @@
 				/* else wait for INT or user interrupt */
 				while ((int_int == 0) &&
 				       (cpu_state == CONTIN_RUN)) {
-					SLEEP_MS(1);
+					sleep_for_ms(1);
 				}
 			}
 #ifdef BUS_8080
@@ -755,7 +755,7 @@
 				while (!(cpu_state & RESET)) {
 					fp_clock++;
 					fp_sampleData();
-					SLEEP_MS(1);
+					sleep_for_ms(1);
 					if (cpu_error != NONE)
 						break;
 				}
@@ -766,7 +766,7 @@
 				       !(cpu_state & RESET)) {
 					fp_clock++;
 					fp_sampleData();
-					SLEEP_MS(1);
+					sleep_for_ms(1);
 					if (cpu_error != NONE)
 						break;
 				}

--- a/z80core/altz80.h
+++ b/z80core/altz80.h
@@ -819,7 +819,7 @@ next_opcode:
 				/* else wait for INT, NMI or user interrupt */
 				while ((int_int == 0) && (int_nmi == 0) &&
 				       (cpu_state == CONTIN_RUN)) {
-					SLEEP_MS(1);
+					sleep_for_ms(1);
 					R += 99;
 				}
 			}
@@ -843,7 +843,7 @@ next_opcode:
 				       !(cpu_state & RESET)) {
 					fp_clock++;
 					fp_sampleData();
-					SLEEP_MS(1);
+					sleep_for_ms(1);
 					R += 99;
 					if (cpu_error != NONE)
 						break;
@@ -855,7 +855,7 @@ next_opcode:
 				       !(cpu_state & RESET)) {
 					fp_clock++;
 					fp_sampleData();
-					SLEEP_MS(1);
+					sleep_for_ms(1);
 					R += 99;
 					if (cpu_error != NONE)
 						break;

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -12,7 +12,7 @@
 #include "simglb.h"
 #include "simmem.h"
 #include "simcore.h"
-#include "simfun.h"
+#include "simport.h"
 #ifdef WANT_ICE
 #include "simice.h"
 #endif
@@ -599,13 +599,8 @@ leave:
 			if (T >= T_max && !cpu_needed) {
 				t2 = get_clock_us();
 				tdiff = t2 - t1;
-#ifdef SLEEP_US
 				if ((tdiff > 0) && (tdiff < 10000))
-					SLEEP_US(10000 - tdiff);
-#else
-				if ((tdiff > 0) && (tdiff < 10000))
-					SLEEP_MS(10 - (tdiff / 1000));
-#endif
+					sleep_for_us(10000 - tdiff);
 				T_max = T + tmax;
 				t1 = get_clock_us();
 			}
@@ -678,7 +673,7 @@ static int op_hlt(void)			/* HLT */
 		} else {
 			/* else wait for INT or user interrupt */
 			while ((int_int == 0) && (cpu_state == CONTIN_RUN)) {
-				SLEEP_MS(1);
+				sleep_for_ms(1);
 			}
 		}
 #ifdef BUS_8080
@@ -699,7 +694,7 @@ static int op_hlt(void)			/* HLT */
 			while (!(cpu_state & RESET)) {
 				fp_clock++;
 				fp_sampleData();
-				SLEEP_MS(1);
+				sleep_for_ms(1);
 				if (cpu_error != NONE)
 					break;
 			}
@@ -709,7 +704,7 @@ static int op_hlt(void)			/* HLT */
 			while ((int_int == 0) && !(cpu_state & RESET)) {
 				fp_clock++;
 				fp_sampleData();
-				SLEEP_MS(1);
+				sleep_for_ms(1);
 				if (cpu_error != NONE)
 					break;
 			}

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -18,7 +18,7 @@
 #include "sim.h"
 #include "simdefs.h"
 #include "simglb.h"
-#include "simfun.h"
+#include "simport.h"
 #include "simmem.h"
 #include "simio.h"
 #ifndef EXCLUDE_I8080

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -5,10 +5,6 @@
  * Copyright (C) 2021 David McNaughton
  */
 
-#include "sim.h"
-
-#ifndef BAREMETAL
-
 /*
  *	This module contains some commonly used functions.
  *	Some functions use the POSIX API available on workstations running
@@ -27,9 +23,11 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "sim.h"
 #include "simdefs.h"
 #include "simglb.h"
 #include "simmem.h"
+#include "simport.h"
 #include "simfun.h"
 
 /* #define LOG_LOCAL_LEVEL LOG_DEBUG */
@@ -44,7 +42,7 @@ static int load_hex(char *fn, WORD start, int size);
 /*
  *	Sleep for time microseconds, 999999 max
  */
-void sleep_us(long time)
+void sleep_for_us(long time)
 {
 	struct timespec timer, rem;
 	int err;
@@ -72,7 +70,7 @@ again:
 /*
  *	Sleep for time milliseconds, 999 max
  */
-void sleep_ms(int time)
+void sleep_for_ms(int time)
 {
 	struct timespec timer, rem;
 	int err;
@@ -362,5 +360,3 @@ static int load_hex(char *fn, WORD start, int size)
 
 	return 0;
 }
-
-#endif /* !BAREMETAL */

--- a/z80core/simfun.h
+++ b/z80core/simfun.h
@@ -8,30 +8,9 @@
 #ifndef SIMFUN_INC
 #define SIMFUN_INC
 
-#include <stdint.h>
-
 #include "sim.h"
-
-#ifndef BAREMETAL
 #include "simdefs.h"
-#endif
 
-/* must be implemented in bare metal simulator */
-#ifndef BAREMETAL
-extern void sleep_us(long time);
-extern void sleep_ms(int time);
-#endif
-
-/* must be implemented in bare metal simulator */
-extern uint64_t get_clock_us(void);
-
-#if defined(WANT_ICE) || defined(BAREMETAL)
-/* must be implemented in bare metal simulator */
-extern int get_cmdline(char *buf, int len);
-#endif
-
-#ifndef BAREMETAL
 extern int load_file(char *fn, WORD start, int size);
-#endif
 
 #endif /* !SIMFUN_INC */

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -32,13 +32,14 @@
 #include "simcore.h"
 #include "simmem.h"
 #include "simdis.h"
-#include "simfun.h"
+#include "simport.h"
 #include "simutil.h"
 #include "simice.h"
 
 #ifndef BAREMETAL
 #include <signal.h>
 #include <sys/time.h>
+#include "simfun.h"
 #include "simint.h"
 #endif
 

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -34,6 +34,7 @@
 #include "simctl.h"
 #include "simmem.h"
 #include "simio.h"
+#include "simport.h"
 #include "simfun.h"
 #include "simint.h"
 #include "simutil.h"

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -19,7 +19,7 @@
 #ifdef FRONTPANEL
 #include <stdint.h>
 #include "frontpanel.h"
-#include "simfun.h"
+#include "simport.h"
 #endif
 
 #if !defined(EXCLUDE_Z80) && !defined(ALT_Z80)

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -20,7 +20,7 @@
 #ifdef FRONTPANEL
 #include <stdint.h>
 #include "frontpanel.h"
-#include "simfun.h"
+#include "simport.h"
 #endif
 
 #if !defined(EXCLUDE_Z80) && !defined(ALT_Z80)

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -20,7 +20,7 @@
 #ifdef FRONTPANEL
 #include <stdint.h>
 #include "frontpanel.h"
-#include "simfun.h"
+#include "simport.h"
 #endif
 
 #if !defined(EXCLUDE_Z80) && !defined(ALT_Z80)

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -20,7 +20,7 @@
 #ifdef FRONTPANEL
 #include <stdint.h>
 #include "frontpanel.h"
-#include "simfun.h"
+#include "simport.h"
 #endif
 
 #if !defined(EXCLUDE_Z80) && !defined(ALT_Z80)

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -12,7 +12,7 @@
 #include "simglb.h"
 #include "simmem.h"
 #include "simcore.h"
-#include "simfun.h"
+#include "simport.h"
 #ifdef WANT_ICE
 #include "simice.h"
 #endif
@@ -611,13 +611,8 @@ leave:
 			if (T >= T_max && !cpu_needed) {
 				t2 = get_clock_us();
 				tdiff = t2 - t1;
-#ifdef SLEEP_US
 				if ((tdiff > 0) && (tdiff < 10000))
-					SLEEP_US(10000 - tdiff);
-#else
-				if ((tdiff > 0) && (tdiff < 10000))
-					SLEEP_MS(10 - (tdiff / 1000));
-#endif
+					sleep_for_us(10000 - tdiff);
 				T_max = T + tmax;
 				t1 = get_clock_us();
 			}
@@ -681,7 +676,7 @@ static int op_halt(void)		/* HALT */
 			/* else wait for INT, NMI or user interrupt */
 			while ((int_int == 0) && (int_nmi == 0) &&
 			       (cpu_state == CONTIN_RUN)) {
-				SLEEP_MS(1);
+				sleep_for_ms(1);
 				R += 99;
 			}
 		}
@@ -703,7 +698,7 @@ static int op_halt(void)		/* HALT */
 			while ((int_nmi == 0) && !(cpu_state & RESET)) {
 				fp_clock++;
 				fp_sampleData();
-				SLEEP_MS(1);
+				sleep_for_ms(1);
 				R += 99;
 				if (cpu_error != NONE)
 					break;
@@ -715,7 +710,7 @@ static int op_halt(void)		/* HALT */
 			       !(cpu_state & RESET)) {
 				fp_clock++;
 				fp_sampleData();
-				SLEEP_MS(1);
+				sleep_for_ms(1);
 				R += 99;
 				if (cpu_error != NONE)
 					break;

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -30,11 +30,6 @@
 /*#define HAS_DISKS*/	/* has no disk drives */
 /*#define HAS_CONFIG*/	/* has no configuration files */
 
-extern void sleep_us(long);
-#define SLEEP_US(t)	sleep_us(t)
-extern void sleep_ms(int);
-#define SLEEP_MS(t)	sleep_ms(t)
-
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -31,11 +31,6 @@
 /*#define HAS_DISKS*/	/* has no disk drives */
 /*#define HAS_CONFIG*/	/* has no configuration files */
 
-extern void sleep_us(long);
-#define SLEEP_US(t)	sleep_us(t)
-extern void sleep_ms(int);
-#define SLEEP_MS(t)	sleep_ms(t)
-
 /*
  *	The following defines may be modified and activated by
  *	user, to print her/his copyright for a simulated system,

--- a/z80sim/srcsim/simport.h
+++ b/z80sim/srcsim/simport.h
@@ -1,8 +1,7 @@
 /*
  * Z80SIM  -  a Z80-CPU simulator
  *
- * Copyright (C) 1987-2024 Udo Munk
- * Copyright (C) 2021 David McNaughton
+ * Copyright (C) 2024 Thomas Eberhardt
  */
 
 #ifndef SIMPORT_INC

--- a/z80sim/srcsim/simport.h
+++ b/z80sim/srcsim/simport.h
@@ -1,0 +1,22 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 1987-2024 Udo Munk
+ * Copyright (C) 2021 David McNaughton
+ */
+
+#ifndef SIMPORT_INC
+#define SIMPORT_INC
+
+#include <stdint.h>
+
+#include "sim.h"
+
+extern void sleep_for_us(long time);
+extern void sleep_for_ms(int time);
+extern uint64_t get_clock_us(void);
+#ifdef WANT_ICE
+extern int get_cmdline(char *buf, int len);
+#endif
+
+#endif /* !SIMPORT_INC */


### PR DESCRIPTION
Remove SLEEP_* macros from sim.h.

Currently simport.h should contain declarations or inline functions for:

void sleep_for_us(long time);
void sleep_for_ms(int time);
uint64_t get_clock_us(void);
int get_cmdline(char *buf, int len);

simfun.c still contains the versions used by desktop OS's.
See picosim/simport.h for example of port.