### PR TITLE
intelmds: change controller present logic on reset

### DIFF
--- a/iodevices/mds-isbc201.c
+++ b/iodevices/mds-isbc201.c
@@ -99,7 +99,7 @@ static const char *TAG = "ISBC201";
 
 static WORD iopb_addr;		/* address of I/O parameter block */
 static BYTE status;		/* status byte */
-static int res_type;		/* result type */
+static BYTE res_type;		/* result type */
 static BYTE ioerr;		/* I/O complete error bits */
 static char fndir[MAX_LFN];	/* directory path for disk image */
 static char fn[MAX_LFN];	/* path/filename for disk image */
@@ -457,11 +457,10 @@ void isbc201_disk_check(void)
 	if (res_type == RT_IOERR)
 		return;
 
-	nstatus = ST_UNITS;
-
 	/* check disk ready status */
 	strcpy(fn_, fndir);
 	pfn = fn_ + strlen(fn_);
+	nstatus = ST_UNITS;
 	for (i = 0; i <= 1; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn_, &s) == -1 || !S_ISREG(s.st_mode))
@@ -490,16 +489,18 @@ void isbc201_reset(void)
 	res_type = RT_DSKRD;
 	ioerr = 0;
 
-	nstatus = ST_PRES | ST_UNITS;
-
 	/* check disk ready status */
 	strcpy(fn, fndir);
 	pfn = fn + strlen(fn);
+	nstatus = ST_UNITS;
 	for (i = 0; i <= 1; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn, &s) == -1 || !S_ISREG(s.st_mode))
 			nstatus &= ~uready[i];
 	}
+	if (nstatus)
+		nstatus |= ST_PRES;
+
 	status = nstatus;
 }
 

--- a/iodevices/mds-isbc202.c
+++ b/iodevices/mds-isbc202.c
@@ -100,7 +100,7 @@ static const char *TAG = "ISBC202";
 
 static WORD iopb_addr;		/* address of I/O parameter block */
 static BYTE status;		/* status byte */
-static int res_type;		/* result type */
+static BYTE res_type;		/* result type */
 static BYTE ioerr;		/* I/O complete error bits */
 static char fndir[MAX_LFN];	/* directory path for disk image */
 static char fn[MAX_LFN];	/* path/filename for disk image */
@@ -452,11 +452,10 @@ void isbc202_disk_check(void)
 	if (res_type == RT_IOERR)
 		return;
 
-	nstatus = ST_UNITS;
-
 	/* check disk ready status */
 	strcpy(fn_, fndir);
 	pfn = fn_ + strlen(fn_);
+	nstatus = ST_UNITS;
 	for (i = 0; i <= 3; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn_, &s) == -1 || !S_ISREG(s.st_mode))
@@ -485,16 +484,18 @@ void isbc202_reset(void)
 	res_type = RT_DSKRD;
 	ioerr = 0;
 
-	nstatus = ST_PRES | ST_DD | ST_UNITS;
-
 	/* check disk ready status */
 	strcpy(fn, fndir);
 	pfn = fn + strlen(fn);
+	nstatus = ST_UNITS;
 	for (i = 0; i <= 3; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn, &s) == -1 || !S_ISREG(s.st_mode))
 			nstatus &= ~uready[i];
 	}
+	if (nstatus)
+		nstatus |= ST_PRES | ST_DD;
+
 	status = nstatus;
 }
 

--- a/iodevices/mds-isbc206.c
+++ b/iodevices/mds-isbc206.c
@@ -104,7 +104,7 @@ static const char *TAG = "ISBC206";
 
 static WORD iopb_addr;		/* address of I/O parameter block */
 static BYTE status;		/* status byte */
-static int res_type;		/* result type */
+static BYTE res_type;		/* result type */
 static BYTE ioerr;		/* I/O complete error bits */
 static char fndir[MAX_LFN];	/* directory path for disk image */
 static char fn[MAX_LFN];	/* path/filename for disk image */
@@ -469,11 +469,10 @@ void isbc206_disk_check(void)
 	if (res_type == RT_IOERR)
 		return;
 
-	nstatus = ST_UNITS;
-
 	/* check disk ready status */
 	strcpy(fn_, fndir);
 	pfn = fn_ + strlen(fn_);
+	nstatus = ST_UNITS;
 	for (i = 0; i <= 3; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn_, &s) == -1 || !S_ISREG(s.st_mode))
@@ -502,16 +501,18 @@ void isbc206_reset(void)
 	res_type = RT_DSKRD;
 	ioerr = 0;
 
-	nstatus = ST_PRES | ST_HD | ST_UNITS;
-
 	/* check disk ready status */
 	strcpy(fn, fndir);
 	pfn = fn + strlen(fn);
+	nstatus = ST_UNITS;
 	for (i = 0; i <= 3; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn, &s) == -1 || !S_ISREG(s.st_mode))
 			nstatus &= ~uready[i];
 	}
+	if (nstatus)
+		nstatus |= ST_PRES | ST_HD;
+
 	status = nstatus;
 }
 


### PR DESCRIPTION
Noticed this during testing when I did my monster clean-up.

The emulator has all three disk controllers (SD, DD, HD) attached. When ISIS boots it configures itself on the present bits returned by the controllers, and since all three controllers set the present bit, ISIS always configured itself for a hard drive system, and if you only had drivea.dsk (= DD unit 0) in the disks directory, you couldn't do anything, since ISIS tried to access the not available drivei.dsk as the system disk (HD unit 0 = F0), and always shows error 30 (drive not ready).

Changed the reset logic of the controllers to no set the present bit when no disk images are available.

Now you need to have at least one disk image (or two HD images) in the disks directory on startup for each controller you want to use.