### PR TITLE
intelmds: add environment convenience variables for disk controllers

### DIFF
--- a/intelmdssim/isisii43
+++ b/intelmdssim/isisii43
@@ -3,4 +3,4 @@
 rm -f disks/drivea.dsk
 ln disks/library/isis-ii-43.dsk disks/drivea.dsk
 
-./intelmdssim $*
+ISBC206_OFF=1 ./intelmdssim $*

--- a/iodevices/mds-isbc202.c
+++ b/iodevices/mds-isbc202.c
@@ -14,6 +14,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
@@ -449,13 +450,14 @@ void isbc202_disk_check(void)
 	struct stat s;
 	static char fn_[MAX_LFN];
 
-	if (res_type == RT_IOERR)
+	if (!(status & ST_PRES) || res_type == RT_IOERR)
 		return;
+
+	nstatus = ST_UNITS;
 
 	/* check disk ready status */
 	strcpy(fn_, fndir);
 	pfn = fn_ + strlen(fn_);
-	nstatus = ST_UNITS;
 	for (i = 0; i <= 3; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn_, &s) == -1 || !S_ISREG(s.st_mode))
@@ -484,17 +486,21 @@ void isbc202_reset(void)
 	res_type = RT_DSKRD;
 	ioerr = 0;
 
+	if (getenv("ISBC202_OFF")) {
+		status = 0;
+		return;
+	}
+
+	nstatus = ST_PRES | ST_DD | ST_UNITS;
+
 	/* check disk ready status */
 	strcpy(fn, fndir);
 	pfn = fn + strlen(fn);
-	nstatus = ST_UNITS;
 	for (i = 0; i <= 3; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn, &s) == -1 || !S_ISREG(s.st_mode))
 			nstatus &= ~uready[i];
 	}
-	if (nstatus)
-		nstatus |= ST_PRES | ST_DD;
 
 	status = nstatus;
 }

--- a/iodevices/mds-isbc206.c
+++ b/iodevices/mds-isbc206.c
@@ -22,6 +22,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
@@ -466,13 +467,14 @@ void isbc206_disk_check(void)
 	struct stat s;
 	static char fn_[MAX_LFN];
 
-	if (res_type == RT_IOERR)
+	if (!(status & ST_PRES) || res_type == RT_IOERR)
 		return;
+
+	nstatus = ST_UNITS;
 
 	/* check disk ready status */
 	strcpy(fn_, fndir);
 	pfn = fn_ + strlen(fn_);
-	nstatus = ST_UNITS;
 	for (i = 0; i <= 3; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn_, &s) == -1 || !S_ISREG(s.st_mode))
@@ -501,17 +503,21 @@ void isbc206_reset(void)
 	res_type = RT_DSKRD;
 	ioerr = 0;
 
+	if (getenv("ISBC206_OFF")) {
+		status = 0;
+		return;
+	}
+
+	nstatus = ST_PRES | ST_HD | ST_UNITS;
+
 	/* check disk ready status */
 	strcpy(fn, fndir);
 	pfn = fn + strlen(fn);
-	nstatus = ST_UNITS;
 	for (i = 0; i <= 3; i++) {
 		strcpy(pfn, disks[i]);
 		if (stat(fn, &s) == -1 || !S_ISREG(s.st_mode))
 			nstatus &= ~uready[i];
 	}
-	if (nstatus)
-		nstatus |= ST_PRES | ST_HD;
 
 	status = nstatus;
 }


### PR DESCRIPTION
This mostly reverts 075c9ad574.

Set present bit of disk controllers to 0 if "ISBC20[126]_OFF" environment variables are set.

Allows running a floppy only ISIS when the HD controller is enabled in sim.h.

Use this in the "isisii43" script.