### PR TITLE
z80asm: use interface header files

### DIFF
--- a/z80asm/Makefile
+++ b/z80asm/Makefile
@@ -23,46 +23,45 @@ INSTALL = install
 INSTALL_PROGRAM = $(INSTALL)
 INSTALL_DATA = $(INSTALL) -m 644
 
-OBJS =	z80amain.o \
-	z80atab.o \
-	z80anum.o \
-	z80aout.o \
-	z80amfun.o \
-	z80arfun.o \
-	z80apfun.o \
-	z80aopc.o \
-	z80aglb.o
+OBJS =	z80amain.o z80atab.o z80anum.o z80aout.o z80amfun.o z80arfun.o \
+	z80apfun.o z80aopc.o z80aglb.o
 
 all: z80asm
 
 z80asm: $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) -o z80asm
 
-z80amain.o: z80amain.c z80a.h z80aglb.h
+z80amain.o: z80amain.c z80a.h z80aglb.h z80amfun.h z80anum.h z80aopc.h \
+		z80aout.h z80atab.h z80amain.h
 	$(CC) $(CFLAGS) -c z80amain.c
 
-z80atab.o: z80atab.c z80a.h z80aglb.h
+z80atab.o: z80atab.c z80a.h z80aglb.h z80amain.h z80aout.h z80atab.h
 	$(CC) $(CFLAGS) -c z80atab.c
 
-z80anum.o: z80anum.c z80a.h z80aglb.h
+z80anum.o: z80anum.c z80a.h z80aglb.h z80aout.h z80atab.h z80anum.h
 	$(CC) $(CFLAGS) -c z80anum.c
 
-z80aout.o: z80aout.c z80a.h z80aglb.h
+z80aout.o: z80aout.c z80a.h z80aglb.h z80amain.h z80amfun.h z80atab.h \
+		z80aout.h
 	$(CC) $(CFLAGS) -c z80aout.c
 
-z80amfun.o: z80amfun.c z80a.h z80aglb.h
+z80amfun.o: z80amfun.c z80a.h z80aglb.h z80amain.h z80anum.h z80aopc.h \
+		z80aout.h z80amfun.h
 	$(CC) $(CFLAGS) -c z80amfun.c
 
-z80arfun.o: z80arfun.c z80a.h z80aglb.h
+z80arfun.o: z80arfun.c z80a.h z80aglb.h z80amain.h z80anum.h z80aopc.h \
+		z80aout.h z80arfun.h
 	$(CC) $(CFLAGS) -c z80arfun.c
 
-z80apfun.o: z80apfun.c z80a.h z80aglb.h
+z80apfun.o: z80apfun.c z80a.h z80aglb.h z80amain.h z80anum.h z80aopc.h \
+		z80aout.h z80atab.h z80apfun.h
 	$(CC) $(CFLAGS) -c z80apfun.c
 
-z80aopc.o: z80aopc.c z80a.h z80aglb.h
+z80aopc.o: z80aopc.c z80a.h z80aglb.h z80amain.h z80amfun.h z80apfun.h \
+		z80arfun.h z80aopc.h
 	$(CC) $(CFLAGS) -c z80aopc.c
 
-z80aglb.o: z80aglb.c z80a.h
+z80aglb.o: z80aglb.c z80a.h z80aglb.h z80aout.h
 	$(CC) $(CFLAGS) -c z80aglb.c
 
 instcoh: z80asm

--- a/z80asm/z80a.h
+++ b/z80asm/z80a.h
@@ -53,121 +53,10 @@
 #endif
 
 /*
- *	types for working with op-codes, addresses, expressions,
- *	and bit flags and masks
+ *	types for working with 8 and 16-bit quantities
  */
 typedef unsigned char BYTE;
 typedef unsigned short WORD;
-
-/*
- *	structure opcode table
- */
-struct opc {
-	const char *op_name;	/* opcode name */
-	WORD (*op_fun)(BYTE, BYTE); /* function pointer code gen. */
-	BYTE op_c1;		/* first base opcode */
-	BYTE op_c2;		/* second base opcode */
-	WORD op_flags;		/* opcode flags */
-};
-
-/*
- *	structure operand table
- */
-struct ope {
-	const char *ope_name;	/* operand name */
-	BYTE ope_sym;		/* operand symbol value */
-	BYTE ope_flags;		/* operand flags */
-};
-
-/*
- *	structure symbol table entries
- */
-struct sym {
-	char *sym_name;		/* symbol name */
-	WORD sym_val;		/* symbol value */
-	int sym_refflg;		/* symbol reference flag */
-	struct sym *sym_next;	/* next entry */
-};
-
-/*
- *	definition of opcode flags
- */
-#define OP_UNDOC	0x0001	/* undocumented opcode */
-#define OP_COND		0x0002	/* concerns conditional assembly */
-#define OP_SET		0x0004	/* assigns value to label */
-#define OP_END		0x0008	/* end of source */
-#define OP_NOPRE	0x0010	/* no preprocessing of operand */
-#define OP_NOLBL	0x0020	/* label not allowed */
-#define OP_NOOPR	0x0040	/* doesn't have an operand */
-#define OP_INCL		0x0080	/* include (list before executing) */
-#define OP_DS		0x0100	/* define space (does own obj_* calls) */
-#define OP_MDEF		0x0200	/* macro definition start */
-#define OP_MEND		0x0400	/* macro definition end */
-
-/*
- *	definition of operand symbols
- *	these are defined as the bits used in opcodes and
- *	may not be changed!
- */
-				/* usable with OPMASK0 and OPMASK3 */
-#define REGB		0000	/* register B */
-#define REGC		0011	/* register C */
-#define REGD		0022	/* register D */
-#define REGE		0033	/* register E */
-#define REGH		0044	/* register H */
-#define REGL		0055	/* register L */
-#define REGIHL		0066	/* register indirect HL */
-#define REGM		0066	/* register indirect HL (8080) */
-#define REGA		0077	/* register A */
-#define REGIXH		0244	/* register IXH */
-#define REGIXL		0255	/* register IXL */
-#define REGIYH		0344	/* register IYH */
-#define REGIYL		0355	/* register IYL */
-				/* usable with OPMASK3 */
-#define REGBC		0001	/* register pair BC */
-#define REGDE		0021	/* register pair DE */
-#define REGHL		0041	/* register pair HL */
-#define REGAF		0061	/* register pair AF */
-#define REGPSW		0061	/* register pair AF (8080) */
-#define REGAFA		0062	/* register pair AF' */
-#define REGSP		0063	/* register SP */
-#define REGIBC		0004	/* register indirect BC */
-#define REGIDE		0024	/* register indirect DE */
-#define REGISP		0064	/* register indirect SP */
-#define REGIX		0240	/* register IX */
-#define REGIIX		0260	/* register indirect IX */
-#define REGIY		0340	/* register IY */
-#define REGIIY		0360	/* register indirect IY */
-#define REGI		0005	/* register I */
-#define REGR		0015	/* register R */
-#define FLGNZ		0100	/* flag not zero */
-#define FLGZ		0110	/* flag zero */
-#define FLGNC		0120	/* flag no carry */
-#define FLGC		0130	/* flag carry */
-#define FLGPO		0140	/* flag parity odd */
-#define FLGPE		0150	/* flag parity even */
-#define FLGP		0160	/* flag plus */
-#define FLGM		0170	/* flag minus */
-
-#define NOOPERA		0376	/* no operand */
-#define NOREG		0377	/* operand isn't register */
-
-#define OPMASK0		0007	/* << 0 bit mask for the registers */
-#define OPMASK3		0070	/* << 3 bit mask for the registers/flags */
-#define XYMASK		0100	/* bit mask for IX/IY */
-
-/*
- *	definition of operand flags
- */
-#define OPE_UNDOC	0x01	/* undocumented operand */
-
-/*
- *	definition of object file formats
- */
-#define OBJ_BIN		0	/* binary file */
-#define OBJ_MOS		1	/* Mostek binary file */
-#define OBJ_HEX		2	/* Intel HEX file */
-#define OBJ_CARY	3	/* C initialized array */
 
 /*
  *	definition of symbol table listing options
@@ -178,37 +67,11 @@ struct sym {
 #define SYM_SORTA	3	/* symbol table sorted by address */
 
 /*
- *	definition of instruction sets
- */
-#define INSTR_NONE	0	/* not yet initialized */
-#define INSTR_Z80 	1	/* Z80 instructions set */
-#define INSTR_8080	2	/* 8080 instructions set */
-
-/*
- *	definition of address output modes for pseudo ops
- */
-#define A_STD		0	/* address from <addr> */
-#define A_EQU		1	/* address from <a_addr>, '=' */
-#define A_SET		2	/* address from <a_addr>, '#' */
-#define A_DS		3	/* address from <a_addr>, no data */
-#define A_NONE		4	/* no address */
-
-/*
  *	definition of macro list flag options
  */
 #define	M_OPS		0	/* only list macro expansions producing ops */
 #define M_ALL		1	/* list all macro expansions */
 #define M_NONE		2	/* list no macro expansions */
-
-/*
- *	definition of character types
- */
-#define C_FSYM		0x01	/* first symbol character */
-#define C_SYM		0x02	/* symbol character */
-#define C_LOW		0x04	/* lower case letter */
-#define C_DIG		0x08	/* decimal digit */
-#define C_XDIG		0x10	/* hexadecimal digit */
-#define C_SPC		0x20	/* white space */
 
 /*
  *	definition of error numbers for error messages in listfile
@@ -271,15 +134,4 @@ struct sym {
 #define NORETURN
 #endif
 
-/*
- *	macros for character classification and conversion
- */
-#define IS_FSYM(c)	(ctype[(BYTE) (c)] & C_FSYM)
-#define IS_SYM(c)	(ctype[(BYTE) (c)] & C_SYM)
-#define IS_DIG(c)	(ctype[(BYTE) (c)] & C_DIG)
-#define IS_XDIG(c)	(ctype[(BYTE) (c)] & C_XDIG)
-#define IS_SPC(c)	(ctype[(BYTE) (c)] & C_SPC)
-/* don't use parameters with side-effects with this! */
-#define TO_UPP(c)	((ctype[(BYTE) (c)] & C_LOW) ? ((c) - 32) : (c))
-
-#endif
+#endif /* !Z80A_INC */

--- a/z80asm/z80aglb.c
+++ b/z80asm/z80aglb.c
@@ -9,7 +9,10 @@
  */
 
 #include <stdio.h>
+
 #include "z80a.h"
+#include "z80aglb.h"
+#include "z80aout.h"
 
 char **infiles,			/* source filenames */
      *srcfn,			/* filename of current processed source file */
@@ -21,15 +24,11 @@ char **infiles,			/* source filenames */
      operand[MAXLINE + 1],	/* buffer for working with operand */
      title[MAXLINE + 1];	/* buffer for title of source */
 
-BYTE ops[OPCARRAY],		/* buffer for generated object code */
-     ctype[256];		/* table for character classification */
+BYTE ops[OPCARRAY];		/* buffer for generated object code */
 
 WORD rpc,			/* real program counter */
      pc,			/* logical program counter, normally equal */
 				/* to rpc, except when inside a .PHASE block */
-     a_addr,			/* output value for A_ADDR/A_VALUE mode */
-     load_addr,			/* load address of program */
-     start_addr,		/* execution start address of program */
      hexlen = MAXHEX,		/* HEX record length */
      carylen = CARYLEN;		/* C array bytes per line */
 
@@ -56,7 +55,6 @@ int  list_flag,			/* flag for option -l */
      mac_symmax,		/* max. macro symbol length encountered */
      errors,			/* error counter */
      errnum,			/* error number in pass 2 */
-     a_mode,			/* address output mode for pseudo ops */
      load_flag,			/* flag for load_addr already set */
      obj_fmt = OBJ_HEX,		/* format of object file (default Intel HEX) */
      symlen = SYMLEN,		/* significant characters in symbols */

--- a/z80asm/z80aglb.h
+++ b/z80asm/z80aglb.h
@@ -21,14 +21,10 @@ extern char	**infiles,
 		operand[],
 		title[];
 
-extern BYTE	ops[],
-		ctype[];
+extern BYTE	ops[];
 
 extern WORD	rpc,
 		pc,
-		a_addr,
-		load_addr,
-		start_addr,
 		hexlen,
 		carylen;
 
@@ -55,7 +51,6 @@ extern int	list_flag,
 		mac_symmax,
 		errors,
 		errnum,
-		a_mode,
 		load_flag,
 		obj_fmt,
 		symlen,
@@ -72,4 +67,4 @@ extern FILE	*srcfp,
 		*lstfp,
 		*errfp;
 
-#endif
+#endif /* !Z80AGLB_INC */

--- a/z80asm/z80amain.c
+++ b/z80asm/z80amain.c
@@ -14,48 +14,25 @@
 #include <unistd.h>
 #endif
 #include <string.h>
+
 #include "z80a.h"
 #include "z80aglb.h"
+#include "z80amfun.h"
+#include "z80anum.h"
+#include "z80aopc.h"
+#include "z80aout.h"
+#include "z80atab.h"
+#include "z80amain.h"
 
-void init(void), options(int, char *[]);
-void usage(void), fatal(int, const char *) NORETURN;
-void do_pass(int), process_file(char *);
-int process_line(char *);
-void open_o_files(char *);
-char *get_fn(char *, const char *, int);
-char *get_symbol(char *, char *, int);
-void get_operand(char *, char *, int);
-
-/* z80aout.c */
-extern void asmerr(int);
-extern void lst_line(char *, WORD, WORD, int);
-extern void lst_mac(int);
-extern void lst_sym(int);
-extern void obj_header(void);
-extern void obj_end(void);
-extern void obj_writeb(WORD);
-
-/* z80anum.c */
-extern WORD eval(char *);
-
-/* z80mfun.c */
-extern void mac_start_pass(void);
-extern void mac_end_pass(void);
-extern char *mac_expand(void);
-extern void mac_add_line(struct opc *, char *);
-extern int mac_lookup(char *);
-extern void mac_call(void);
-
-/* z80anum.c */
-extern void init_ctype(void);
-
-/* z80aopc.c */
-extern void instrset(int);
-extern struct opc *search_op(char *);
-
-/* z80atab.c */
-extern void put_sym(char *, WORD);
-extern void put_label(void);
+static void init(void);
+static void options(int argc, char *argv[]);
+static void usage(void);
+static void do_pass(int p);
+static int process_line(char *l);
+static void open_o_files(char *source);
+static char *get_fn(char *src, const char *ext, int replace);
+static char *get_symbol(char *s, char *l, int lbl_flag);
+static void get_operand(char *s, char *l, int nopre_flag);
 
 static const char *errmsg[] = {		/* error messages for fatal() */
 	"out of memory: %s",		/* 0 */
@@ -105,7 +82,7 @@ int main(int argc, char *argv[])
 /*
  *	initialization
  */
-void init(void)
+static void init(void)
 {
 	init_ctype();
 	errfp = stdout;
@@ -114,7 +91,7 @@ void init(void)
 /*
  *	process options
  */
-void options(int argc, char *argv[])
+static void options(int argc, char *argv[])
 {
 	register char *s, *t;
 	register char **p;
@@ -271,7 +248,7 @@ void options(int argc, char *argv[])
 /*
  *	error in options, print usage
  */
-void usage(void)
+static void usage(void)
 {
 	fatal(F_USAGE, RELEASE);
 }
@@ -279,7 +256,7 @@ void usage(void)
 /*
  *	print error message and abort
  */
-void fatal(int i, const char *arg)
+void NORETURN fatal(int i, const char *arg)
 {
 	printf(errmsg[i], arg);
 	putchar('\n');
@@ -293,7 +270,7 @@ void fatal(int i, const char *arg)
 /*
  *	process all source files
  */
-void do_pass(int p)
+static void do_pass(int p)
 {
 	register int i;
 	register char **ip;
@@ -372,7 +349,7 @@ void process_file(char *fn)
  *	process one line of source from l
  *	returns FALSE when END encountered, otherwise TRUE
  */
-int process_line(char *l)
+static int process_line(char *l)
 {
 	register struct opc *op;
 	register int lbl_flag;
@@ -488,7 +465,7 @@ int process_line(char *l)
  *	list and object filenames are build from source filename if
  *	not given by options
  */
-void open_o_files(char *source)
+static void open_o_files(char *source)
 {
 	if (objfn == NULL)
 		objfn = get_fn(source, obj_str[obj_fmt].ext, TRUE);
@@ -509,7 +486,7 @@ void open_o_files(char *source)
  *	append "ext" if "src" has no extension
  *	replace existing extension with "ext" if "replace" is TRUE
  */
-char *get_fn(char *src, const char *ext, int replace)
+static char *get_fn(char *src, const char *ext, int replace)
 {
 	register char *sp, *dp;
 	register char *ep;
@@ -553,7 +530,7 @@ char *strsave(char *s)
  *	if lbl_flag is TRUE skip LABSEP at end of symbol
  *	convert names to upper case and truncate length of name
  */
-char *get_symbol(char *s, char *l, int lbl_flag)
+static char *get_symbol(char *s, char *l, int lbl_flag)
 {
 	register int i;
 
@@ -583,7 +560,7 @@ char *get_symbol(char *s, char *l, int lbl_flag)
  *	delimited strings are copied without changes
  *	if nopre_flag is TRUE removes only leading white space
  */
-void get_operand(char *s, char *l, int nopre_flag)
+static void get_operand(char *s, char *l, int nopre_flag)
 {
 	register char *s0;
 	register char c;

--- a/z80asm/z80amain.h
+++ b/z80asm/z80amain.h
@@ -1,0 +1,20 @@
+/*
+ *	Z80/8080-Macro-Assembler
+ *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
+ */
+
+#ifndef Z80AMAIN_INC
+#define Z80AMAIN_INC
+
+#include "z80a.h"
+
+extern void NORETURN fatal(int i, const char *arg);
+
+extern void process_file(char *fn);
+
+extern char *strsave(char *s);
+
+extern char *next_arg(char *p, int *str_flag);
+
+#endif /* !Z80AMAIN_INC */

--- a/z80asm/z80amfun.h
+++ b/z80asm/z80amfun.h
@@ -1,0 +1,31 @@
+/*
+ *	Z80/8080-Macro-Assembler - Intel-like macro implementation
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
+ */
+
+#ifndef Z80AMFUN_INC
+#define Z80AMFUN_INC
+
+#include "z80a.h"
+#include "z80aopc.h"
+
+extern char *mac_first(int sort_mode, int *rp);
+extern char *mac_next(int *rp);
+
+extern void mac_start_pass(void);
+extern void mac_end_pass(void);
+
+extern void mac_add_line(struct opc *op, char *line);
+extern char *mac_expand(void);
+extern int mac_lookup(char *opcode);
+extern void mac_call(void);
+
+extern WORD op_endm(BYTE dummy1, BYTE dummy2);
+extern WORD op_exitm(BYTE dummy1, BYTE dummy2);
+extern WORD op_mcond(BYTE op_code, BYTE dummy);
+extern WORD op_irp(BYTE op_code, BYTE dummy);
+extern WORD op_local(BYTE dummy1, BYTE dummy2);
+extern WORD op_macro(BYTE dummy1, BYTE dummy2);
+extern WORD op_rept(BYTE dummy1, BYTE dummy2);
+
+#endif /* !Z80AMFUN_INC */

--- a/z80asm/z80anum.c
+++ b/z80asm/z80anum.c
@@ -11,16 +11,16 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+
 #include "z80a.h"
 #include "z80aglb.h"
+#include "z80aout.h"
+#include "z80atab.h"
+#include "z80anum.h"
 
-int expr(WORD *);
+static int expr(WORD *resultp);
 
-/* z80aout.c */
-extern void asmerr(int);
-
-/* z80atab.c */
-extern struct sym *get_sym(char *);
+BYTE ctype[256];		/* table for character classification */
 
 /*
  *	definition of token types
@@ -121,7 +121,7 @@ void init_ctype(void)
  *	do binary search for operator s in sorted table oprtab
  *	returns symbol for operator or T_UNDSYM if not found
  */
-BYTE search_opr(char *s)
+static BYTE search_opr(char *s)
 {
 	register struct opr *low, *mid;
 	register struct opr *high;
@@ -146,7 +146,7 @@ BYTE search_opr(char *s)
  *	updates tok_type, tok_val and scan_pos
  *	returns E_OK on success, otherwise a hard error code
  */
-int get_token(void)
+static int get_token(void)
 {
 	register char *s, *p1;
 	register char *p2;
@@ -335,7 +335,7 @@ int get_token(void)
  *	inspired by the previous expression parser by Didier Derny.
  */
 
-int factor(WORD *resultp)
+static int factor(WORD *resultp)
 {
 	register int err, erru;
 	register char *s;
@@ -426,7 +426,7 @@ int factor(WORD *resultp)
 	}
 }
 
-int mul_term(WORD *resultp)
+static int mul_term(WORD *resultp)
 {
 	register int err, erru;
 	register BYTE opr_type;
@@ -472,7 +472,7 @@ int mul_term(WORD *resultp)
 	return erru;
 }
 
-int add_term(WORD *resultp)
+static int add_term(WORD *resultp)
 {
 	register int err, erru;
 	register BYTE opr_type;
@@ -504,7 +504,7 @@ int add_term(WORD *resultp)
 	return erru;
 }
 
-int cmp_term(WORD *resultp)
+static int cmp_term(WORD *resultp)
 {
 	register int err, erru;
 	register BYTE opr_type;
@@ -550,7 +550,7 @@ int cmp_term(WORD *resultp)
 	return erru;
 }
 
-int expr(WORD *resultp)
+static int expr(WORD *resultp)
 {
 	register int err, erru;
 	register BYTE opr_type;

--- a/z80asm/z80anum.h
+++ b/z80asm/z80anum.h
@@ -1,0 +1,41 @@
+/*
+ *	Z80/8080-Macro-Assembler
+ *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (C) 2022 by Thomas Eberhardt
+ */
+
+#ifndef Z80ANUM_INC
+#define Z80ANUM_INC
+
+#include "z80a.h"
+
+extern BYTE ctype[256];
+
+/*
+ *	definition of character types
+ */
+#define C_FSYM		0x01	/* first symbol character */
+#define C_SYM		0x02	/* symbol character */
+#define C_LOW		0x04	/* lower case letter */
+#define C_DIG		0x08	/* decimal digit */
+#define C_XDIG		0x10	/* hexadecimal digit */
+#define C_SPC		0x20	/* white space */
+
+/*
+ *	macros for character classification and conversion
+ */
+#define IS_FSYM(c)	(ctype[(BYTE) (c)] & C_FSYM)
+#define IS_SYM(c)	(ctype[(BYTE) (c)] & C_SYM)
+#define IS_DIG(c)	(ctype[(BYTE) (c)] & C_DIG)
+#define IS_XDIG(c)	(ctype[(BYTE) (c)] & C_XDIG)
+#define IS_SPC(c)	(ctype[(BYTE) (c)] & C_SPC)
+/* don't use parameters with side-effects with this! */
+#define TO_UPP(c)	((ctype[(BYTE) (c)] & C_LOW) ? ((c) - 32) : (c))
+
+extern void init_ctype(void);
+
+extern WORD eval(char *s);
+extern BYTE chk_byte(WORD w);
+extern BYTE chk_sbyte(WORD w);
+
+#endif /* !Z80ANUM_INC */

--- a/z80asm/z80aopc.c
+++ b/z80asm/z80aopc.c
@@ -11,38 +11,25 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+
 #include "z80a.h"
 #include "z80aglb.h"
+#include "z80amain.h"
+#include "z80amfun.h"
+#include "z80apfun.h"
+#include "z80arfun.h"
+#include "z80aopc.h"
 
-int opccmp(const void *, const void *);
+static int opccmp(const void *p1, const void *p2);
 
-/* z80amain.c */
-extern void fatal(int, const char *) NORETURN;
-
-/* z80amfun.c */
-extern WORD op_endm(BYTE, BYTE), op_exitm(BYTE, BYTE), op_irp(BYTE, BYTE);
-extern WORD op_local(BYTE, BYTE), op_macro(BYTE, BYTE), op_mcond(BYTE, BYTE);
-extern WORD op_rept(BYTE, BYTE);
-
-/* z80apfun.c */
-extern WORD op_instrset(BYTE, BYTE), op_org(BYTE, BYTE), op_radix(BYTE, BYTE);
-extern WORD op_equ(BYTE, BYTE), op_dl(BYTE, BYTE), op_ds(BYTE, BYTE);
-extern WORD op_db(BYTE, BYTE), op_dw(BYTE, BYTE), op_misc(BYTE, BYTE);
-extern WORD op_cond(BYTE, BYTE), op_glob(BYTE, BYTE), op_end(BYTE, BYTE);
-
-/* z80arfun.c */
-extern WORD op_1b(BYTE, BYTE), op_2b(BYTE, BYTE), op_im(BYTE, BYTE);
-extern WORD op_pupo(BYTE, BYTE), op_ex(BYTE, BYTE), op_rst(BYTE, BYTE);
-extern WORD op_ret(BYTE, BYTE), op_jpcall(BYTE, BYTE), op_jr(BYTE, BYTE);
-extern WORD op_djnz(BYTE, BYTE), op_ld(BYTE, BYTE), op_add(BYTE, BYTE);
-extern WORD op_sbadc(BYTE, BYTE), op_decinc(BYTE, BYTE), op_alu(BYTE, BYTE);
-extern WORD op_out(BYTE, BYTE), op_in(BYTE, BYTE), op_cbgrp(BYTE, BYTE);
-extern WORD op8080_mov(BYTE, BYTE), op8080_alu(BYTE, BYTE);
-extern WORD op8080_dcrinr(BYTE, BYTE), op8080_reg16(BYTE, BYTE);
-extern WORD op8080_regbd(BYTE, BYTE), op8080_imm(BYTE, BYTE);
-extern WORD op8080_rst(BYTE, BYTE), op8080_pupo(BYTE, BYTE);
-extern WORD op8080_addr(BYTE, BYTE), op8080_mvi(BYTE, BYTE);
-extern WORD op8080_lxi(BYTE, BYTE);
+/*
+ *	structure operand table
+ */
+struct ope {
+	const char *ope_name;	/* operand name */
+	BYTE ope_sym;		/* operand symbol value */
+	BYTE ope_flags;		/* operand flags */
+};
 
 /*
  *	pseudo op table
@@ -405,7 +392,7 @@ void instrset(int is)
 /*
  *	compares two opcodes for qsort()
  */
-int opccmp(const void *p1, const void *p2)
+static int opccmp(const void *p1, const void *p2)
 {
 	return (strcmp((*(const struct opc **) p1)->op_name,
 		       (*(const struct opc **) p2)->op_name));

--- a/z80asm/z80aopc.h
+++ b/z80asm/z80aopc.h
@@ -1,0 +1,106 @@
+/*
+ *	Z80/8080-Macro-Assembler
+ *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
+ */
+
+#ifndef Z80AOPC_INC
+#define Z80AOPC_INC
+
+#include "z80a.h"
+
+/*
+ *	definition of instruction sets
+ */
+#define INSTR_NONE	0	/* not yet initialized */
+#define INSTR_Z80 	1	/* Z80 instructions set */
+#define INSTR_8080	2	/* 8080 instructions set */
+
+/*
+ *	definition of opcode flags
+ */
+#define OP_UNDOC	0x0001	/* undocumented opcode */
+#define OP_COND		0x0002	/* concerns conditional assembly */
+#define OP_SET		0x0004	/* assigns value to label */
+#define OP_END		0x0008	/* end of source */
+#define OP_NOPRE	0x0010	/* no preprocessing of operand */
+#define OP_NOLBL	0x0020	/* label not allowed */
+#define OP_NOOPR	0x0040	/* doesn't have an operand */
+#define OP_INCL		0x0080	/* include (list before executing) */
+#define OP_DS		0x0100	/* define space (does own obj_* calls) */
+#define OP_MDEF		0x0200	/* macro definition start */
+#define OP_MEND		0x0400	/* macro definition end */
+
+/*
+ *	definition of operand symbols
+ *	these are defined as the bits used in opcodes and
+ *	may not be changed!
+ */
+				/* usable with OPMASK0 and OPMASK3 */
+#define REGB		0000	/* register B */
+#define REGC		0011	/* register C */
+#define REGD		0022	/* register D */
+#define REGE		0033	/* register E */
+#define REGH		0044	/* register H */
+#define REGL		0055	/* register L */
+#define REGIHL		0066	/* register indirect HL */
+#define REGM		0066	/* register indirect HL (8080) */
+#define REGA		0077	/* register A */
+#define REGIXH		0244	/* register IXH */
+#define REGIXL		0255	/* register IXL */
+#define REGIYH		0344	/* register IYH */
+#define REGIYL		0355	/* register IYL */
+				/* usable with OPMASK3 */
+#define REGBC		0001	/* register pair BC */
+#define REGDE		0021	/* register pair DE */
+#define REGHL		0041	/* register pair HL */
+#define REGAF		0061	/* register pair AF */
+#define REGPSW		0061	/* register pair AF (8080) */
+#define REGAFA		0062	/* register pair AF' */
+#define REGSP		0063	/* register SP */
+#define REGIBC		0004	/* register indirect BC */
+#define REGIDE		0024	/* register indirect DE */
+#define REGISP		0064	/* register indirect SP */
+#define REGIX		0240	/* register IX */
+#define REGIIX		0260	/* register indirect IX */
+#define REGIY		0340	/* register IY */
+#define REGIIY		0360	/* register indirect IY */
+#define REGI		0005	/* register I */
+#define REGR		0015	/* register R */
+#define FLGNZ		0100	/* flag not zero */
+#define FLGZ		0110	/* flag zero */
+#define FLGNC		0120	/* flag no carry */
+#define FLGC		0130	/* flag carry */
+#define FLGPO		0140	/* flag parity odd */
+#define FLGPE		0150	/* flag parity even */
+#define FLGP		0160	/* flag plus */
+#define FLGM		0170	/* flag minus */
+
+#define NOOPERA		0376	/* no operand */
+#define NOREG		0377	/* operand isn't register */
+
+#define OPMASK0		0007	/* << 0 bit mask for the registers */
+#define OPMASK3		0070	/* << 3 bit mask for the registers/flags */
+#define XYMASK		0100	/* bit mask for IX/IY */
+
+/*
+ *	definition of operand flags
+ */
+#define OPE_UNDOC	0x01	/* undocumented operand */
+
+/*
+ *	structure opcode table
+ */
+struct opc {
+	const char *op_name;	/* opcode name */
+	WORD (*op_fun)(BYTE b1, BYTE b2); /* function pointer code gen. */
+	BYTE op_c1;		/* first base opcode */
+	BYTE op_c2;		/* second base opcode */
+	WORD op_flags;		/* opcode flags */
+};
+
+extern void instrset(int is);
+extern struct opc *search_op(char *op_name);
+extern BYTE get_reg(char *s);
+
+#endif /* !Z80AOPC_INC */

--- a/z80asm/z80aout.h
+++ b/z80asm/z80aout.h
@@ -1,0 +1,47 @@
+/*
+ *	Z80/8080-Macro-Assembler
+ *	Copyright (C) 1987-2024 by Udo Munk
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
+ */
+
+#ifndef Z80AOUT_INC
+#define Z80AOUT_INC
+
+#include "z80a.h"
+
+/*
+ *	definition of object file formats
+ */
+#define OBJ_BIN		0	/* binary file */
+#define OBJ_MOS		1	/* Mostek binary file */
+#define OBJ_HEX		2	/* Intel HEX file */
+#define OBJ_CARY	3	/* C initialized array */
+
+/*
+ *	definition of address output modes for pseudo ops
+ */
+#define A_STD		0	/* address from <addr> */
+#define A_EQU		1	/* address from <a_addr>, '=' */
+#define A_SET		2	/* address from <a_addr>, '#' */
+#define A_DS		3	/* address from <a_addr>, no data */
+#define A_NONE		4	/* no address */
+
+extern WORD a_addr;
+extern int  a_mode;
+extern WORD load_addr;
+extern WORD start_addr;
+
+extern void asmerr(int i);
+
+extern void lst_line(char *l, WORD addr, WORD op_cnt, int expn_flag);
+extern void lst_mac(int sort_mode);
+extern void lst_sym(int sort_mode);
+
+extern void obj_header(void);
+extern void obj_end(void);
+extern void obj_org(WORD addr);
+extern void obj_writeb(WORD op_cnt);
+extern void obj_fill(WORD count);
+extern void obj_fill_value(WORD count, WORD value);
+
+#endif /* !Z80AOUT_INC */

--- a/z80asm/z80apfun.c
+++ b/z80asm/z80apfun.c
@@ -12,33 +12,15 @@
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
+
 #include "z80a.h"
 #include "z80aglb.h"
-
-/* z80amain.c */
-extern void fatal(int, const char *) NORETURN;
-extern void process_file(char *);
-extern char *strsave(char *);
-extern char *next_arg(char *, int *);
-
-/* z80anum.c */
-extern WORD eval(char *);
-extern BYTE chk_byte(WORD);
-
-/* z80aopc.c */
-extern void instrset(int);
-
-/* z80aout.c */
-extern void asmerr(int);
-extern void obj_org(WORD);
-extern void obj_fill(WORD);
-extern void obj_fill_value(WORD, WORD);
-
-/* z80atab.c */
-extern struct sym *look_sym(char *);
-extern struct sym *get_sym(char *);
-extern struct sym *new_sym(char *);
-extern void put_sym(char *, WORD);
+#include "z80amain.h"
+#include "z80anum.h"
+#include "z80aopc.h"
+#include "z80aout.h"
+#include "z80atab.h"
+#include "z80apfun.h"
 
 /*
  *	.Z80 and .8080

--- a/z80asm/z80apfun.h
+++ b/z80asm/z80apfun.h
@@ -1,0 +1,25 @@
+/*
+ *	Z80/8080-Macro-Assembler
+ *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
+ */
+
+#ifndef Z80APFUN_INC
+#define Z80APFUN_INC
+
+#include "z80a.h"
+
+extern WORD op_instrset(BYTE op_code, BYTE dummy);
+extern WORD op_org(BYTE op_code, BYTE dummy);
+extern WORD op_radix(BYTE dummy1, BYTE dummy2);
+extern WORD op_equ(BYTE dummy1, BYTE dummy2);
+extern WORD op_dl(BYTE dummy1, BYTE dummy2);
+extern WORD op_ds(BYTE dummy1, BYTE dummy2);
+extern WORD op_db(BYTE op_code, BYTE dummy);
+extern WORD op_dw(BYTE dummy1, BYTE dummy2);
+extern WORD op_misc(BYTE op_code, BYTE dummy);
+extern WORD op_cond(BYTE op_code, BYTE dummy);
+extern WORD op_glob(BYTE op_code, BYTE dummy);
+extern WORD op_end(BYTE dummy1, BYTE dummy2);
+
+#endif /* !Z80APFUN_INC */

--- a/z80asm/z80arfun.c
+++ b/z80asm/z80arfun.c
@@ -10,24 +10,24 @@
 
 #include <stdio.h>
 #include <string.h>
+
 #include "z80a.h"
 #include "z80aglb.h"
+#include "z80amain.h"
+#include "z80anum.h"
+#include "z80aopc.h"
+#include "z80aout.h"
+#include "z80arfun.h"
 
-WORD ldreg(BYTE, char *), ldixhl(BYTE, char *), ldiyhl(BYTE, char *);
-WORD ldsp(char *), ldihl(BYTE, char *), ldiixy(BYTE, BYTE, char *);
-WORD ldinn(char *), aluop(BYTE, char *), cbgrp_iixy(BYTE, BYTE, BYTE, char *);
-
-/* z80amain.c */
-extern void asmerr(int);
-extern char *next_arg(char *, int *);
-
-/* z80anum.c */
-extern WORD eval(char *);
-extern BYTE chk_byte(WORD);
-extern BYTE chk_sbyte(WORD);
-
-/* z80aopc.c */
-extern BYTE get_reg(char *);
+static WORD ldreg(BYTE base_op, char *sec);
+static WORD ldixhl(BYTE base_op, char *sec);
+static WORD ldiyhl(BYTE base_op, char *sec);
+static WORD ldsp(char *sec);
+static WORD ldihl(BYTE base_op, char *sec);
+static WORD ldiixy(BYTE prefix, BYTE base_op, char *sec);
+static WORD ldinn(char *sec);
+static WORD aluop(BYTE base_op, char *sec);
+static WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec);
 
 /*
  *	process 1-byte opcodes without arguments
@@ -512,7 +512,7 @@ WORD op_ld(BYTE base_op, BYTE dummy)
 /*
  *	LD [A,B,C,D,E,H,L],?
  */
-WORD ldreg(BYTE base_op, char *sec)
+static WORD ldreg(BYTE base_op, char *sec)
 {
 	register BYTE op;
 	register WORD n;
@@ -610,7 +610,7 @@ WORD ldreg(BYTE base_op, char *sec)
 /*
  *	LD IX[HL],? (undoc)
  */
-WORD ldixhl(BYTE base_op, char *sec)
+static WORD ldixhl(BYTE base_op, char *sec)
 {
 	register BYTE op;
 	register WORD len = 0;
@@ -648,7 +648,7 @@ WORD ldixhl(BYTE base_op, char *sec)
 /*
  *	LD IY[HL],? (undoc)
  */
-WORD ldiyhl(BYTE base_op, char *sec)
+static WORD ldiyhl(BYTE base_op, char *sec)
 {
 	register BYTE op;
 	register WORD len = 0;
@@ -686,7 +686,7 @@ WORD ldiyhl(BYTE base_op, char *sec)
 /*
  *	LD SP,?
  */
-WORD ldsp(char *sec)
+static WORD ldsp(char *sec)
 {
 	register BYTE op;
 	register WORD n;
@@ -736,7 +736,7 @@ WORD ldsp(char *sec)
 /*
  *	LD (HL),?
  */
-WORD ldihl(BYTE base_op, char *sec)
+static WORD ldihl(BYTE base_op, char *sec)
 {
 	register BYTE op;
 	register WORD len = 0;
@@ -772,7 +772,7 @@ WORD ldihl(BYTE base_op, char *sec)
 /*
  *	LD (I[XY]{[+-]d}),?
  */
-WORD ldiixy(BYTE prefix, BYTE base_op, char *sec)
+static WORD ldiixy(BYTE prefix, BYTE base_op, char *sec)
 {
 	register BYTE op;
 	register WORD len = 0;
@@ -824,7 +824,7 @@ WORD ldiixy(BYTE prefix, BYTE base_op, char *sec)
 /*
  *	LD (nn),?
  */
-WORD ldinn(char *sec)
+static WORD ldinn(char *sec)
 {
 	register BYTE op;
 	register WORD n;
@@ -1086,7 +1086,7 @@ WORD op_alu(BYTE base_op, BYTE dummy)
 /*
  *	ADD A, ADC A, SUB, SBC A, AND, XOR, OR, CP
  */
-WORD aluop(BYTE base_op, char *sec)
+static WORD aluop(BYTE base_op, char *sec)
 {
 	register BYTE op;
 	register WORD len = 0;
@@ -1330,7 +1330,7 @@ WORD op_cbgrp(BYTE base_op, BYTE dummy)
 /*
  *	CBOP {n,}(I[XY]{[+-]d}){,reg}
  */
-WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
+static WORD cbgrp_iixy(BYTE prefix, BYTE base_op, BYTE bit, char *sec)
 {
 	register BYTE op;
 	register char *tert;

--- a/z80asm/z80arfun.h
+++ b/z80asm/z80arfun.h
@@ -1,0 +1,43 @@
+/*
+ *	Z80/8080-Macro-Assembler
+ *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
+ */
+
+#ifndef Z80ARFUN_INC
+#define Z80ARFUN_INC
+
+#include "z80a.h"
+
+extern WORD op_1b(BYTE b1, BYTE dummy);
+extern WORD op_2b(BYTE b1, BYTE b2);
+extern WORD op_im(BYTE base_op1, BYTE base_op2);
+extern WORD op_pupo(BYTE base_op, BYTE dummy);
+extern WORD op_ex(BYTE base_ops, BYTE base_opd);
+extern WORD op_rst(BYTE base_op, BYTE dummy);
+extern WORD op_ret(BYTE base_op, BYTE base_opc);
+extern WORD op_jpcall(BYTE base_op, BYTE base_opc);
+extern WORD op_jr(BYTE base_op, BYTE base_opc);
+extern WORD op_djnz(BYTE base_op, BYTE dummy);
+extern WORD op_ld(BYTE base_op, BYTE dummy);
+extern WORD op_add(BYTE base_op, BYTE base_op16);
+extern WORD op_sbadc(BYTE base_op, BYTE base_op16);
+extern WORD op_decinc(BYTE base_op, BYTE base_op16);
+extern WORD op_alu(BYTE base_op, BYTE dummy);
+extern WORD op_out(BYTE op_base, BYTE op_basec);
+extern WORD op_in(BYTE op_base, BYTE op_basec);
+extern WORD op_cbgrp(BYTE base_op, BYTE dummy);
+
+extern WORD op8080_mov(BYTE base_op, BYTE dummy);
+extern WORD op8080_alu(BYTE base_op, BYTE dummy);
+extern WORD op8080_dcrinr(BYTE base_op, BYTE dummy);
+extern WORD op8080_reg16(BYTE base_op, BYTE dummy);
+extern WORD op8080_regbd(BYTE base_op, BYTE dummy);
+extern WORD op8080_imm(BYTE base_op, BYTE dummy);
+extern WORD op8080_rst(BYTE base_op, BYTE dummy);
+extern WORD op8080_pupo(BYTE base_op, BYTE dummy);
+extern WORD op8080_addr(BYTE base_op, BYTE dummy);
+extern WORD op8080_mvi(BYTE base_op, BYTE dummy);
+extern WORD op8080_lxi(BYTE base_op, BYTE dummy);
+
+#endif /* !Z80ARFUN_INC */

--- a/z80asm/z80atab.c
+++ b/z80asm/z80atab.c
@@ -11,21 +11,16 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+
 #include "z80a.h"
 #include "z80aglb.h"
+#include "z80amain.h"
+#include "z80aout.h"
+#include "z80atab.h"
 
-struct sym *look_sym(char *);
-struct sym *get_sym(char *);
-struct sym *new_sym(char *);
-int hash(char *);
-int namecmp(const void *, const void *);
-int valcmp(const void *, const void *);
-
-/* z80amain.c */
-extern void fatal(int, const char *) NORETURN;
-
-/* z80aout.c */
-extern void asmerr(int);
+static int hash(char *name);
+static int namecmp(const void *p1, const void *p2);
+static int valcmp(const void *p1, const void *p2);
 
 static struct sym *symtab[HASHSIZE];	/* symbol table */
 static int symcnt;			/* number of symbols defined */
@@ -118,7 +113,7 @@ void put_label(void)
  *	calculate the hash value of the string name
  *	returns hash value
  */
-int hash(char *name)
+static int hash(char *name)
 {
 	register unsigned h;
 
@@ -188,7 +183,7 @@ struct sym *next_sym(void)
 /*
  *	compares two symbol names for qsort()
  */
-int namecmp(const void *p1, const void *p2)
+static int namecmp(const void *p1, const void *p2)
 {
 	return (strcmp((*(const struct sym **) p1)->sym_name,
 		       (*(const struct sym **) p2)->sym_name));
@@ -198,7 +193,7 @@ int namecmp(const void *p1, const void *p2)
  *	compares two symbol values for qsort(), result like strcmp()
  *	if equal compares symbol names
  */
-int valcmp(const void *p1, const void *p2)
+static int valcmp(const void *p1, const void *p2)
 {
 	register WORD n1, n2;
 

--- a/z80asm/z80atab.h
+++ b/z80asm/z80atab.h
@@ -1,0 +1,32 @@
+/*
+ *	Z80/8080-Macro-Assembler
+ *	Copyright (C) 1987-2022 by Udo Munk
+ *	Copyright (C) 2022-2024 by Thomas Eberhardt
+ */
+
+#ifndef Z80ATAB_INC
+#define Z80ATAB_INC
+
+#include "z80a.h"
+
+/*
+ *	structure symbol table entries
+ */
+struct sym {
+	char *sym_name;		/* symbol name */
+	WORD sym_val;		/* symbol value */
+	int sym_refflg;		/* symbol reference flag */
+	struct sym *sym_next;	/* next entry */
+};
+
+extern struct sym *look_sym(char *sym_name);
+extern struct sym *get_sym(char *sym_name);
+extern struct sym *new_sym(char *sym_name);
+
+extern void put_sym(char *sym_name, WORD sym_val);
+extern void put_label(void);
+
+extern struct sym *first_sym(int sort_mode);
+extern struct sym *next_sym(void);
+
+#endif /* !Z80ATAB_INC */


### PR DESCRIPTION
Still compiles on Coherent 3.2 and 4.2, and also compiles and runs on 2.11BSD PL481 on a PDP-11.