### PR TITLE
add back lost no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/.gitignore

### DIFF
--- a/picosim/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/.gitignore
+++ b/picosim/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/.gitignore
@@ -1,0 +1,9 @@
+**/build
+*.html
+*.png
+*.zip
+*.xlsx
+*.bak
+**/.vscode
+*.tar.gz
+PlatformIO.notes.txt


### PR DESCRIPTION
So that no-OS-FatFS-SD-SDIO-SPI-RPi-Pico is a clean copy of the 2.3.2 release, except for pico-sdk 2.0.0 changes.