### PR TITLE
sync with SDK 2.1.0 pico_stdio_usb, move USB manu/prod to CMakeLists.txt

### DIFF
--- a/picosim/rp2040/CMakeLists.txt
+++ b/picosim/rp2040/CMakeLists.txt
@@ -65,6 +65,8 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 	PICO_STACK_SIZE=4096
 	PICO_CORE1_STACK_SIZE=4096
 	PICO_HEAP_SIZE=8192
+	USBD_MANUFACTURER="Z80pack"
+	USBD_PRODUCT="Pi Pico RP2040"
 )
 
 # compiler diagnostic options

--- a/picosim/rp2040/stdio_msc_usb/include/stdio_msc_usb.h
+++ b/picosim/rp2040/stdio_msc_usb/include/stdio_msc_usb.h
@@ -47,7 +47,7 @@
 #define STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE 1
 #endif
 
-// PICO_CONFIG: STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE, baud rate that if selected causes a reset into BOOTSEL mode (if STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE is set), default=1200, group=stdio_msc_usb
+// PICO_CONFIG: STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE, Baud rate that if selected causes a reset into BOOTSEL mode (if STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE is set), default=1200, group=stdio_msc_usb
 #ifndef STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE
 #define STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE 1200
 #endif
@@ -67,7 +67,12 @@
 #define STDIO_MSC_USB_DEINIT_DELAY_MS 110
 #endif
 
-// PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED, Optionally define a pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=29, group=stdio_msc_usb
+// PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED, Optionally define a pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=47 on RP2350B, 29 otherwise, group=stdio_msc_usb
+
+// PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED_ACTIVE_LOW, Whether pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE) is active low, type=bool, default=0, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED_ACTIVE_LOW
+#define STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED_ACTIVE_LOW 0
+#endif
 
 // PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED, Whether the pin specified by STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED is fixed or can be modified by picotool over the VENDOR USB interface, type=bool, default=0, group=stdio_msc_usb
 #ifndef STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED

--- a/picosim/rp2040/stdio_msc_usb/reset_interface.c
+++ b/picosim/rp2040/stdio_msc_usb/reset_interface.c
@@ -122,16 +122,19 @@ static bool resetd_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_
 #if STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL
         if (request->bRequest == RESET_REQUEST_BOOTSEL) {
 #ifdef STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED
-            uint gpio_mask = 1u << STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED;
+            int gpio = STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED;
+            bool active_low = STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED_ACTIVE_LOW;
 #else
-            uint gpio_mask = 0u;
+            int gpio = -1;
+            bool active_low = false;
 #endif
 #if !STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
             if (request->wValue & 0x100) {
-                gpio_mask = 1u << (request->wValue >> 9u);
+                gpio = request->wValue >> 9u;
             }
+            active_low = request->wValue & 0x200;
 #endif
-            reset_usb_boot(gpio_mask, (request->wValue & 0x7f) | STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
+            rom_reset_usb_boot_extra(gpio, (request->wValue & 0x7f) | STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK, active_low);
             // does not return, otherwise we'd return true
         }
 #endif
@@ -176,11 +179,13 @@ usbd_class_driver_t const *usbd_app_driver_get_cb(uint8_t *driver_count) {
 void tud_cdc_line_coding_cb(__unused uint8_t itf, cdc_line_coding_t const* p_line_coding) {
     if (p_line_coding->bit_rate == STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE) {
 #ifdef STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED
-        const uint gpio_mask = 1u << STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED;
+        int gpio = STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED;
+        bool active_low = STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED_ACTIVE_LOW;
 #else
-        const uint gpio_mask = 0u;
+        int gpio = -1;
+        bool active_low = false;
 #endif
-        reset_usb_boot(gpio_mask, STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
+        rom_reset_usb_boot_extra(gpio, STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK, active_low);
     }
 }
 #endif

--- a/picosim/rp2040/stdio_msc_usb/stdio_msc_usb_descriptors.c
+++ b/picosim/rp2040/stdio_msc_usb/stdio_msc_usb_descriptors.c
@@ -44,11 +44,11 @@
 #endif
 
 #ifndef USBD_MANUFACTURER
-#define USBD_MANUFACTURER "Z80pack"
+#define USBD_MANUFACTURER "Raspberry Pi"
 #endif
 
 #ifndef USBD_PRODUCT
-#define USBD_PRODUCT "Pi Pico RP2040"
+#define USBD_PRODUCT "Pico"
 #endif
 
 #define TUD_RPI_RESET_DESC_LEN  9
@@ -124,7 +124,15 @@
 static const tusb_desc_device_t usbd_desc_device = {
     .bLength = sizeof(tusb_desc_device_t),
     .bDescriptorType = TUSB_DESC_DEVICE,
+// On Windows, if bcdUSB = 0x210 then a Microsoft OS 2.0 descriptor is required, else the device won't be detected
+// This is only needed for driverless access to the reset interface - the CDC interface doesn't require these descriptors
+// for driverless access, but will still not work if bcdUSB = 0x210 and no descriptor is provided. Therefore always
+// use bcdUSB = 0x200 if the Microsoft OS 2.0 descriptor isn't enabled
+#if STDIO_MSC_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE && STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_MS_OS_20_DESCRIPTOR
     .bcdUSB = 0x0210,
+#else
+    .bcdUSB = 0x0200,
+#endif
     .bDeviceClass = TUSB_CLASS_MISC,
     .bDeviceSubClass = MISC_SUBCLASS_COMMON,
     .bDeviceProtocol = MISC_PROTOCOL_IAD,

--- a/picosim/rp2350/CMakeLists.txt.arm
+++ b/picosim/rp2350/CMakeLists.txt.arm
@@ -64,6 +64,8 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 	PICO_STACK_SIZE=4096
 	PICO_CORE1_STACK_SIZE=4096
 	PICO_HEAP_SIZE=8192
+	USBD_MANUFACTURER="Z80pack"
+	USBD_PRODUCT="Pi Pico RP2350"
 )
 
 # compiler diagnostic options

--- a/picosim/rp2350/CMakeLists.txt.corev
+++ b/picosim/rp2350/CMakeLists.txt.corev
@@ -64,6 +64,8 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 	PICO_STACK_SIZE=4096
 	PICO_CORE1_STACK_SIZE=4096
 	PICO_HEAP_SIZE=8192
+	USBD_MANUFACTURER="Z80pack"
+	USBD_PRODUCT="Pi Pico RP2350"
 )
 
 # compiler diagnostic options

--- a/picosim/rp2350/stdio_msc_usb/include/stdio_msc_usb.h
+++ b/picosim/rp2350/stdio_msc_usb/include/stdio_msc_usb.h
@@ -47,7 +47,7 @@
 #define STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE 1
 #endif
 
-// PICO_CONFIG: STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE, baud rate that if selected causes a reset into BOOTSEL mode (if STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE is set), default=1200, group=stdio_msc_usb
+// PICO_CONFIG: STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE, Baud rate that if selected causes a reset into BOOTSEL mode (if STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE is set), default=1200, group=stdio_msc_usb
 #ifndef STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE
 #define STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE 1200
 #endif
@@ -67,7 +67,12 @@
 #define STDIO_MSC_USB_DEINIT_DELAY_MS 110
 #endif
 
-// PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED, Optionally define a pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=29, group=stdio_msc_usb
+// PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED, Optionally define a pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=47 on RP2350B, 29 otherwise, group=stdio_msc_usb
+
+// PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED_ACTIVE_LOW, Whether pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE) is active low, type=bool, default=0, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED_ACTIVE_LOW
+#define STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED_ACTIVE_LOW 0
+#endif
 
 // PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED, Whether the pin specified by STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED is fixed or can be modified by picotool over the VENDOR USB interface, type=bool, default=0, group=stdio_msc_usb
 #ifndef STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED

--- a/picosim/rp2350/stdio_msc_usb/reset_interface.c
+++ b/picosim/rp2350/stdio_msc_usb/reset_interface.c
@@ -122,16 +122,19 @@ static bool resetd_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_
 #if STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL
         if (request->bRequest == RESET_REQUEST_BOOTSEL) {
 #ifdef STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED
-            uint gpio_mask = 1u << STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED;
+            int gpio = STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED;
+            bool active_low = STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED_ACTIVE_LOW;
 #else
-            uint gpio_mask = 0u;
+            int gpio = -1;
+            bool active_low = false;
 #endif
 #if !STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
             if (request->wValue & 0x100) {
-                gpio_mask = 1u << (request->wValue >> 9u);
+                gpio = request->wValue >> 9u;
             }
+            active_low = request->wValue & 0x200;
 #endif
-            reset_usb_boot(gpio_mask, (request->wValue & 0x7f) | STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
+            rom_reset_usb_boot_extra(gpio, (request->wValue & 0x7f) | STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK, active_low);
             // does not return, otherwise we'd return true
         }
 #endif
@@ -176,11 +179,13 @@ usbd_class_driver_t const *usbd_app_driver_get_cb(uint8_t *driver_count) {
 void tud_cdc_line_coding_cb(__unused uint8_t itf, cdc_line_coding_t const* p_line_coding) {
     if (p_line_coding->bit_rate == STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE) {
 #ifdef STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED
-        const uint gpio_mask = 1u << STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED;
+        int gpio = STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED;
+        bool active_low = STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED_ACTIVE_LOW;
 #else
-        const uint gpio_mask = 0u;
+        int gpio = -1;
+        bool active_low = false;
 #endif
-        reset_usb_boot(gpio_mask, STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
+        rom_reset_usb_boot_extra(gpio, STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK, active_low);
     }
 }
 #endif

--- a/picosim/rp2350/stdio_msc_usb/stdio_msc_usb_descriptors.c
+++ b/picosim/rp2350/stdio_msc_usb/stdio_msc_usb_descriptors.c
@@ -44,11 +44,11 @@
 #endif
 
 #ifndef USBD_MANUFACTURER
-#define USBD_MANUFACTURER "Z80pack"
+#define USBD_MANUFACTURER "Raspberry Pi"
 #endif
 
 #ifndef USBD_PRODUCT
-#define USBD_PRODUCT "Pi Pico RP2350"
+#define USBD_PRODUCT "Pico"
 #endif
 
 #define TUD_RPI_RESET_DESC_LEN  9
@@ -124,7 +124,15 @@
 static const tusb_desc_device_t usbd_desc_device = {
     .bLength = sizeof(tusb_desc_device_t),
     .bDescriptorType = TUSB_DESC_DEVICE,
+// On Windows, if bcdUSB = 0x210 then a Microsoft OS 2.0 descriptor is required, else the device won't be detected
+// This is only needed for driverless access to the reset interface - the CDC interface doesn't require these descriptors
+// for driverless access, but will still not work if bcdUSB = 0x210 and no descriptor is provided. Therefore always
+// use bcdUSB = 0x200 if the Microsoft OS 2.0 descriptor isn't enabled
+#if STDIO_MSC_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE && STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_MS_OS_20_DESCRIPTOR
     .bcdUSB = 0x0210,
+#else
+    .bcdUSB = 0x0200,
+#endif
     .bDeviceClass = TUSB_CLASS_MISC,
     .bDeviceSubClass = MISC_SUBCLASS_COMMON,
     .bDeviceProtocol = MISC_PROTOCOL_IAD,


### PR DESCRIPTION
BTW, I've ordered a [RP2350-GEEK](https://www.waveshare.com/rp2350-geek.htm) at [Amazon](https://www.amazon.de/Waveshare-RP2350-GEEK-Development-Microcontroller-Downloader/dp/B0DNFHZPGX). Should be here in 2 weeks.

I've started porting FatFS to RISC-V, it compiles, but I can't test it, since I don't have a RP2350 board yet. Can you test my [riscv-fatfs](https://github.com/sneakywumpus/z80pack/tree/riscv-fatfs) z80pack branch on your Pico 2?
