### PR TITLE
no-OS-FatFS-SD-SDIO-SPI-RPi-Pico: use Pico SDK API's instead of ARM CMSIS ones

### DIFF
--- a/picosim/rp2350/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/CMakeLists.txt
+++ b/picosim/rp2350/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/CMakeLists.txt
@@ -40,5 +40,4 @@ target_link_libraries(no-OS-FatFS-SD-SDIO-SPI-RPi-Pico INTERFACE
     hardware_spi
     pico_aon_timer
     pico_stdlib
-    cmsis_core
 )

--- a/picosim/rp2350/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/include/delays.h
+++ b/picosim/rp2350/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/include/delays.h
@@ -51,20 +51,15 @@ call to millis() returns 0xFFFFFFFF:
 #include <stdint.h>
 //
 #include "pico/stdlib.h"
-#if PICO_RP2040
-#include "RP2040.h"
-#else
-#include "RP2350.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 static inline uint32_t millis() {
-    __COMPILER_BARRIER();
+    __compiler_memory_barrier();
     return time_us_64() / 1000;
-    __COMPILER_BARRIER();
+    __compiler_memory_barrier();
 }
 
 static inline void delay_ms(uint32_t ulTime_ms) {
@@ -72,9 +67,9 @@ static inline void delay_ms(uint32_t ulTime_ms) {
 }
 
 static inline uint64_t micros() {
-    __COMPILER_BARRIER();
+    __compiler_memory_barrier();
     return to_us_since_boot(get_absolute_time());
-    __COMPILER_BARRIER();
+    __compiler_memory_barrier();
 }
 
 #ifdef __cplusplus

--- a/picosim/rp2350/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/include/util.h
+++ b/picosim/rp2350/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/include/util.h
@@ -18,12 +18,6 @@ specific language governing permissions and limitations under the License.
 #include <stdint.h>
 #include <string.h>
 //
-#if PICO_RP2040
-#include "RP2040.h"
-#else
-#include "RP2350.h"
-#endif
-//
 #include "my_debug.h"
 
 #ifdef __cplusplus

--- a/picosim/rp2350/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/src/my_debug.c
+++ b/picosim/rp2350/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/src/my_debug.c
@@ -17,12 +17,8 @@ specific language governing permissions and limitations under the License.
 #include <stdint.h>
 #include <string.h>
 //
-#if PICO_RP2040
-#include "RP2040.h"
-#else
-#include "RP2350.h"
-#endif
 #include "pico/stdlib.h"
+#include "hardware/sync.h"
 //
 #include "crash.h"
 //
@@ -144,7 +140,7 @@ void __attribute__((weak)) my_assert_func(const char *file, int line, const char
                                           const char *pred) {
     error_message_printf_plain("assertion \"%s\" failed: file \"%s\", line %d, function: %s\n",
                                pred, file, line, func);
-    __disable_irq(); /* Disable global interrupts. */
+    (void)save_and_disable_interrupts(); /* Disable global interrupts. */
     capture_assert(file, line, func, pred);
 }
 


### PR DESCRIPTION
rp2040_sdio.c(rp2040_sdio_tx_poll): I think there is no way to determine if we are in an interrupt/exception-handler on RISC-V, therefore only do this on ARM.

crash.c(reset): Use watchdog_reboot() instead of CMSIS NVIC_SystemReset().

crash.c: exclude ARM specific DebugMon_Handler()/isr_hardfault() on RISC-V.