### PR TITLE
fix relative jump address wrap-around disassembly

### DIFF
--- a/z80core/simdis.c
+++ b/z80core/simdis.c
@@ -599,7 +599,8 @@ static int iout(const char *s, WORD a)
  */
 static int rout(const char *s, WORD a)
 {
-	sprintf(Disass_Str, "%s%04X", s, a + (SBYTE) getmem(a + 1) + 2);
+	sprintf(Disass_Str, "%s%04X", s,
+		(WORD) (a + (SBYTE) getmem(a + 1) + 2));
 	return 2;
 }
 


### PR DESCRIPTION
before:
0010 - 10 E0            DJNZ    FFFFFFF2
fff0 - 10 20            DJNZ    10012

now:
0010 - 10 E0            DJNZ    FFF2
fff0 - 10 20            DJNZ    0012