### PR TITLE
add jpeg dependency to Ubuntu github action

### DIFF
--- a/.github/workflows/makefile-ubuntu.yml
+++ b/.github/workflows/makefile-ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt install libglu1-mesa-dev
+      run: sudo apt install libjpeg-turbo8-dev libglu1-mesa-dev
 
     - name: Build binaries
       run: make


### PR DESCRIPTION
Got github mails with build failures when you pushed to master and I synced my repo. Must to related to the Ubuntu 24.04 update. Hope this fixes that.