### PR TITLE
clean-ups & picosim hardware breakpoint support

### DIFF
--- a/altairsim/srcsim/sim.h
+++ b/altairsim/srcsim/sim.h
@@ -38,8 +38,10 @@
 #define CPU_SPEED 2	/* default CPU speed */
 /*#define ALT_I8080*/	/* use alt. 8080 sim. primarily optimized for size */
 /*#define ALT_Z80*/	/* use alt. Z80 sim. primarily optimized for size */
-#define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_INST	/* compile undocumented instrs. (required by ALT_*) */
+#ifndef EXCLUDE_Z80
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
+#endif
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */
 #ifdef WANT_ICE

--- a/cpmsim/srcsim/sim.h
+++ b/cpmsim/srcsim/sim.h
@@ -15,8 +15,10 @@
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 /*#define ALT_I8080*/	/* use alt. 8080 sim. primarily optimized for size */
 /*#define ALT_Z80*/	/* use alt. Z80 sim. primarily optimized for size */
-#define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_INST	/* compile undocumented instrs. (required by ALT_*) */
+#ifndef EXCLUDE_Z80
 #define FAST_BLOCK	/* much faster but not accurate Z80 block instr. */
+#endif
 
 /*#define WANT_ICE*/	/* attach ICE to machine */
 #ifdef WANT_ICE

--- a/cromemcosim/srcsim/sim.h
+++ b/cromemcosim/srcsim/sim.h
@@ -39,8 +39,10 @@
 #define CPU_SPEED 4	/* default CPU speed */
 /*#define ALT_I8080*/	/* use alt. 8080 sim. primarily optimized for size */
 /*#define ALT_Z80*/	/* use alt. Z80 sim. primarily optimized for size */
-#define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_INST	/* compile undocumented instrs. (required by ALT_*) */
+#ifndef EXCLUDE_Z80
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
+#endif
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */
 #ifdef WANT_ICE

--- a/imsaisim/srcsim/sim.h
+++ b/imsaisim/srcsim/sim.h
@@ -39,8 +39,10 @@
 #define CPU_SPEED 2	/* default CPU speed */
 /*#define ALT_I8080*/	/* use alt. 8080 sim. primarily optimized for size */
 /*#define ALT_Z80*/	/* use alt. Z80 sim. primarily optimized for size */
-#define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_INST	/* compile undocumented instrs. (required by ALT_*) */
+#ifndef EXCLUDE_Z80
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
+#endif
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */
 #ifdef WANT_ICE

--- a/intelmdssim/srcsim/sim.h
+++ b/intelmdssim/srcsim/sim.h
@@ -23,8 +23,10 @@
 #define EXCLUDE_Z80	/* Intel Intellec MDS-800 was an 8080 machine */
 /*#define ALT_I8080*/	/* use alt. 8080 sim. primarily optimized for size */
 /*#define ALT_Z80*/	/* use alt. Z80 sim. primarily optimized for size */
-#define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_INST	/* compile undocumented instrs. (required by ALT_*) */
+#ifndef EXCLUDE_Z80
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
+#endif
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */
 #ifdef WANT_ICE

--- a/mosteksim/srcsim/sim.h
+++ b/mosteksim/srcsim/sim.h
@@ -22,11 +22,13 @@
  */
 #define DEF_CPU Z80	/* default CPU (Z80 or I8080) */
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
+#define EXCLUDE_I8080	/* this was a Z80 machine */
 /*#define ALT_I8080*/	/* use alt. 8080 sim. primarily optimized for size */
 /*#define ALT_Z80*/	/* use alt. Z80 sim. primarily optimized for size */
-#define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_INST	/* compile undocumented instrs. (required by ALT_*) */
+#ifndef EXCLUDE_Z80
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
-#define EXCLUDE_I8080	/* this was a Z80 machine */
+#endif
 
 #define WANT_ICE	/* attach ICE to headless machine */
 #ifdef WANT_ICE

--- a/picosim/srcsim/sim.h
+++ b/picosim/srcsim/sim.h
@@ -14,8 +14,10 @@
 #define CPU_SPEED 4	/* CPU speed 0=unlimited */
 /*#define ALT_I8080*/	/* use alt. 8080 sim. primarily optimized for size */
 /*#define ALT_Z80*/	/* use alt. Z80 sim. primarily optimized for size */
-#define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_INST	/* compile undocumented instrs. (required by ALT_*) */
+#ifndef EXCLUDE_Z80
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
+#endif
 #define BAREMETAL	/* set up the simulator core for bare metal use */
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */

--- a/picosim/srcsim/sim.h
+++ b/picosim/srcsim/sim.h
@@ -25,6 +25,7 @@
 #define WANT_TIM	/* count t-states */
 #define HISIZE	100	/* number of entries in history */
 #define SBSIZE	4	/* number of software breakpoints */
+#define WANT_HB		/* hardware breakpoint */
 #endif
 
 #if PICO_RP2040

--- a/z80core/simdefs.h
+++ b/z80core/simdefs.h
@@ -34,33 +34,8 @@
 #if defined(EXCLUDE_Z80) && DEF_CPU != I8080
 #error "DEF_CPU=Z80 and no Z80 simulation included"
 #endif
-#if defined(EXCLUDE_Z80) && defined(FAST_BLOCK)
-#error "FAST_BLOCK makes only sense without EXCLUDE_Z80"
-#endif
 #if (defined(ALT_I8080) || defined(ALT_Z80)) && !defined(UNDOC_INST)
 #error "UNDOC_INST required for alternate simulators"
-#endif
-#ifdef HISIZE
-#ifndef WANT_ICE
-#error "WANT_ICE required for HISIZE"
-#endif
-#if HISIZE < 1 || HISIZE > 1000
-#error "HISIZE must be between 1 and 1000"
-#endif
-#endif /* HISIZE */
-#ifdef SBSIZE
-#ifndef WANT_ICE
-#error "WANT_ICE required for SBSIZE"
-#endif
-#if SBSIZE < 1 || SBSIZE > 10
-#error "SBSIZE must be between 1 and 10"
-#endif
-#endif /* SBSIZE */
-#if defined(WANT_TIM) && !defined(WANT_ICE)
-#error "WANT_ICE required for WANT_TIM"
-#endif
-#if defined(WANT_HB) && !defined(WANT_ICE)
-#error "WANT_ICE required for WANT_HB"
 #endif
 
 				/* bit definitions of CPU flags */

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -369,7 +369,7 @@ static int handle_break(void)
 			fputs("write", stdout);
 		else
 			fputs("execute", stdout);
-		printf(" access to %04x\n", hb_addr);
+		fprintf(stdout, " access to %04x\n", hb_addr);
 		hb_trig = 0;
 		cpu_error = NONE;
 		return 0;
@@ -879,7 +879,7 @@ static void do_break(char *s)
 		puts("Please recompile with WANT_HB defined in sim.h");
 #else /* WANT_HB */
 		s++;
-		if (*s == '\n') {
+		if (*s == '\n' || *s == '\0') {
 			if (hb_flag) {
 				fputs("Hardware breakpoint set with ", stdout);
 				n = 0;
@@ -889,16 +889,17 @@ static void do_break(char *s)
 				}
 				if (hb_mode & HB_WRITE) {
 					if (n)
-						putchar('/');
+						fputc('/', stdout);
 					fputs("write", stdout);
 					n = 1;
 				}
 				if (hb_mode & HB_EXEC) {
 					if (n)
-						putchar('/');
+						fputc('/', stdout);
 					fputs("execute", stdout);
 				}
-				printf(" access trigger to %04x\n", hb_addr);
+				fprintf(stdout, " access trigger to %04x\n",
+					hb_addr);
 			} else
 				puts("No hardware breakpoint set");
 			return;
@@ -953,7 +954,7 @@ static void do_break(char *s)
 	puts("Sorry, no software breakpoints available");
 	puts("Please recompile with SBSIZE defined in sim.h");
 #else /* SBSIZE */
-	if (*s == '\n') {
+	if (*s == '\n' || *s == '\0') {
 		hdr_flag = 0;
 		for (i = 0; i < SBSIZE; i++)
 			if (soft[i].sb_pass) {

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -864,21 +864,20 @@ static void print_reg(void)
  */
 static void do_break(char *s)
 {
-#if !defined(SBSIZE) && !defined(WANT_HB)
-	UNUSED(s);
-
-	puts("Sorry, no breakpoints available");
-	puts("Please recompile with SBSIZE and/or WANT_HB defined in sim.h");
-#else /* SBSIZE || WANT_HB */
+#if defined(SBSIZE) || defined(WANT_HB)
 	WORD a;
 	int n;
 #ifdef SBSIZE
 	register int i;
 	int hdr_flag;
 #endif
+#endif
 
-#ifdef WANT_HB
 	if (*s == 'h') {
+#ifndef WANT_HB
+		puts("Sorry, no hardware breakpoint available");
+		puts("Please recompile with WANT_HB defined in sim.h");
+#else /* WANT_HB */
 		s++;
 		if (*s == '\n') {
 			if (hb_flag) {
@@ -947,10 +946,13 @@ static void do_break(char *s)
 		hb_addr = a;
 		hb_mode = n;
 		hb_flag = 1;
+#endif /* WANT_HB */
 		return;
 	}
-#endif /* WANT_HB */
-#ifdef SBSIZE
+#ifndef SBSIZE
+	puts("Sorry, no software breakpoints available");
+	puts("Please recompile with SBSIZE defined in sim.h");
+#else /* SBSIZE */
 	if (*s == '\n') {
 		hdr_flag = 0;
 		for (i = 0; i < SBSIZE; i++)
@@ -1042,7 +1044,6 @@ static void do_break(char *s)
 		soft[i].sb_passcount = 0;
 	}
 #endif /* SBSIZE */
-#endif /* SBSIZE || WANT_HB */
 }
 
 /*
@@ -1259,7 +1260,7 @@ static void do_show(void)
 #else
 	i = 0;
 #endif
-	printf("T-State counting %spossible\n", i ? "" : "im");
+	printf("T-State counting %spossible\n", i ? "" : "not ");
 }
 
 /*

--- a/z80sim/srcsim/sim.h.debug
+++ b/z80sim/srcsim/sim.h.debug
@@ -17,8 +17,10 @@
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 /*#define ALT_I8080*/	/* use alt. 8080 sim. primarily optimized for size */
 /*#define ALT_Z80*/	/* use alt. Z80 sim. primarily optimized for size */
-/*#define UNDOC_INST*/	/* compile undocumented instructions */
+/*#define UNDOC_INST*/	/* compile undocumented instrs. (required by ALT_*) */
+#ifndef EXCLUDE_Z80
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
+#endif
 
 #define WANT_ICE	/* attach ICE to headless machine */
 #ifdef WANT_ICE

--- a/z80sim/srcsim/sim.h.fast
+++ b/z80sim/srcsim/sim.h.fast
@@ -18,8 +18,10 @@
 #define CPU_SPEED 0	/* default CPU speed 0=unlimited */
 /*#define ALT_I8080*/	/* use alt. 8080 sim. primarily optimized for size */
 /*#define ALT_Z80*/	/* use alt. Z80 sim. primarily optimized for size */
-#define UNDOC_INST	/* compile undocumented instructions */
+#define UNDOC_INST	/* compile undocumented instrs. (required by ALT_*) */
+#ifndef EXCLUDE_Z80
 #define FAST_BLOCK	/* much faster but not accurate Z80 block instr. */
+#endif
 
 #define WANT_ICE	/* attach ICE to headless machine */
 #ifdef WANT_ICE

--- a/z80sim/srcsim/simmem.h
+++ b/z80sim/srcsim/simmem.h
@@ -60,8 +60,8 @@ static inline BYTE memrdr(WORD addr)
 	data = memory[addr];
 
 #ifdef BUS_8080
-	cpu_bus |= CPU_WO | CPU_MEMR;
 	cpu_bus &= ~CPU_M1;
+	cpu_bus |= CPU_WO | CPU_MEMR;
 #endif
 
 	return data;

--- a/z80sim/srcsim/simmem.h
+++ b/z80sim/srcsim/simmem.h
@@ -21,6 +21,10 @@
 #include "simice.h"
 #endif
 
+#ifdef BUS_8080
+#include "simglb.h"
+#endif
+
 extern BYTE memory[65536];
 
 extern void init_memory(void);


### PR DESCRIPTION
Guard FAST_BLOCK by !EXCLUDE_Z80.
Remove unneeded checks from simdefs.h (already guarded in sim.h).

simice: clean-up optional features messages.

Add hardware breakpoint support to picosim, so we can test performance impact.

Or we could switch from the "See what you are missing" paradigm and remove the not enabled commands entirely from the ICE. Thoughts?