### PR TITLE
fix single step software breakpoint handling

### DIFF
--- a/picosim/srcsim/simmem.h
+++ b/picosim/srcsim/simmem.h
@@ -71,6 +71,7 @@ static inline BYTE memrdr(WORD addr)
 		}
 	}
 #endif
+
 	if ((selbnk == 0) || (addr >= 0xc000))
 		data = bnk0[addr];
 	else

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -239,9 +239,9 @@ static void do_step(void)
 {
 	install_softbp();
 	step_cpu();
-	uninstall_softbp();
 	if (cpu_error == OPHALT)
 		(void) handle_break();
+	uninstall_softbp();
 	report_cpu_error();
 	print_head();
 	print_reg();


### PR DESCRIPTION
uninstall_softbp() was in the wrong place, would lead to loss of original instruction...