### PR TITLE
log.h and ICE 'i' and 'u' commands

### DIFF
--- a/doc/README-ice.txt
+++ b/doc/README-ice.txt
@@ -30,7 +30,7 @@ Pico. Because on bare metal there is no operating system all commands
 that require one are disabled. To enable bare metal support add the
 following to the sim.h file for the machine:
 
-#define BAREMETAL       /* set up the simulator core for bare metal use */
+#define BAREMETAL       /* disable ICE commands that require a full OS */
 
 Also watch out what code you are going to execute, because without an
 operating system that provides signal handling for applications, we

--- a/picosim/srcsim/sim.h
+++ b/picosim/srcsim/sim.h
@@ -18,10 +18,10 @@
 #ifndef EXCLUDE_Z80
 /*#define FAST_BLOCK*/	/* much faster but not accurate Z80 block instr. */
 #endif
-#define BAREMETAL	/* set up the simulator core for bare metal use */
 
 /*#define WANT_ICE*/	/* attach ICE to headless machine */
 #ifdef WANT_ICE
+#define BAREMETAL	/* disable ICE commands that require a full OS */
 #define WANT_TIM	/* count t-states */
 #define HISIZE	100	/* number of entries in history */
 #define SBSIZE	4	/* number of software breakpoints */

--- a/z80core/log.h
+++ b/z80core/log.h
@@ -19,8 +19,8 @@
 #ifndef LOG_INC
 #define LOG_INC
 
+#include <inttypes.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <stdarg.h>
 #include <time.h>
 #define CONFIG_LOG_COLORS
@@ -82,17 +82,17 @@ static inline uint32_t _log_timestamp(void) {
 #define LOG_RESET_COLOR
 #endif /* CONFIG_LOG_COLORS */
 
-#define _LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%d) %s: " format LOG_RESET_COLOR "\r\n"
+#define _LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\r\n"
 
 #ifndef LOG_LOCAL_LEVEL
 #define LOG_LOCAL_LEVEL  ((log_level_t) LOG_DEFAULT_LEVEL)
 #endif
 
-#define LOG( tag, format, ... )  _log_write(LOG_NONE, NULL, format, ##__VA_ARGS__);
-#define LOGE( tag, format, ... )  if (LOG_LOCAL_LEVEL >= LOG_ERROR)   { _log_write(LOG_ERROR,   tag, _LOG_FORMAT(E, format), _log_timestamp(), tag, ##__VA_ARGS__); }
-#define LOGW( tag, format, ... )  if (LOG_LOCAL_LEVEL >= LOG_WARN)    { _log_write(LOG_WARN,    tag, _LOG_FORMAT(W, format), _log_timestamp(), tag, ##__VA_ARGS__); }
-#define LOGI( tag, format, ... )  if (LOG_LOCAL_LEVEL >= LOG_INFO)    { _log_write(LOG_INFO,    tag, _LOG_FORMAT(I, format), _log_timestamp(), tag, ##__VA_ARGS__); }
-#define LOGD( tag, format, ... )  if (LOG_LOCAL_LEVEL >= LOG_DEBUG)   { _log_write(LOG_DEBUG,   tag, _LOG_FORMAT(D, format), _log_timestamp(), tag, ##__VA_ARGS__); }
-#define LOGV( tag, format, ... )  if (LOG_LOCAL_LEVEL >= LOG_VERBOSE) { _log_write(LOG_VERBOSE, tag, _LOG_FORMAT(V, format), _log_timestamp(), tag, ##__VA_ARGS__); }
+#define LOG( tag, format, ... )  _log_write(LOG_NONE, NULL, format, ##__VA_ARGS__)
+#define LOGE( tag, format, ... )  do { if (LOG_LOCAL_LEVEL >= LOG_ERROR)   { _log_write(LOG_ERROR,   tag, _LOG_FORMAT(E, format), _log_timestamp(), tag, ##__VA_ARGS__); } } while (0)
+#define LOGW( tag, format, ... )  do { if (LOG_LOCAL_LEVEL >= LOG_WARN)    { _log_write(LOG_WARN,    tag, _LOG_FORMAT(W, format), _log_timestamp(), tag, ##__VA_ARGS__); } } while (0)
+#define LOGI( tag, format, ... )  do { if (LOG_LOCAL_LEVEL >= LOG_INFO)    { _log_write(LOG_INFO,    tag, _LOG_FORMAT(I, format), _log_timestamp(), tag, ##__VA_ARGS__); } } while (0)
+#define LOGD( tag, format, ... )  do { if (LOG_LOCAL_LEVEL >= LOG_DEBUG)   { _log_write(LOG_DEBUG,   tag, _LOG_FORMAT(D, format), _log_timestamp(), tag, ##__VA_ARGS__); } } while (0)
+#define LOGV( tag, format, ... )  do { if (LOG_LOCAL_LEVEL >= LOG_VERBOSE) { _log_write(LOG_VERBOSE, tag, _LOG_FORMAT(V, format), _log_timestamp(), tag, ##__VA_ARGS__); } } while (0)
 
 #endif /* !LOG_INC */

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -34,11 +34,9 @@
 #include "simctl.h"
 #endif
 
-#ifndef BAREMETAL
 /* #define LOG_LOCAL_LEVEL LOG_DEBUG */
 #include "log.h"
 static const char *TAG = "core";
-#endif
 
 /*
  *	Initialize the CPU
@@ -184,59 +182,11 @@ void report_cpu_error(void)
 		return;
 
 	/* always start on a new line */
-#ifdef BAREMETAL
-	printf("\n");
-#else
 	LOG(TAG, "\r\n");
-#endif
 
 	switch (cpu_error) {
 	case NONE:
 		break;
-#ifdef BAREMETAL
-	case OPHALT:
-		printf("INT disabled and HALT Op-Code reached at 0x%04x\n",
-		       PC - 1);
-		break;
-	case IOTRAPIN:
-		printf("I/O input Trap at 0x%04x, port 0x%02x\n", PC, io_port);
-		break;
-	case IOTRAPOUT:
-		printf("I/O output Trap at 0x%04x, port 0x%02x\n",
-		       PC, io_port);
-		break;
-	case IOHALT:
-		printf("System halted\n");
-		break;
-	case IOERROR:
-		printf("Fatal I/O Error at 0x%04x\n", PC);
-		break;
-	case OPTRAP1:
-		printf("Op-code trap at 0x%04x 0x%02x\n",
-		       PC - 1, getmem(PC - 1));
-		break;
-	case OPTRAP2:
-		printf("Op-code trap at 0x%04x 0x%02x 0x%02x\n",
-		       PC - 2, getmem(PC - 2), getmem(PC - 1));
-		break;
-	case OPTRAP4:
-		printf("Op-code trap at 0x%04x 0x%02x 0x%02x 0x%02x 0x%02x\n",
-		       PC - 4, getmem(PC - 4), getmem(PC - 3),
-		       getmem(PC - 2), getmem(PC - 1));
-		break;
-	case USERINT:
-		printf("User Interrupt at 0x%04x\n", PC);
-		break;
-	case INTERROR:
-		printf("Unsupported bus data during INT: 0x%02x\n", int_data);
-		break;
-	case POWEROFF:
-		printf("System powered off\n");
-		break;
-	default:
-		printf("Unknown error %d\n", cpu_error);
-		break;
-#else /* !BAREMETAL */
 	case OPHALT:
 		LOG(TAG, "INT disabled and HALT Op-Code reached at 0x%04x\r\n",
 		    PC - 1);
@@ -280,7 +230,6 @@ void report_cpu_error(void)
 	default:
 		LOGW(TAG, "Unknown error %d", cpu_error);
 		break;
-#endif /* !BAREMETAL */
 	}
 }
 
@@ -349,9 +298,7 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 	fp_led_data = io_data;
 #endif
 
-#ifndef BAREMETAL
 	LOGD(TAG, "input %02x from port %02x", io_data, io_port);
-#endif
 
 	cpu_time -= get_clock_us() - clk;
 
@@ -375,9 +322,7 @@ void io_out(BYTE addrl, BYTE addrh, BYTE data)
 	io_port = addrl;
 	io_data = data;
 
-#ifndef BAREMETAL
 	LOGD(TAG, "output %02x to port %02x", io_data, io_port);
-#endif
 
 	busy_loop_cnt = 0;
 


### PR DESCRIPTION
Make log.h usable in picosim and more robust.
Use `PRIu32` in _log_timestamp().
Encapsulate `LOG?()` in `do { ... } while (0)` so that they work correctly with statements like:
```
if (foo)
        LOGW(TAG, "...");
else
        bar();
```
Use `LOG?` everywhere and make `BAREMETAL` an ICE only options.
Add i_flag/u_flag toggle commands to the ICE. Also report CPU errors in 'p' command. Clean-up 's' command a bit.