### PR TITLE
compile {non-}SDL files conditionally, fix native MS Windows compilation

### DIFF
--- a/altairsim/srcsim/Makefile
+++ b/altairsim/srcsim/Makefile
@@ -51,6 +51,7 @@ include $(CORE_DIR)/Makefile.in-os
 ###
 ifeq ($(WANT_SDL),YES)
 PLAT_DEFS = -DWANT_SDL
+PLAT_SRCS = simsdl.c
 ifeq ($(TARGET_OS),BSD)
 PLAT_INCS = -I/usr/local/include/SDL2
 PLAT_LDFLAGS = -L/usr/local/lib
@@ -133,9 +134,9 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simsdl.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c \
-	simz80-ed.c simz80-fd.c simz80-fdcb.c
-SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
+SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS) $(PLAT_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)
 

--- a/cpmsim/srcsim/Makefile
+++ b/cpmsim/srcsim/Makefile
@@ -68,8 +68,8 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simsdl.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c \
-	simz80-ed.c simz80-fd.c simz80-fdcb.c
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)

--- a/cromemcosim/srcsim/Makefile
+++ b/cromemcosim/srcsim/Makefile
@@ -58,6 +58,7 @@ include $(CORE_DIR)/Makefile.in-os
 ###
 ifeq ($(WANT_SDL),YES)
 PLAT_DEFS = -DWANT_SDL
+PLAT_SRCS = simsdl.c
 ifeq ($(TARGET_OS),BSD)
 PLAT_INCS = -I/usr/local/include/SDL2
 PLAT_LDFLAGS = -L/usr/local/lib
@@ -142,9 +143,9 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simsdl.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c \
-	simz80-ed.c simz80-fd.c simz80-fdcb.c
-SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
+SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS) $(PLAT_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)
 

--- a/frontpanel/Makefile
+++ b/frontpanel/Makefile
@@ -3,7 +3,11 @@ WANT_SDL ?= NO
 
 LIB = libfrontpanel.a
 
-SRCS = jpeg.c lpanel.c lp_gfx.c lp_main.c lp_utils.c lp_window.c \
+ifneq ($(WANT_SDL),YES)
+JPEGC = jpeg.c
+endif
+
+SRCS = $(JPEGC) lpanel.c lp_gfx.c lp_main.c lp_utils.c lp_window.c \
 	lp_switch.c lp_font.c lp_materials.c
 
 CORE_DIR = ../z80core

--- a/frontpanel/jpeg.c
+++ b/frontpanel/jpeg.c
@@ -1,7 +1,5 @@
 // jpeg
 
-#ifndef WANT_SDL
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -278,5 +276,3 @@ read_jpeg (char *fname, int *width, int *height, int *num_components)
 
   return pixels;
 }
-
-#endif /* !WANT_SDL */

--- a/frontpanel/jpeg.h
+++ b/frontpanel/jpeg.h
@@ -3,13 +3,9 @@
 #ifndef _JPEG_DEFS
 #define _JPEG_DEFS
 
-#ifndef WANT_SDL
-
 #include "jpeglib.h"
 
 EXTERN(unsigned char *) read_jpeg JPP((char *fname, int *width, int *height,
 				       int *num_components));
-
-#endif
 
 #endif /* !_JPEG_DEFS */

--- a/frontpanel/lp_window.c
+++ b/frontpanel/lp_window.c
@@ -353,7 +353,7 @@ LRESULT CALLBACK Lpanel_WndProc(Lpanel_t *p, UINT msg, WPARAM wParam, LPARAM lPa
 
 		case VK_DOWN:
 			if (p->do_cursor)
-				Lpanel_inc_cursor(p, 0., -cursor_inc);
+				Lpanel_inc_cursor(p, 0., -p->cursor_inc);
 			else {
 				if (p->shift_key_pressed)
 					p->view.pan[1] += 0.1;
@@ -437,27 +437,27 @@ LRESULT CALLBACK Lpanel_WndProc(Lpanel_t *p, UINT msg, WPARAM wParam, LPARAM lPa
 		case 'v':
 		case 'V':
 			if (p->view.projection == LP_ORTHO)
-				view.projection = LP_PERSPECTIVE;
+				p->view.projection = LP_PERSPECTIVE;
 			else
-				view.projection = LP_ORTHO;
+				p->view.projection = LP_ORTHO;
 
-			view.redo_projections = true;
+			p->view.redo_projections = true;
 			break;
 
 		case 'z':
-			view.pan[2] -= .1;
-			view.redo_projections = true;
+			p->view.pan[2] -= .1;
+			p->view.redo_projections = true;
 			break;
 
 		case 'Z':
-			view.pan[2] += .1;
-			view.redo_projections = true;
+			p->view.pan[2] += .1;
+			p->view.redo_projections = true;
 			break;
 
 		case '1':
 			break;
 		}
-		break;
+		return 0;
 
 	case WM_MOUSEWHEEL:
 		p->view.pan[2] += (float) GET_WHEEL_DELTA_WPARAM(wParam) / 250.0;
@@ -486,8 +486,8 @@ LRESULT CALLBACK Lpanel_WndProc(Lpanel_t *p, UINT msg, WPARAM wParam, LPARAM lPa
 				p->view.pan[0] += ((float) LOWORD(lParam) - (float) omx) * .02;
 				p->view.pan[1] -= ((float) HIWORD(lParam) - (float) omy) * .02;
 			} else {
-				view.rot[1] += ((float) LOWORD(lParam) - (float) omx) * .2;
-				view.rot[0] += ((float) HIWORD(lParam) - (float) omy) * .2;
+				p->view.rot[1] += ((float) LOWORD(lParam) - (float) omx) * .2;
+				p->view.rot[0] += ((float) HIWORD(lParam) - (float) omy) * .2;
 			}
 
 			mousex = LOWORD(lParam);
@@ -523,8 +523,8 @@ LRESULT CALLBACK Lpanel_WndProc(Lpanel_t *p, UINT msg, WPARAM wParam, LPARAM lPa
 	case WM_DESTROY:
 		UnregisterClass(FPClassName, p->hInstance);
 		PostQuitMessage(0);
-		if (quit_callbackfunc)
-			(*quit_callbackfunc)();
+		if (p->quit_callbackfunc)
+			(*p->quit_callbackfunc)();
 		else
 			exit(EXIT_SUCCESS);
 		return 0;
@@ -1082,6 +1082,10 @@ void Lpanel_setProjection(Lpanel_t *p, bool dopick)
 			p->bbox.xyz_min[1], p->bbox.xyz_max[1],
 			.1, 1000.);
 		break;
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 	case LP_PERSPECTIVE: {
 		// gluPerspective(p->view.fovy, p->view.aspect, p->view.znear, p->view.zfar);

--- a/imsaisim/srcsim/Makefile
+++ b/imsaisim/srcsim/Makefile
@@ -59,6 +59,7 @@ include $(CORE_DIR)/Makefile.in-os
 ###
 ifeq ($(WANT_SDL),YES)
 PLAT_DEFS = -DWANT_SDL
+PLAT_SRCS = simsdl.c
 ifeq ($(TARGET_OS),BSD)
 PLAT_INCS = -I/usr/local/include/SDL2
 PLAT_LDFLAGS = -L/usr/local/lib
@@ -143,9 +144,9 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simsdl.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c \
-	simz80-ed.c simz80-fd.c simz80-fdcb.c
-SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
+SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS) $(PLAT_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)
 

--- a/intelmdssim/srcsim/Makefile
+++ b/intelmdssim/srcsim/Makefile
@@ -50,6 +50,7 @@ include $(CORE_DIR)/Makefile.in-os
 ###
 ifeq ($(WANT_SDL),YES)
 PLAT_DEFS = -DWANT_SDL
+PLAT_SRCS = simsdl.c
 ifeq ($(TARGET_OS),BSD)
 PLAT_INCS = -I/usr/local/include/SDL2
 PLAT_LDFLAGS = -L/usr/local/lib
@@ -132,9 +133,9 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simsdl.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c \
-	simz80-ed.c simz80-fd.c simz80-fdcb.c
-SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
+SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS) $(PLAT_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)
 

--- a/mosteksim/srcsim/Makefile
+++ b/mosteksim/srcsim/Makefile
@@ -71,8 +71,8 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simsdl.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c \
-	simz80-ed.c simz80-fd.c simz80-fdcb.c
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)

--- a/picosim/srcsim/CMakeLists.txt
+++ b/picosim/srcsim/CMakeLists.txt
@@ -50,13 +50,13 @@ add_executable(${PROJECT_NAME}
 	${Z80PACK}/z80core/simdis.c
 	${Z80PACK}/z80core/simglb.c
 	${Z80PACK}/z80core/simice.c
+	${Z80PACK}/z80core/simz80.c
 	${Z80PACK}/z80core/simz80-cb.c
 	${Z80PACK}/z80core/simz80-dd.c
 	${Z80PACK}/z80core/simz80-ddcb.c
 	${Z80PACK}/z80core/simz80-ed.c
 	${Z80PACK}/z80core/simz80-fd.c
 	${Z80PACK}/z80core/simz80-fdcb.c
-	${Z80PACK}/z80core/simz80.c
 )
 
 # generate the header file into the source tree

--- a/z80core/simsdl.c
+++ b/z80core/simsdl.c
@@ -8,8 +8,6 @@
  *	This module contains the SDL2 integration for the simulator.
  */
 
-#ifdef WANT_SDL
-
 #include <stdbool.h>
 #include <stdlib.h>
 #include <SDL.h>
@@ -151,5 +149,3 @@ static int sim_thread_func(void *data)
 
 	return status;
 }
-
-#endif /* WANT_SDL */

--- a/z80core/simsdl.h
+++ b/z80core/simsdl.h
@@ -7,8 +7,6 @@
 #ifndef SIMSDL_INC
 #define SIMSDL_INC
 
-#ifdef WANT_SDL
-
 #include <stdbool.h>
 #include <SDL.h>
 
@@ -21,7 +19,5 @@ typedef struct win_funcs {
 
 extern int simsdl_create(win_funcs_t *funcs);
 extern void simsdl_destroy(int i);
-
-#endif /* WANT_SDL */
 
 #endif /* !SIMSDL_INC */

--- a/z80sim/srcsim/Makefile
+++ b/z80sim/srcsim/Makefile
@@ -63,8 +63,8 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 # core system source files for the CPU simulation
 CORE_SRCS = sim8080.c simcore.c simdis.c simfun.c simglb.c simice.c simint.c \
-	simmain.c simsdl.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c \
-	simz80-ed.c simz80-fd.c simz80-fdcb.c
+	simmain.c simz80.c simz80-cb.c simz80-dd.c simz80-ddcb.c simz80-ed.c \
+	simz80-fd.c simz80-fdcb.c
 SRCS = $(CORE_SRCS) $(MACHINE_SRCS) $(IO_SRCS)
 OBJS = $(SRCS:.c=.o)
 DEPS = $(SRCS:.c=.d)


### PR DESCRIPTION
Fixed native MS Windows compilation of the frontpanel library after the C conversion. Can't test if it works, but the code-flow didn't change with the C conversion, so it should. Used MSYS2 with mingw-w64-ucrt-x86_64-gcc on my Windows 11 VM to check that it compiles.
