### PR TITLE
move swap buffer calls outside of Lpanel_draw()

### DIFF
--- a/frontpanel/lp_main.c
+++ b/frontpanel/lp_main.c
@@ -91,6 +91,12 @@ static void *lp_mainloop_thread(void *n)
 		pthread_mutex_unlock(&data_lock);
 
 		// sleep remainder of fps time
+#if defined(__MINGW32__) || defined(_WIN32) || defined(_WIN32_) || defined(__WIN32__)
+		SwapBuffers(panel->hDC);
+		// UpdateWindow(panel->hWnd);
+#else
+		glXSwapBuffers(panel->dpy, panel->window);
+#endif
 		glFinish();
 		framerate_wait();
 		t2 = frate_gettime();
@@ -314,6 +320,7 @@ void fp_draw(bool tick)
 	SDL_LockMutex(data_sample_lock);
 	Lpanel_draw(panel);
 	SDL_UnlockMutex(data_sample_lock);
+	SDL_GL_SwapWindow(panel->window);
 	glFinish();
 	framecount++;
 	if (tick) {
@@ -339,6 +346,12 @@ void fp_procEvents(void)
 void fp_draw(void)
 {
 	Lpanel_draw(panel);
+#if defined(__MINGW32__) || defined(_WIN32) || defined(_WIN32_) || defined(__WIN32__)
+	SwapBuffers(panel->hDC);
+	// UpdateWindow(panel->hWnd);
+#else
+	glXSwapBuffers(panel->dpy, panel->window);
+#endif
 }
 
 #endif /* !WANT_SDL */

--- a/frontpanel/lp_window.c
+++ b/frontpanel/lp_window.c
@@ -1212,7 +1212,7 @@ void Lpanel_draw_stats(Lpanel_t *p)
 	glColor3f(1., 1., 0.);
 	snprintf(p->perf_txt, sizeof(p->perf_txt), "fps:%d sps:%d",
 		 p->frames_per_second, p->samples_per_second);
-	printStringAt(p->perf_txt, p->bbox.xyz_min[0] + .2, p->bbox.xyz_min[1] + .2);
+	printStringAt(p->perf_txt, 0, 0);
 
 	glMatrixMode(GL_PROJECTION);
 	glPopMatrix();
@@ -1246,9 +1246,9 @@ void Lpanel_draw_cursor(Lpanel_t *p)
 	glMatrixMode(GL_MODELVIEW);
 	glPushMatrix();
 	glLoadIdentity();
-	glTranslatef(200., 0., -10.);
+	glTranslatef(0., 0., -10.);
 
-	printStringAt(p->cursor_txt, p->cursor_textpos[0], p->cursor_textpos[1]);
+	printStringAt(p->cursor_txt, 200, 0);
 
 	glMatrixMode(GL_PROJECTION);
 	glPopMatrix();
@@ -1272,8 +1272,6 @@ void Lpanel_inc_cursor(Lpanel_t *p, float x, float y)
 
 void Lpanel_make_cursor_text(Lpanel_t *p)
 {
-	p->cursor_textpos[0] = (p->bbox.xyz_max[0] + p->bbox.xyz_min[0]) * .5;
-	p->cursor_textpos[1] = p->bbox.xyz_min[1] + .1;
 	snprintf(p->cursor_txt, sizeof(p->cursor_txt), "cursor position=%7.3f,%7.3f",
 		 p->cursor[0], p->cursor[1]);
 }

--- a/frontpanel/lpanel.c
+++ b/frontpanel/lpanel.c
@@ -1044,17 +1044,6 @@ void Lpanel_draw(Lpanel_t *p)
 	if (p->do_stats)
 		Lpanel_draw_stats(p);
 	glDisable(GL_POLYGON_OFFSET_LINE);
-
-#ifdef WANT_SDL
-	SDL_GL_SwapWindow(p->window);
-#else
-#if defined(__MINGW32__) || defined(_WIN32) || defined(_WIN32_) || defined(__WIN32__)
-	SwapBuffers(p->hDC);
-	// UpdateWindow(p->hWnd);
-#else
-	glXSwapBuffers(p->dpy, p->window);
-#endif
-#endif
 }
 
 void Lpanel_growLights(Lpanel_t *p)

--- a/frontpanel/lpanel.h
+++ b/frontpanel/lpanel.h
@@ -191,7 +191,6 @@ typedef struct Lpanel {
 	char		perf_txt[30];
 
 	char		cursor_txt[60];
-	float		cursor_textpos[2];
 	bool		do_cursor, do_stats;
 	float		cursor[3], cursor_inc;
 	bool		shift_key_pressed;


### PR DESCRIPTION
The swap buffer calls where made with the data lock mutexes held, this caused fp_sampleData() to be blocked until the next VSync on macOS and Linux using NVIDIA graphics, which is obviously not what we want.