### PR TITLE
clang 19 static analyzer run & clean-up

### DIFF
--- a/altairsim/srcsim/simcfg.c
+++ b/altairsim/srcsim/simcfg.c
@@ -75,8 +75,8 @@ void config(void)
 	}
 
 	if ((fp = fopen(fn, "r")) != NULL) {
-		s = buf;
-		while (fgets(s, BUFSIZE, fp) != NULL) {
+		while (fgets(buf, BUFSIZE, fp) != NULL) {
+			s = buf;
 			if ((*s == '\n') || (*s == '\r') || (*s == '#'))
 				continue;
 			if ((t1 = strtok(s, " \t")) == NULL) {

--- a/cpmsim/srcsim/simio.c
+++ b/cpmsim/srcsim/simio.c
@@ -536,13 +536,13 @@ static void net_server_config(void)
 	char *s;
 	char fn[MAX_LFN];
 
-	strcpy(&fn[0], &confdir[0]);
-	strcat(&fn[0], "/net_server.conf");
+	strcpy(fn, confdir);
+	strcat(fn, "/net_server.conf");
 
 	if ((fp = fopen(fn, "r")) != NULL) {
 		LOG(TAG, "Server network configuration:\r\n");
-		s = &buf[0];
-		while (fgets(s, BUFSIZE, fp) != NULL) {
+		while (fgets(buf, BUFSIZE, fp) != NULL) {
+			s = buf;
 			if ((*s == '\n') || (*s == '#'))
 				continue;
 			i = atoi(s);
@@ -578,20 +578,20 @@ static void net_client_config(void)
 	char *s, *d;
 	char fn[MAX_LFN];
 
-	strcpy(&fn[0], &confdir[0]);
-	strcat(&fn[0], "/net_client.conf");
+	strcpy(fn, confdir);
+	strcat(fn, "/net_client.conf");
 
 	if ((fp = fopen(fn, "r")) != NULL) {
 		LOG(TAG, "Client network configuration:\r\n");
-		s = &buf[0];
-		while (fgets(s, BUFSIZE, fp) != NULL) {
+		while (fgets(buf, BUFSIZE, fp) != NULL) {
+			s = buf;
 			if ((*s == '\n') || (*s == '#'))
 				continue;
 			while ((*s != ' ') && (*s != '\t'))
 				s++;
 			while ((*s == ' ') || (*s == '\t'))
 				s++;
-			d = &cs_host[0];
+			d = cs_host;
 			while ((*s != ' ') && (*s != '\t'))
 				*d++ = *s++;
 			*d = '\0';

--- a/cpmsim/srcsim/simmem.h
+++ b/cpmsim/srcsim/simmem.h
@@ -101,13 +101,14 @@ static inline BYTE memrdr(WORD addr)
 	}
 #endif
 
-	if (selbnk == 0)
+	if (selbnk == 0) {
 		data = *(memory[0] + addr);
-
-	if (addr >= segsize)
-		data = *(memory[0] + addr);
-	else
-		data = *(memory[selbnk] + addr);
+	} else {
+		if (addr >= segsize)
+			data = *(memory[0] + addr);
+		else
+			data = *(memory[selbnk] + addr);
+	}
 
 #ifdef BUS_8080
 	cpu_bus &= ~CPU_M1;

--- a/cpmsim/srctools/bin2hex.c
+++ b/cpmsim/srctools/bin2hex.c
@@ -1,161 +1,172 @@
 #include <stdio.h>
-#include <unistd.h>
 #include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
+#include <unistd.h>
 #include <sys/stat.h>
 
 void help(char *name)
 {
-  printf("%s - BINARY to Intel HEX file convertor version 1.00\n"\
-         "(c)BCL Vysoke Myto 2001 (benedikt@lphard.cz)\n\n",name);
-  printf("Usage: %s [-option] binfile hexfile\n"\
-	 " -l  Bytes to read from binary file\n"\
-	 " -i  Binary file starting offset\n"\
-	 " -o  Output file offset (where HEX data starts)\n"\
-	 " -t  Exclude EOF record\n"\
-	 " -a  Append to end of existing HEX file\n"\
-	 " -q  Quiet mode (no statistics are printed)\n", name);
+	printf("%s - BINARY to Intel HEX file convertor version 1.00\n"
+	       "(c)BCL Vysoke Myto 2001 (benedikt@lphard.cz)\n\n", name);
+	printf("Usage: %s [-option] binfile hexfile\n"
+	       " -l  Bytes to read from binary file\n"
+	       " -i  Binary file starting offset\n"
+	       " -o  Output file offset (where HEX data starts)\n"
+	       " -t  Exclude EOF record\n"
+	       " -a  Append to end of existing HEX file\n"
+	       " -q  Quiet mode (no statistics are printed)\n", name);
 }
 
-int main(int argc,char *argv[])/*Main routine*/
+int main(int argc, char *argv[]) /* Main routine */
 {
-  char *ifile = NULL;
-  char *ofile = NULL;
-  int c;
-  FILE *inp, *outp;
-  int ch,csum;
-  int ofsa = 0;
-  int cnt = 0;
-  struct stat statbuf;
-  long int foffset = 0;
-  long int fsize = 0;
-  long int fsub;
-  long int fpoint = 0;
-  long int adrs = 0;
-  unsigned char quiet = 0;
-  unsigned char eofrec = 0;
-  unsigned char append = 0;
+	char *ifile = NULL;
+	char *ofile = NULL;
+	int c;
+	FILE *inp, *outp;
+	int ch, csum;
+	int ofsa = 0;
+	int cnt = 0;
+	struct stat statbuf;
+	long foffset = 0;
+	long fsize = 0;
+	long fsub;
+	long fpoint = 0;
+	long adrs = 0;
+	unsigned char quiet = 0;
+	unsigned char eofrec = 0;
+	unsigned char append = 0;
 
-  opterr = 0; //print error message if unknown option
+	opterr = 0; //print error message if unknown option
 
-  while ((c = getopt (argc, argv, "l:i:o:taqv")) != -1)
-  switch (c) {
-    case 'l':
-      fsize = atol(optarg);
-      break;
-    case 'i':
-      foffset = atol(optarg);
-      break;
-    case 'o':
-      adrs = atol(optarg);
-      break;
-    case 't':
-      eofrec = 1;
-      break;
-    case 'a':
-      append = 1;
-      break;
-    case 'q':
-      quiet = 1;
-      break;
-    case 'v':
-      printf("%s - BINARY to Intel HEX file convertor version 1.00\n"\
-             "(c)BCL Vysoke Myto 2001 (benedikt@lphard.cz)\n",argv[0]);
-      return EXIT_SUCCESS;
-    case '?':
-      help (argv[0]);
-      return EXIT_FAILURE;
-  }
+	while ((c = getopt(argc, argv, "l:i:o:taqv")) != -1)
+		switch (c) {
+		case 'l':
+			fsize = atol(optarg);
+			break;
+		case 'i':
+			foffset = atol(optarg);
+			break;
+		case 'o':
+			adrs = atol(optarg);
+			break;
+		case 't':
+			eofrec = 1;
+			break;
+		case 'a':
+			append = 1;
+			break;
+		case 'q':
+			quiet = 1;
+			break;
+		case 'v':
+			printf("%s - BINARY to Intel HEX file convertor version 1.00\n"
+			       "(c)BCL Vysoke Myto 2001 (benedikt@lphard.cz)\n", argv[0]);
+			return EXIT_SUCCESS;
+		case '?':
+			help(argv[0]);
+			return EXIT_FAILURE;
+		}
 
-  if ((argc - optind) != 2) {
-    printf("ERROR: Missing input/output file.\n");
-    help(argv[0]);
-    return EXIT_FAILURE;
-  }
-  ifile = argv[optind];
-  ofile = argv[optind+1];
+	if ((argc - optind) != 2) {
+		printf("ERROR: Missing input/output file.\n");
+		help(argv[0]);
+		return EXIT_FAILURE;
+	}
+	ifile = argv[optind];
+	ofile = argv[optind + 1];
 
-  /*Open file check*/
-  if((inp = fopen(ifile, "rb")) == NULL){
-    printf("ERROR: Cannot open input file.\n");
-    return EXIT_FAILURE;
-  }
-  fseek (inp, foffset, SEEK_SET);
+	/* Open file check */
+	if ((inp = fopen(ifile, "rb")) == NULL) {
+		printf("ERROR: Cannot open input file.\n");
+		return EXIT_FAILURE;
+	}
+	fseek(inp, foffset, SEEK_SET);
 
-  if (append == 0) {
-    if((outp = fopen(ofile, "wt")) == NULL){
-      printf("ERROR: Cannot open output file.\n");
-      return EXIT_FAILURE;
-    }
-  } else {
-    if((outp = fopen(ofile, "at")) == NULL){
-      printf("ERROR: Cannot re-open output file.\n");
-      return EXIT_FAILURE;
-    }
-    fseek (outp, 0, SEEK_END);
-  }
+	if (append == 0) {
+		if ((outp = fopen(ofile, "wt")) == NULL) {
+			fclose(inp);
+			printf("ERROR: Cannot open output file.\n");
+			return EXIT_FAILURE;
+		}
+	} else {
+		if ((outp = fopen(ofile, "at")) == NULL) {
+			fclose(inp);
+			printf("ERROR: Cannot re-open output file.\n");
+			return EXIT_FAILURE;
+		}
+		fseek(outp, 0, SEEK_END);
+	}
 
-  fstat(fileno(inp), &statbuf);
-  if (quiet == 0) printf("Input file size=%ld\n",(long)statbuf.st_size);
-  if (foffset > statbuf.st_size) {
-    printf("ERROR: Input offset > input file length\n");
-  }
-  if ((fsize == 0) || (fsize > (statbuf.st_size - foffset)))
-    fsize = statbuf.st_size - foffset;
+	fstat(fileno(inp), &statbuf);
+	if (quiet == 0)
+		printf("Input file size=%ld\n", (long) statbuf.st_size);
+	if (foffset > statbuf.st_size)
+		printf("ERROR: Input offset > input file length\n");
+	if (fsize == 0 || fsize > (statbuf.st_size - foffset))
+		fsize = statbuf.st_size - foffset;
 
-//  fprintf(outp,":020000020000FC\n");/*Start Header*/
-  fsub = fsize - fpoint;
-  if (fsub > 0x20) {
-  	fprintf(outp,":20%04X00",(unsigned int) adrs); /*Hex line Header*/
-    csum = 0x20 + (adrs>>8) + (adrs & 0xFF);
-    adrs += 0x20;
-  }
-  else {
-  	fprintf(outp, ":%02X%04X00", (unsigned int) fsub, (unsigned int) adrs);/*Hex line Header*/
-    csum = fsub + (adrs>>8) + (adrs & 0xFF);
-    adrs += fsub;
-  }
-  while (fsub > 0){
-    ch = fgetc(inp);
-    fprintf(outp,"%02X",ch); /*Put data*/
-    cnt++; fpoint++;
-    fsub = fsize - fpoint;
-    csum = ch + csum;
-    if((fsub == 0)||(cnt == 0x20)){
-      cnt = 0; csum = 0xFF & (~csum + 1);
-      fprintf(outp,"%02X\n",csum); /*Put checksum*/
-      if(fsub == 0) break;
-      if(adrs > 0xFFFF){
-		ofsa = 0x1000 + ofsa;
-		adrs = 0;
-		fprintf(outp,":02000002%04X",ofsa); /*Change offset address*/
-		csum = 0x02 + 0x02 + (ofsa>>8) + (ofsa & 0xFF);
-		csum = 0xFF & (~csum + 1);
-        fprintf(outp,"%02X\n", csum);
-      }
-      adrs = 0xFFFF & adrs;
-	  if (fsub > 0x20) {
-  		fprintf(outp,":20%04X00", (unsigned int) adrs); /*Next Hex line Header*/
-    	csum = 0x20 + (adrs>>8) + (adrs & 0xFF);
-        adrs += 0x20;
-      }
-      else {
-      	if(fsub > 0){
-  			fprintf(outp, ":%02X%04X00", (unsigned int) fsub, (unsigned int) adrs); /*Next Hex line Header*/
-    		csum = fsub + (adrs>>8) + (adrs & 0xFF);
-        	adrs += fsub;
-        }
-      }
-    }
-  }
-  if (eofrec == 0) fprintf(outp,":00000001FF\n"); /*End footer*/
-  fflush (outp);
+	// fprintf(outp, ":020000020000FC\n"); /* Start Header */
+	fsub = fsize - fpoint;
+	if (fsub > 0x20) {
+		fprintf(outp, ":20%04X00", (unsigned) adrs); /* Hex line Header */
+		csum = 0x20 + (adrs >> 8) + (adrs & 0xFF);
+		adrs += 0x20;
+	} else {
+		fprintf(outp, ":%02X%04X00", (unsigned) fsub,
+			(unsigned) adrs); /* Hex line Header */
+		csum = fsub + (adrs >> 8) + (adrs & 0xFF);
+		adrs += fsub;
+	}
+	while (fsub > 0) {
+		if ((ch = fgetc(inp)) == EOF) {
+			fclose(inp);
+			fclose(outp);
+			printf("ERROR: Cannot read from input file.\n");
+			return EXIT_FAILURE;
+		}
+		fprintf(outp, "%02X", ch); /* Put data */
+		cnt++;
+		fpoint++;
+		fsub = fsize - fpoint;
+		csum = ch + csum;
+		if (fsub == 0 || cnt == 0x20) {
+			cnt = 0;
+			csum = 0xFF & (~csum + 1);
+			fprintf(outp, "%02X\n", csum); /* Put checksum */
+			if (fsub == 0)
+				break;
+			if (adrs > 0xFFFF) {
+				ofsa = 0x1000 + ofsa;
+				adrs = 0;
+				fprintf(outp, ":02000002%04X", ofsa); /* Change offset address */
+				csum = 0x02 + 0x02 + (ofsa >> 8) + (ofsa & 0xFF);
+				csum = 0xFF & (~csum + 1);
+				fprintf(outp, "%02X\n", csum);
+			}
+			adrs = 0xFFFF & adrs;
+			if (fsub > 0x20) {
+				fprintf(outp, ":20%04X00",
+					(unsigned) adrs); /* Next Hex line Header */
+				csum = 0x20 + (adrs >> 8) + (adrs & 0xFF);
+				adrs += 0x20;
+			} else {
+				if (fsub > 0) {
+					fprintf(outp, ":%02X%04X00", (unsigned) fsub,
+						(unsigned) adrs); /* Next Hex line Header */
+					csum = fsub + (adrs >> 8) + (adrs & 0xFF);
+					adrs += fsub;
+				}
+			}
+		}
+	}
+	if (eofrec == 0)
+		fprintf(outp, ":00000001FF\n"); /* End footer */
+	fflush(outp);
 
-  fstat(fileno(outp), &statbuf);
-  if (quiet == 0) printf("Output file size=%ld\n",(long)statbuf.st_size);
+	fstat(fileno(outp), &statbuf);
+	if (quiet == 0)
+		printf("Output file size=%ld\n", (long) statbuf.st_size);
 
-  fclose(inp);
-  fclose(outp);
-  return EXIT_SUCCESS;
+	fclose(inp);
+	fclose(outp);
+	return EXIT_SUCCESS;
 }

--- a/cpmsim/srctools/mkdskimg.c
+++ b/cpmsim/srctools/mkdskimg.c
@@ -77,6 +77,7 @@ int main(int argc, char *argv[])
 	}
 	memset((char *) sector, 0xe5, 128);
 	if ((fd = open(fn, O_RDONLY)) != -1) {
+		close(fd);
 		printf("disk file \"%s\" exists, aborting\n", fn);
 		exit(EXIT_FAILURE);
 	}

--- a/cromemcosim/srcsim/simcfg.c
+++ b/cromemcosim/srcsim/simcfg.c
@@ -50,15 +50,15 @@ void config(void)
 	int section = 0;
 
 	if (c_flag) {
-		strcpy(fn, &conffn[0]);
+		strcpy(fn, conffn);
 	} else {
-		strcpy(fn, &confdir[0]);
+		strcpy(fn, confdir);
 		strcat(fn, "/system.conf");
 	}
 
 	if ((fp = fopen(fn, "r")) != NULL) {
-		s = &buf[0];
-		while (fgets(s, BUFSIZE, fp) != NULL) {
+		while (fgets(buf, BUFSIZE, fp) != NULL) {
+			s = buf;
 			if ((*s == '\n') || (*s == '\r') || (*s == '#'))
 				continue;
 			if ((t1 = strtok(s, " \t")) == NULL) {

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -107,7 +107,7 @@ void mon(void)
 		XInitThreads();
 #endif
 		/* initialize front panel */
-		if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
+		if (!fp_init2(confdir, "panel.conf", fp_size)) {
 			LOGE(TAG, "frontpanel error");
 			exit(EXIT_FAILURE);
 		}

--- a/frontpanel/jpeg.c
+++ b/frontpanel/jpeg.c
@@ -228,13 +228,13 @@ read_jpeg (char *fname, int *width, int *height, int *num_components)
 
   int num_scanlines;
 
-  if( (fd = fopen(fname,"rb")) == NULL) {
-    fprintf(stderr,"read_jpeg: could not open file %s\n",fname);
+  if ((fd = fopen(fname, "rb")) == NULL) {
+    fprintf(stderr, "read_jpeg: could not open file %s\n", fname);
     return NULL;
   }
 
 #if DBG
-  fprintf(stderr,"read_jpeg: reading file %s\n",fname);
+  fprintf(stderr, "read_jpeg: reading file %s\n", fname);
 #endif
 
   cinfo.err = jpeg_std_error(&jerr);
@@ -253,7 +253,7 @@ read_jpeg (char *fname, int *width, int *height, int *num_components)
   /* Start decompressor */
   (void) jpeg_start_decompress(&cinfo);
 #if DBG
-  fprintf(stderr,"read_jpeg: started decompressor for  file %s\n",fname);
+  fprintf(stderr, "read_jpeg: started decompressor for file %s\n", fname);
 #endif
 
   /* Write output file header */
@@ -269,6 +269,8 @@ read_jpeg (char *fname, int *width, int *height, int *num_components)
   (*dest_mgr->finish_output) (&cinfo, dest_mgr);
   (void) jpeg_finish_decompress(&cinfo);
   jpeg_destroy_decompress(&cinfo);
+
+  fclose(fd);
 
   *width = xsize;
   *height = ysize;

--- a/frontpanel/lp_gfx.c
+++ b/frontpanel/lp_gfx.c
@@ -840,7 +840,7 @@ int lpTextures_downloadTextures(lpTextures_t *p)
 
 			// get a bind id from OpenGL
 
-			n = glGetError();	/* clear any gl errors */
+			(void) glGetError();	/* clear any gl errors */
 
 			glGenTextures(1, (GLuint *) &tp->bind_id);
 			glBindTexture(GL_TEXTURE_2D, tp->bind_id);

--- a/frontpanel/lp_utils.c
+++ b/frontpanel/lp_utils.c
@@ -367,7 +367,7 @@ int xpand(const char *s, char **namelist[])
 				    abs(inc_ival) + 1;
 
 			new_namelist = (char **) malloc(sizeof(char *) * max_names);
-			*namelist = &new_namelist[0];
+			*namelist = new_namelist;
 			num_names = 0;
 
 			do {
@@ -406,7 +406,7 @@ int xpand(const char *s, char **namelist[])
 			strcat(obuf, suffix);
 
 		new_namelist = (char **) malloc(sizeof(char *));
-		*namelist = &new_namelist[0];
+		*namelist = new_namelist;
 		num_names = 0;
 
 		new_namelist[num_names] = (char *) malloc(strlen(obuf) + 1);

--- a/frontpanel/lpanel.c
+++ b/frontpanel/lpanel.c
@@ -1087,7 +1087,7 @@ int Lpanel_pick(Lpanel_t *p, int button, bool state, int x, int y)
 #endif
 
 	namebuf[0] = 0;
-	glSelectBuffer(500, &namebuf[0]);
+	glSelectBuffer(500, namebuf);
 	glRenderMode(GL_SELECT);
 	glInitNames();
 	glPushName(0);
@@ -1230,7 +1230,6 @@ bool Lpanel_readConfig(Lpanel_t *p, const char *_fname)
 				       lineno, fname);
 				printf("could not load sound '%s'.\n", sound_path);
 				bailout = true;
-				break;
 			}
 
 			free(sound_path);

--- a/imsaisim/srcsim/simcfg.c
+++ b/imsaisim/srcsim/simcfg.c
@@ -80,8 +80,8 @@ void config(void)
 	}
 
 	if ((fp = fopen(fn, "r")) != NULL) {
-		s = buf;
-		while (fgets(s, BUFSIZE, fp) != NULL) {
+		while (fgets(buf, BUFSIZE, fp) != NULL) {
+			s = buf;
 			if ((*s == '\n') || (*s == '\r') || (*s == '#'))
 				continue;
 			if ((t1 = strtok(s, " \t")) == NULL) {

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -113,7 +113,7 @@ void mon(void)
 #endif
 		/* initialize front panel */
 		putchar('\n');
-		if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
+		if (!fp_init2(confdir, "panel.conf", fp_size)) {
 			LOGE(TAG, "frontpanel error");
 			exit(EXIT_FAILURE);
 		}

--- a/intelmdssim/srcsim/simcfg.c
+++ b/intelmdssim/srcsim/simcfg.c
@@ -47,8 +47,8 @@ void config(void)
 	}
 
 	if ((fp = fopen(fn, "r")) != NULL) {
-		s = buf;
-		while (fgets(s, BUFSIZE, fp) != NULL) {
+		while (fgets(buf, BUFSIZE, fp) != NULL) {
+			s = buf;
 			if ((*s == '\n') || (*s == '\r') || (*s == '#'))
 				continue;
 			if ((t1 = strtok(s, " \t")) == NULL) {

--- a/intelmdssim/srcsim/simctl.c
+++ b/intelmdssim/srcsim/simctl.c
@@ -80,7 +80,7 @@ void mon(void)
 #endif
 
 		/* initialize frontpanel */
-		if (!fp_init2(&confdir[0], "panel.conf", fp_size)) {
+		if (!fp_init2(confdir, "panel.conf", fp_size)) {
 			LOGE(TAG, "frontpanel error");
 			exit(EXIT_FAILURE);
 		}

--- a/iodevices/cromemco-fdc.c
+++ b/iodevices/cromemco-fdc.c
@@ -450,7 +450,7 @@ BYTE cromemco_fdc_data_in(void)
 				return (BYTE) 0;
 			}
 			/* read the sector */
-			if (read(fd, &buf[0], secsz) != secsz) {
+			if (read(fd, buf, secsz) != secsz) {
 				state = FDC_IDLE;	/* abort command */
 				fdc_flags |= 1;		/* set EOJ */
 				fdc_flags &= ~128;	/* reset DRQ */
@@ -594,7 +594,7 @@ void cromemco_fdc_data_out(BYTE data)
 			state = FDC_IDLE;		/* done */
 			fdc_flags |= 1;			/* set EOJ */
 			fdc_flags &= ~128;		/* reset DRQ */
-			if (write(fd, &buf[0], secsz) == secsz)
+			if (write(fd, buf, secsz) == secsz)
 				fdc_stat = 0;
 			else
 				fdc_stat = 0x20;	/* write fault */

--- a/iodevices/mostek-fdc.c
+++ b/iodevices/mostek-fdc.c
@@ -364,7 +364,7 @@ BYTE fdc1771_data_in(void)
 			}
 
 			/* read the sector */
-			if (read(fd, &buf[0], SEC_SZ) != SEC_SZ) {
+			if (read(fd, buf, SEC_SZ) != SEC_SZ) {
 				state = FDC_IDLE;	/* abort read command */
 				fdc_stat = sRECORD_NOT_FOUND;
 				close(fd);
@@ -469,7 +469,7 @@ void fdc1771_data_out(BYTE data)
 		/* last byte? */
 		if (dcnt == SEC_SZ) {
 			state = FDC_IDLE;
-			if (write(fd, &buf[0], SEC_SZ) == SEC_SZ)
+			if (write(fd, buf, SEC_SZ) == SEC_SZ)
 				fdc_stat = 0;
 			else
 				fdc_stat = sWRITE_FAULT;

--- a/iodevices/sd-fdc.c
+++ b/iodevices/sd-fdc.c
@@ -59,7 +59,7 @@ void fdc_out(BYTE data)
 			break;
 
 		case FDC_READ:
-			get_fdccmd(&fdc_cmd[0], fdc_cmd_addr);
+			get_fdccmd(fdc_cmd, fdc_cmd_addr);
 			fdc_dma_addr = fdc_cmd[DD_DMAL] +
 				       (fdc_cmd[DD_DMAH] << 8);
 			fdc_stat = read_sec(data & 0x0f, fdc_cmd[DD_TRACK],
@@ -67,7 +67,7 @@ void fdc_out(BYTE data)
 			break;
 
 		case FDC_WRITE:
-			get_fdccmd(&fdc_cmd[0], fdc_cmd_addr);
+			get_fdccmd(fdc_cmd, fdc_cmd_addr);
 			fdc_dma_addr = fdc_cmd[DD_DMAL] +
 				       (fdc_cmd[DD_DMAH] << 8);
 			fdc_stat = write_sec(data & 0x0f, fdc_cmd[DD_TRACK],

--- a/iodevices/tarbell_fdc.c
+++ b/iodevices/tarbell_fdc.c
@@ -293,7 +293,7 @@ BYTE tarbell_data_in(void)
 			}
 
 			/* read the sector */
-			if (read(fd, &buf[0], SEC_SZ) != SEC_SZ) {
+			if (read(fd, buf, SEC_SZ) != SEC_SZ) {
 				state = FDC_IDLE;	/* abort read command */
 				fdc_stat = 0x10;	/* record not found */
 				close(fd);
@@ -406,7 +406,7 @@ void tarbell_data_out(BYTE data)
 		/* last byte? */
 		if (dcnt == SEC_SZ) {
 			state = FDC_IDLE;		/* reset DRQ */
-			if (write(fd, &buf[0], SEC_SZ) == SEC_SZ)
+			if (write(fd, buf, SEC_SZ) == SEC_SZ)
 				fdc_stat = 0;
 			else
 				fdc_stat = 0x20;	/* write fault */

--- a/mosteksim/srcsim/simcfg.c
+++ b/mosteksim/srcsim/simcfg.c
@@ -42,8 +42,8 @@ void config(void)
 	}
 
 	if ((fp = fopen(fn, "r")) != NULL) {
-		s = buf;
-		while (fgets(s, BUFSIZE, fp) != NULL) {
+		while (fgets(buf, BUFSIZE, fp) != NULL) {
+			s = buf;
 			if ((*s == '\n') || (*s == '\r') || (*s == '#'))
 				continue;
 			if ((t1 = strtok(s, "= \t\r\n")) == NULL) {

--- a/picosim/srcsim/disks.c
+++ b/picosim/srcsim/disks.c
@@ -162,7 +162,7 @@ bool load_file(const char *name)
 	}
 
 	/* read file into memory */
-	while ((sd_res = f_read(&sd_file, &dsk_buf[0], SEC_SZ, &br)) == FR_OK) {
+	while ((sd_res = f_read(&sd_file, dsk_buf, SEC_SZ, &br)) == FR_OK) {
 		for (j = 0; j < br; j++)
 			dma_write(i + j, dsk_buf[j]);
 		if (br < SEC_SZ)	/* last record reached */
@@ -292,7 +292,7 @@ BYTE read_sec(int drive, int track, int sector, WORD addr)
 	if (stat == FDC_STAT_OK) {
 
 		/* read sector into memory */
-		sd_res = f_read(&sd_file, &dsk_buf[0], SEC_SZ, &br);
+		sd_res = f_read(&sd_file, dsk_buf, SEC_SZ, &br);
 		if (sd_res == FR_OK) {
 			if (br < SEC_SZ)	/* UH OH */
 				stat = FDC_STAT_READ;
@@ -329,7 +329,7 @@ BYTE write_sec(int drive, int track, int sector, WORD addr)
 		/* write sector to disk image */
 		for (i = 0; i < SEC_SZ; i++)
 			dsk_buf[i] = dma_read(addr + i);
-		sd_res = f_write(&sd_file, &dsk_buf[0], SEC_SZ, &br);
+		sd_res = f_write(&sd_file, dsk_buf, SEC_SZ, &br);
 		if (sd_res == FR_OK) {
 			if (br < SEC_SZ)	/* UH OH */
 				stat = FDC_STAT_WRITE;

--- a/webfrontend/netsrv.c
+++ b/webfrontend/netsrv.c
@@ -461,7 +461,7 @@ int DirectoryHandler(HttpdConnection_t *conn, void *path) {
 
             while ((pDirent = readdir(pDir)) != NULL) {
                 LOGD(TAG, "GET directory: %s type: %d", pDirent->d_name, pDirent->d_type);
-		snprintf(&fullpath[0], MAX_LFN, "%s/%s", (char *) path, pDirent->d_name);
+		snprintf(fullpath, MAX_LFN, "%s/%s", (char *) path, pDirent->d_name);
 		/*
 		 * not working with some filesystems like Linux xfs, need to use stat()
                  * if (pDirent->d_type==DT_REG) {


### PR DESCRIPTION
altairsim/srcsim/simcfg.c,
cpmsim/srcsim/simio.c,
cromemcosim/srcsim/simcfg.c,
imsaisim/srcsim/simcfg.c,
intelmdssim/srcsim/simcfg.c,
mosteksim/srcsim/simcfg.c:

Changed
```
        s = buf;
        while (fgets(s, BUFSIZE, ...)) {
```
to
```
        while (fget(buf, BUFSIZE, ...)) {
                s = buf;
```
since s was sometimes manipulated inside the loop.

cpmsim/srcsim/simmem.h:

Changed memrdr to match memwrt, no functional change. Analyzer complained about a useless assignment.

cpmsim/srctools/bin2hex.c,
cpmsim/srctools/mkdskimg.c,
frontpanel/jpeg.c:

Unclosed files, also reformatted bin2hex.c.

z80core/simmain.c:

Re-did save_core and load_core since the analyzer complained about unchecked errors.

iodevices/altair-88-dcdd.c:

Renamed dsk_check to dsk_open and leave file open on success. Analyzer complained about possible open(2) fail in altair_dsk_data_out and altair_dsk_data_in.

frontpanel/lpanel.c:

Fix possible memory leak.

Rest of files: Changed `&buf[0]` to `buf`, for strings and buffers, since this looks more natural in C.