### PR TITLE
time/timing code rework

### DIFF
--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -324,10 +324,10 @@ static void step_clicked(int state, int val)
 /*
  * Single step through the machine cycles after first M1
  */
-bool wait_step(void)
+bool wait_step(bool tadj)
 {
 	bool ret = false;
-	uint64_t t1, t2;
+	uint64_t t = 0;
 
 	if (cpu_state != ST_SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
@@ -342,7 +342,8 @@ bool wait_step(void)
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	t1 = get_clock_us();
+	if (tadj)
+		t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		/* when INP update data bus LEDs */
 		if (cpu_bus == (CPU_WO | CPU_INP)) {
@@ -354,10 +355,9 @@ bool wait_step(void)
 		fp_sampleData();
 		sleep_for_ms(10);
 		ret = true;
-		t2 = get_clock_us();
-		cpu_start += t2 - t1;
-		t1 = t2;
 	}
+	if (tadj)
+		cpu_tadj += get_clock_us() - t;
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = false;
@@ -369,22 +369,20 @@ bool wait_step(void)
  */
 void wait_int_step(void)
 {
-	uint64_t t1, t2;
+	uint64_t t;
 
 	if (cpu_state != ST_SINGLE_STEP)
 		return;
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	t1 = get_clock_us();
+	t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		fp_clock++;
 		fp_sampleData();
 		sleep_for_ms(10);
-		t2 = get_clock_us();
-		cpu_start += t2 - t1;
-		t1 = t2;
 	}
+	cpu_tadj += get_clock_us() - t;
 }
 
 /*

--- a/altairsim/srcsim/simctl.h
+++ b/altairsim/srcsim/simctl.h
@@ -14,7 +14,7 @@ extern int boot_switch;			/* boot address for switch */
 
 extern void mon(void);
 
-extern bool wait_step(void);
+extern bool wait_step(bool tadj);
 extern void wait_int_step(void);
 
 #endif /* !SIMCTL_INC */

--- a/altairsim/srcsim/simio.c
+++ b/altairsim/srcsim/simio.c
@@ -155,6 +155,9 @@ void init_io(void)
 	/* create local sockets */
 	init_unix_server_socket(&ucons[0], "altairsim.tape");
 	init_unix_server_socket(&ucons[1], "altairsim.sio2");
+
+	altair_sio_reset();
+	altair_2sio_reset();
 }
 
 /*
@@ -191,6 +194,8 @@ void reset_io(void)
 	cromemco_dazzler_off();
 	tarbell_reset();
 	altair_dsk_reset();
+	altair_sio_reset();
+	altair_2sio_reset();
 }
 
 #if 0		/* currently not used */

--- a/altairsim/srcsim/simmem.h
+++ b/altairsim/srcsim/simmem.h
@@ -86,7 +86,7 @@ static inline void memwrt(WORD addr, BYTE data)
 		fp_led_address = addr;
 		fp_led_data = 0xff;
 		fp_sampleData();
-		wait_step();
+		wait_step(true);
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif
@@ -148,7 +148,7 @@ static inline BYTE memrdr(WORD addr)
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step();
+		wait_step(true);
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif

--- a/cpmsim/srcsim/simio.c
+++ b/cpmsim/srcsim/simio.c
@@ -2076,8 +2076,11 @@ static BYTE speedl_in(void)
 static void speedh_out(BYTE data)
 {
 	speed += data << 8;
-	tmax = speed * 10000;
 	f_value = speed;
+	if (f_value)
+		tmax = speed * 10000;
+	else
+		tmax = 100000;
 }
 
 /*

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -329,10 +329,10 @@ static void step_clicked(int state, int val)
 /*
  * Single step through the machine cycles after M1
  */
-bool wait_step(void)
+bool wait_step(bool tadj)
 {
 	bool ret = false;
-	uint64_t t1, t2;
+	uint64_t t = 0;
 
 	if (cpu_state != ST_SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
@@ -347,7 +347,8 @@ bool wait_step(void)
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	t1 = get_clock_us();
+	if (tadj)
+		t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		/* when INP update data bus LEDs */
 		if (cpu_bus == (CPU_WO | CPU_INP)) {
@@ -359,10 +360,9 @@ bool wait_step(void)
 		fp_sampleData();
 		sleep_for_ms(10);
 		ret = true;
-		t2 = get_clock_us();
-		cpu_start += t2 - t1;
-		t1 = t2;
 	}
+	if (tadj)
+		cpu_tadj += get_clock_us() - t;
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = false;
@@ -374,22 +374,20 @@ bool wait_step(void)
  */
 void wait_int_step(void)
 {
-	uint64_t t1, t2;
+	uint64_t t;
 
 	if (cpu_state != ST_SINGLE_STEP)
 		return;
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	t1 = get_clock_us();
+	t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		fp_clock++;
 		fp_sampleData();
 		sleep_for_ms(10);
-		t2 = get_clock_us();
-		cpu_start += t2 - t1;
-		t1 = t2;
 	}
+	cpu_tadj += get_clock_us() - t;
 }
 
 /*

--- a/cromemcosim/srcsim/simctl.h
+++ b/cromemcosim/srcsim/simctl.h
@@ -12,7 +12,7 @@
 
 extern void mon(void);
 
-extern bool wait_step(void);
+extern bool wait_step(bool tadj);
 extern void wait_int_step(void);
 
 #endif /* !SIMCTL_INC */

--- a/cromemcosim/srcsim/simmem.h
+++ b/cromemcosim/srcsim/simmem.h
@@ -104,7 +104,7 @@ static inline void memwrt(WORD addr, BYTE data)
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step();
+		wait_step(true);
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif
@@ -168,7 +168,7 @@ static inline BYTE memrdr(WORD addr)
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step();
+		wait_step(true);
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif

--- a/imsaisim/srcsim/simctl.h
+++ b/imsaisim/srcsim/simctl.h
@@ -12,7 +12,7 @@
 
 extern void mon(void);
 
-extern bool wait_step(void);
+extern bool wait_step(bool tadj);
 extern void wait_int_step(void);
 
 #endif /* !SIMCTL_INC */

--- a/imsaisim/srcsim/simio.c
+++ b/imsaisim/srcsim/simio.c
@@ -285,6 +285,7 @@ void init_io(void)
 		imsai_vio_init();
 	}
 
+	imsai_sio_reset();
 	imsai_fif_reset();
 
 #ifdef HAS_DAZZLER
@@ -340,6 +341,7 @@ void reset_io(void)
 #ifdef HAS_DAZZLER
 	cromemco_dazzler_off();
 #endif
+	imsai_sio_reset();
 	imsai_fif_reset();
 #ifdef HAS_APU
 	am_reset(am9511);

--- a/imsaisim/srcsim/simmem.h
+++ b/imsaisim/srcsim/simmem.h
@@ -125,7 +125,7 @@ static inline void memwrt(WORD addr, BYTE data)
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step();
+		wait_step(true);
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif
@@ -183,7 +183,7 @@ static inline BYTE memrdr(WORD addr)
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step();
+		wait_step(true);
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif

--- a/intelmdssim/srcsim/simctl.c
+++ b/intelmdssim/srcsim/simctl.c
@@ -221,8 +221,10 @@ static void int_clicked(int state, int val)
 /*
  *	Single step through the machine cycles after M1
  */
-bool wait_step(void)
+bool wait_step(bool tadj)
 {
+	UNUSED(tadj);
+
 	cpu_bus &= ~CPU_M1;
 	m1_step = false;
 	return false;

--- a/intelmdssim/srcsim/simctl.h
+++ b/intelmdssim/srcsim/simctl.h
@@ -15,7 +15,7 @@ extern BYTE boot_switch;
 
 extern void mon(void);
 
-extern bool wait_step(void);
+extern bool wait_step(bool tadj);
 extern void wait_int_step(void);
 
 #endif /* !SIMCTL_INC */

--- a/intelmdssim/srcsim/simio.c
+++ b/intelmdssim/srcsim/simio.c
@@ -458,15 +458,14 @@ static void hwctl_out(BYTE data)
 static void *timing(void *arg)
 {
 	uint64_t t, tick;
-	int64_t tdiff;
+	long tleft;
 
 	UNUSED(arg);
 
 	tick = 0;
+	t = get_clock_us();
 
 	while (true) {	/* 260 usec per loop iteration */
-
-		t = get_clock_us();
 
 		/* do nothing if thread is suspended */
 		if (th_suspend)
@@ -495,11 +494,14 @@ static void *timing(void *arg)
 		int_pending();
 
 next:
-		tdiff = 260L - (get_clock_us() - t);
-		if (tdiff > 0)
-			sleep_for_us(tdiff);
+		/* sleep rest to 260us */
+		tleft = 260L - (long) (get_clock_us() - t);
+		if (tleft > 0)
+			sleep_for_us(tleft);
 
 		tick++;
+
+		t = get_clock_us();
 	}
 
 	/* never reached, this thread is running endless */

--- a/iodevices/altair-88-2sio.h
+++ b/iodevices/altair-88-2sio.h
@@ -41,6 +41,8 @@ extern bool sio2_strip_parity;	/* SIO 2 strip parity from output */
 extern bool sio2_drop_nulls;	/* SIO 2 drop nulls after CR/LF */
 extern int sio2_baud_rate;	/* SIO 2 baud rate */
 
+extern void altair_2sio_reset(void);
+
 extern BYTE altair_sio1_status_in(void);
 extern void altair_sio1_status_out(BYTE data);
 extern BYTE altair_sio1_data_in(void);

--- a/iodevices/altair-88-sio.h
+++ b/iodevices/altair-88-sio.h
@@ -36,6 +36,8 @@ extern int sio0_baud_rate;	/* SIO 0 baud rate */
 
 extern int sio3_baud_rate;	/* SIO 3 baud rate */
 
+extern void altair_sio_reset(void);
+
 extern BYTE altair_sio0_status_in(void);
 extern void altair_sio0_status_out(BYTE data);
 extern BYTE altair_sio0_data_in(void);

--- a/iodevices/cromemco-88ccc.c
+++ b/iodevices/cromemco-88ccc.c
@@ -45,8 +45,8 @@ static pthread_t thread = 0;
 /* thread for requesting, receiving & storing the camera image using DMA */
 static void *store_image(void *arg)
 {
-	uint64_t t1, t2;
-	int tdiff;
+	uint64_t t;
+	long tleft;
 	int i, j, len;
 	BYTE buffer[FIELDSIZE];
 	struct {
@@ -60,7 +60,7 @@ static void *store_image(void *arg)
 	UNUSED(arg);
 
 	memset(&msg, 0, sizeof(msg));
-	t1 = get_clock_us();
+	t = get_clock_us();
 
 	while (state) {	/* do until total frame is received */
 		if (net_device_alive(DEV_88ACC)) {
@@ -99,12 +99,11 @@ static void *store_image(void *arg)
 		/* sleep_for_ms(j); */
 
 		/* sleep rest of total frame time */
-		t2 = get_clock_us();
-		tdiff = t2 - t1;
-		if (tdiff < (j * 1000))
-			sleep_for_ms(j - tdiff / 1000);
+		tleft = j * 1000 - (long) (get_clock_us() - t1);
+		if (tleft > 0)
+			sleep_for_us(tleft);
 
-		LOGD(TAG, "Time: %d", tdiff);
+		LOGD(TAG, "Time: %ld", tleft);
 
 		state = false;
 	}

--- a/iodevices/cromemco-dazzler.c
+++ b/iodevices/cromemco-dazzler.c
@@ -742,12 +742,12 @@ static win_funcs_t dazzler_funcs = {
 /* thread for updating the X11 display or web server */
 static void *update_thread(void *arg)
 {
-	uint64_t t1, t2;
-	int tdiff;
+	uint64_t t;
+	long tleft;
 
 	UNUSED(arg);
 
-	t1 = get_clock_us();
+	t = get_clock_us();
 
 	while (true) {	/* do forever or until canceled */
 
@@ -788,13 +788,12 @@ static void *update_thread(void *arg)
 		sleep_for_ms(4);
 		flags = 64;
 
-		/* sleep rest to 33ms so that we get 30 fps */
-		t2 = get_clock_us();
-		tdiff = t2 - t1;
-		if ((tdiff > 0) && (tdiff < 33000))
-			sleep_for_ms(33 - (tdiff / 1000));
+		/* sleep rest to 33333us so that we get 30 fps */
+		tleft = 33333L - (long) (get_clock_us() - t);
+		if (tleft > 0)
+			sleep_for_us(tleft);
 
-		t1 = get_clock_us();
+		t = get_clock_us();
 	}
 
 	/* just in case it ever gets here */

--- a/iodevices/imsai-sio2.c
+++ b/iodevices/imsai-sio2.c
@@ -88,6 +88,14 @@ static uint64_t sio2b_t1, sio2b_t2;
 static BYTE sio2b_stat = 0;
 
 /*
+ * reset IMSAI SIO-2
+ */
+void imsai_sio_reset(void)
+{
+	sio1a_t1 = sio1b_t1 = sio2a_t1 = sio2b_t1 = get_clock_us();
+}
+
+/*
  * the IMSAI SIO-2 occupies 16 I/O ports, from which only
  * 5 have a function. the following two functions are used
  * for the ports without function.
@@ -118,13 +126,10 @@ void imsai_sio_nofun_out(BYTE data)
  */
 BYTE imsai_sio1a_status_in(void)
 {
-	int tdiff;
-
 	sio1a_t2 = get_clock_us();
-	tdiff = sio1a_t2 - sio1a_t1;
-	if (sio1a_baud_rate > 0)
-		if ((tdiff >= 0) && (tdiff < BAUDTIME / sio1a_baud_rate))
-			return sio1a_stat;
+	if (sio1a_baud_rate > 0 &&
+	    (int) (sio1a_t2 - sio1a_t1) < BAUDTIME / sio1a_baud_rate)
+		return sio1a_stat;
 
 	hal_status_in(SIO1A, &sio1a_stat);
 
@@ -196,13 +201,10 @@ void imsai_sio1a_data_out(BYTE data)
  */
 BYTE imsai_sio1b_status_in(void)
 {
-	int tdiff;
-
 	sio1b_t2 = get_clock_us();
-	tdiff = sio1b_t2 - sio1b_t1;
-	if (sio1b_baud_rate > 0)
-		if ((tdiff >= 0) && (tdiff < BAUDTIME / sio1b_baud_rate))
-			return sio1b_stat;
+	if (sio1b_baud_rate > 0 &&
+	    (int) (sio1b_t2 - sio1b_t1) < BAUDTIME / sio1b_baud_rate)
+		return sio1b_stat;
 
 	hal_status_in(SIO1B, &sio1b_stat);
 
@@ -271,13 +273,10 @@ void imsai_sio1b_data_out(BYTE data)
  */
 BYTE imsai_sio2a_status_in(void)
 {
-	int tdiff;
-
 	sio2a_t2 = get_clock_us();
-	tdiff = sio2a_t2 - sio2a_t1;
-	if (sio2a_baud_rate > 0)
-		if ((tdiff >= 0) && (tdiff < BAUDTIME / sio2a_baud_rate))
-			return sio2a_stat;
+	if (sio2a_baud_rate > 0 &&
+	    (int) (sio2a_t2 - sio2a_t1) < BAUDTIME / sio2a_baud_rate)
+		return sio2a_stat;
 
 	hal_status_in(SIO2A, &sio2a_stat);
 
@@ -352,13 +351,10 @@ void imsai_sio2a_data_out(BYTE data)
  */
 BYTE imsai_sio2b_status_in(void)
 {
-	int tdiff;
-
 	sio2b_t2 = get_clock_us();
-	tdiff = sio2b_t2 - sio2b_t1;
-	if (sio2b_baud_rate > 0)
-		if ((tdiff >= 0) && (tdiff < BAUDTIME / sio2b_baud_rate))
-			return sio2b_stat;
+	if (sio2b_baud_rate > 0 &&
+	    (int) (sio2b_t2 - sio2b_t1) < BAUDTIME / sio2b_baud_rate)
+		return sio2b_stat;
 
 	hal_status_in(SIO2B, &sio2b_stat);
 

--- a/iodevices/imsai-sio2.h
+++ b/iodevices/imsai-sio2.h
@@ -60,6 +60,8 @@ extern bool sio2b_strip_parity;	/* SIO 2 B strip parity from output */
 extern bool sio2b_drop_nulls;	/* SIO 2 B drop nulls after CR/LF */
 extern int sio2b_baud_rate;	/* SIO 2 B simulated baud rate */
 
+extern void imsai_sio_reset(void);
+
 extern BYTE imsai_sio_nofun_in(void);
 extern void imsai_sio_nofun_out(BYTE data);
 

--- a/iodevices/imsai-vio.c
+++ b/iodevices/imsai-vio.c
@@ -690,12 +690,12 @@ static win_funcs_t vio_funcs = {
 /* thread for updating the X11 display or web server */
 static void *update_thread(void *arg)
 {
-	uint64_t t1, t2;
-	int tdiff;
+	uint64_t t;
+	long tleft;
 
 	UNUSED(arg);
 
-	t1 = get_clock_us();
+	t = get_clock_us();
 
 	while (state) {
 #ifdef HAS_NETSERVER
@@ -721,13 +721,12 @@ static void *update_thread(void *arg)
 			ws_refresh();
 #endif
 
-		/* sleep rest to 33ms so that we get 30 fps */
-		t2 = get_clock_us();
-		tdiff = t2 - t1;
-		if ((tdiff > 0) && (tdiff < 33000))
-			sleep_for_ms(33 - (tdiff / 1000));
+		/* sleep rest to 33333us so that we get 30 fps */
+		tleft = 33333L - (long) (get_clock_us() - t);
+		if (tleft > 0)
+			sleep_for_us(tleft);
 
-		t1 = get_clock_us();
+		t = get_clock_us();
 	}
 
 	pthread_exit(NULL);

--- a/iodevices/proctec-vdm.c
+++ b/iodevices/proctec-vdm.c
@@ -413,15 +413,14 @@ static win_funcs_t proctec_funcs = {
 /* thread for updating the display */
 static void *update_display(void *arg)
 {
-	uint64_t t1, t2;
-	int tdiff;
+	uint64_t t;
+	long tleft;
 
 	UNUSED(arg);
 
-	t1 = get_clock_us();
+	t = get_clock_us();
 
 	while (state) {
-
 		/* lock display, don't cancel thread while locked */
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 		XLockDisplay(display);
@@ -436,13 +435,12 @@ static void *update_display(void *arg)
 		XUnlockDisplay(display);
 		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
-		/* sleep rest to 33ms so that we get 30 fps */
-		t2 = get_clock_us();
-		tdiff = t2 - t1;
-		if ((tdiff > 0) && (tdiff < 33000))
-			sleep_for_ms(33 - (tdiff / 1000));
+		/* sleep rest to 33333us so that we get 30 fps */
+		tleft = 33333L - (long) (get_clock_us() - t);
+		if (tleft > 0)
+			sleep_for_us(tleft);
 
-		t1 = get_clock_us();
+		t = get_clock_us();
 	}
 
 	pthread_exit(NULL);

--- a/picosim/srcsim/picosim.c
+++ b/picosim/srcsim/picosim.c
@@ -205,7 +205,10 @@ int main(void)
 	config();		/* configure the machine */
 
 	f_value = speed;	/* setup speed of the CPU */
-	tmax = speed * 10000;	/* theoretically */
+	if (f_value)
+		tmax = speed * 10000;	/* theoretically */
+	else
+		tmax = 100000;
 
 	put_pixel(0x440000);	/* LED green */
 

--- a/z80core/alt8080.h
+++ b/z80core/alt8080.h
@@ -76,7 +76,6 @@
 
 	BYTE t, res, cout, P;
 	cpu_reg_t w;		/* working register */
-	uint64_t clk;
 
 #define W	w.w
 #define WH	w.h
@@ -740,7 +739,7 @@
 		break;
 
 	case 0x76:			/* HLT */
-		clk = get_clock_us();
+		t2 = get_clock_us();
 #ifdef BUS_8080
 		cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
 #endif
@@ -799,7 +798,7 @@
 			}
 		}
 #endif /* FRONTPANEL */
-		cpu_start += get_clock_us() - clk;
+		cpu_tadj += get_clock_us() - t2;
 		t += 3;
 		break;
 

--- a/z80core/altz80.h
+++ b/z80core/altz80.h
@@ -85,7 +85,6 @@
 #endif
 	cpu_reg_t w;		/* working register */
 	cpu_reg_t ir;		/* current index register (HL, IX, IY) */
-	uint64_t clk;
 
 #define W	w.w
 #define WH	w.h
@@ -802,7 +801,7 @@ next_opcode:
 		break;
 
 	case 0x76:			/* HALT */
-		clk = get_clock_us();
+		t2 = get_clock_us();
 #ifdef BUS_8080
 		cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
 #endif
@@ -865,7 +864,7 @@ next_opcode:
 			}
 		}
 #endif /* FRONTPANEL */
-		cpu_start += get_clock_us() - clk;
+		cpu_tadj += get_clock_us() - t2;
 		break;
 
 	case 0x77:			/* LD (ir),A */

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -94,14 +94,23 @@ again:
 }
 
 /*
- *	returns time in microseconds
+ *	returns monotonic time in microseconds
  */
 uint64_t get_clock_us(void)
 {
 	struct timeval tv;
+	uint64_t t;
+	static uint64_t old_t;
 
 	gettimeofday(&tv, NULL);
-	return (uint64_t) (tv.tv_sec) * 1000000ULL + (uint64_t) (tv.tv_usec);
+	t = (uint64_t) (tv.tv_sec) * 1000000ULL + (uint64_t) (tv.tv_usec);
+	if (t < old_t) {
+		LOGD(TAG, "get_clock_us() time jumped backwards %"
+		     PRIu64 " > %" PRIu64, old_t, t);
+		t = old_t;
+	} else
+		old_t = t;
+	return t;
 }
 
 #ifdef WANT_ICE

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -40,8 +40,9 @@ BYTE IFF;			/* interrupt flags */
 cpu_regs_t cpu_regs;		/* CPU registers */
 #endif
 Tstates_t T;			/* CPU clock */
-int64_t cpu_start;		/* timestamp at start of CPU run/step */
-int64_t cpu_time;		/* time spent running CPU in us */
+Tstates_t T_freq;		/* CPU clock used for frequency calculation */
+uint64_t cpu_time;		/* time spent running CPU in us */
+uint64_t cpu_tadj;		/* time spent in non CPU execution areas */
 
 #ifdef BUS_8080
 BYTE cpu_bus;			/* CPU bus status, for frontpanels */
@@ -64,7 +65,8 @@ bool int_protection;		/* to delay interrupts after EI */
 BYTE bus_request;		/* request address/data bus from CPU */
 BusDMA_t bus_mode;		/* current bus mode for DMA */
 BusDMAFunc_t *dma_bus_master;	/* DMA bus master call back func */
-int tmax;			/* max t-states to execute in 10ms */
+int tmax;			/* max t-states to execute in 10ms or
+				   when to update the CPU times */
 bool cpu_needed;		/* don't adjust CPU freq if needed */
 
 /*

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -31,9 +31,8 @@ extern BYTE	IFF;
 #else
 #include "altregs.h"
 #endif
-extern Tstates_t T;
-extern int64_t	cpu_start;
-extern int64_t	cpu_time;
+extern Tstates_t T, T_freq;
+extern uint64_t	cpu_time, cpu_tadj;
 
 #ifdef BUS_8080
 extern BYTE	cpu_bus;

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -66,7 +66,10 @@ int main(int argc, char *argv[])
 #endif
 #ifdef CPU_SPEED
 	f_value = CPU_SPEED;
-	tmax = CPU_SPEED * 10000; /* theoretically */
+	if (f_value)
+		tmax = CPU_SPEED * 10000; /* theoretically */
+	else
+		tmax = 100000;
 #endif
 
 	while (--argc > 0 && (*++argv)[0] == '-')
@@ -113,7 +116,10 @@ int main(int argc, char *argv[])
 					argv++;
 					f_value = atoi(argv[0]);
 				}
-				tmax = f_value * 10000; /* theoretically */
+				if (f_value)
+					tmax = f_value * 10000; /* theoretically */
+				else
+					tmax = 100000;
 				break;
 
 			case 'x':	/* get filename with executable */

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -365,14 +365,6 @@ int op_dd_handle(void)
  */
 static int trap_dd(void)
 {
-#ifdef UNDOC_INST
-	if (!u_flag) {
-		/* Treat 0xdd prefix as NOP on non IX-instructions */
-		PC--;
-		R--;
-		return 4;
-	}
-#endif
 	cpu_error = OPTRAP2;
 	cpu_state = ST_STOPPED;
 	return 0;

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -365,14 +365,6 @@ int op_fd_handle(void)
  */
 static int trap_fd(void)
 {
-#ifdef UNDOC_INST
-	if (!u_flag) {
-		/* Treat 0xfd prefix as NOP on non IY-instructions */
-		PC--;
-		R--;
-		return 4;
-	}
-#endif
 	cpu_error = OPTRAP2;
 	cpu_state = ST_STOPPED;
 	return 0;


### PR DESCRIPTION
Changed get_clock_us() to ensure time doesn't go backwards. Happens a lot in intelmdssim, probably because of a lot of really close (timewise) calls in the 260us loop in the timing/interrupt thread.

Removed checks in the code for negative time differences. This uncovered a bug in altair-88-sio.c, altair-88-2sio.c and imsai-sio2.c. Added a reset function for these that initialize the timing variables. It previously worked only because of integer arithmetic overflows.

We really should be using something like clock_gettime(CLOCK_MONOTONIC,...) for time measurements.

The global variable cpu_tadj accumulates time spend doing stuff not related to the CPU core. This is currently done in io_in()/io_out() and wait_step()/wait_int_step() and HALT/HLT.

Added a parameter to wait_step() to not calculate a time adjustment. Needed for io_in()/io_out() since they also calculate an adjustment. This caused the wild frequency estimation jumps before.

Timing is now calculated in cpu_8080()/cpu_z80() in the speed adjustment code block (which is now also used for timing calculations when f_value=0 every 100000 T-states) and at the end of these functions.

Redid the timing code in all loops what repeat at a specific interval, so they all use equal code for this.