### PR TITLE
more time work, hopefully last one; use dma_read/write() in simbdos.c

### DIFF
--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -324,10 +324,9 @@ static void step_clicked(int state, int val)
 /*
  * Single step through the machine cycles after first M1
  */
-bool wait_step(bool tadj)
+bool wait_step(void)
 {
 	bool ret = false;
-	uint64_t t = 0;
 
 	if (cpu_state != ST_SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
@@ -342,8 +341,6 @@ bool wait_step(bool tadj)
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	if (tadj)
-		t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		/* when INP update data bus LEDs */
 		if (cpu_bus == (CPU_WO | CPU_INP)) {
@@ -356,8 +353,6 @@ bool wait_step(bool tadj)
 		sleep_for_ms(10);
 		ret = true;
 	}
-	if (tadj)
-		cpu_tadj += get_clock_us() - t;
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = false;
@@ -369,20 +364,16 @@ bool wait_step(bool tadj)
  */
 void wait_int_step(void)
 {
-	uint64_t t;
-
 	if (cpu_state != ST_SINGLE_STEP)
 		return;
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		fp_clock++;
 		fp_sampleData();
 		sleep_for_ms(10);
 	}
-	cpu_tadj += get_clock_us() - t;
 }
 
 /*

--- a/altairsim/srcsim/simctl.h
+++ b/altairsim/srcsim/simctl.h
@@ -14,7 +14,7 @@ extern int boot_switch;			/* boot address for switch */
 
 extern void mon(void);
 
-extern bool wait_step(bool tadj);
+extern bool wait_step(void);
 extern void wait_int_step(void);
 
 #endif /* !SIMCTL_INC */

--- a/altairsim/srcsim/simmem.h
+++ b/altairsim/srcsim/simmem.h
@@ -37,6 +37,7 @@
 #endif
 #ifdef FRONTPANEL
 #include "simctl.h"
+#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -73,6 +74,10 @@ extern void init_memory(void);
  */
 static inline void memwrt(WORD addr, BYTE data)
 {
+#ifdef FRONTPANEL
+	uint64_t t;
+#endif
+
 #ifdef BUS_8080
 #ifndef FRONTPANEL
 	cpu_bus &= ~CPU_M1;
@@ -82,11 +87,13 @@ static inline void memwrt(WORD addr, BYTE data)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = 0xff;
 		fp_sampleData();
-		wait_step(true);
+		wait_step();
+		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif
@@ -105,6 +112,9 @@ static inline void memwrt(WORD addr, BYTE data)
 static inline BYTE memrdr(WORD addr)
 {
 	register BYTE data;
+#ifdef FRONTPANEL
+	uint64_t t;
+#endif
 
 #ifdef WANT_HB
 	if (hb_flag && hb_addr == addr) {
@@ -144,11 +154,13 @@ static inline BYTE memrdr(WORD addr)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step(true);
+		wait_step();
+		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -329,10 +329,9 @@ static void step_clicked(int state, int val)
 /*
  * Single step through the machine cycles after M1
  */
-bool wait_step(bool tadj)
+bool wait_step(void)
 {
 	bool ret = false;
-	uint64_t t = 0;
 
 	if (cpu_state != ST_SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
@@ -347,8 +346,6 @@ bool wait_step(bool tadj)
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	if (tadj)
-		t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		/* when INP update data bus LEDs */
 		if (cpu_bus == (CPU_WO | CPU_INP)) {
@@ -361,8 +358,6 @@ bool wait_step(bool tadj)
 		sleep_for_ms(10);
 		ret = true;
 	}
-	if (tadj)
-		cpu_tadj += get_clock_us() - t;
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = false;
@@ -374,20 +369,16 @@ bool wait_step(bool tadj)
  */
 void wait_int_step(void)
 {
-	uint64_t t;
 
-	if (cpu_state != ST_SINGLE_STEP)
 		return;
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		fp_clock++;
 		fp_sampleData();
 		sleep_for_ms(10);
 	}
-	cpu_tadj += get_clock_us() - t;
 }
 
 /*

--- a/cromemcosim/srcsim/simctl.h
+++ b/cromemcosim/srcsim/simctl.h
@@ -12,7 +12,7 @@
 
 extern void mon(void);
 
-extern bool wait_step(bool tadj);
+extern bool wait_step(void);
 extern void wait_int_step(void);
 
 #endif /* !SIMCTL_INC */

--- a/cromemcosim/srcsim/simmem.h
+++ b/cromemcosim/srcsim/simmem.h
@@ -36,6 +36,7 @@
 #endif
 #ifdef FRONTPANEL
 #include "simctl.h"
+#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -90,6 +91,9 @@ extern void reset_fdc_rom_map(void);
 static inline void memwrt(WORD addr, BYTE data)
 {
 	register int i;
+#ifdef FRONTPANEL
+	uint64_t t;
+#endif
 
 #ifdef BUS_8080
 #ifndef FRONTPANEL
@@ -100,11 +104,13 @@ static inline void memwrt(WORD addr, BYTE data)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step(true);
+		wait_step();
+		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif
@@ -134,6 +140,9 @@ static inline void memwrt(WORD addr, BYTE data)
 static inline BYTE memrdr(WORD addr)
 {
 	register BYTE data;
+#ifdef FRONTPANEL
+	uint64_t t;
+#endif
 
 #ifdef WANT_HB
 	if (hb_flag && hb_addr == addr) {
@@ -164,11 +173,13 @@ static inline BYTE memrdr(WORD addr)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step(true);
+		wait_step();
+		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif

--- a/imsaisim/srcsim/simctl.c
+++ b/imsaisim/srcsim/simctl.c
@@ -330,10 +330,9 @@ static void step_clicked(int state, int val)
 /*
  * Single step through the machine cycles after M1
  */
-bool wait_step(bool tadj)
+bool wait_step(void)
 {
 	bool ret = false;
-	uint64_t t = 0;
 
 	if (cpu_state != ST_SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
@@ -348,8 +347,6 @@ bool wait_step(bool tadj)
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	if (tadj)
-		t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		/* when INP update data bus LEDs */
 		if (cpu_bus == (CPU_WO | CPU_INP)) {
@@ -362,8 +359,6 @@ bool wait_step(bool tadj)
 		sleep_for_ms(10);
 		ret = true;
 	}
-	if (tadj)
-		cpu_tadj += get_clock_us() - t;
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = false;
@@ -375,20 +370,16 @@ bool wait_step(bool tadj)
  */
 void wait_int_step(void)
 {
-	uint64_t t;
-
 	if (cpu_state != ST_SINGLE_STEP)
 		return;
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
-	t = get_clock_us();
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		fp_clock++;
 		fp_sampleData();
 		sleep_for_ms(10);
 	}
-	cpu_tadj += get_clock_us() - t;
 }
 
 /*

--- a/imsaisim/srcsim/simctl.h
+++ b/imsaisim/srcsim/simctl.h
@@ -12,7 +12,7 @@
 
 extern void mon(void);
 
-extern bool wait_step(bool tadj);
+extern bool wait_step(void);
 extern void wait_int_step(void);
 
 #endif /* !SIMCTL_INC */

--- a/imsaisim/srcsim/simmem.h
+++ b/imsaisim/srcsim/simmem.h
@@ -38,6 +38,7 @@
 #endif
 #ifdef FRONTPANEL
 #include "simctl.h"
+#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -112,6 +113,10 @@ extern void groupswap(void);
  */
 static inline void memwrt(WORD addr, BYTE data)
 {
+#ifdef FRONTPANEL
+	uint64_t t;
+#endif
+
 #ifdef BUS_8080
 #ifndef FRONTPANEL
 	cpu_bus &= ~CPU_M1;
@@ -121,11 +126,13 @@ static inline void memwrt(WORD addr, BYTE data)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step(true);
+		wait_step();
+		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif
@@ -147,6 +154,9 @@ static inline void memwrt(WORD addr, BYTE data)
 static inline BYTE memrdr(WORD addr)
 {
 	register BYTE data;
+#ifdef FRONTPANEL
+	uint64_t t;
+#endif
 
 #ifdef WANT_HB
 	if (hb_flag && hb_addr == addr) {
@@ -179,11 +189,13 @@ static inline BYTE memrdr(WORD addr)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
-		wait_step(true);
+		wait_step();
+		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif

--- a/intelmdssim/srcsim/simctl.c
+++ b/intelmdssim/srcsim/simctl.c
@@ -221,10 +221,8 @@ static void int_clicked(int state, int val)
 /*
  *	Single step through the machine cycles after M1
  */
-bool wait_step(bool tadj)
+bool wait_step(void)
 {
-	UNUSED(tadj);
-
 	cpu_bus &= ~CPU_M1;
 	m1_step = false;
 	return false;

--- a/intelmdssim/srcsim/simctl.h
+++ b/intelmdssim/srcsim/simctl.h
@@ -15,7 +15,7 @@ extern BYTE boot_switch;
 
 extern void mon(void);
 
-extern bool wait_step(bool tadj);
+extern bool wait_step(void);
 extern void wait_int_step(void);
 
 #endif /* !SIMCTL_INC */

--- a/iodevices/simbdos.c
+++ b/iodevices/simbdos.c
@@ -96,14 +96,14 @@ void host_bdos_out(BYTE outByte)
 
 	if ((C == OPENF) || (C == MAKEF)) {
 		for (i = 0; i < 8; i++) {	/* copy file name */
-			fname[i] = tolower(memrdr(fcbAddr + 1 + i));
+			fname[i] = tolower(dma_read(fcbAddr + 1 + i));
 			if (fname[i] == ' ')
 				break;
 		}
 		fname[i] = 0;
 
 		for (i = 0; i < 3; i++) {	/* copy extension */
-			extension[i] = tolower(memrdr(fcbAddr + 9 + i));
+			extension[i] = tolower(dma_read(fcbAddr + 9 + i));
 			if (extension[i] == ' ')
 				break;
 		}
@@ -152,9 +152,9 @@ void host_bdos_out(BYTE outByte)
 			xferLen = fread(buf, 1, SECLEN, fp);
 			if (xferLen != 0) {
 				for (i = 0; i < xferLen; i++)
-					memwrt(dmaAddr + i, buf[i]);
+					dma_write(dmaAddr + i, buf[i]);
 				for (; i < SECLEN; i++)
-					memwrt(dmaAddr + i, CTRL_Z);
+					dma_write(dmaAddr + i, CTRL_Z);
 				A = 0;
 			}
 		}
@@ -165,7 +165,7 @@ void host_bdos_out(BYTE outByte)
 	else if (C == WRITEF) {
 		if (fp != NULL) {
 			for (xferLen = 0; xferLen < SECLEN; xferLen++) {
-				buf[xferLen] = memrdr(dmaAddr + xferLen);
+				buf[xferLen] = dma_read(dmaAddr + xferLen);
 				if ((buf[xferLen] == CTRL_Z) && textFile)
 					break;	/* ctrl-z (EOF) found */
 			}

--- a/z80core/altz80.h
+++ b/z80core/altz80.h
@@ -1379,9 +1379,11 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 			if (F_flag) {
+				t2 = get_clock_us();
 				/* update frontpanel */
 				fp_clock++;
 				fp_sampleLightGroup(0, 0);
+				cpu_adj += get_clock_us() - t2;
 			}
 #endif
 
@@ -1621,9 +1623,11 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 		if (F_flag) {
+			t2 = get_clock_us();
 			/* update frontpanel */
 			fp_clock++;
 			fp_sampleLightGroup(0, 0);
+			cpu_tadj += get_clock_us() - t2;
 		}
 #endif
 
@@ -1717,9 +1721,11 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 		if (F_flag) {
+			t2 = get_clock_us();
 			/* update frontpanel */
 			fp_clock++;
 			fp_sampleLightGroup(0, 0);
+			cpu_tadj += get_clock_us() - t2;
 		}
 #endif
 
@@ -2395,9 +2401,11 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 		if (F_flag) {
+			t2 = get_clock_us();
 			/* update frontpanel */
 			fp_clock++;
 			fp_sampleLightGroup(0, 0);
+			cpu_tadj += get_clock_us() - t2;
 		}
 #endif
 

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -278,7 +278,7 @@ BYTE io_in(BYTE addrl, BYTE addrh)
 		fp_led_address = (addrh << 8) + addrl;
 		fp_led_data = io_data;
 		fp_sampleData();
-		val = wait_step(false);
+		val = wait_step();
 
 		/* when single stepped INP get last set value of port */
 		if (val && port_in[addrl])
@@ -342,7 +342,7 @@ void io_out(BYTE addrl, BYTE addrh, BYTE data)
 		fp_led_address = (addrh << 8) + addrl;
 		fp_led_data = IO_DATA_UNUSED;
 		fp_sampleData();
-		wait_step(false);
+		wait_step();
 	}
 #endif
 #ifdef SIMPLEPANEL

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -17,6 +17,7 @@
 #include "simz80-cb.h"
 
 #ifdef FRONTPANEL
+#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -371,6 +372,9 @@ int op_cb_handle(void)
 #undef UNDOC
 
 	register int t;
+#ifdef FRONTPANEL
+	uint64_t t0;
+#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -379,9 +383,11 @@ int op_cb_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t0 = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
+		cpu_tadj += get_clock_us() - t0;
 	}
 #endif
 

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -18,6 +18,7 @@
 #include "simz80-ddcb.h"
 
 #ifdef FRONTPANEL
+#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -338,6 +339,9 @@ int op_dd_handle(void)
 #undef UNDOC
 
 	register int t;
+#ifdef FRONTPANEL
+	uint64_t t0;
+#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -346,9 +350,11 @@ int op_dd_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t0 = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
+		cpu_tadj += get_clock_us() - t0;
 	}
 #endif
 

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -18,6 +18,7 @@
 #include "simz80-ed.h"
 
 #ifdef FRONTPANEL
+#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -320,6 +321,9 @@ int op_ed_handle(void)
 #undef UNDOC
 
 	register int t;
+#ifdef FRONTPANEL
+	uint64_t t0;
+#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -328,9 +332,11 @@ int op_ed_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t0 = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
+		cpu_tadj += get_clock_us() - t0;
 	}
 #endif
 

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -18,6 +18,7 @@
 #include "simz80-fdcb.h"
 
 #ifdef FRONTPANEL
+#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -338,6 +339,9 @@ int op_fd_handle(void)
 #undef UNDOC
 
 	register int t;
+#ifdef FRONTPANEL
+	uint64_t t0;
+#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -346,9 +350,11 @@ int op_fd_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
+		t0 = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
+		cpu_tadj += get_clock_us() - t0;
 	}
 #endif
 


### PR DESCRIPTION
Add back adjustment calculations to fp_sample*() calls including in memrdr()/memwrt() which wasn't done before.

Remove parameter from wait_step(), not needed anymore, because of memrdr()/memwrt() changes.

Only use cpu_tadj when in free running mode (f_value == 0) to get a hopefully sensible CPU frequency. In frequency locked mode the adjustment doesn't make sense in my opinion.

When single stepping pretend we spent the right amount of time, or in free running mode use an arbitrary 100 MHz value.

Changed simbdos.c to use dma_read/write() instead of memrdr()/memwrt(). Seems to make more sense, and it was the only I/O device that used memrdr()/memwrt() and using these in I/O devices screws up the time adjustment calculations.