### PR TITLE
another timing update...

### DIFF
--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -369,7 +369,7 @@ bool wait_step(void)
  */
 void wait_int_step(void)
 {
-
+	if (cpu_state != ST_SINGLE_STEP)
 		return;
 
 	cpu_switch = CPUSW_STEPCYCLE;

--- a/picosim/srcsim/picosim.c
+++ b/picosim/srcsim/picosim.c
@@ -350,7 +350,7 @@ static void picosim_ice_cmd(char *cmd, WORD *wrk_addr)
 			freq = (unsigned) ((T - T0) / 30000ULL);
 			printf("CPU executed %" PRIu64 " %s instructions "
 			       "in 3 seconds\n", (T - T0) / 10, s);
-			printf("clock frequency = %5u.%02u MHz\n",
+			printf("clock frequency = %u.%02u MHz\n",
 			       freq / 100, freq % 100);
 		} else
 			puts("Interrupted by user");

--- a/picosim/srcsim/picosim.c
+++ b/picosim/srcsim/picosim.c
@@ -208,7 +208,7 @@ int main(void)
 	if (f_value)
 		tmax = speed * 10000;	/* theoretically */
 	else
-		tmax = 100000;
+		tmax = 100000;	/* for periodic CPU accounting updates */
 
 	put_pixel(0x440000);	/* LED green */
 
@@ -295,6 +295,7 @@ static void picosim_ice_cmd(char *cmd, WORD *wrk_addr)
 	BYTE save[3];
 	WORD save_PC;
 	Tstates_t T0;
+	unsigned freq;
 #ifdef WANT_HB
 	bool save_hb_flag;
 #endif
@@ -346,10 +347,11 @@ static void picosim_ice_cmd(char *cmd, WORD *wrk_addr)
 			s = "JMP";
 #endif
 		if (cpu_error == NONE) {
+			freq = (unsigned) ((T - T0) / 30000ULL);
 			printf("CPU executed %" PRIu64 " %s instructions "
 			       "in 3 seconds\n", (T - T0) / 10, s);
-			printf("clock frequency = %5.2f MHz\n",
-			       ((float) (T - T0)) / 3000000.0);
+			printf("clock frequency = %5u.%02u MHz\n",
+			       freq / 100, freq % 100);
 		} else
 			puts("Interrupted by user");
 		break;

--- a/z80core/altz80.h
+++ b/z80core/altz80.h
@@ -1383,7 +1383,7 @@ next_opcode:
 				/* update frontpanel */
 				fp_clock++;
 				fp_sampleLightGroup(0, 0);
-				cpu_adj += get_clock_us() - t2;
+				cpu_tadj += get_clock_us() - t2;
 			}
 #endif
 

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -406,14 +406,9 @@ void cpu_8080(void)
 
 #endif /* !ALT_I8080 */
 
-	Tstates_t T_max, T_dma, T_start;
+	Tstates_t T_max, T_dma;
 	uint64_t t1, t2;
 	long tdiff;
-	bool single_step;
-
-	/* remember CPU clock and single step mode for frequency calculation */
-	T_start = T;
-	single_step = (cpu_state & ST_SINGLE_STEP) != 0;
 
 	T_max = T + tmax;
 	t1 = get_clock_us();
@@ -463,11 +458,11 @@ void cpu_8080(void)
 				if (dma_bus_master) {
 					/* hand control to the DMA bus master
 					   without BUS_ACK */
-					T += (T_dma = (*dma_bus_master)(0));
-					if (f_value) {
-						T_freq = T;
-						cpu_time += T_dma / f_value;
-					}
+					T_dma = (*dma_bus_master)(0);
+					T += T_dma;
+					if (cpu_freq)
+						cpu_time += (1000000ULL *
+							     T_dma) / cpu_freq;
 				}
 			}
 
@@ -483,11 +478,11 @@ void cpu_8080(void)
 				if (dma_bus_master) {
 					/* hand control to the DMA bus master
 					   with BUS_ACK */
-					T += (T_dma = (*dma_bus_master)(1));
-					if (f_value) {
-						T_freq = T;
-						cpu_time += T_dma / f_value;
-					}
+					T_dma = (*dma_bus_master)(1);
+					T += T_dma;
+					if (cpu_freq)
+						cpu_time += (1000000ULL *
+							     T_dma) / cpu_freq;
 				}
 				/* FOR NOW -
 				   MAY BE NEED A PRIORITY SYSTEM LATER */
@@ -510,7 +505,7 @@ void cpu_8080(void)
 		if (int_int) {
 			if (IFF != 3)
 				goto leave;
-			if (int_protection)	/* protect first instr */
+			if (int_protection)	/* protect first instruction */
 				goto leave;	/* after EI */
 
 			IFF = 0;
@@ -597,8 +592,8 @@ void cpu_8080(void)
 			if (F_flag)
 				m1_step = true;
 #endif
+		leave:
 		}
-leave:
 
 #ifdef BUS_8080
 		/* M1 opcode fetch */
@@ -612,22 +607,22 @@ leave:
 #include "alt8080.h"
 #endif
 
-					/* adjust CPU speed and update time */
-		if (T >= T_max && !single_step) {
+					/* adjust CPU speed and
+					   update CPU accounting */
+		if (T >= T_max) {
 			T_max = T + tmax;
 			t2 = get_clock_us();
 			tdiff = t2 - t1;
-			if (f_value) {
-				if (!cpu_needed && tdiff < 10000L) {
-					sleep_for_us(10000L - tdiff);
-					t2 = get_clock_us();
-					tdiff = t2 - t1;
-				}
+			if (f_value && !cpu_needed && tdiff < 10000L) {
+				sleep_for_us(10000L - tdiff);
+				t2 = get_clock_us();
+				tdiff = t2 - t1; /* should be really close
+						    to 10000, but isn't */
+				cpu_time += tdiff;
 			} else
-				tdiff -= cpu_tadj;
-			T_freq = T;
-			cpu_time += tdiff;
+				cpu_time += tdiff - cpu_tadj;
 			cpu_tadj = 0;
+			cpu_freq = T * 1000000ULL / cpu_time;
 			t1 = t2;
 		}
 
@@ -676,22 +671,10 @@ leave:
 	fp_led_data = getmem(PC);
 #endif
 
-					/* update CPU time */
-	if (single_step) {		/* if single stepping */
-		if (f_value)		/* use f_value MHz in locked mode */
-			tdiff = (T - T_start) / f_value;
-		else if (T_freq)	/* else use current frequency */
-			tdiff = ((T - T_start) * cpu_time) / T_freq;
-		else			/* avoid division by 0 */
-			tdiff = T - T_start;
-	} else {
-		tdiff = get_clock_us() - t1;
-		if (!f_value)
-			tdiff -= cpu_tadj;
-	}
-	T_freq = T;
-	cpu_time += tdiff;
+					/* update CPU accounting */
+	cpu_time += (get_clock_us() - t1) - cpu_tadj;
 	cpu_tadj = 0;
+	cpu_freq = T * 1000000ULL / cpu_time;
 }
 
 #ifndef ALT_I8080
@@ -716,6 +699,7 @@ static int op_hlt(void)			/* HLT */
 	uint64_t t;
 
 	t = get_clock_us();
+
 #ifdef BUS_8080
 	cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
 #endif

--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -622,7 +622,8 @@ void cpu_8080(void)
 			} else
 				cpu_time += tdiff - cpu_tadj;
 			cpu_tadj = 0;
-			cpu_freq = T * 1000000ULL / cpu_time;
+			if (cpu_time)
+				cpu_freq = T * 1000000ULL / cpu_time;
 			t1 = t2;
 		}
 
@@ -674,7 +675,8 @@ void cpu_8080(void)
 					/* update CPU accounting */
 	cpu_time += (get_clock_us() - t1) - cpu_tadj;
 	cpu_tadj = 0;
-	cpu_freq = T * 1000000ULL / cpu_time;
+	if (cpu_time)
+		cpu_freq = T * 1000000ULL / cpu_time;
 }
 
 #ifndef ALT_I8080

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -236,7 +236,7 @@ void report_cpu_stats(void)
 		freq = (unsigned) (cpu_freq / 10000ULL);
 		printf("CPU ran %" PRIu64 " ms ", cpu_time / 1000);
 		printf("and executed %" PRIu64 " t-states\n", T);
-		printf("Clock frequency %4u.%02u MHz\n",
+		printf("Clock frequency %u.%02u MHz\n",
 		       freq / 100, freq % 100);
 	}
 }

--- a/z80core/simcore.c
+++ b/z80core/simcore.c
@@ -229,12 +229,15 @@ void report_cpu_error(void)
  */
 void report_cpu_stats(void)
 {
+	unsigned freq;
+
 	if (cpu_time)
 	{
+		freq = (unsigned) (cpu_freq / 10000ULL);
 		printf("CPU ran %" PRIu64 " ms ", cpu_time / 1000);
-		printf("and executed %" PRIu64 " t-states\n", T_freq);
-		printf("Clock frequency %4.2f MHz\n",
-		       (float) (T_freq) / (float) cpu_time);
+		printf("and executed %" PRIu64 " t-states\n", T);
+		printf("Clock frequency %4u.%02u MHz\n",
+		       freq / 100, freq % 100);
 	}
 }
 

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -40,9 +40,9 @@ BYTE IFF;			/* interrupt flags */
 cpu_regs_t cpu_regs;		/* CPU registers */
 #endif
 Tstates_t T;			/* CPU clock */
-Tstates_t T_freq;		/* CPU clock used for frequency calculation */
 uint64_t cpu_time;		/* time spent running CPU in us */
 uint64_t cpu_tadj;		/* time spent in non CPU execution areas */
+uint64_t cpu_freq;		/* estimated CPU frequency in Hz */
 
 #ifdef BUS_8080
 BYTE cpu_bus;			/* CPU bus status, for frontpanels */
@@ -66,7 +66,7 @@ BYTE bus_request;		/* request address/data bus from CPU */
 BusDMA_t bus_mode;		/* current bus mode for DMA */
 BusDMAFunc_t *dma_bus_master;	/* DMA bus master call back func */
 int tmax;			/* max t-states to execute in 10ms or
-				   when to update the CPU times */
+				   when to update the CPU accounting */
 bool cpu_needed;		/* don't adjust CPU freq if needed */
 
 /*

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -31,8 +31,8 @@ extern BYTE	IFF;
 #else
 #include "altregs.h"
 #endif
-extern Tstates_t T, T_freq;
-extern uint64_t	cpu_time, cpu_tadj;
+extern Tstates_t T;
+extern uint64_t	cpu_time, cpu_tadj, cpu_freq;
 
 #ifdef BUS_8080
 extern BYTE	cpu_bus;

--- a/z80core/simice.c
+++ b/z80core/simice.c
@@ -1341,9 +1341,10 @@ static void do_clock(void)
 	BYTE save[3];
 	WORD save_PC;
 	Tstates_t T0;
-	static struct sigaction newact;
-	static struct itimerval tim;
 	const char *s = NULL;
+	struct sigaction newact;
+	struct itimerval tim;
+	unsigned freq;
 #ifdef WANT_HB
 	bool save_hb_flag;
 
@@ -1387,10 +1388,11 @@ static void do_clock(void)
 		s = "JMP";
 #endif
 	if (cpu_error == NONE) {
+		freq = (unsigned) ((T - T0) / 30000ULL);
 		printf("CPU executed %" PRIu64 " %s instructions "
 		       "in 3 seconds\n", (T - T0) / 10, s);
-		printf("clock frequency = %5.2f MHz\n",
-		       ((float) (T - T0)) / 3000000.0);
+		printf("clock frequency = %5u.%02u MHz\n",
+		       freq / 100, freq % 100);
 	} else
 		puts("Interrupted by user");
 }

--- a/z80core/simmain.c
+++ b/z80core/simmain.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 	if (f_value)
 		tmax = CPU_SPEED * 10000; /* theoretically */
 	else
-		tmax = 100000;
+		tmax = 100000;	/* for periodic CPU accounting updates */
 #endif
 
 	while (--argc > 0 && (*++argv)[0] == '-')
@@ -119,7 +119,8 @@ int main(int argc, char *argv[])
 				if (f_value)
 					tmax = f_value * 10000; /* theoretically */
 				else
-					tmax = 100000;
+					tmax = 100000; /* for periodic CPU
+							  accounting updates */
 				break;
 
 			case 'x':	/* get filename with executable */

--- a/z80core/simpanel.c
+++ b/z80core/simpanel.c
@@ -945,7 +945,8 @@ static void draw_info(bool tick)
 	const unsigned n = xsize / w;
 	const unsigned x = (xsize - n * w) / 2;
 	const unsigned y = ysize - font->height;
-	static int count, fps, freq;
+	static unsigned count, fps;
+	static uint64_t freq;
 
 	/* draw product info */
 	s = "Z80pack " RELEASE;
@@ -976,8 +977,8 @@ static void draw_info(bool tick)
 
 	/* update frequency every second */
 	if (tick && cpu_time)
-		freq = (int) ((float) T_freq / (float) cpu_time * 100.0);
-	f = freq;
+		freq = cpu_freq;
+	f = (unsigned) (freq / 10000ULL);
 	digit = 100000;
 	onlyz = true;
 	for (i = 0; i < 7; i++) {

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -5,6 +5,8 @@
  * Copyright (C) 2024 by Thomas Eberhardt
  */
 
+#include <stdio.h>
+
 #include "sim.h"
 #include "simdefs.h"
 #include "simglb.h"
@@ -386,15 +388,10 @@ void cpu_z80(void)
 	};
 #endif /* !ALT_Z80 */
 
-	Tstates_t T_max, T_dma, T_start;
+	Tstates_t T_max, T_dma;
 	uint64_t t1, t2;
 	long tdiff;
 	WORD p;
-	bool single_step;
-
-	/* remember CPU clock and single step mode for frequency calculation */
-	T_start = T;
-	single_step = (cpu_state & ST_SINGLE_STEP) != 0;
 
 	T_max = T + tmax;
 	t1 = get_clock_us();
@@ -446,11 +443,11 @@ void cpu_z80(void)
 				if (dma_bus_master) {
 					/* hand control to the DMA bus master
 					   without BUS_ACK */
-					T += (T_dma = (*dma_bus_master)(0));
-					if (f_value) {
-						T_freq = T;
-						cpu_time += T_dma / f_value;
-					}
+					T_dma = (*dma_bus_master)(0);
+					T += T_dma;
+					if (cpu_freq)
+						cpu_time += (1000000ULL *
+							     T_dma) / cpu_freq;
 				}
 			}
 
@@ -466,11 +463,11 @@ void cpu_z80(void)
 				if (dma_bus_master) {
 					/* hand control to the DMA bus master
 					   with BUS_ACK */
-					T += (T_dma = (*dma_bus_master)(1));
-					if (f_value) {
-						T_freq = T;
-						cpu_time += T_dma / f_value;
-					}
+					T_dma = (*dma_bus_master)(1);
+					T += T_dma;
+					if (cpu_freq)
+						cpu_time += (1000000ULL *
+							     T_dma) / cpu_freq;
 				}
 				/* FOR NOW -
 				   MAY BE NEED A PRIORITY SYSTEM LATER */
@@ -503,8 +500,8 @@ void cpu_z80(void)
 		if (int_int) {		/* maskable interrupt */
 			if (IFF != 3)
 				goto leave;
-			if (int_protection)	/* protect first instr */
-				goto leave;
+			if (int_protection)	/* protect first instruction */
+				goto leave;	/* after EI */
 
 			IFF = 0;
 
@@ -607,8 +604,8 @@ void cpu_z80(void)
 				m1_step = true;
 #endif
 			R++;		/* increment refresh register */
+		leave:
 		}
-leave:
 
 #ifdef BUS_8080
 		/* M1 opcode fetch */
@@ -624,22 +621,22 @@ leave:
 #include "altz80.h"
 #endif
 
-					/* adjust CPU speed and update time */
-		if (T >= T_max && !single_step) {
+					/* adjust CPU speed and
+					   update CPU accounting */
+		if (T >= T_max) {
 			T_max = T + tmax;
 			t2 = get_clock_us();
 			tdiff = t2 - t1;
-			if (f_value) {
-				if (!cpu_needed && tdiff < 10000L) {
-					sleep_for_us(10000L - tdiff);
-					t2 = get_clock_us();
-					tdiff = t2 - t1;
-				}
+			if (f_value && !cpu_needed && tdiff < 10000L) {
+				sleep_for_us(10000L - tdiff);
+				t2 = get_clock_us();
+				tdiff = t2 - t1; /* should be really close
+						    to 10000, but isn't */
+				cpu_time += tdiff;
 			} else
-				tdiff -= cpu_tadj;
-			T_freq = T;
-			cpu_time += tdiff;
+				cpu_time += tdiff - cpu_tadj;
 			cpu_tadj = 0;
+			cpu_freq = T * 1000000ULL / cpu_time;
 			t1 = t2;
 		}
 
@@ -689,22 +686,10 @@ leave:
 	fp_led_data = getmem(PC);
 #endif
 
-					/* update CPU time */
-	if (single_step) {		/* if single stepping */
-		if (f_value)		/* use f_value MHz in locked mode */
-			tdiff = (T - T_start) / f_value;
-		else if (T_freq)	/* else use current frequency */
-			tdiff = ((T - T_start) * cpu_time) / T_freq;
-		else			/* avoid division by 0 */
-			tdiff = T - T_start;
-	} else {
-		tdiff = get_clock_us() - t1;
-		if (!f_value)
-			tdiff -= cpu_tadj;
-	}
-	T_freq = T;
-	cpu_time += tdiff;
+					/* update CPU accounting */
+	cpu_time += (get_clock_us() - t1) - cpu_tadj;
 	cpu_tadj = 0;
+	cpu_freq = T * 1000000ULL / cpu_time;
 }
 
 #ifndef ALT_Z80
@@ -719,6 +704,7 @@ static int op_halt(void)		/* HALT */
 	uint64_t t;
 
 	t = get_clock_us();
+
 #ifdef BUS_8080
 	cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
 #endif

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -636,7 +636,8 @@ void cpu_z80(void)
 			} else
 				cpu_time += tdiff - cpu_tadj;
 			cpu_tadj = 0;
-			cpu_freq = T * 1000000ULL / cpu_time;
+			if (cpu_time)
+				cpu_freq = T * 1000000ULL / cpu_time;
 			t1 = t2;
 		}
 
@@ -689,7 +690,8 @@ void cpu_z80(void)
 					/* update CPU accounting */
 	cpu_time += (get_clock_us() - t1) - cpu_tadj;
 	cpu_tadj = 0;
-	cpu_freq = T * 1000000ULL / cpu_time;
+	if (cpu_time)
+		cpu_freq = T * 1000000ULL / cpu_time;
 }
 
 #ifndef ALT_Z80


### PR DESCRIPTION
Restore line deleted by mistake and fix typo.

Remove unnecessary single_step stuff.

Keep a constantly updated cpu_freq frequency estimate variable and use integer arithmetic for frequency calculations.

When sleeping for CPU speed adjustment don't use the timing adjustment, in all other cases subtract it from the spent time.

Move "leave" label inside the "if (int_int)" block, looks cleaner.