### PR TITLE
add some keyboard/mouse controls to change memory display base address

### DIFF
--- a/z80core/sim8080.c
+++ b/z80core/sim8080.c
@@ -592,8 +592,8 @@ void cpu_8080(void)
 			if (F_flag)
 				m1_step = true;
 #endif
-		leave:
 		}
+	leave:
 
 #ifdef BUS_8080
 		/* M1 opcode fetch */

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -604,8 +604,8 @@ void cpu_z80(void)
 				m1_step = true;
 #endif
 			R++;		/* increment refresh register */
-		leave:
 		}
+	leave:
 
 #ifdef BUS_8080
 		/* M1 opcode fetch */


### PR DESCRIPTION
Left/Right changes base address by 1.
Up/Down by 16.
Page Up/Page Down by 256.
Begin rounds down to xxx0.
End rounds up to xxx0.
Shift multiplies/rounding change by 16.
Mouse wheel works too.

Also move "leave" label back. My Mac compiler didn't like it.