### PR TITLE
More time code fiddling, use more modern panel colors, adapt to SDK 2.1.1

### DIFF
--- a/altairsim/srcsim/simctl.c
+++ b/altairsim/srcsim/simctl.c
@@ -327,6 +327,7 @@ static void step_clicked(int state, int val)
 bool wait_step(void)
 {
 	bool ret = false;
+	uint64_t t1, t2, tio = 0;
 
 	if (cpu_state != ST_SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
@@ -339,20 +340,28 @@ bool wait_step(void)
 		return ret;
 	}
 
+	t1 = get_clock_us();
+
 	cpu_switch = CPUSW_STEPCYCLE;
 
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		/* when INP update data bus LEDs */
 		if (cpu_bus == (CPU_WO | CPU_INP)) {
-			if (port_in[fp_led_address & 0xff])
+			if (port_in[fp_led_address & 0xff]) {
+				t2 = get_clock_us();
 				fp_led_data =
 					(*port_in[fp_led_address & 0xff])();
+				tio += get_clock_us() - t2;
+			}
 		}
 		fp_clock++;
 		fp_sampleData();
 		sleep_for_ms(10);
 		ret = true;
 	}
+
+	wait_time += get_clock_us() - t1 - tio;
+	io_time += tio;
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = false;
@@ -364,8 +373,12 @@ bool wait_step(void)
  */
 void wait_int_step(void)
 {
+	uint64_t t;
+
 	if (cpu_state != ST_SINGLE_STEP)
 		return;
+
+	t = get_clock_us();
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
@@ -374,6 +387,8 @@ void wait_int_step(void)
 		fp_sampleData();
 		sleep_for_ms(10);
 	}
+
+	wait_time += get_clock_us() - t;
 }
 
 /*

--- a/altairsim/srcsim/simmem.h
+++ b/altairsim/srcsim/simmem.h
@@ -37,7 +37,6 @@
 #endif
 #ifdef FRONTPANEL
 #include "simctl.h"
-#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -74,10 +73,6 @@ extern void init_memory(void);
  */
 static inline void memwrt(WORD addr, BYTE data)
 {
-#ifdef FRONTPANEL
-	uint64_t t;
-#endif
-
 #ifdef BUS_8080
 #ifndef FRONTPANEL
 	cpu_bus &= ~CPU_M1;
@@ -87,13 +82,11 @@ static inline void memwrt(WORD addr, BYTE data)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = 0xff;
 		fp_sampleData();
 		wait_step();
-		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif
@@ -112,9 +105,6 @@ static inline void memwrt(WORD addr, BYTE data)
 static inline BYTE memrdr(WORD addr)
 {
 	register BYTE data;
-#ifdef FRONTPANEL
-	uint64_t t;
-#endif
 
 #ifdef WANT_HB
 	if (hb_flag && hb_addr == addr) {
@@ -154,13 +144,11 @@ static inline BYTE memrdr(WORD addr)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
 		wait_step();
-		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif

--- a/cromemcosim/srcsim/simctl.c
+++ b/cromemcosim/srcsim/simctl.c
@@ -332,6 +332,7 @@ static void step_clicked(int state, int val)
 bool wait_step(void)
 {
 	bool ret = false;
+	uint64_t t1, t2, tio = 0;
 
 	if (cpu_state != ST_SINGLE_STEP) {
 		cpu_bus &= ~CPU_M1;
@@ -344,20 +345,28 @@ bool wait_step(void)
 		return ret;
 	}
 
+	t1 = get_clock_us();
+
 	cpu_switch = CPUSW_STEPCYCLE;
 
 	while ((cpu_switch == CPUSW_STEPCYCLE) && !reset) {
 		/* when INP update data bus LEDs */
 		if (cpu_bus == (CPU_WO | CPU_INP)) {
-			if (port_in[fp_led_address & 0xff])
+			if (port_in[fp_led_address & 0xff]) {
+				t2 = get_clock_us();
 				fp_led_data =
 					(*port_in[fp_led_address & 0xff])();
+				tio += get_clock_us() - t2;
+			}
 		}
 		fp_clock++;
 		fp_sampleData();
 		sleep_for_ms(10);
 		ret = true;
 	}
+
+	wait_time += get_clock_us() - t1 - tio;
+	io_time += tio;
 
 	cpu_bus &= ~CPU_M1;
 	m1_step = false;
@@ -369,8 +378,12 @@ bool wait_step(void)
  */
 void wait_int_step(void)
 {
+	uint64_t t;
+
 	if (cpu_state != ST_SINGLE_STEP)
 		return;
+
+	t = get_clock_us();
 
 	cpu_switch = CPUSW_STEPCYCLE;
 
@@ -379,6 +392,8 @@ void wait_int_step(void)
 		fp_sampleData();
 		sleep_for_ms(10);
 	}
+
+	wait_time += get_clock_us() - t;
 }
 
 /*

--- a/cromemcosim/srcsim/simmem.h
+++ b/cromemcosim/srcsim/simmem.h
@@ -36,7 +36,6 @@
 #endif
 #ifdef FRONTPANEL
 #include "simctl.h"
-#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -91,9 +90,6 @@ extern void reset_fdc_rom_map(void);
 static inline void memwrt(WORD addr, BYTE data)
 {
 	register int i;
-#ifdef FRONTPANEL
-	uint64_t t;
-#endif
 
 #ifdef BUS_8080
 #ifndef FRONTPANEL
@@ -104,13 +100,11 @@ static inline void memwrt(WORD addr, BYTE data)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
 		wait_step();
-		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif
@@ -140,9 +134,6 @@ static inline void memwrt(WORD addr, BYTE data)
 static inline BYTE memrdr(WORD addr)
 {
 	register BYTE data;
-#ifdef FRONTPANEL
-	uint64_t t;
-#endif
 
 #ifdef WANT_HB
 	if (hb_flag && hb_addr == addr) {
@@ -173,13 +164,11 @@ static inline BYTE memrdr(WORD addr)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
 		wait_step();
-		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif

--- a/imsaisim/srcsim/simmem.h
+++ b/imsaisim/srcsim/simmem.h
@@ -38,7 +38,6 @@
 #endif
 #ifdef FRONTPANEL
 #include "simctl.h"
-#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -113,10 +112,6 @@ extern void groupswap(void);
  */
 static inline void memwrt(WORD addr, BYTE data)
 {
-#ifdef FRONTPANEL
-	uint64_t t;
-#endif
-
 #ifdef BUS_8080
 #ifndef FRONTPANEL
 	cpu_bus &= ~CPU_M1;
@@ -126,13 +121,11 @@ static inline void memwrt(WORD addr, BYTE data)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
 		wait_step();
-		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif
@@ -154,9 +147,6 @@ static inline void memwrt(WORD addr, BYTE data)
 static inline BYTE memrdr(WORD addr)
 {
 	register BYTE data;
-#ifdef FRONTPANEL
-	uint64_t t;
-#endif
 
 #ifdef WANT_HB
 	if (hb_flag && hb_addr == addr) {
@@ -189,13 +179,11 @@ static inline BYTE memrdr(WORD addr)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t = get_clock_us();
 		fp_clock++;
 		fp_led_address = addr;
 		fp_led_data = data;
 		fp_sampleData();
 		wait_step();
-		cpu_tadj += get_clock_us() - t;
 	} else
 		cpu_bus &= ~CPU_M1;
 #endif

--- a/picosim/README
+++ b/picosim/README
@@ -11,7 +11,7 @@ picosim also on these:
 	https://github.com/udo-munk/RP2xxx-GEEK-80
 
 
-To build the software you need to have the SDK for RP2040/RP2350 devices
+To build the software you need to have the SDK 2.1.1 for RP2040/RP2350 devices
 installed and configured. The SDK manual has detailed instructions how
 to install on all major PC platforms, it is available here:
 

--- a/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/.gitignore
+++ b/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/.gitignore
@@ -1,4 +1,5 @@
 **/build
+**/cppcheck_project-cppcheck-build-dir
 *.html
 *.png
 *.zip
@@ -7,3 +8,4 @@
 **/.vscode
 *.tar.gz
 PlatformIO.notes.txt
+examples/command_line/cppcheck_project.cppcheck

--- a/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/README.md
+++ b/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/README.md
@@ -376,7 +376,7 @@ See [An instance of `sd_spi_if_t` describes the configuration of one SPI to SD c
 * Follow instructions in [Getting started with Raspberry Pi Pico](https://datasheets.raspberrypi.org/pico/getting-started-with-pico.pdf) to set up the development environment.
 * Install source code:
   ```bash
-  git clone --recurse-submodules git@github.com:carlk3/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico.git no-OS-FatFs
+  git clone --recurse-submodules https://github.com/carlk3/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico.git
   ```
 * Customize:
   * Configure the code to match the hardware: see section 
@@ -386,7 +386,7 @@ See [An instance of `sd_spi_if_t` describes the configuration of one SPI to SD c
 (See *4.1. Serial input and output on Raspberry Pi Pico* in [Getting started with Raspberry Pi Pico](https://datasheets.raspberrypi.org/pico/getting-started-with-pico.pdf) and *2.7.1. Standard Input/Output (stdio) Support* in [Raspberry Pi Pico C/C++ SDK](https://datasheets.raspberrypi.org/pico/raspberry-pi-pico-c-sdk.pdf).) 
 * Build:
 ```bash
-   cd no-OS-FatFs/examples/command_line
+   cd no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/examples/command_line
    mkdir build
    cd build
    cmake ..
@@ -1051,6 +1051,8 @@ Obviously, if possible, use 4-bit SDIO instead of 1-bit SPI.
 
 Obviously, set the baud rate as high as you can. (See
 [Customizing for the Hardware Configuration](#customizing-for-the-hardware-configuration)).
+
+Consider increasing the system clock frequency (clk_sys).
 
 If you are using SPI, try SPI mode 3 (CPOL=1, CPHA=1) instead of 0 (CPOL=0, CPHA=0). (See
 [SPI Controller Configuration](#spi-controller-configuration).) This could buy a 15% speed boost.

--- a/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/examples/command_line/CMakeLists.txt
+++ b/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/examples/command_line/CMakeLists.txt
@@ -1,12 +1,12 @@
-# == DO NEVER EDIT THE NEXT LINES for Raspberry Pi Pico VS Code Extension to work ==
+# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
 if(WIN32)
     set(USERHOME $ENV{USERPROFILE})
 else()
     set(USERHOME $ENV{HOME})
 endif()
-set(sdkVersion 2.0.0)
-set(toolchainVersion 13_2_Rel1)
-set(picotoolVersion 2.0.0)
+set(sdkVersion 2.1.0)
+set(toolchainVersion RISCV_RPI_2_0_0_5)
+set(picotoolVersion 2.1.0)
 set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
 if (EXISTS ${picoVscode})
     include(${picoVscode})

--- a/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/examples/stdio_buffering/CMakeLists.txt
+++ b/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/examples/stdio_buffering/CMakeLists.txt
@@ -1,12 +1,12 @@
-# == DO NEVER EDIT THE NEXT LINES for Raspberry Pi Pico VS Code Extension to work ==
+# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
 if(WIN32)
     set(USERHOME $ENV{USERPROFILE})
 else()
     set(USERHOME $ENV{HOME})
 endif()
-set(sdkVersion 2.0.0)
-set(toolchainVersion 13_2_Rel1)
-set(picotoolVersion 2.0.0)
+set(sdkVersion 2.1.0)
+set(toolchainVersion 13_3_Rel1)
+set(picotoolVersion 2.1.0)
 set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
 if (EXISTS ${picoVscode})
     include(${picoVscode})

--- a/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/sd_driver/SDIO/SdioCard.h
+++ b/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/sd_driver/SDIO/SdioCard.h
@@ -61,17 +61,17 @@ bool sd_sdio_erase(sd_card_t *sd_card_p, uint32_t firstSector, uint32_t lastSect
 /**
  * \return code for the last error. See SdCardInfo.h for a list of error codes.
  */
-uint8_t sd_sdio_errorCode() /* const */;
+uint8_t sd_sdio_errorCode(sd_card_t *sd_card_p) /* const */;
 /** \return error data for last error. */
 uint32_t sd_sdio_errorData() /* const */;
 /** \return error line for last error. Tmp function for debug. */
-uint32_t sd_sdio_errorLine() /* const */;
+uint32_t sd_sdio_errorLine(sd_card_t *sd_card_p) /* const */;
 /**
  * Check for busy with CMD13.
  *
  * \return true if busy else false.
  */
-bool sd_sdio_isBusy();
+bool sd_sdio_isBusy(sd_card_t *sd_card_p);
 /** \return the SD clock frequency in kHz. */
 //uint32_t sd_sdio_kHzSdClk();
 /**

--- a/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/sd_driver/SDIO/rp2040_sdio.c
+++ b/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/sd_driver/SDIO/rp2040_sdio.c
@@ -56,7 +56,7 @@
 
 
 // Force everything to idle state
-static sdio_status_t rp2040_sdio_stop();
+static sdio_status_t rp2040_sdio_stop(sd_card_t *sd_card_p);
 
 /*******************************************************
  * Checksum algorithms

--- a/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/src/file_stream.c
+++ b/picosim/libs/no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src/src/file_stream.c
@@ -126,7 +126,8 @@ FILE *open_file_stream(const char *pathname, const char *pcMode) {
 
     FRESULT fr = f_open(&cookie_p->file, pathname, mode);
     if (FR_OK != fr) {
-        DBG_PRINTF("f_lseek error: %s\n", FRESULT_str(fr));
+        DBG_PRINTF("f_open error: %s\n", FRESULT_str(fr));
+        free( cookie_p);
         return NULL;
     }
     cookie_io_functions_t iofs = {cookie_read_function, cookie_write_function,

--- a/picosim/srcsim/picosim.c
+++ b/picosim/srcsim/picosim.c
@@ -347,7 +347,7 @@ static void picosim_ice_cmd(char *cmd, WORD *wrk_addr)
 			s = "JMP";
 #endif
 		if (cpu_error == NONE) {
-			freq = (unsigned) ((T - T0) / 30000ULL);
+			freq = (unsigned) ((T - T0) / 30000);
 			printf("CPU executed %" PRIu64 " %s instructions "
 			       "in 3 seconds\n", (T - T0) / 10, s);
 			printf("clock frequency = %u.%02u MHz\n",

--- a/picosim/srcsim/simcfg.c
+++ b/picosim/srcsim/simcfg.c
@@ -147,9 +147,6 @@ void config(void)
 	ts.tv_sec = mktime(&t);
 	ts.tv_nsec = 0;
 	aon_timer_start(&ts);
-#if PICO_RP2040
-	sleep_us(64);
-#endif
 
 	menu = 1;
 
@@ -229,9 +226,6 @@ void config(void)
 				ds3231_set_datetime(&dt, &rtc);
 				ts.tv_sec = mktime(&t);
 				aon_timer_set_time(&ts);
-#if PICO_RP2040
-				sleep_us(64);
-#endif
 			}
 			putchar('\n');
 			break;
@@ -260,9 +254,6 @@ void config(void)
 				ds3231_set_datetime(&dt, &rtc);
 				ts.tv_sec = mktime(&t);
 				aon_timer_set_time(&ts);
-#if PICO_RP2040
-				sleep_us(64);
-#endif
 			}
 			putchar('\n');
 			break;

--- a/z80core/alt8080.h
+++ b/z80core/alt8080.h
@@ -740,6 +740,7 @@
 
 	case 0x76:			/* HLT */
 		t2 = get_clock_us();
+
 #ifdef BUS_8080
 		cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
 #endif
@@ -798,7 +799,9 @@
 			}
 		}
 #endif /* FRONTPANEL */
-		cpu_tadj += get_clock_us() - t2;
+
+		wait_time += get_clock_us() - t2;
+
 		t += 3;
 		break;
 

--- a/z80core/altz80.h
+++ b/z80core/altz80.h
@@ -802,6 +802,7 @@ next_opcode:
 
 	case 0x76:			/* HALT */
 		t2 = get_clock_us();
+
 #ifdef BUS_8080
 		cpu_bus = CPU_WO | CPU_HLTA | CPU_MEMR;
 #endif
@@ -864,7 +865,9 @@ next_opcode:
 			}
 		}
 #endif /* FRONTPANEL */
-		cpu_tadj += get_clock_us() - t2;
+
+		wait_time += get_clock_us() - t2;
+
 		break;
 
 	case 0x77:			/* LD (ir),A */
@@ -1379,11 +1382,9 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 			if (F_flag) {
-				t2 = get_clock_us();
 				/* update frontpanel */
 				fp_clock++;
 				fp_sampleLightGroup(0, 0);
-				cpu_tadj += get_clock_us() - t2;
 			}
 #endif
 
@@ -1623,11 +1624,9 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 		if (F_flag) {
-			t2 = get_clock_us();
 			/* update frontpanel */
 			fp_clock++;
 			fp_sampleLightGroup(0, 0);
-			cpu_tadj += get_clock_us() - t2;
 		}
 #endif
 
@@ -1721,11 +1720,9 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 		if (F_flag) {
-			t2 = get_clock_us();
 			/* update frontpanel */
 			fp_clock++;
 			fp_sampleLightGroup(0, 0);
-			cpu_tadj += get_clock_us() - t2;
 		}
 #endif
 
@@ -2401,11 +2398,9 @@ next_opcode:
 #endif
 #ifdef FRONTPANEL
 		if (F_flag) {
-			t2 = get_clock_us();
 			/* update frontpanel */
 			fp_clock++;
 			fp_sampleLightGroup(0, 0);
-			cpu_tadj += get_clock_us() - t2;
 		}
 #endif
 

--- a/z80core/simfun.c
+++ b/z80core/simfun.c
@@ -103,7 +103,7 @@ uint64_t get_clock_us(void)
 	static uint64_t old_t;
 
 	gettimeofday(&tv, NULL);
-	t = (uint64_t) (tv.tv_sec) * 1000000ULL + (uint64_t) (tv.tv_usec);
+	t = (uint64_t) tv.tv_sec * 1000000 + (uint64_t) tv.tv_usec;
 	if (t < old_t) {
 		LOGD(TAG, "get_clock_us() time jumped backwards %"
 		     PRIu64 " > %" PRIu64, old_t, t);

--- a/z80core/simglb.c
+++ b/z80core/simglb.c
@@ -39,10 +39,15 @@ BYTE IFF;			/* interrupt flags */
 #else
 cpu_regs_t cpu_regs;		/* CPU registers */
 #endif
+
 Tstates_t T;			/* CPU clock */
-uint64_t cpu_time;		/* time spent running CPU in us */
-uint64_t cpu_tadj;		/* time spent in non CPU execution areas */
+uint64_t cpu_time;		/* time spent running CPU in usec */
 uint64_t cpu_freq;		/* estimated CPU frequency in Hz */
+uint64_t io_time;		/* time spent doing I/O in time block */
+uint64_t wait_time;		/* time spent waiting in time block */
+uint64_t total_io_time;		/* total time spent doing I/O */
+uint64_t total_wait_time;	/* total time spent waiting */
+
 
 #ifdef BUS_8080
 BYTE cpu_bus;			/* CPU bus status, for frontpanels */

--- a/z80core/simglb.h
+++ b/z80core/simglb.h
@@ -31,8 +31,11 @@ extern BYTE	IFF;
 #else
 #include "altregs.h"
 #endif
+
 extern Tstates_t T;
-extern uint64_t	cpu_time, cpu_tadj, cpu_freq;
+extern uint64_t	cpu_time, cpu_freq;
+extern uint64_t io_time, wait_time;
+extern uint64_t total_io_time, total_wait_time;
 
 #ifdef BUS_8080
 extern BYTE	cpu_bus;

--- a/z80core/simpanel.c
+++ b/z80core/simpanel.c
@@ -48,15 +48,20 @@ static const char *TAG = "panel";
 #define C_MAGENTA	0x00ff00ff
 #define C_YELLOW	0x00ffff00
 #define C_WHITE		0x00ffffff
-#define C_DKRED		0x00800000
-#define C_DKGREEN	0x00008000
-#define C_DKBLUE	0x00000080
-#define C_DKCYAN	0x00008080
-#define C_DKMAGENTA	0x00800080
-#define C_DKYELLOW	0x00808000
-#define C_GRAY		0x00808080
-#define C_ORANGE	0x00ffa500
-#define C_WHEAT		0x00f5deb3
+
+#define C_BUTTER_1	0x00fce94f
+#define C_BUTTER_3	0x00c4a000
+#define C_ORANGE_1	0x00fcaf3e
+#define C_CHOC_1	0x00e9b96e
+#define C_CHAM_2	0x0073d216
+#define C_CHAM_3	0x004e9a06
+#define C_BLUE_1	0x00729fcf
+#define C_PLUM_1	0x00e090d7
+#define C_RED_2		0x00cc0000
+#define C_ALUM_2	0x00d3d7cf
+#define C_ALUM_4	0x00888a85
+#define C_ALUM_5	0x00555753
+#define C_ALUM_6	0x002e3436
 
 #define C_TRANS		0xffffffff
 
@@ -176,6 +181,7 @@ static pthread_t thread;
 static int panel;		/* current panel type */
 static WORD mbase;		/* memory panel base address */
 static bool sticky;		/* I/O ports panel sticky flag */
+static bool showfps;		/* show FPS flag */
 
 /*
  * Create the SDL2 or X11 window for panel display
@@ -393,6 +399,9 @@ static void process_event(SDL_Event *event)
 					mbase = (mbase + 0x000f) & 0xfff0;
 			}
 			break;
+		case SDLK_s:
+			showfps = !showfps;
+			break;
 		default:
 			break;
 		}
@@ -516,6 +525,10 @@ static inline void process_events(void)
 						mbase = (mbase + 0x000f) &
 							0xfff0;
 				}
+				break;
+			case XK_s:
+			case XK_S:
+				showfps = !showfps;
 				break;
 			default:
 				break;
@@ -827,14 +840,14 @@ static inline void draw_led(const unsigned x, const unsigned y,
 {
 	int i;
 
-	draw_hline(x + 2, y, 6, C_GRAY);
-	draw_pixel(x + 1, y + 1, C_GRAY);
-	draw_pixel(x + 8, y + 1, C_GRAY);
-	draw_vline(x, y + 2, 6, C_GRAY);
-	draw_vline(x + 9, y + 2, 6, C_GRAY);
-	draw_pixel(x + 1, y + 8, C_GRAY);
-	draw_pixel(x + 8, y + 8, C_GRAY);
-	draw_hline(x + 2, y + 9, 6, C_GRAY);
+	draw_hline(x + 2, y, 6, C_ALUM_5);
+	draw_pixel(x + 1, y + 1, C_ALUM_5);
+	draw_pixel(x + 8, y + 1, C_ALUM_5);
+	draw_vline(x, y + 2, 6, C_ALUM_5);
+	draw_vline(x + 9, y + 2, 6, C_ALUM_5);
+	draw_pixel(x + 1, y + 8, C_ALUM_5);
+	draw_pixel(x + 8, y + 8, C_ALUM_5);
+	draw_hline(x + 2, y + 9, 6, C_ALUM_5);
 	for (i = 1; i < 9; i++) {
 		if (i == 1 || i == 8)
 			draw_hline(x + 2, y + i, 6, col);
@@ -978,14 +991,14 @@ static void draw_cpu_regs(void)
 		draw_setup_grid(&grid, RXOFF, RYOFF, 47, 3, &font18, RSPC);
 
 		/* draw vertical grid lines */
-		draw_grid_vline(7, 0, 2, &grid, C_DKYELLOW);
-		draw_grid_vline(15, 0, 3, &grid, C_DKYELLOW);
-		draw_grid_vline(23, 0, 3, &grid, C_DKYELLOW);
-		draw_grid_vline(31, 0, 3, &grid, C_DKYELLOW);
-		draw_grid_vline(39, 0, 2, &grid, C_DKYELLOW);
+		draw_grid_vline(7, 0, 2, &grid, C_ALUM_4);
+		draw_grid_vline(15, 0, 3, &grid, C_ALUM_4);
+		draw_grid_vline(23, 0, 3, &grid, C_ALUM_4);
+		draw_grid_vline(31, 0, 3, &grid, C_ALUM_4);
+		draw_grid_vline(39, 0, 2, &grid, C_ALUM_4);
 		/* draw horizontal grid lines */
-		draw_grid_hline(0, 1, grid.cols, &grid, C_DKYELLOW);
-		draw_grid_hline(0, 2, grid.cols, &grid, C_DKYELLOW);
+		draw_grid_hline(0, 1, grid.cols, &grid, C_ALUM_4);
+		draw_grid_hline(0, 2, grid.cols, &grid, C_ALUM_4);
 	}
 #endif
 #ifndef EXCLUDE_I8080
@@ -993,13 +1006,13 @@ static void draw_cpu_regs(void)
 		draw_setup_grid(&grid, RXOFF, RYOFF, 47, 2, &font18, RSPC);
 
 		/* draw vertical grid lines */
-		draw_grid_vline(7, 0, 1, &grid, C_DKYELLOW);
-		draw_grid_vline(15, 0, 2, &grid, C_DKYELLOW);
-		draw_grid_vline(23, 0, 1, &grid, C_DKYELLOW);
-		draw_grid_vline(31, 0, 1, &grid, C_DKYELLOW);
-		draw_grid_vline(39, 0, 1, &grid, C_DKYELLOW);
+		draw_grid_vline(7, 0, 1, &grid, C_ALUM_4);
+		draw_grid_vline(15, 0, 2, &grid, C_ALUM_4);
+		draw_grid_vline(23, 0, 1, &grid, C_ALUM_4);
+		draw_grid_vline(31, 0, 1, &grid, C_ALUM_4);
+		draw_grid_vline(39, 0, 1, &grid, C_ALUM_4);
 		/* draw horizontal grid line */
-		draw_grid_hline(0, 1, grid.cols, &grid, C_DKYELLOW);
+		draw_grid_hline(0, 1, grid.cols, &grid, C_ALUM_4);
 	}
 #endif
 	/* draw register labels & contents */
@@ -1010,7 +1023,7 @@ static void draw_cpu_regs(void)
 				x++;
 			while (*s)
 				draw_grid_char(x++, rp->y, *s++, &grid,
-					       C_WHITE, C_DKBLUE);
+					       C_ALUM_2, C_ALUM_6);
 		}
 		switch (rp->type) {
 		case RB: /* byte sized register */
@@ -1027,13 +1040,13 @@ static void draw_cpu_regs(void)
 			break;
 		case RF: /* flags */
 			draw_grid_char(rp->x, rp->y, rp->f.c, &grid,
-				       (F & rp->f.m) ? C_GREEN : C_RED,
-				       C_DKBLUE);
+				       (F & rp->f.m) ? C_CHAM_2 : C_RED_2,
+				       C_ALUM_6);
 			continue;
 		case RI: /* interrupt register */
 			draw_grid_char(rp->x, rp->y, rp->f.c, &grid,
 				       (IFF & rp->f.m) == rp->f.m ?
-				       C_GREEN : C_RED, C_DKBLUE);
+				       C_CHAM_2 : C_RED_2, C_ALUM_6);
 			continue;
 #ifndef EXCLUDE_Z80
 		case RR: /* refresh register */
@@ -1048,8 +1061,8 @@ static void draw_cpu_regs(void)
 		while (j--) {
 			c = w & 0xf;
 			c += (c < 10 ? '0' : 'A' - 10);
-			draw_grid_char(x--, rp->y, c, &grid, C_GREEN,
-				       C_DKBLUE);
+			draw_grid_char(x--, rp->y, c, &grid, C_CHAM_2,
+				       C_ALUM_6);
 			w >>= 4;
 		}
 	}
@@ -1079,37 +1092,37 @@ static void draw_memory_panel(void)
 
 	/* draw vertical grid lines */
 	for (i = 0; i < 17; i++)
-		draw_grid_vline(5 + i * 3, 0, grid.rows, &grid, C_DKYELLOW);
+		draw_grid_vline(5 + i * 3, 0, grid.rows, &grid, C_ALUM_4);
 
 	a = mbase;
 	for (i = 0; i < 16; i++) {
 		c = ((a & 0xf) + i) & 0xf;
 		c += (c < 10 ? '0' : 'A' - 10);
-		draw_grid_char(7 + i * 3, 0, c, &grid, C_GREEN, C_DKBLUE);
+		draw_grid_char(7 + i * 3, 0, c, &grid, C_ALUM_2, C_ALUM_6);
 	}
 	for (j = 0; j < 16; j++) {
-		draw_grid_hline(0, j + 1, grid.cols, &grid, C_DKYELLOW);
+		draw_grid_hline(0, j + 1, grid.cols, &grid, C_ALUM_4);
 		c = (a >> 12) & 0xf;
 		c += (c < 10 ? '0' : 'A' - 10);
-		draw_grid_char(0, j + 1, c, &grid, C_GREEN, C_DKBLUE);
+		draw_grid_char(0, j + 1, c, &grid, C_ALUM_2, C_ALUM_6);
 		c = (a >> 8) & 0xf;
 		c += (c < 10 ? '0' : 'A' - 10);
-		draw_grid_char(1, j + 1, c, &grid, C_GREEN, C_DKBLUE);
+		draw_grid_char(1, j + 1, c, &grid, C_ALUM_2, C_ALUM_6);
 		c = (a >> 4) & 0xf;
 		c += (c < 10 ? '0' : 'A' - 10);
-		draw_grid_char(2, j + 1, c, &grid, C_GREEN, C_DKBLUE);
+		draw_grid_char(2, j + 1, c, &grid, C_ALUM_2, C_ALUM_6);
 		c = a & 0xf;
 		c += (c < 10 ? '0' : 'A' - 10);
-		draw_grid_char(3, j + 1, c, &grid, C_GREEN, C_DKBLUE);
+		draw_grid_char(3, j + 1, c, &grid, C_ALUM_2, C_ALUM_6);
 		for (i = 0; i < 16; i++) {
 			c = (getmem(a) >> 4) & 0xf;
 			c += (c < 10 ? '0' : 'A' - 10);
-			draw_grid_char(6 + i * 3, j + 1, c, &grid, C_CYAN,
-				       C_DKBLUE);
+			draw_grid_char(6 + i * 3, j + 1, c, &grid, C_CHAM_2,
+				       C_ALUM_6);
 			c = getmem(a++) & 0xf;
 			c += (c < 10 ? '0' : 'A' - 10);
-			draw_grid_char(7 + i * 3, j + 1, c, &grid, C_CYAN,
-				       C_DKBLUE);
+			draw_grid_char(7 + i * 3, j + 1, c, &grid, C_CHAM_2,
+				       C_ALUM_6);
 		}
 		a -= 16;
 		for (i = 0; i < 16; i++) {
@@ -1118,8 +1131,8 @@ static void draw_memory_panel(void)
 			if (dc < 32 || dc == 127)
 				dc = '.';
 			draw_grid_char(55 + i, j + 1, dc, &grid,
-				       (c & 0x80) ? C_ORANGE : C_YELLOW,
-				       C_DKBLUE);
+				       (c & 0x80) ? C_PLUM_1 : C_BUTTER_1,
+				       C_ALUM_6);
 		}
 	}
 }
@@ -1149,22 +1162,22 @@ static void draw_ports_panel(void)
 
 	/* draw vertical grid lines */
 	for (i = 0; i < 16; i++)
-		draw_grid_vline(3 + i * 4, 0, grid.rows, &grid, C_DKYELLOW);
+		draw_grid_vline(3 + i * 4, 0, grid.rows, &grid, C_ALUM_4);
 
 	for (i = 0; i < 16; i++) {
 		c = i + (i < 10 ? '0' : 'A' - 10);
-		draw_grid_char(5 + i * 4, 0, c, &grid, C_GREEN, C_DKBLUE);
+		draw_grid_char(5 + i * 4, 0, c, &grid, C_ALUM_2, C_ALUM_6);
 	}
 	for (j = 0; j < 16; j++) {
-		draw_grid_hline(0, j + 1, grid.cols, &grid, C_DKYELLOW);
+		draw_grid_hline(0, j + 1, grid.cols, &grid, C_ALUM_4);
 		c = j + (j < 10 ? '0' : 'A' - 10);
-		draw_grid_char(0, j + 1, c, &grid, C_GREEN, C_DKBLUE);
-		draw_grid_char(1, j + 1, '0', &grid, C_GREEN, C_DKBLUE);
+		draw_grid_char(0, j + 1, c, &grid, C_ALUM_2, C_ALUM_6);
+		draw_grid_char(1, j + 1, '0', &grid, C_ALUM_2, C_ALUM_6);
 		for (i = 0; i < 16; i++) {
 			x = (4 + i * 4) * grid.cwidth + grid.xoff + 1;
 			y = (j + 1) * grid.cheight + grid.yoff + 3;
-			draw_led(x, y, p->in ? C_GREEN : C_DKBLUE);
-			draw_led(x + 13, y, p->out ? C_RED : C_DKBLUE);
+			draw_led(x, y, p->in ? C_CHAM_2 : C_ALUM_6);
+			draw_led(x + 13, y, p->out ? C_RED_2 : C_ALUM_6);
 			p++;
 		}
 	}
@@ -1196,13 +1209,13 @@ static void draw_info(bool tick)
 	/* draw product info */
 	s = "Z80pack " RELEASE;
 	for (i = 0; *s; i++)
-		draw_char(i * w + x, y, *s++, font, C_ORANGE, C_DKBLUE);
+		draw_char(i * w + x, y, *s++, font, C_ORANGE_1, C_ALUM_6);
 
 	/* draw frequency label */
-	draw_char((n - 7) * w + x, y, '.', font, C_ORANGE, C_DKBLUE);
-	draw_char((n - 3) * w + x, y, 'M', font, C_ORANGE, C_DKBLUE);
-	draw_char((n - 2) * w + x, y, 'H', font, C_ORANGE, C_DKBLUE);
-	draw_char((n - 1) * w + x, y, 'z', font, C_ORANGE, C_DKBLUE);
+	draw_char((n - 7) * w + x, y, '.', font, C_ORANGE_1, C_ALUM_6);
+	draw_char((n - 3) * w + x, y, 'M', font, C_ORANGE_1, C_ALUM_6);
+	draw_char((n - 2) * w + x, y, 'H', font, C_ORANGE_1, C_ALUM_6);
+	draw_char((n - 1) * w + x, y, 'z', font, C_ORANGE_1, C_ALUM_6);
 
 	/* update fps every second */
 	count++;
@@ -1210,20 +1223,22 @@ static void draw_info(bool tick)
 		fps = count;
 		count = 0;
 	}
-	draw_char(30 * w + x, y, fps > 99 ? fps / 100 + '0' : ' ',
-		  font, C_ORANGE, C_DKBLUE);
-	draw_char(31 * w + x, y, fps > 9 ? (fps / 10) % 10 + '0' : ' ',
-		  font, C_ORANGE, C_DKBLUE);
-	draw_char(32 * w + x, y, fps % 10 + '0',
-		  font, C_ORANGE, C_DKBLUE);
-	draw_char(34 * w + x, y, 'f', font, C_ORANGE, C_DKBLUE);
-	draw_char(35 * w + x, y, 'p', font, C_ORANGE, C_DKBLUE);
-	draw_char(36 * w + x, y, 's', font, C_ORANGE, C_DKBLUE);
+	if (showfps) {
+		draw_char(30 * w + x, y, fps > 99 ? fps / 100 + '0' : ' ',
+			  font, C_ORANGE_1, C_ALUM_6);
+		draw_char(31 * w + x, y, fps > 9 ? (fps / 10) % 10 + '0' : ' ',
+			  font, C_ORANGE_1, C_ALUM_6);
+		draw_char(32 * w + x, y, fps % 10 + '0',
+			  font, C_ORANGE_1, C_ALUM_6);
+		draw_char(34 * w + x, y, 'f', font, C_ORANGE_1, C_ALUM_6);
+		draw_char(35 * w + x, y, 'p', font, C_ORANGE_1, C_ALUM_6);
+		draw_char(36 * w + x, y, 's', font, C_ORANGE_1, C_ALUM_6);
+	}
 
 	/* update frequency every second */
-	if (tick && cpu_time)
+	if (tick)
 		freq = cpu_freq;
-	f = (unsigned) (freq / 10000ULL);
+	f = (unsigned) (freq / 10000);
 	digit = 100000;
 	onlyz = true;
 	for (i = 0; i < 7; i++) {
@@ -1237,7 +1252,7 @@ static void draw_info(bool tick)
 		else
 			onlyz = false;
 		draw_char((n - 11 + i) * w + x, y, c,
-			  font, C_ORANGE, C_DKBLUE);
+			  font, C_ORANGE_1, C_ALUM_6);
 		if (i < 6)
 			digit /= 10;
 		if (i == 3)
@@ -1258,7 +1273,7 @@ static void draw_buttons(void)
 
 	for (i = 0; i < nbuttons; i++) {
 		if (p->enabled) {
-			color = p->hilighted ? C_ORANGE : C_WHITE;
+			color = p->hilighted ? C_ORANGE_1 : C_ALUM_2;
 			draw_hline(p->x + 2, p->y, p->width - 4, color);
 			draw_pixel(p->x + 1, p->y + 1, color);
 			draw_pixel(p->x + p->width - 2, p->y + 1, color);
@@ -1271,11 +1286,11 @@ static void draw_buttons(void)
 			draw_hline(p->x + 2, p->y + p->height - 1,
 				   p->width - 4, color);
 
-			color = C_DKBLUE;
+			color = C_ALUM_6;
 			if (p->active)
-				color = C_DKGREEN;
+				color = C_CHAM_3;
 			if (p->pressed)
-				color = C_DKYELLOW;
+				color = C_BLUE_1;
 			draw_hline(p->x + 2, p->y + 1, p->width - 4, color);
 			for (y = p->y + 2; y < p->y + p->height - 2; y++)
 				draw_hline(p->x + 1, y, p->width - 2, color);
@@ -1286,7 +1301,7 @@ static void draw_buttons(void)
 					p->font->width) / 2;
 			y = p->y + 1 + (p->height - 2 - p->font->height) / 2;
 			for (s = p->text; *s; s++) {
-				draw_char(x, y, *s, p->font, C_CYAN, C_TRANS);
+				draw_char(x, y, *s, p->font, C_CHOC_1, C_TRANS);
 				x += p->font->width;
 			}
 		}
@@ -1379,7 +1394,7 @@ static void check_buttons(unsigned x, unsigned y, int event)
  */
 static void refresh(bool tick)
 {
-	draw_clear(C_DKBLUE);
+	draw_clear(C_ALUM_6);
 
 	update_buttons();
 	draw_buttons();

--- a/z80core/simsdl.c
+++ b/z80core/simsdl.c
@@ -8,6 +8,7 @@
  *	This module contains the SDL2 integration for the simulator.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <SDL.h>
 #include <SDL_main.h>

--- a/z80core/simz80-cb.c
+++ b/z80core/simz80-cb.c
@@ -17,7 +17,6 @@
 #include "simz80-cb.h"
 
 #ifdef FRONTPANEL
-#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -372,9 +371,6 @@ int op_cb_handle(void)
 #undef UNDOC
 
 	register int t;
-#ifdef FRONTPANEL
-	uint64_t t0;
-#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -383,11 +379,9 @@ int op_cb_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t0 = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
-		cpu_tadj += get_clock_us() - t0;
 	}
 #endif
 

--- a/z80core/simz80-dd.c
+++ b/z80core/simz80-dd.c
@@ -18,7 +18,6 @@
 #include "simz80-ddcb.h"
 
 #ifdef FRONTPANEL
-#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -339,9 +338,6 @@ int op_dd_handle(void)
 #undef UNDOC
 
 	register int t;
-#ifdef FRONTPANEL
-	uint64_t t0;
-#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -350,11 +346,9 @@ int op_dd_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t0 = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
-		cpu_tadj += get_clock_us() - t0;
 	}
 #endif
 

--- a/z80core/simz80-ed.c
+++ b/z80core/simz80-ed.c
@@ -18,7 +18,6 @@
 #include "simz80-ed.h"
 
 #ifdef FRONTPANEL
-#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -321,9 +320,6 @@ int op_ed_handle(void)
 #undef UNDOC
 
 	register int t;
-#ifdef FRONTPANEL
-	uint64_t t0;
-#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -332,11 +328,9 @@ int op_ed_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t0 = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
-		cpu_tadj += get_clock_us() - t0;
 	}
 #endif
 

--- a/z80core/simz80-fd.c
+++ b/z80core/simz80-fd.c
@@ -18,7 +18,6 @@
 #include "simz80-fdcb.h"
 
 #ifdef FRONTPANEL
-#include "simport.h"
 #include "frontpanel.h"
 #endif
 
@@ -339,9 +338,6 @@ int op_fd_handle(void)
 #undef UNDOC
 
 	register int t;
-#ifdef FRONTPANEL
-	uint64_t t0;
-#endif
 
 #ifdef BUS_8080
 	/* M1 opcode fetch */
@@ -350,11 +346,9 @@ int op_fd_handle(void)
 #endif
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t0 = get_clock_us();
 		/* update frontpanel */
 		fp_clock++;
 		fp_sampleLightGroup(0, 0);
-		cpu_tadj += get_clock_us() - t0;
 	}
 #endif
 

--- a/z80core/simz80.c
+++ b/z80core/simz80.c
@@ -388,19 +388,18 @@ void cpu_z80(void)
 
 	Tstates_t T_max, T_dma;
 	uint64_t t1, t2;
-	long tdiff;
+	unsigned long tdiff;
 	WORD p;
+
+#ifdef FRONTPANEL
+	if (F_flag) {
+		fp_clock++;
+		fp_sampleData();
+	}
+#endif
 
 	T_max = T + tmax;
 	t1 = get_clock_us();
-#ifdef FRONTPANEL
-	if (F_flag) {
-		t2 = get_clock_us();
-		fp_clock++;
-		fp_sampleData();
-		cpu_tadj += get_clock_us() - t2;
-	}
-#endif
 
 	do {
 
@@ -444,18 +443,16 @@ void cpu_z80(void)
 					T_dma = (*dma_bus_master)(0);
 					T += T_dma;
 					if (cpu_freq)
-						cpu_time += (1000000ULL *
-							     T_dma) / cpu_freq;
+						cpu_time += (1000000 * T_dma) /
+							    cpu_freq;
 				}
 			}
 
 			if (bus_request) {		/* DMA bus request */
 #ifdef FRONTPANEL
 				if (F_flag) {
-					t2 = get_clock_us();
 					fp_clock += 1000;
 					fp_sampleData();
-					cpu_tadj += get_clock_us() - t2;
 				}
 #endif
 				if (dma_bus_master) {
@@ -464,8 +461,8 @@ void cpu_z80(void)
 					T_dma = (*dma_bus_master)(1);
 					T += T_dma;
 					if (cpu_freq)
-						cpu_time += (1000000ULL *
-							     T_dma) / cpu_freq;
+						cpu_time += (1000000 * T_dma) /
+							    cpu_freq;
 				}
 				/* FOR NOW -
 				   MAY BE NEED A PRIORITY SYSTEM LATER */
@@ -475,10 +472,8 @@ void cpu_z80(void)
 				}
 #ifdef FRONTPANEL
 				if (F_flag) {
-					t2 = get_clock_us();
 					fp_clock += 1000;
 					fp_sampleData();
-					cpu_tadj += get_clock_us() - t2;
 				}
 #endif
 			}
@@ -509,13 +504,11 @@ void cpu_z80(void)
 #endif
 #ifdef FRONTPANEL
 				if (F_flag) {
-					t2 = get_clock_us();
 					fp_clock += 1000;
 					fp_led_data = (int_data != -1) ?
 						      (BYTE) int_data : 0xff;
 					fp_sampleData();
 					wait_int_step();
-					cpu_tadj += get_clock_us() - t2;
 					if (cpu_state & ST_RESET)
 						goto leave;
 				}
@@ -619,26 +612,6 @@ void cpu_z80(void)
 #include "altz80.h"
 #endif
 
-					/* adjust CPU speed and
-					   update CPU accounting */
-		if (T >= T_max) {
-			T_max = T + tmax;
-			t2 = get_clock_us();
-			tdiff = t2 - t1;
-			if (f_value && !cpu_needed && tdiff < 10000L) {
-				sleep_for_us(10000L - tdiff);
-				t2 = get_clock_us();
-				tdiff = t2 - t1; /* should be really close
-						    to 10000, but isn't */
-				cpu_time += tdiff;
-			} else
-				cpu_time += tdiff - cpu_tadj;
-			cpu_tadj = 0;
-			if (cpu_time)
-				cpu_freq = T * 1000000ULL / cpu_time;
-			t1 = t2;
-		}
-
 #ifdef WANT_ICE
 
 #ifdef WANT_TIM
@@ -663,7 +636,38 @@ void cpu_z80(void)
 		check_gui_break();
 #endif
 
+					/* adjust CPU speed and
+					   update CPU accounting */
+		if (T >= T_max) {
+			T_max = T + tmax;
+			t2 = get_clock_us();
+			tdiff = t2 - t1;
+			if (f_value && !cpu_needed && tdiff < 10000L) {
+				sleep_for_us(10000L - tdiff);
+				t2 = get_clock_us();
+				tdiff = t2 - t1;
+			}
+			cpu_time += tdiff - (io_time + wait_time);
+			total_io_time += io_time;
+			total_wait_time += wait_time;
+			io_time = wait_time = 0;
+			if (cpu_time)
+				cpu_freq = (T * 1000000) / cpu_time;
+			t1 = t2;
+		}
+
 	} while (cpu_state == ST_CONTIN_RUN);
+
+					/* update CPU accounting
+					   if necessary */
+	if (T > T_max - tmax) {
+		cpu_time += (get_clock_us() - t1) - (io_time + wait_time);
+		total_io_time += io_time;
+		total_wait_time += wait_time;
+		io_time = wait_time = 0;
+		if (cpu_time)
+			cpu_freq = (T * 1000000) / cpu_time;
+	}
 
 #ifdef BUS_8080
 	if (!(cpu_bus & CPU_INTA))
@@ -672,24 +676,16 @@ void cpu_z80(void)
 
 #ifdef FRONTPANEL
 	if (F_flag) {
-		t2 = get_clock_us();
 		fp_led_address = PC;
 		fp_led_data = getmem(PC);
 		fp_clock++;
 		fp_sampleData();
-		cpu_tadj += get_clock_us() - t2;
 	}
 #endif
 #ifdef SIMPLEPANEL
 	fp_led_address = PC;
 	fp_led_data = getmem(PC);
 #endif
-
-					/* update CPU accounting */
-	cpu_time += (get_clock_us() - t1) - cpu_tadj;
-	cpu_tadj = 0;
-	if (cpu_time)
-		cpu_freq = T * 1000000ULL / cpu_time;
 }
 
 #ifndef ALT_Z80
@@ -765,7 +761,9 @@ static int op_halt(void)		/* HALT */
 		}
 	}
 #endif /* FRONTPANEL */
-	cpu_tadj += get_clock_us() - t;
+
+	wait_time += get_clock_us() - t;
+
 	return 4;
 }
 


### PR DESCRIPTION
Show time spent doing I/O and waiting (single step, HALT).

CPU frequency shown is the speed we would achive without doing I/O and waiting but reflects the impact that the frontpanel sampling has.

Change info panel colors to be less MS-DOSy, hide FPS behind 's'.

Specify the SDK version in picosim/README.

The aon_timer delay bug got fixed.

Also update FatFS to latest main commits which include my fix for unused parameter warning.