### PR TITLE
Update Makefiles for MacOS and Homebrew

### DIFF
--- a/altairsim/srcsim/Makefile
+++ b/altairsim/srcsim/Makefile
@@ -67,10 +67,9 @@ else ifeq ($(TARGET_OS),LINUX)
 PLAT_INCS = -I/usr/include/SDL2
 PLAT_LDLIBS = -lSDL2 -lSDL2main
 else ifeq ($(TARGET_OS),OSX)
-PLAT_INCS = -F/Library/Frameworks -I/Library/Frameworks/SDL2.framework/Headers
-PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names \
-	-Wl,-rpath,/Library/Frameworks
-PLAT_LDLIBS = -framework SDL2
+PLAT_INCS = -I/opt/homebrew/include/SDL2 
+PLAT_LDLIBS = -L/opt/homebrew/lib -lSDL2
+PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names -Wl,-rpath,/Library/Frameworks
 endif
 else
 ifeq ($(INFOPANEL),YES)
@@ -101,10 +100,8 @@ FP_DEFS = -DFRONTPANEL
 FP_LIB = $(FP_DIR)/libfrontpanel.a
 ifeq ($(WANT_SDL),YES)
 ifeq ($(TARGET_OS),OSX)
-FP_INCS = -I/Library/Frameworks/SDL2_image.framework/Headers \
-	-I/Library/Frameworks/SDL2_mixer.framework/Headers
-FP_LDLIBS = -lfrontpanel -framework SDL2_image -framework SDL2_mixer \
-	-framework OpenGL
+FP_INCS = -I/opt/homebrew/include/SDL2 
+FP_LDLIBS = -lfrontpanel -L/opt/homebrew/lib -lSDL2_mixer -lSDL2_image -framework OpenGL
 else
 FP_LDLIBS = -lfrontpanel -lSDL2_image -lSDL2_mixer -lGL
 endif

--- a/cpmsim/srcsim/Makefile
+++ b/cpmsim/srcsim/Makefile
@@ -56,10 +56,9 @@ else ifeq ($(TARGET_OS),LINUX)
 PLAT_INCS = -I/usr/include/SDL2
 PLAT_LDLIBS = -lSDL2 -lSDL2main
 else ifeq ($(TARGET_OS),OSX)
-PLAT_INCS = -F/Library/Frameworks -I/Library/Frameworks/SDL2.framework/Headers
-PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names \
-	-Wl,-rpath,/Library/Frameworks
-PLAT_LDLIBS = -framework SDL2
+PLAT_INCS = -I/opt/homebrew/include/SDL2 
+PLAT_LDLIBS = -L/opt/homebrew/lib -lSDL2
+PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names -Wl,-rpath,/Library/Frameworks
 endif
 else
 PLAT_DEFS = -DINFOPANEL

--- a/cromemcosim/srcsim/Makefile
+++ b/cromemcosim/srcsim/Makefile
@@ -74,10 +74,9 @@ else ifeq ($(TARGET_OS),LINUX)
 PLAT_INCS = -I/usr/include/SDL2
 PLAT_LDLIBS = -lSDL2 -lSDL2main
 else ifeq ($(TARGET_OS),OSX)
-PLAT_INCS = -F/Library/Frameworks -I/Library/Frameworks/SDL2.framework/Headers
-PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names \
-	-Wl,-rpath,/Library/Frameworks
-PLAT_LDLIBS = -framework SDL2
+PLAT_INCS = -I/opt/homebrew/include/SDL2 
+PLAT_LDLIBS = -L/opt/homebrew/lib -lSDL2
+PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names -Wl,-rpath,/Library/Frameworks
 endif
 else
 ifeq ($(INFOPANEL),YES)
@@ -108,10 +107,8 @@ FP_DEFS = -DFRONTPANEL
 FP_LIB = $(FP_DIR)/libfrontpanel.a
 ifeq ($(WANT_SDL),YES)
 ifeq ($(TARGET_OS),OSX)
-FP_INCS = -I/Library/Frameworks/SDL2_image.framework/Headers \
-	-I/Library/Frameworks/SDL2_mixer.framework/Headers
-FP_LDLIBS = -lfrontpanel -framework SDL2_image -framework SDL2_mixer \
-	-framework OpenGL
+FP_INCS = -I/opt/homebrew/include/SDL2 
+FP_LDLIBS = -lfrontpanel -L/opt/homebrew/lib -lSDL2_mixer -lSDL2_image -framework OpenGL
 else
 FP_LDLIBS = -lfrontpanel -lSDL2_image -lSDL2_mixer -lGL
 endif

--- a/frontpanel/Makefile
+++ b/frontpanel/Makefile
@@ -24,9 +24,7 @@ PLAT_INCS = -I/usr/local/include/SDL2
 else ifeq ($(TARGET_OS),LINUX)
 PLAT_INCS = -I/usr/include/SDL2
 else ifeq ($(TARGET_OS),OSX)
-PLAT_INCS = -F/Library/Frameworks -I/Library/Frameworks/SDL2.framework/Headers \
-	-I/Library/Frameworks/SDL2_image.framework/Headers \
-	-I/Library/Frameworks/SDL2_mixer.framework/Headers
+PLAT_INCS = -I/opt/homebrew/include/SDL2 
 endif
 else
 ifeq ($(TARGET_OS),BSD)

--- a/imsaisim/srcsim/Makefile
+++ b/imsaisim/srcsim/Makefile
@@ -75,10 +75,9 @@ else ifeq ($(TARGET_OS),LINUX)
 PLAT_INCS = -I/usr/include/SDL2
 PLAT_LDLIBS = -lSDL2 -lSDL2main
 else ifeq ($(TARGET_OS),OSX)
-PLAT_INCS = -F/Library/Frameworks -I/Library/Frameworks/SDL2.framework/Headers
-PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names \
-	-Wl,-rpath,/Library/Frameworks
-PLAT_LDLIBS = -framework SDL2
+PLAT_INCS = -I/opt/homebrew/include/SDL2 
+PLAT_LDLIBS = -L/opt/homebrew/lib -lSDL2
+PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names -Wl,-rpath,/Library/Frameworks
 endif
 else
 ifeq ($(INFOPANEL),YES)
@@ -109,10 +108,8 @@ FP_DEFS = -DFRONTPANEL
 FP_LIB = $(FP_DIR)/libfrontpanel.a
 ifeq ($(WANT_SDL),YES)
 ifeq ($(TARGET_OS),OSX)
-FP_INCS = -I/Library/Frameworks/SDL2_image.framework/Headers \
-	-I/Library/Frameworks/SDL2_mixer.framework/Headers
-FP_LDLIBS = -lfrontpanel -framework SDL2_image -framework SDL2_mixer \
-	-framework OpenGL
+FP_INCS = -I/opt/homebrew/include/SDL2 
+FP_LDLIBS = -lfrontpanel -L/opt/homebrew/lib -lSDL2_mixer -lSDL2_image -framework OpenGL
 else
 FP_LDLIBS = -lfrontpanel -lSDL2_image -lSDL2_mixer -lGL
 endif

--- a/intelmdssim/srcsim/Makefile
+++ b/intelmdssim/srcsim/Makefile
@@ -66,10 +66,9 @@ else ifeq ($(TARGET_OS),LINUX)
 PLAT_INCS = -I/usr/include/SDL2
 PLAT_LDLIBS = -lSDL2 -lSDL2main
 else ifeq ($(TARGET_OS),OSX)
-PLAT_INCS = -F/Library/Frameworks -I/Library/Frameworks/SDL2.framework/Headers
-PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names \
-	-Wl,-rpath,/Library/Frameworks
-PLAT_LDLIBS = -framework SDL2
+PLAT_INCS = -I/opt/homebrew/include/SDL2 
+PLAT_LDLIBS = -L/opt/homebrew/lib -lSDL2
+PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names -Wl,-rpath,/Library/Frameworks
 endif
 else
 ifeq ($(INFOPANEL),YES)
@@ -100,10 +99,8 @@ FP_DEFS = -DFRONTPANEL
 FP_LIB = $(FP_DIR)/libfrontpanel.a
 ifeq ($(WANT_SDL),YES)
 ifeq ($(TARGET_OS),OSX)
-FP_INCS = -I/Library/Frameworks/SDL2_image.framework/Headers \
-	-I/Library/Frameworks/SDL2_mixer.framework/Headers
-FP_LDLIBS = -lfrontpanel -framework SDL2_image -framework SDL2_mixer \
-	-framework OpenGL
+FP_INCS = -I/opt/homebrew/include/SDL2 
+FP_LDLIBS = -lfrontpanel -L/opt/homebrew/lib -lSDL2_mixer -lSDL2_image -framework OpenGL
 else
 FP_LDLIBS = -lfrontpanel -lSDL2_image -lSDL2_mixer -lGL
 endif

--- a/mosteksim/srcsim/Makefile
+++ b/mosteksim/srcsim/Makefile
@@ -58,10 +58,9 @@ else ifeq ($(TARGET_OS),LINUX)
 PLAT_INCS = -I/usr/include/SDL2
 PLAT_LDLIBS = -lSDL2 -lSDL2main
 else ifeq ($(TARGET_OS),OSX)
-PLAT_INCS = -F/Library/Frameworks -I/Library/Frameworks/SDL2.framework/Headers
-PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names \
-	-Wl,-rpath,/Library/Frameworks
-PLAT_LDLIBS = -framework SDL2
+PLAT_INCS = -I/opt/homebrew/include/SDL2 
+PLAT_LDLIBS = -L/opt/homebrew/lib -lSDL2
+PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names -Wl,-rpath,/Library/Frameworks
 endif
 else
 PLAT_DEFS = -DINFOPANEL

--- a/z80sim/srcsim/Makefile
+++ b/z80sim/srcsim/Makefile
@@ -51,10 +51,9 @@ else ifeq ($(TARGET_OS),LINUX)
 PLAT_INCS = -I/usr/include/SDL2
 PLAT_LDLIBS = -lSDL2 -lSDL2main
 else ifeq ($(TARGET_OS),OSX)
-PLAT_INCS = -F/Library/Frameworks -I/Library/Frameworks/SDL2.framework/Headers
-PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names \
-	-Wl,-rpath,/Library/Frameworks
-PLAT_LDLIBS = -framework SDL2
+PLAT_INCS = -I/opt/homebrew/include/SDL2 
+PLAT_LDLIBS = -L/opt/homebrew/lib -lSDL2
+PLAT_LDFLAGS = -Wl,-search_paths_first -Wl,-headerpad_max_install_names -Wl,-rpath,/Library/Frameworks
 endif
 else
 PLAT_DEFS = -DINFOPANEL


### PR DESCRIPTION
The current Makefiles are expecting that the SDL2 libraries was installed as a framework. This is not the case when using Homebrew on MacOS (Sonoma on M1). This commit updates the Makefiles to use the correct library paths for MacOS and Homebrew.

Currently I have sdl2 sdl2_gfx sdl2_image sdl2_mixer sdl2_sound and sdl2_ttf installed on my machine,but all of them might not be required.