### PR TITLE
Fixed bug with sio3/socket interaction.

### DIFF
--- a/iodevices/altair-88-sio.c
+++ b/iodevices/altair-88-sio.c
@@ -201,6 +201,35 @@ again:
 		sio0_stat |= 0b10000000;
 }
 
+
+/*
+ * Helper function to check and accept incoming socket connection.
+ * Called from both sio3_status_in() and sio3_data_in() to ensure
+ * the connection is established regardless of which port is accessed
+ * first. Fixes a bug where reading data port 7 directly (without
+ * polling status port 6 first) would always return stale data because
+ * accept() was only called from the status path.
+ */
+static void sio3_check_connection(void)
+{
+    struct pollfd p[1];
+    if (ucons[0].ssc == 0) {
+        p[0].fd = ucons[0].ss;
+        p[0].events = POLLIN;
+        p[0].revents = 0;
+        poll(p, 1, 0);
+        if (p[0].revents) {
+            if ((ucons[0].ssc = accept(ucons[0].ss, NULL, NULL)) == -1) {
+                LOGW(TAG, "can't accept server socket");
+                ucons[0].ssc = 0;
+            }
+        }
+    }
+}
+
+
+
+
 /*
  * read status register
  *
@@ -214,20 +243,7 @@ BYTE altair_sio3_status_in(void)
 	struct pollfd p[1];
 
 	/* if socket not connected check for a new connection */
-	if (ucons[0].ssc == 0) {
-		p[0].fd = ucons[0].ss;
-		p[0].events = POLLIN;
-		p[0].revents = 0;
-		poll(p, 1, 0);
-		/* accept a new connection */
-		if (p[0].revents) {
-			if ((ucons[0].ssc = accept(ucons[0].ss, NULL,
-						   NULL)) == -1) {
-				LOGW(TAG, "can't accept server socket");
-				ucons[0].ssc = 0;
-			}
-		}
-	}
+        sio3_check_connection();
 
 	sio3_t2 = get_clock_us();
 	if (sio3_baud_rate > 0 &&
@@ -268,6 +284,7 @@ BYTE altair_sio3_data_in(void)
 	static BYTE last;
 	struct pollfd p[1];
 
+        sio3_check_connection();
 	/* if not connected return last */
 	if (ucons[0].ssc == 0)
 		return last;


### PR DESCRIPTION
Previously, the logic to accept() incoming socket connections for SIO3 was located exclusively within the altair_sio3_status_in() function. This caused a bug where a direct read from the data port (port 7) before a status poll (port 6) would fail to trigger the connection, resulting in zeroes being read as data.

I don't believe that's how original Altair 8800 worked -- while checking the status before reading was standard practice, it was not required. For example, some leader check routines won't work because of that: code that expects to poll the data stream directly would fail because the socket remained unaccepted.

This PR extracts the connection-checking logic into a helper function sio3_check_connection() and ensures it is called during both status and data input operations.